### PR TITLE
Use a real quadrature grid in diatomic density_grid

### DIFF
--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -277,10 +277,14 @@ namespace helfem {
 
         /// Evaluate basis functions derivatives at quadrature points
         void eval_df(size_t iel, size_t irad, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const;
+        /// Translate dummy indices to real indices
+        arma::uvec dummy_idx_to_real_idx(const arma::uvec & idx) const;
+        /// Get list of basis function dummy indices in element
+        arma::uvec bf_list_dummy(size_t iel) const;
+        /// Get list of basis function dummy indices in element with m=m
+        arma::uvec bf_list_dummy(size_t iel, int m) const;
         /// Get list of basis function indices in element
         arma::uvec bf_list(size_t iel) const;
-        /// Get list of basis function indices in element with m=m
-        arma::uvec bf_list(size_t iel, int m) const;
 
         /// Get number of radial elements
         size_t get_rad_Nel() const;
@@ -288,6 +292,8 @@ namespace helfem {
         arma::vec get_wrad(size_t iel) const;
         /// Get r values
         arma::vec get_r(size_t iel) const;
+        /// Get radial basis functions
+        arma::mat get_rad_bf(size_t iel) const;
 
         /// Electron density at nuclei
         arma::vec nuclear_density(const arma::mat & P) const;

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -13,14 +13,19 @@
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
  */
+
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"
 #include "../general/constants.h"
+#include "../general/spherical_harmonics.h"
 #include "../general/timer.h"
 #include "utils.h"
 #include "basis.h"
 #include <cfloat>
 #include <climits>
+
+// Angular quadrature
+#include "../general/angular.h"
 
 using namespace helfem;
 
@@ -29,19 +34,22 @@ int main(int argc, char **argv) {
 
   // full option name, no short option, description, argument required
   parser.add<std::string>("load", 0, "load guess from checkpoint", false, "");
-  parser.add<double>("mumax", 0, "mu max (negative for same as input)", false, -1.0);
-  parser.add<double>("phi", 0, "value of phi angle", false, 0.0);
-  parser.add<int>("Nmu", 0, "number of points in mu (negative for same as input)", false, -1);
-  parser.add<int>("Nnu", 0, "number of points in nu (negative for same as input)", false, -1);
-  parser.add<bool>("offset", 0, "use nu and mu offset?", false, false);
-  parser.add<std::string>("savedens", 0, "save density to file", false, "density.hdf5");
+  parser.add<int>("nquad", 0, "number of quadrature points in mu (automatic default)", false, -1);
+  parser.add<int>("lang", 0, "number of quadrature points in nu (automatic default)", false, -1);
+  parser.add<int>("mang", 0, "number of quadrature points in phi (automatic default)", false, -1);
+  parser.add<std::string>("output", 0, "save density to file", false, "density.hdf5");
   parser.parse_check(argc, argv);
 
   // Get parameters
   std::string load(parser.get<std::string>("load"));
-  double mumax(parser.get<double>("mumax"));
-  double phi(parser.get<double>("phi"));
-  std::string savedens(parser.get<std::string>("savedens"));
+
+  int nquad(parser.get<int>("nquad"));
+
+  // Angular grid
+  int lang(parser.get<int>("lang"));
+  int mang(parser.get<int>("mang"));
+
+  std::string output(parser.get<std::string>("output"));
 
   // Load checkpoint
   Checkpoint loadchk(load,false);
@@ -49,81 +57,175 @@ int main(int argc, char **argv) {
   diatomic::basis::TwoDBasis basis;
   loadchk.read(basis);
 
-  // Sanity check
-  if(mumax<0 || mumax>basis.get_mumax())
-    mumax=basis.get_mumax();
+  // Process defaults
+  if(nquad<=0)
+    nquad=5*basis.get_poly_nnodes();
+  if(lang<=0)
+    lang=4*arma::max(basis.get_lval())+12;
+  if(mang<=0)
+    mang=4*arma::max(arma::abs(basis.get_mval()))+5;
 
-  int Nmu(parser.get<int>("Nmu"));
-  if(Nmu<=0)
-    Nmu=2*basis.Nrad();
-
-  int Nnu(parser.get<int>("Nnu"));
-  if(Nnu<=0)
-    Nnu=2*arma::max(basis.get_lval());
-
-  printf("Grid spanning mu = 0 .. %e, Nmu = %i, Nnu = %i\n",mumax,Nmu,Nnu);
+  arma::vec cth, phi, wang;
+  helfem::angular::angular_chebyshev(lang,mang,cth,phi,wang);
+  printf("Using angular quadrature grid with L=%i M=%i with %i points\n",lang,mang,(int) cth.n_elem);
 
   // Density matrix
-  arma::mat P, Pa, Pb;
-  loadchk.read("Pa",Pa);
-  loadchk.read("Pb",Pb);
-  loadchk.read("P",P);
+  arma::mat Ca, Cb;
+  loadchk.read("Ca",Ca);
+  loadchk.read("Cb",Cb);
+  int nela, nelb;
+  loadchk.read("nela",nela);
+  loadchk.read("nelb",nelb);
 
   // mu array
-  arma::vec mu, nu;
-  bool offset(parser.get<bool>("offset"));
-  if(offset) {
-    double dmu=mumax/Nmu;
-    double dnu=M_PI/Nnu;
-    mu=arma::linspace<arma::vec>(dmu,mumax,Nmu);
-    nu=arma::linspace<arma::vec>(0.5*dnu,(Nnu-0.5)*dnu,Nnu);
-  } else {
-    mu=arma::linspace<arma::vec>(0.0,mumax,Nmu);
-    nu=arma::linspace<arma::vec>(0.0,M_PI,Nnu);
+  std::vector<arma::vec> mu(basis.get_rad_Nel()), wmu(basis.get_rad_Nel());
+  for(size_t iel=0;iel<mu.size();iel++) {
+    mu[iel]=basis.get_r(iel);
+    wmu[iel]=basis.get_wrad(iel);
   }
-  double dmudnu=(mu(1)-mu(0))*(nu(1)-nu(0));
+
+  size_t Nradpts=mu.size()*mu[0].n_elem;
+  printf("Using radial quadrature grid with %i points\n",(int) Nradpts);
+
+  // Size of total matrix
+  size_t Ngrid = Nradpts*wang.n_elem;
+
+  // Pretabulate basis function data
+  arma::ivec lval(basis.get_lval());
+  arma::ivec mval(basis.get_mval());
+  arma::cx_mat sph(wang.n_elem,lval.n_elem);
+  for(size_t il=0;il<lval.n_elem;il++)
+    for(size_t iang=0;iang<wang.n_elem;iang++)
+      sph(iang,il)=::spherical_harmonics(lval(il),mval(il),cth(iang),phi(iang));
+
+  // Evaluate radial functions
+  std::vector<arma::mat> radbf(basis.get_rad_Nel());
+  for(size_t iel=0;iel<mu.size();iel++) {
+    radbf[iel] = basis.get_rad_bf(iel);
+  }
 
   // Density arrays
-  arma::mat dena(Nmu,Nnu);
-  dena.zeros();
-  arma::mat denb(Nmu,Nnu);
-  denb.zeros();
-  arma::mat dV(Nmu,Nnu);
-  dV.zeros();
-  for(size_t inu=0;inu<nu.n_elem;inu++)
-    for(size_t imu=0;imu<mu.n_elem;imu++) {
-      // Evaluate basis functions
-      double muval(mu(imu));
-      double cosnu(cos(nu(inu)));
-      arma::cx_vec bf(basis.eval_bf(muval, cosnu, phi));
+  arma::vec dena(Ngrid,arma::fill::zeros), denb(Ngrid,arma::fill::zeros), dV(Ngrid,arma::fill::zeros);
+  arma::mat orba(Ngrid,nela,arma::fill::zeros), orbb(Ngrid,nelb,arma::fill::zeros);
 
-      // Evaluate density at the point
-      dena(imu,inu)=std::real(arma::as_scalar(bf.t()*Pa*bf));
-      denb(imu,inu)=std::real(arma::as_scalar(bf.t()*Pb*bf));
+  arma::vec mugrid(Ngrid,arma::fill::zeros);
+  arma::vec cthgrid(Ngrid,arma::fill::zeros);
+  arma::vec phigrid(Ngrid,arma::fill::zeros);
+  arma::cx_mat orbagrid(Ngrid,nela,arma::fill::zeros);
+  arma::cx_mat orbbgrid;
+  if(nelb)
+    orbbgrid.zeros(Ngrid,nelb);
 
-      // Volume element is
-      double shmu(sinh(muval));
-      double chmu(cosh(muval));
-      double sinnu(sin(nu(inu)));
-      // Get 2 pi from phi integral (assuming density is symmetric)
-      dV(imu,inu)=2.0*M_PI*std::pow(basis.get_Rhalf(),3)*shmu*(chmu*chmu - cosnu*cosnu)*sinnu*dmudnu;
+  arma::cx_mat Sa(nela,nela,arma::fill::zeros), Sb;
+  if(nelb>0)
+    Sb.zeros(nelb,nelb);
+
+  size_t igrid=0;
+  // Loop over radial elements
+  for(size_t iel=0;iel<mu.size();iel++) {
+    // Get the list of basis functions in the element in the dummy
+    // indexing
+    arma::uvec bidx=basis.bf_list(iel);
+
+    // Orbital submatrices
+    arma::mat Casub(Ca.cols(0,nela-1));
+    Casub = Casub.rows(bidx);
+    arma::mat Cbsub;
+    if(nelb) {
+      Cbsub=Cb.cols(0,nelb-1);
+      Cbsub=Cbsub.rows(bidx);
     }
 
+    // Radial values
+    arma::vec r(mu[iel]);
+    arma::vec wr(wmu[iel]);
+
+    // Loop over angular output grid
+    for(size_t iang=0;iang<wang.n_elem;iang++) {
+      // Loop over radial points
+      for(size_t irad=0;irad<radbf[iel].n_rows;irad++) {
+        // Form matrix of basis function values
+        arma::cx_rowvec bf(bidx.n_elem);
+        {
+          size_t ioff=0;
+          // Loop over angular basis
+          for(size_t il=0;il<lval.n_elem;il++) {
+            // Loop over in-element radial functions
+            size_t firstfun = ((iel==0) && (mval(il)!=0)) ? 1 : 0;
+            for(size_t ifun=firstfun;ifun<radbf[iel].n_cols;ifun++) {
+              bf(ioff++) = sph(iang,il)*radbf[iel](irad,ifun);
+            }
+          }
+          if(ioff != bidx.n_elem) {
+            printf("iel=%i iang=%i ioff=%i bidx.n_elem=%i\n",(int) iel,(int) iang,(int) ioff,(int) bidx.n_elem);
+            fflush(stdout);
+            throw std::logic_error("Indexing problem!\n");
+          }
+        }
+
+        // Compute orbital values
+        arma::cx_rowvec orbaval = bf*Casub;
+        arma::cx_rowvec orbbval;
+        if(nelb)
+          orbbval = bf*Cbsub;
+
+        // Store result
+        dena(igrid)=std::real(arma::cdot(orbaval,orbaval));
+        denb(igrid)=nelb ? std::real(arma::cdot(orbbval,orbbval)) : 0.0;
+
+        // Store grid values
+        mugrid(igrid) = r(irad);
+        cthgrid(igrid) = cth(iang);
+        phigrid(igrid) = phi(iang);
+
+        // Volume element is
+        double shmu(sinh(r(irad)));
+        double chmu(cosh(r(irad)));
+        dV(igrid)=std::pow(basis.get_Rhalf(),3)*shmu*(chmu*chmu - cth(iang)*cth(iang))*wr(irad)*wang(iang);
+
+        // Orbital values
+        orbagrid.row(igrid) = orbaval;
+        if(nelb)
+          orbbgrid.row(igrid) = orbbval;
+
+        Sa += arma::trans(orbaval)*dV(igrid)*orbaval;
+        if(nelb)
+          Sb += arma::trans(orbbval)*dV(igrid)*orbbval;
+
+        igrid++;
+      }
+    }
+  }
+  if(igrid != dena.n_elem)
+    throw std::logic_error("Indexing error!\n");
+
   // Total density
-  arma::mat den(dena+denb);
+  arma::vec den(dena+denb);
 
-  printf("Norm of Pa on grid is %e\n",arma::sum(arma::sum(dena%dV)));
-  printf("Norm of Pb on grid is %e\n",arma::sum(arma::sum(denb%dV)));
-  printf("Norm of P on grid is %e\n",arma::sum(arma::sum(den%dV)));
+  printf("Norm of Pa on grid is %e\n",arma::sum(dena%dV));
+  printf("Norm of Pb on grid is %e\n",arma::sum(denb%dV));
+  printf("Norm of P on grid is %e\n",arma::sum(den%dV));
 
-  Checkpoint savechk(savedens,true);
-  savechk.write("mu",mu);
-  savechk.write("nu",nu);
+  printf("Alpha-alpha orbital non-orthonormality %e\n",arma::norm(Sa-arma::eye<arma::cx_mat>(Sa.n_rows,Sa.n_cols),"fro"));
+  if(nelb)
+    printf("Beta-beta   orbital non-orthonormality %e\n",arma::norm(Sb-arma::eye<arma::cx_mat>(Sb.n_rows,Sb.n_cols),"fro"));
+
+  Checkpoint savechk(output,true);
+  savechk.write("mu",mugrid);
+  savechk.write("dV",dV);
+  savechk.write("cth",cth);
+  savechk.write("phi",phi);
   savechk.write("P",den);
   savechk.write("Pa",dena);
   savechk.write("Pb",denb);
+  savechk.write("orba.re",arma::real(orbagrid));
+  savechk.write("orba.im",arma::imag(orbagrid));
+  if(nelb) {
+    savechk.write("orbb.re",arma::real(orbbgrid));
+    savechk.write("orbb.im",arma::imag(orbbgrid));
+  }
   savechk.write("R",2*basis.get_Rhalf());
-  printf("Saved density to file %s\n",savedens.c_str());
+  printf("Saved density to file %s\n",output.c_str());
 
   return 0;
 }

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -706,7 +706,7 @@ namespace helfem {
 
       void DFTGridWorker::compute_bf(size_t iel, size_t irad) {
         // Update function list
-        bf_ind=basp->bf_list(iel);
+        bf_ind=basp->bf_list_dummy(iel);
 
         // Get radial weights. Only do one radial quadrature point at a
         // time, since this is an easy way to save a lot of memory.

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -38,7 +38,7 @@ namespace helfem {
         // Store m
         m=m_;
         // Update function list
-        bf_ind=basp->bf_list(iel,m);
+        bf_ind=basp->bf_list_dummy(iel,m);
 
         // Get radial weights. Only do one radial quadrature point at a
         // time, since this is an easy way to save a lot of memory.


### PR DESCRIPTION
The earlier implementation of the diatomic program `diatomic_dgrid` used a uniform dummy grid. This PR modifies the program such that it prints out an actual quadrature grid that can be used to study the orbitals.