### PR TITLE
Implement atomic radius based on electron count outside the atom

### DIFF
--- a/libhelfem/include/FiniteElementBasis.h
+++ b/libhelfem/include/FiniteElementBasis.h
@@ -95,6 +95,8 @@ namespace helfem {
 
       /// Evaluate real coordinate values from primitive coordinates
       arma::vec eval_coord(const arma::vec & xprim, size_t iel) const;
+      /// Evaluate real coordinate values from primitive coordinates
+      double eval_coord(double xprim, size_t iel) const;
       /// Evaluate full set of coordinate valuess from primitive coordinates
       arma::vec eval_coord(const arma::vec & xq) const;
 
@@ -188,7 +190,8 @@ namespace helfem {
        */
       arma::mat matrix_element(const std::function<arma::mat(arma::vec,size_t)> & eval_lh, const std::function<arma::mat(arma::vec,size_t)> & eval_rh, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
       /// The driver function
-      arma::mat matrix_element(size_t iel, const std::function<arma::mat(arma::vec,size_t)> & eval_lh, const std::function<arma::mat(arma::vec,size_t)> & eval_rh, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      arma::mat matrix_element(size_t iel, const std::function<arma::mat(arma::vec,size_t)> & eval_lh, const std::function<arma::mat(arma::vec,size_t)> & eval_rh, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f, double x_left = -1.0, double x_right = 1.0) const;
+
 
       /**
        * Compute vector elements in the finite element basis <bf|f>

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -100,7 +100,7 @@ namespace helfem {
                                   size_t iel) const;
         /// Compute radial matrix elements <r^n> in element (overlap is n=0,
         /// nuclear is n=-1)
-        arma::mat radial_integral(int n, size_t iel) const;
+        arma::mat radial_integral(int n, size_t iel, double x_left = -1.0, double x_right = 1.0) const;
 
         /// Compute Bessel i_L integral
         arma::mat bessel_il_integral(int L, double lambda, size_t iel) const;
@@ -184,6 +184,8 @@ namespace helfem {
         arma::vec get_r(size_t iel) const;
         /// Get r values
         arma::vec get_r(const arma::vec & x, size_t iel) const;
+	/// Get r value
+        double get_r(double x, size_t iel) const;
 
         /// Evaluate nuclear density
         double nuclear_density(const arma::mat &P) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -186,11 +186,12 @@ namespace helfem {
         return taylor_diff;
       }
 
-      arma::mat RadialBasis::radial_integral(int Rexp, size_t iel) const {
+
+      arma::mat RadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
         std::function<double(double)> rpowL = [Rexp](double r){return std::pow(r,Rexp+2);};
         std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
         radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
-        arma::mat ret(fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, rpowL));
+        arma::mat ret(fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, rpowL, x_left, x_right));
         if(ret.has_nan()) {
           printf("radial_integral(%i,%i) has NaN!\n",Rexp,(int) iel);
         }
@@ -709,6 +710,10 @@ namespace helfem {
       }
 
       arma::vec RadialBasis::get_r(const arma::vec & x, size_t iel) const {
+        return fem.eval_coord(x, iel);
+      }
+
+      double RadialBasis::get_r(double x, size_t iel) const {
         return fem.eval_coord(x, iel);
       }
 

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -142,10 +142,12 @@ namespace helfem {
         arma::vec electron_density(const arma::vec & x, size_t iel, const arma::mat & Prad, bool rsqweight = false) const;
         /// Compute the electron density in given element at default quadrature points
         arma::vec electron_density(size_t iel, const arma::mat & Prad, bool rsqweight = false) const;
-        /// Compute the electron density in given element at default quadrature points
-        double electron_density_maximum(const arma::mat & Prad, bool rsqweight = true, double eps=1e-10) const;
+        /// Compute the position of the electron density maximum
+        double electron_density_maximum_radius(const arma::mat & Prad, bool rsqweight = true, double conv_thr=1e-10) const;
         /// Compute the van der Waals radius, see doi:10.1002/chem.201602949
-        double vdw_radius(const arma::mat & Prad, bool rsqweight = false, double thr=0.001, double eps=1e-10) const;
+        double vdw_radius(const arma::mat & Prad, double eps=0.001, double conv_thr=1e-10) const;
+	/// Compute the atomic radius by electron density inclusion
+	double electron_count_radius(const arma::mat & Prad, const double eps=0.001, const double conv_thr=1e-10) const;
 
         /// Compute the electron density
         arma::vec electron_density(const arma::mat & Prad, bool rsqweight = false) const;

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
   parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
   parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
   parser.add<double>("vdwthr", 0, "Density threshold for van der Waals radius", false, 0.001);
-  parser.add<double>("eps_el", 0, "Density threshold for atomic size with electron density inclusion", false, 0.078130238); // PBE0 H atom gives same radius as vdW routine with 1e-3 threshold, as defined by Rahm 2016
+  parser.add<double>("eps_el", 0, "Density threshold for atomic size with electron density inclusion", false, 0.078130234); // PBE0 H atom gives same radius as vdW routine with 1e-3 threshold, as defined by Rahm 2016
   parser.add<bool>("completeness", 0, "Compute completeness and importance profiles?", false, false);
   parser.add<int>("iconf", 0, "Confinement potential: 1 for polynomial, 2 for exponential", false, 0);
   parser.add<int>("conf_N", 0, "Exponent in polynomial confinement potential", false, 0);
@@ -708,9 +708,9 @@ int main(int argc, char **argv) {
     while(eps_right-eps_left>1e-10) {
       eps_el = (eps_right+eps_left)/2.0;
       double radius = solver.electron_count_radius(uconf,eps_el);
-      if(radius > 2.928573)
+      if(radius > rvdw)
 	eps_left = eps_el;
-      else if(radius < 2.928573)
+      else if(radius < rvdw)
 	eps_right = eps_el;
       else
 	break;

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -700,9 +700,10 @@ int main(int argc, char **argv) {
 
     double rvdw(solver.vdw_radius(uconf,vdw_thr));
     printf("\nEstimated vdW radius with density threshold %e is %.6f bohr = %.6f A\n",vdw_thr,rvdw,rvdw*BOHRINANGSTROM);
+    printf("Note that this criterion is sensitive to numerical noise.\n");
 
     double rincl(solver.electron_count_radius(uconf,eps_el));
-    printf("Atomic radius from electron density inclusion with threshold %e is %.6f bohr = %.6f A\n",eps_el,rincl,rincl*BOHRINANGSTROM);
+    printf("Estimated vdW radius with electron count threshold %e is %.6f bohr = %.6f A\n",eps_el,rincl,rincl*BOHRINANGSTROM);
 
     printf("\nResult in NIST format\n");
     printf("Etot  = % 18.9f\n",uconf.Econf);

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -703,20 +703,6 @@ int main(int argc, char **argv) {
     double rincl(solver.electron_count_radius(uconf,eps_el));
     printf("Atomic radius from electron density inclusion with threshold %e is %.6f bohr = %.6f A\n",eps_el,rincl,rincl*BOHRINANGSTROM);
 
-    double eps_left=0;
-    double eps_right=1;
-    while(eps_right-eps_left>1e-10) {
-      eps_el = (eps_right+eps_left)/2.0;
-      double radius = solver.electron_count_radius(uconf,eps_el);
-      if(radius > rvdw)
-	eps_left = eps_el;
-      else if(radius < rvdw)
-	eps_right = eps_el;
-      else
-	break;
-    }
-    printf("Converged eps_el = %.9f + %.9f\n",eps_el,0.5*(eps_right-eps_left));
-
     printf("\nResult in NIST format\n");
     printf("Etot  = % 18.9f\n",uconf.Econf);
     printf("Ekin  = % 18.9f\n",uconf.Ekin);

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
   parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
   parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
   parser.add<double>("vdwthr", 0, "Density threshold for van der Waals radius", false, 0.001);
-  parser.add<double>("eps_el", 0, "Density threshold for atomic size with electron density inclusion", false, 0.078130234); // PBE0 H atom gives same radius as vdW routine with 1e-3 threshold, as defined by Rahm 2016
+  parser.add<double>("eps_el", 0, "Density threshold for atomic size with electron density inclusion", false, 0.073416683704840394115); // H atom analytical solution gives same radius as vdW routine with 1e-3 threshold as used by Rahm 2016
   parser.add<bool>("completeness", 0, "Compute completeness and importance profiles?", false, false);
   parser.add<int>("iconf", 0, "Confinement potential: 1 for polynomial, 2 for exponential", false, 0);
   parser.add<int>("conf_N", 0, "Exponent in polynomial confinement potential", false, 0);
@@ -629,9 +629,10 @@ int main(int argc, char **argv) {
 
     double rvdw(solver.vdw_radius(rconf,vdw_thr));
     printf("\nEstimated vdW radius with density threshold %e is %.6f bohr = %.6f A\n",vdw_thr,rvdw,rvdw*BOHRINANGSTROM);
+    printf("Note that this criterion is sensitive to numerical noise.\n");
 
     double rincl(solver.electron_count_radius(rconf,eps_el));
-    printf("Atomic radius from electron density inclusion with threshold %e is %.6f bohr = %.6f A\n",eps_el,rincl,rincl*BOHRINANGSTROM);
+    printf("Estimated vdW radius with electron count threshold %e is %.6f bohr = %.6f A\n",eps_el,rincl,rincl*BOHRINANGSTROM);
 
     printf("\nResult in NIST format\n");
     printf("Etot  = % 18.9f\n",rconf.Econf);

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -181,7 +181,7 @@ namespace helfem {
           }
 
           // Electron density maximum
-          printf(" %e\n",basis.electron_density_maximum(P));
+          printf(" %e\n",basis.electron_density_maximum_radius(P));
         }
       }
 
@@ -1595,12 +1595,20 @@ namespace helfem {
         return basis.nuclear_density_gradient(TotalDensity(conf.Pal+conf.Pbl));
       }
 
-      double SCFSolver::vdw_radius(const rconf_t & conf, double thr, bool rsqweight) const {
-        return basis.vdw_radius(TotalDensity(conf.Pl), rsqweight, thr);
+      double SCFSolver::vdw_radius(const rconf_t & conf, double thr) const {
+        return basis.vdw_radius(TotalDensity(conf.Pl), thr);
       }
 
-      double SCFSolver::vdw_radius(const uconf_t & conf, double thr, bool rsqweight) const {
-        return basis.vdw_radius(TotalDensity(conf.Pal+conf.Pbl), rsqweight, thr);
+      double SCFSolver::vdw_radius(const uconf_t & conf, double thr) const {
+        return basis.vdw_radius(TotalDensity(conf.Pal+conf.Pbl), thr);
+      }
+
+      double SCFSolver::electron_count_radius(const rconf_t & conf, const double eps) const {
+        return basis.electron_count_radius(TotalDensity(conf.Pl), eps);
+      }
+
+      double SCFSolver::electron_count_radius(const uconf_t & conf, const double eps) const {
+        return basis.electron_count_radius(TotalDensity(conf.Pal+conf.Pbl), eps);
       }
     }
   }

--- a/src/sadatom/solver.h
+++ b/src/sadatom/solver.h
@@ -315,9 +315,12 @@ namespace helfem {
         /// Compute the nuclear density gradient
         double nuclear_density_gradient(const uconf_t & conf) const;
         /// Compute the van der Waals radius
-        double vdw_radius(const rconf_t & conf, double thr, bool rsqweight) const;
+        double vdw_radius(const rconf_t & conf, double thr) const;
         /// Compute the nuclear density gradient
-        double vdw_radius(const uconf_t & conf, double thr, bool rsqweight) const;
+        double vdw_radius(const uconf_t & conf, double thr) const;
+	/// Compute atomic size form electron density inclusion
+	double electron_count_radius(const rconf_t & conf, double eps) const;
+	double electron_count_radius(const uconf_t & conf, double eps) const;
 
         /// Compute the GTO completeness profile
         void gto_completeness_profile(double minexp=1e-5, double maxexp=1e10, size_t nexp=501) const;


### PR DESCRIPTION
Calculate the vdW radius as

$$  4 \pi \int_{r_\epsilon}^\infty r^2 n(r) dr = \epsilon $$

with a value of $\epsilon$ to match the radius for the hydrogen atom.