### PR TITLE
Improvements to numerical stability of two-electron integrals

### DIFF
--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -187,7 +187,11 @@ namespace helfem {
         std::function<double(double)> rpowL = [Rexp](double r){return std::pow(r,Rexp+2);};
         std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
         radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
-        return fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, rpowL);
+        arma::mat ret(fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, rpowL));
+        if(ret.has_nan()) {
+          printf("radial_integral(%i,%i) has NaN!\n",Rexp,(int) iel);
+        }
+        return ret;
       }
 
       arma::mat RadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {
@@ -347,7 +351,9 @@ namespace helfem {
         // Integral by quadrature
         std::shared_ptr<const polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
         arma::mat tei(quadrature::twoe_integral(Rmin, Rmax, xq, wq, p, L));
-
+        if(tei.has_nan()) {
+          printf("twoe_integral(%i,%i) has NaN!\n",L,(int) iel);
+        }
         return tei;
       }
 

--- a/libhelfem/src/quadrature.cpp
+++ b/libhelfem/src/quadrature.cpp
@@ -258,13 +258,13 @@ namespace helfem {
       arma::mat V(std::pow(poly->get_nbf(),2),x.n_elem);
       V.zeros();
       for(size_t ip=0;ip<x.n_elem;ip++) {
-        // int_0^r Bi(r) Bj(r)
+        // \int_0^r Bi(r) Bj(r) dr
         for(size_t jp=0;jp<=ip;jp++)
           V.col(ip)+=zero.col(jp)*r(jp);
         // divided by r
         V.col(ip) /= r(ip);
 
-        // plus the integral to infinity
+        // plus the integral to infinity \int_r^\infty r^{-1} Bi(r) Bj(r) dr
         for(size_t jp=ip;jp<x.n_elem;jp++)
           V.col(ip)+=minusone.col(jp);
       }

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -45,7 +45,7 @@ namespace helfem {
     }
 
     double bessel_il(double r, int L) {
-      // GSL calculates exp(-|x|)k_l(x)
+      // GSL calculates exp(-|x|)i_l(x)
       return exp(std::abs(r))*gsl_sf_bessel_il_scaled(L, r);
     }
 

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -57,9 +57,9 @@ namespace helfem {
     }
 
     double bessel_kl(double r, int L) {
-      // GSL calculates exp(-|x|)k_l(x). Also, the definition in GSL
+      // GSL calculates exp(x)k_l(x). Also, the definition in GSL
       // is \sqrt(\pi/(2x)), not \sqrt(2/(\pi x))
-      return exp(std::abs(r))*gsl_sf_bessel_kl_scaled(L, r) / M_PI_2;
+      return exp(-r)*gsl_sf_bessel_kl_scaled(L, r) / M_PI_2;
     }
 
     arma::vec bessel_kl(const arma::vec & r, int L) {

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -1159,7 +1159,7 @@ namespace helfem {
 
         arma::vec r(basis.radii());
         arma::vec wt(basis.quadrature_weights());
-        arma::mat vcoul(basis.coulomb_screening(P));
+        arma::vec vcoul(basis.coulomb_screening(P));
         arma::vec vxc(basis.xc_screening(P,x_func,c_func));
         arma::vec Zeff(vcoul+vxc);
         arma::vec rho(basis.electron_density(P));

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -1178,6 +1178,9 @@ namespace helfem {
         result.col(7)=wt;
         result.col(8)=arma::ones<arma::vec>(Zeff.n_elem)*basis.charge()-Zeff;
 
+        printf("Electron density by quadrature: %.10e\n",arma::sum(wt%rho%r%r));
+        printf("Quadrature of tabulated Coulomb potential yields Coulomb energy %.10e\n",arma::sum(0.5*r%rho%wt%vcoul));
+
         return result;
       }
 
@@ -1206,8 +1209,6 @@ namespace helfem {
         arma::vec lrho(basis.electron_density_laplacian(P));
         arma::vec tau(basis.kinetic_energy_density(Pl));
 
-        printf("Electron density by quadrature: %e\n",arma::sum(wt%rho%r%r));
-
         arma::mat result(r.n_elem,9);
         result.col(0)=r;
         result.col(1)=rho;
@@ -1218,6 +1219,9 @@ namespace helfem {
         result.col(6)=vxc;
         result.col(7)=wt;
         result.col(8)=arma::ones<arma::vec>(Zeff.n_elem)*basis.charge()-Zeff;
+
+        printf("Electron density by quadrature: %.10e\n",arma::sum(wt%rho%r%r));
+        printf("Quadrature of tabulated Coulomb potential yields Coulomb energy %.10e\n",arma::sum(0.5*r%rho%wt%vcoul));
 
         return result;
       }


### PR DESCRIPTION
This PR improves the numerical stability of intraelement two-electron integrals, where instead of computing 

$$ R^{-L-1} \int B_i(r) B_j(r) r^{L} dr$$ 

the code now uses a more floating-point friendly form

$$ R^{-1} \int^R B_i(r) B_j(r) \left( \frac r R \right)^{L} dr$$

that is less likely to over- and overflow and produce NaNs.

I also found a nasty typo introduced in commit d62f1c1b that broke Yukawa range separated functionals. 