### PR TITLE
Add missing header for std::swap

### DIFF
--- a/libhelfem/src/erfc_expn.cpp
+++ b/libhelfem/src/erfc_expn.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "erfc_expn.h"
+#include <algorithm>
 #include <cmath>
 #include <cfloat>
 #include <stdexcept>


### PR DESCRIPTION
According to [docs](https://en.cppreference.com/w/cpp/algorithm/swap) std::swap requires ```#include <algorithm>``` in pre-c++-11 code.
