### PR TITLE
Some bug fixes

### DIFF
--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -95,12 +95,15 @@ namespace helfem {
         arma::mat diff_lf(lft-lf0);
 
         // Accumulated differences
-        arma::mat diffs(diff_f.n_rows,5);
+        arma::mat diffs(diff_f.n_rows,5,arma::fill::zeros);
         diffs.col(0)=rcut/fem.element_length(0);
         for(size_t i=0;i<diffs.n_rows;i++) {
           diffs(i,1) = arma::norm(diff_f.row(i),2)/arma::norm(bf0.row(i),2);
-          diffs(i,2) = arma::norm(diff_df.row(i),2)/arma::norm(df0.row(i),2);
-          diffs(i,3) = arma::norm(diff_lf.row(i),2)/arma::norm(lf0.row(i),2);
+          // Only try to maximize fit of derivatives if they are nonzero
+          if(taylor_order>=1)
+            diffs(i,2) = arma::norm(diff_df.row(i),2)/arma::norm(df0.row(i),2);
+          if(taylor_order>1)
+            diffs(i,3) = arma::norm(diff_lf.row(i),2)/arma::norm(lf0.row(i),2);
           diffs(i,4) = diffs(i,1)+diffs(i,2)+diffs(i,3);
         }
 

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -926,11 +926,11 @@ namespace helfem {
           arma::vec a(1), b(1);
 
           if(imax == 0) {
-            a(0) = xq(imax);
+            a(0) = -1.0;
             b(0) = xq(imax+1);
           } else if(imax == xq.n_elem-1) {
             a(0) = xq(imax-1);
-            b(0) = xq(imax);
+            b(0) = 1.0;
           } else {
             a(0) = xq(imax-1);
             b(0) = xq(imax+1);

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -139,6 +139,8 @@ namespace helfem {
         arma::vec electron_density(size_t iel, const arma::mat & Prad, bool rsqweight = false) const;
         /// Compute the electron density in given element at default quadrature points
         double electron_density_maximum(const arma::mat & Prad, double eps=1e-10) const;
+        /// Compute the van der Waals radius, see doi:10.1002/chem.201602949
+        double vdw_radius(const arma::mat & Prad, double thr=0.001, double eps=1e-10) const;
 
         /// Compute the electron density
         arma::vec electron_density(const arma::mat & Prad) const;

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -132,6 +132,7 @@ int main(int argc, char **argv) {
   parser.add<bool>("zeroder", 0, "zero derivative at Rmax?", false, false);
   parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
   parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
+  parser.add<double>("vdwthr", 0, "Density threshold for van der Waals radius", false, 0.0015);
   if(!parser.parse(argc, argv))
     throw std::logic_error("Error parsing arguments!\n");
 
@@ -169,6 +170,8 @@ int main(int argc, char **argv) {
   double diisthr=parser.get<double>("diisthr");
   int diisorder=parser.get<int>("diisorder");
   int iguess(parser.get<int>("iguess"));
+
+  double vdw_thr=parser.get<double>("vdwthr");
 
   std::string method(parser.get<std::string>("method"));
   std::string potmethod(parser.get<std::string>("pot"));
@@ -604,6 +607,9 @@ int main(int argc, char **argv) {
     printf("Electron density gradient at the nucleus is % e\n",gnucd);
     printf("Cusp condition is %.10f\n",-1.0/(2*Z)*gnucd/nucd);
 
+    double rvdw(solver.vdw_radius(rconf,vdw_thr));
+    printf("\nEstimated vdW radius with density threshold %e is %.2f bohr = %.2f Å\n",vdw_thr,rvdw,rvdw*BOHRINANGSTROM);
+
     printf("\nResult in NIST format\n");
     printf("Etot  = % 18.9f\n",rconf.Econf);
     printf("Ekin  = % 18.9f\n",rconf.Ekin);
@@ -655,6 +661,8 @@ int main(int argc, char **argv) {
     printf("\nElectron density          at the nucleus is % e\n",nucd);
     printf("Electron density gradient at the nucleus is % e\n",gnucd);
     printf("Cusp condition is %.10f\n",-1.0/(2*Z)*gnucd/nucd);
+
+    printf("\nEstimated vdW radius with thr=%e is % .3f\n",vdw_thr,solver.vdw_radius(uconf,vdw_thr));
 
     printf("\nResult in NIST format\n");
     printf("Etot  = % 18.9f\n",uconf.Econf);

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -1430,6 +1430,14 @@ namespace helfem {
       double SCFSolver::nuclear_density_gradient(const uconf_t & conf) const {
         return basis.nuclear_density_gradient(TotalDensity(conf.Pal+conf.Pbl));
       }
+
+      double SCFSolver::vdw_radius(const rconf_t & conf, double thr) const {
+        return basis.vdw_radius(TotalDensity(conf.Pl), thr);
+      }
+
+      double SCFSolver::vdw_radius(const uconf_t & conf, double thr) const {
+        return basis.vdw_radius(TotalDensity(conf.Pal+conf.Pbl), thr);
+      }
     }
   }
 }

--- a/src/sadatom/solver.h
+++ b/src/sadatom/solver.h
@@ -296,6 +296,10 @@ namespace helfem {
         double nuclear_density_gradient(const rconf_t & conf) const;
         /// Compute the nuclear density gradient
         double nuclear_density_gradient(const uconf_t & conf) const;
+        /// Compute the van der Waals radius
+        double vdw_radius(const rconf_t & conf, double thr) const;
+        /// Compute the nuclear density gradient
+        double vdw_radius(const uconf_t & conf, double thr) const;
       };
     }
   }


### PR DESCRIPTION
Fixes the logic in electron_density_maximum and only tries to maximize the agreement of derivative functions if the derivatives are nonzero.

Also implements the computation of van der Waals radii following [doi:10.1002/chem.201602949](https://doi.org/10.1002/chem.201602949).