### PR TITLE
More accurate computation of orbital electron density maximum

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -48,6 +48,8 @@ namespace helfem {
 
         /// Get number of quadrature points
         int get_nquad() const;
+        /// Get quadrature points
+        arma::vec get_xq() const;
         /// Get boundary values
         arma::vec get_bval() const;
         /// Get polynomial basis identifier
@@ -123,14 +125,24 @@ namespace helfem {
 
         /// Evaluate basis functions at quadrature points
         arma::mat get_bf(size_t iel) const;
+        /// Evaluate basis functions at given points
+        arma::mat get_bf(const arma::vec & x, size_t iel) const;
         /// Evaluate derivatives of basis functions at quadrature points
         arma::mat get_df(size_t iel) const;
+        /// Evaluate basis functions at given points
+        arma::mat get_df(const arma::vec & x, size_t iel) const;
         /// Evaluate second derivatives of basis functions at quadrature points
         arma::mat get_lf(size_t iel) const;
+        /// Evaluate basis functions at given points
+        arma::mat get_lf(const arma::vec & x, size_t iel) const;
         /// Get quadrature weights
         arma::vec get_wrad(size_t iel) const;
+        /// Get quadrature weights
+        arma::vec get_wrad(const arma::vec & w, size_t iel) const;
         /// Get r values
         arma::vec get_r(size_t iel) const;
+        /// Get r values
+        arma::vec get_r(const arma::vec & x, size_t iel) const;
 
         /// Evaluate nuclear density
         double nuclear_density(const arma::mat &P) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -45,6 +45,10 @@ namespace helfem {
         return (int)xq.n_elem;
       }
 
+      arma::vec RadialBasis::get_xq() const {
+        return xq;
+      }
+
       size_t RadialBasis::Nbf() const {
         return fem.get_nbf();
       }
@@ -315,10 +319,14 @@ namespace helfem {
       }
 
       arma::mat RadialBasis::get_bf(size_t iel) const {
+        return get_bf(xq, iel);
+      }
+
+      arma::mat RadialBasis::get_bf(const arma::vec & x, size_t iel) const {
         // Element function values at quadrature points are
-        arma::mat val(fem.eval_f(xq, iel));
+        arma::mat val(fem.eval_f(x, iel));
         // but we also need to put in the 1/r factor
-        arma::vec r(fem.eval_coord(xq, iel));
+        arma::vec r(fem.eval_coord(x, iel));
         for (size_t j = 0; j < val.n_cols; j++)
           for (size_t i = 0; i < val.n_rows; i++)
             val(i, j) /= r(i);
@@ -327,10 +335,14 @@ namespace helfem {
       }
 
       arma::mat RadialBasis::get_df(size_t iel) const {
+        return get_df(xq ,iel);
+      }
+
+      arma::mat RadialBasis::get_df(const arma::vec & x, size_t iel) const {
         // Element function values at quadrature points are
-        arma::mat fval(fem.eval_f(xq, iel));
-        arma::mat dval(fem.eval_df(xq, iel));
-        arma::vec r(fem.eval_coord(xq, iel));
+        arma::mat fval(fem.eval_f(x, iel));
+        arma::mat dval(fem.eval_df(x, iel));
+        arma::vec r(fem.eval_coord(x, iel));
 
         // Derivative is then
         arma::mat der(fval);
@@ -342,11 +354,15 @@ namespace helfem {
       }
 
       arma::mat RadialBasis::get_lf(size_t iel) const {
+        return get_lf(xq, iel);
+      }
+
+      arma::mat RadialBasis::get_lf(const arma::vec & x, size_t iel) const {
         // Element function values at quadrature points are
-        arma::mat fval(fem.eval_f(xq, iel));
-        arma::mat dval(fem.eval_df(xq, iel));
-        arma::mat lval(fem.eval_d2f(xq, iel));
-        arma::vec r(fem.eval_coord(xq, iel));
+        arma::mat fval(fem.eval_f(x, iel));
+        arma::mat dval(fem.eval_df(x, iel));
+        arma::mat lval(fem.eval_d2f(x, iel));
+        arma::vec r(fem.eval_coord(x, iel));
 
         // Laplacian is then
         arma::mat lapl(fval);
@@ -360,12 +376,20 @@ namespace helfem {
       }
 
       arma::vec RadialBasis::get_wrad(size_t iel) const {
+        return get_wrad(wq, iel);
+      }
+
+      arma::vec RadialBasis::get_wrad(const arma::vec & w, size_t iel) const {
         // This is just the radial rule, no r^2 factor included here
-        return fem.scaling_factor(iel) * wq;
+        return fem.scaling_factor(iel) * w;
       }
 
       arma::vec RadialBasis::get_r(size_t iel) const {
-        return fem.eval_coord(xq, iel);
+        return get_r(xq, iel);
+      }
+
+      arma::vec RadialBasis::get_r(const arma::vec & x, size_t iel) const {
+        return fem.eval_coord(x, iel);
       }
 
       double RadialBasis::nuclear_density(const arma::mat &Prad) const {

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -126,6 +126,14 @@ namespace helfem {
         arma::vec radii() const;
         /// Compute radial orbitals
         arma::mat orbitals(const arma::mat & C) const;
+
+        /// Compute the electron density in given element at wanted points
+        arma::vec electron_density(const arma::vec & x, size_t iel, const arma::mat & Prad, bool rsqweight = false) const;
+        /// Compute the electron density in given element at default quadrature points
+        arma::vec electron_density(size_t iel, const arma::mat & Prad, bool rsqweight = false) const;
+        /// Compute the electron density in given element at default quadrature points
+        double electron_density_maximum(const arma::mat & Prad, double eps=1e-10) const;
+
         /// Compute the electron density
         arma::vec electron_density(const arma::mat & Prad) const;
         /// Compute the electron density gradient

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -178,15 +178,8 @@ namespace helfem {
             printf(" %e",rpos(ir));
           }
 
-          // Test function: total number of electrons at each value of r
-          arma::vec rho(basis.electron_density(P));
-          arma::vec totel(arma::square(r)%rho);
-
-          // Position of maximum
-          arma::uword ridx;
-          totel.max(ridx);
-
-          printf(" %e\n",r(ridx));
+          // Electron density maximum
+          printf(" %e\n",basis.electron_density_maximum(P));
         }
       }
 


### PR DESCRIPTION
Old code only looked for maximum amongst quadrature points, which made rmax printout grid dependent. This PR switches to golden section search to find electron density maximum. 