### PR TITLE
Do not convert from Rbond to Rhalf in diatomic constructor

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -428,11 +428,11 @@ namespace helfem {
       TwoDBasis::TwoDBasis() {
       }
 
-      TwoDBasis::TwoDBasis(int Z1_, int Z2_, double Rbond, const polynomial_basis::PolynomialBasis * poly, int n_quad, const arma::vec & bval, const arma::ivec & lval_, const arma::ivec & mval_, int lpad, bool legendre) {
+      TwoDBasis::TwoDBasis(int Z1_, int Z2_, double Rhalf_, const polynomial_basis::PolynomialBasis * poly, int n_quad, const arma::vec & bval, const arma::ivec & lval_, const arma::ivec & mval_, int lpad, bool legendre) {
         // Nuclear charge
         Z1=Z1_;
         Z2=Z2_;
-        Rhalf=0.5*Rbond;
+        Rhalf=Rhalf_;
 
         // Construct radial basis
         radial=RadialBasis(poly, n_quad, bval);

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -182,7 +182,7 @@ namespace helfem {
         // Dummy constructor
         TwoDBasis();
         /// Constructor
-        TwoDBasis(int Z1, int Z2, double Rbond, const polynomial_basis::PolynomialBasis * poly, int n_quad, const arma::vec & bval, const arma::ivec & lval, const arma::ivec & mval, int lpad=0, bool legendre=true);
+        TwoDBasis(int Z1, int Z2, double Rhalf, const polynomial_basis::PolynomialBasis * poly, int n_quad, const arma::vec & bval, const arma::ivec & lval, const arma::ivec & mval, int lpad=0, bool legendre=true);
         /// Destructor
         ~TwoDBasis();
 

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -39,7 +39,7 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const polyno
   arma::ivec lval, mval;
   diatomic::basis::lm_to_l_m(lmmax,lval,mval);
 
-  diatomic::basis::TwoDBasis basis(Z1, Z2, Rbond, poly, Nquad, bval, lval, mval, lpad, false);
+  diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval, lpad, false);
 
   bool diag=true;
   // Symmetry indices

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char **argv) {
   double mumax(utils::arcosh(Rmax/Rhalf));
   arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, igrid, zexp));
 
-  diatomic::basis::TwoDBasis basis(Z1, Z2, Rbond, poly, Nquad, bval, lval, mval, lpad);
+  diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval, lpad);
   chkpt.write(basis);
   printf("Basis set consists of %i angular shells composed of %i radial functions, totaling %i basis functions\n",(int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf());
 


### PR DESCRIPTION
Do not convert from Rbond to Rhalf in diatomic constructor since this leads to problems with saving&loading.