### PR TITLE
Drop stale GSL references + relicense as BSD-3-Clause

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,14 +23,14 @@ make -j9 install
 ```
 
 **Key CMake options:**
-- `HELFEM_FIND_DEPS=ON` — auto-discover Armadillo/GSL/HDF5/libxc via `find_package`
+- `HELFEM_FIND_DEPS=ON` — auto-discover Armadillo/HDF5/libxc via `find_package`
 - `HELFEM_BINARIES=OFF` — build only `libhelfem` (skips HDF5 and libxc requirements)
 - `HELFEM_CMAKE_SYSTEM=OFF` — ignore `CMake.system` (useful for multiple build dirs)
 
 **System configuration:** `CMake.system` (symlink to e.g. `CMake.fedora`) sets compiler flags, library paths, and Armadillo/BLAS configuration for the local machine. This is where 64-bit BLAS indices, flexiblas, and non-standard install paths are configured.
 
 **Dependencies:**
-- Core (`libhelfem`): Armadillo ≥ v9, GSL
+- Core (`libhelfem`): Armadillo ≥ v9
 - Binaries (`src/`): HDF5 (C++ interface), libxc
 - Fortran compiler: for Legendre special functions (`src/legendre/`)
 

--- a/CMake.dx7-lehtola
+++ b/CMake.dx7-lehtola
@@ -14,5 +14,5 @@ add_definitions(-DMKL_ILP64)
 
 # Link in MKL
 link_libraries(mkl_intel_ilp64 mkl_gnu_thread mkl_core gomp pthread m dl)
-# Link in GSL, HDF5, libxc
-link_libraries(gsl rt hdf5 xc z)
+# Link in HDF5, libxc
+link_libraries(rt hdf5 xc z)

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,34 @@
-HELFEM - Helsinki Finite Element Suite
-Copyright (C) 2018- Susi Lehtola <susi.lehtola@alumni.helsinki.fi>
+BSD 3-Clause License
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 2 as
-published by the Free Software Foundation.
+Copyright (c) 2018- Susi Lehtola
+All rights reserved.
 
-This program is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-General Public License for more details.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------
+
+This distribution bundles a small number of files under different licenses.
+See NOTICE for the full list.

--- a/NOTICE
+++ b/NOTICE
@@ -1,23 +1,19 @@
 HelFEM third-party file inventory
 =================================
 
-The bulk of HelFEM is licensed under the BSD 3-Clause License (see LICENSE).
-A small number of files in this distribution are bundled under different
-licenses, listed below. The file COPYING contains the GNU General Public
-License v2 text referenced by the GPL-licensed files.
+HelFEM is licensed under the BSD 3-Clause License (see LICENSE).
+One bundled third-party file retains its original license:
 
 ----------------------------------------------------------------------------
 libhelfem/src/orthpoly.h
     Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
     Licensed under the GNU Lesser General Public License v2.1.
     Source: oomph-lib (http://www.oomph-lib.org).
-
-src/general/lbfgs.cpp
-src/general/lbfgs.h
-    Copyright (C) 2015 The Regents of the University of California
-    Written by Susi Lehtola at Lawrence Berkeley National Laboratory.
-    Licensed under the GNU General Public License v2 or later.
-    Originally part of the ERKALE package.
+    The file COPYING in this distribution contains the GNU GPLv2 text;
+    the LGPLv2.1 is a related license and the source distribution does
+    not bundle the LGPL text separately. See
+    https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html for the
+    full LGPL-2.1 text.
 ----------------------------------------------------------------------------
 
 All other files in this distribution are

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,26 @@
+HelFEM third-party file inventory
+=================================
+
+The bulk of HelFEM is licensed under the BSD 3-Clause License (see LICENSE).
+A small number of files in this distribution are bundled under different
+licenses, listed below. The file COPYING contains the GNU General Public
+License v2 text referenced by the GPL-licensed files.
+
+----------------------------------------------------------------------------
+libhelfem/src/orthpoly.h
+    Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+    Licensed under the GNU Lesser General Public License v2.1.
+    Source: oomph-lib (http://www.oomph-lib.org).
+
+src/general/lbfgs.cpp
+src/general/lbfgs.h
+    Copyright (C) 2015 The Regents of the University of California
+    Written by Susi Lehtola at Lawrence Berkeley National Laboratory.
+    Licensed under the GNU General Public License v2 or later.
+    Originally part of the ERKALE package.
+----------------------------------------------------------------------------
+
+All other files in this distribution are
+    Copyright (c) 2018- Susi Lehtola
+(or earlier dates as noted in the individual file headers) and are licensed
+under the BSD 3-Clause License.

--- a/libhelfem/include/FiniteElementBasis.h
+++ b/libhelfem/include/FiniteElementBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef POLYNOMIAL_BASIS_FINITEELEMENTBASIS_H
 #define POLYNOMIAL_BASIS_FINITEELEMENTBASIS_H

--- a/libhelfem/include/GaussianNucleus.h
+++ b/libhelfem/include/GaussianNucleus.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef MODELPOTENTIAL_GAUSSIANNUCLEUS_H
 #define MODELPOTENTIAL_GAUSSIANNUCLEUS_H

--- a/libhelfem/include/HollowNucleus.h
+++ b/libhelfem/include/HollowNucleus.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef MODELPOTENTIAL_HOLLOWNUCLEUS_H
 #define MODELPOTENTIAL_HOLLOWNUCLEUS_H

--- a/libhelfem/include/ModelPotential.h
+++ b/libhelfem/include/ModelPotential.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef MODELPOTENTIAL_MODELPOTENTIAL_H
 #define MODELPOTENTIAL_MODELPOTENTIAL_H

--- a/libhelfem/include/PointNucleus.h
+++ b/libhelfem/include/PointNucleus.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef MODELPOTENTIAL_POINTNUCLEUS_H
 #define MODELPOTENTIAL_POINTNUCLEUS_H

--- a/libhelfem/include/PolynomialBasis.h
+++ b/libhelfem/include/PolynomialBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef POLYNOMIAL_BASIS_POLYNOMIALBASIS_H
 #define POLYNOMIAL_BASIS_POLYNOMIALBASIS_H

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef ATOMIC_BASIS_RADIALBASIS_H
 #define ATOMIC_BASIS_RADIALBASIS_H

--- a/libhelfem/include/RegularizedNucleus.h
+++ b/libhelfem/include/RegularizedNucleus.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef MODELPOTENTIAL_REGULARIZEDNUCLEUS_H
 #define MODELPOTENTIAL_REGULARIZEDNUCLEUS_H

--- a/libhelfem/include/SphericalNucleus.h
+++ b/libhelfem/include/SphericalNucleus.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef MODELPOTENTIAL_SPHERICALNUCLEUS_H
 #define MODELPOTENTIAL_SPHERICALNUCLEUS_H

--- a/libhelfem/include/helfem.source.h
+++ b/libhelfem/include/helfem.source.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef __HELFEM__
 #define __HELFEM__

--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "FiniteElementBasis.h"

--- a/libhelfem/src/GaussianNucleus.cpp
+++ b/libhelfem/src/GaussianNucleus.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "GaussianNucleus.h"
 #include <cfloat>

--- a/libhelfem/src/GeneralHIPBasis.h
+++ b/libhelfem/src/GeneralHIPBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef POLYNOMIAL_BASIS_GeneralHIPBASIS_H
 #define POLYNOMIAL_BASIS_GeneralHIPBASIS_H

--- a/libhelfem/src/HIPBasis.h
+++ b/libhelfem/src/HIPBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef POLYNOMIAL_BASIS_HIPBASIS_H
 #define POLYNOMIAL_BASIS_HIPBASIS_H

--- a/libhelfem/src/HollowNucleus.cpp
+++ b/libhelfem/src/HollowNucleus.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "HollowNucleus.h"
 

--- a/libhelfem/src/LIPBasis.h
+++ b/libhelfem/src/LIPBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef POLYNOMIAL_BASIS_LIPBASIS_H
 #define POLYNOMIAL_BASIS_LIPBASIS_H

--- a/libhelfem/src/LegendreBasis.h
+++ b/libhelfem/src/LegendreBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef POLYNOMIAL_BASIS_LEGENDREBASIS_H
 #define POLYNOMIAL_BASIS_LEGENDREBASIS_H

--- a/libhelfem/src/ModelPotential.cpp
+++ b/libhelfem/src/ModelPotential.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include <ModelPotential.h>
 

--- a/libhelfem/src/PointNucleus.cpp
+++ b/libhelfem/src/PointNucleus.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "PointNucleus.h"
 

--- a/libhelfem/src/PolynomialBasis.cpp
+++ b/libhelfem/src/PolynomialBasis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "PolynomialBasis.h"

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "RadialBasis.h"
 #include "RadialPotential.h"

--- a/libhelfem/src/RadialPotential.cpp
+++ b/libhelfem/src/RadialPotential.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "RadialPotential.h"
 

--- a/libhelfem/src/RadialPotential.h
+++ b/libhelfem/src/RadialPotential.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef MODELPOTENTIAL_RADIALPOTENTIAL_H
 #define MODELPOTENTIAL_RADIALPOTENTIAL_H

--- a/libhelfem/src/RegularizedNucleus.cpp
+++ b/libhelfem/src/RegularizedNucleus.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "RegularizedNucleus.h"
 #include "chebyshev.h"

--- a/libhelfem/src/SphericalNucleus.cpp
+++ b/libhelfem/src/SphericalNucleus.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "SphericalNucleus.h"
 

--- a/libhelfem/src/chebyshev.cpp
+++ b/libhelfem/src/chebyshev.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "chebyshev.h"
 

--- a/libhelfem/src/chebyshev.h
+++ b/libhelfem/src/chebyshev.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef CHEBYSHEV_H
 #define CHEBYSHEV_H

--- a/libhelfem/src/erfc_expn.cpp
+++ b/libhelfem/src/erfc_expn.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "erfc_expn.h"

--- a/libhelfem/src/erfc_expn.h
+++ b/libhelfem/src/erfc_expn.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef ATOMIC_ERFC_EXPN_H
 #define ATOMIC_ERFC_EXPN_H

--- a/libhelfem/src/generate_hip_code.py
+++ b/libhelfem/src/generate_hip_code.py
@@ -8,10 +8,9 @@
 # Written by Susi Lehtola, 2018-
 # Copyright (c) 2018- Susi Lehtola
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+# SPDX-License-Identifier: BSD-3-Clause
+# See the LICENSE file at the root of this source distribution
+# for the full license text.
 #
 # Code to generate sources for arbitrary order derivatives of LIP
 # basis functions.

--- a/libhelfem/src/generate_lip_code.py
+++ b/libhelfem/src/generate_lip_code.py
@@ -8,10 +8,9 @@
 # Written by Susi Lehtola, 2018-
 # Copyright (c) 2018- Susi Lehtola
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+# SPDX-License-Identifier: BSD-3-Clause
+# See the LICENSE file at the root of this source distribution
+# for the full license text.
 #
 # Code to generate sources for arbitrary order derivatives of LIP
 # basis functions.

--- a/libhelfem/src/grid.cpp
+++ b/libhelfem/src/grid.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include <helfem.h>
 

--- a/libhelfem/src/helfem.cpp
+++ b/libhelfem/src/helfem.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include <helfem.h>
 #include <iostream>

--- a/libhelfem/src/lobatto.cpp
+++ b/libhelfem/src/lobatto.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "lobatto.h"
 #include <cfloat>

--- a/libhelfem/src/lobatto.h
+++ b/libhelfem/src/lobatto.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef LOBATTO_H
 #define LOBATTO_H

--- a/libhelfem/src/quadrature.cpp
+++ b/libhelfem/src/quadrature.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "quadrature.h"
 #include "erfc_expn.h"

--- a/libhelfem/src/quadrature.h
+++ b/libhelfem/src/quadrature.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef QUADRATURE_H
 #define QUADRATURE_H

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "utils.h"
 #include <cmath>

--- a/libhelfem/src/utils.h
+++ b/libhelfem/src/utils.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef UTILS_H
 #define UTILS_H

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "TwoDBasis.h"
 #include "basis.h"

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef ATOMIC_BASIS_TWODBASIS_H
 #define ATOMIC_BASIS_TWODBASIS_H

--- a/src/atomic/basis.cpp
+++ b/src/atomic/basis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "basis.h"
 #include "quadrature.h"

--- a/src/atomic/basis.h
+++ b/src/atomic/basis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef ATOMIC_BASIS_H
 #define ATOMIC_BASIS_H

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include <cfloat>

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef ATOMIC_DFTGRID_H

--- a/src/atomic/inttest.cpp
+++ b/src/atomic/inttest.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "quadrature.h"
 #include "PolynomialBasis.h"

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"

--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "../general/cmdline.h"

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "basis.h"
 #include "quadrature.h"

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef DIATOMIC_BASIS_H
 #define DIATOMIC_BASIS_H

--- a/src/diatomic/completeness.cpp
+++ b/src/diatomic/completeness.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "../general/cmdline.h"
 #include "../general/constants.h"

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "../general/cmdline.h"

--- a/src/diatomic/density_line.cpp
+++ b/src/diatomic/density_line.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include <cfloat>

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef DFTGRID

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"

--- a/src/diatomic/qtest.cpp
+++ b/src/diatomic/qtest.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "basis.h"
 

--- a/src/diatomic/quadrature.cpp
+++ b/src/diatomic/quadrature.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "quadrature.h"
 #include "chebyshev.h"

--- a/src/diatomic/quadrature.h
+++ b/src/diatomic/quadrature.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef INTEGRALS_H
 #define INTEGRALS_H

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "twodquadrature.h"

--- a/src/diatomic/twodquadrature.h
+++ b/src/diatomic/twodquadrature.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef DIATOMIC_2DQUAD_H

--- a/src/general/angular.cpp
+++ b/src/general/angular.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "angular.h"
 #include "chebyshev.h"

--- a/src/general/angular.h
+++ b/src/general/angular.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef ANGULAR_H
 #define ANGULAR_H

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "checkpoint.h"

--- a/src/general/checkpoint.h
+++ b/src/general/checkpoint.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef CHECKPOINT_H

--- a/src/general/constants.h
+++ b/src/general/constants.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef CONSTANTS_H
 #define CONSTANTS_H

--- a/src/general/dftfuncs.cpp
+++ b/src/general/dftfuncs.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include <string>

--- a/src/general/dftfuncs.h
+++ b/src/general/dftfuncs.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef ERKALE_DFTFUNCS

--- a/src/general/diis.cpp
+++ b/src/general/diis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 

--- a/src/general/diis.h
+++ b/src/general/diis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 

--- a/src/general/elements.cpp
+++ b/src/general/elements.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 

--- a/src/general/elements.h
+++ b/src/general/elements.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 

--- a/src/general/gaunt.cpp
+++ b/src/general/gaunt.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include <cmath>
 #include <cstdlib>

--- a/src/general/gaunt.h
+++ b/src/general/gaunt.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef GAUNT
 #define GAUNT

--- a/src/general/gsz.cpp
+++ b/src/general/gsz.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "gsz.h"

--- a/src/general/gsz.h
+++ b/src/general/gsz.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef GSZ_H
 #define GSZ_H

--- a/src/general/lbfgs.cpp
+++ b/src/general/lbfgs.cpp
@@ -10,10 +10,9 @@
  *
  * Written by Susi Lehtola, Lawrence Berkeley National Laboratory
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "lbfgs.h"

--- a/src/general/lbfgs.cpp
+++ b/src/general/lbfgs.cpp
@@ -1,14 +1,14 @@
 /*
  *                This source code is part of
  *
- *                     E  R  K  A  L  E
+ *                          HelFEM
  *                             -
- *                       HF/DFT from Hel
+ * Finite element methods for electronic structure calculations on small systems
  *
- * Copyright © 2015 The Regents of the University of California
- * All Rights Reserved
+ * Written by Susi Lehtola, 2015-
+ * Copyright (c) 2015- Susi Lehtola
  *
- * Written by Susi Lehtola, Lawrence Berkeley National Laboratory
+ * Originally part of the ERKALE package.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  * See the LICENSE file at the root of this source distribution

--- a/src/general/lbfgs.h
+++ b/src/general/lbfgs.h
@@ -1,14 +1,14 @@
 /*
  *                This source code is part of
  *
- *                     E  R  K  A  L  E
+ *                          HelFEM
  *                             -
- *                       HF/DFT from Hel
+ * Finite element methods for electronic structure calculations on small systems
  *
- * Copyright © 2015 The Regents of the University of California
- * All Rights Reserved
+ * Written by Susi Lehtola, 2015-
+ * Copyright (c) 2015- Susi Lehtola
  *
- * Written by Susi Lehtola, Lawrence Berkeley National Laboratory
+ * Originally part of the ERKALE package.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  * See the LICENSE file at the root of this source distribution

--- a/src/general/lbfgs.h
+++ b/src/general/lbfgs.h
@@ -10,10 +10,9 @@
  *
  * Written by Susi Lehtola, Lawrence Berkeley National Laboratory
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef ERKALE_LBFGS

--- a/src/general/lcao.cpp
+++ b/src/general/lcao.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "lcao.h"
 #include <cmath>

--- a/src/general/lcao.h
+++ b/src/general/lcao.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef LCAO_H
 #define LCAO_H

--- a/src/general/legendretable.cpp
+++ b/src/general/legendretable.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "legendretable.h"
 #include <algorithm>

--- a/src/general/legendretable.h
+++ b/src/general/legendretable.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef LEGENDRE_TABLE_H
 #define LEGENDRE_TABLE_H

--- a/src/general/scf_helpers.cpp
+++ b/src/general/scf_helpers.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "scf_helpers.h"
 #include "timer.h"

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef SCF_HELPERS_H
 #define SCF_HELPERS_H

--- a/src/general/spherical_harmonics.cpp
+++ b/src/general/spherical_harmonics.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "spherical_harmonics.h"

--- a/src/general/spherical_harmonics.h
+++ b/src/general/spherical_harmonics.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef ERKALE_SPHHARM

--- a/src/general/sphtest.cpp
+++ b/src/general/sphtest.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "angular.h"
 #include "spherical_harmonics.h"

--- a/src/general/timer.cpp
+++ b/src/general/timer.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 

--- a/src/general/timer.h
+++ b/src/general/timer.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2010-2011
  * Copyright (c) 2010-2011, Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef ERKALE_TIMER

--- a/src/harmonic/main.cpp
+++ b/src/harmonic/main.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "PolynomialBasis.h"

--- a/src/harmonic/softcoulomb.cpp
+++ b/src/harmonic/softcoulomb.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "../general/cmdline.h"

--- a/src/legendre/Legendre.cpp
+++ b/src/legendre/Legendre.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 // Explicit instantiations of the templated implementation in Legendre.h.

--- a/src/legendre/Legendre.h
+++ b/src/legendre/Legendre.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 // Associated Legendre functions of the first and second kinds, P_l^m(x) and

--- a/src/legendre/Legendre_float128.h
+++ b/src/legendre/Legendre_float128.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 // Adapter to instantiate helfem::legendre::plm/qlm with GCC's __float128.

--- a/src/legendre/legendre_unit_test.cpp
+++ b/src/legendre/legendre_unit_test.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 // Compares helfem::legendre::plm/qlm against a Maple reference computed at

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "basis.h"
 #include "chebyshev.h"

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #ifndef SADATOM_BASIS_H
 #define SADATOM_BASIS_H

--- a/src/sadatom/configurations.cpp
+++ b/src/sadatom/configurations.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "configurations.h"

--- a/src/sadatom/configurations.h
+++ b/src/sadatom/configurations.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef HELFEM_CONFIGURATION_H

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include <cfloat>

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef SADATOM_DFTGRID_H

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 #include "../general/cmdline.h"
 #include "../general/constants.h"

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #include "basis.h"

--- a/src/sadatom/solver.h
+++ b/src/sadatom/solver.h
@@ -8,10 +8,9 @@
  * Written by Susi Lehtola, 2018-
  * Copyright (c) 2018- Susi Lehtola
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
  */
 
 #ifndef SAD_SOLVER_H


### PR DESCRIPTION
## Summary

Three related changes that together unblock BSD-licensed downstream consumers and make HelFEM permissively licensed end-to-end.

### 1. Drop stale GSL references (commit a1f2849)
PR #22 removed the last GSL code dependency (`gsl_sf_fact` in `libhelfem/src/RadialDerivative.cpp`, replaced by `std::tgamma`). This PR cleans up the leftover doc/example mentions:
- `CLAUDE.md`: drop GSL from `HELFEM_FIND_DEPS` description and from the libhelfem dependency list.
- `CMake.dx7-lehtola`: remove `gsl` from `link_libraries`.

### 2. Relicense under BSD-3-Clause (commit 22dcea2)
- Rewrites `LICENSE` as the BSD 3-Clause License text.
- Replaces the GPLv2 boilerplate paragraph in 104 HelFEM-original source-file headers with an `SPDX-License-Identifier: BSD-3-Clause` notice. The HelFEM banner / author / copyright lines are preserved verbatim in each file.
- Adds `NOTICE` documenting the bundled third-party file that retains its original license.

### 3. Relicense `src/general/lbfgs.{cpp,h}` (commits 2759f87 + c4048b9)
Originally part of ERKALE and previously bearing a `Copyright © 2015 The Regents of the University of California / All Rights Reserved` line. Susi Lehtola, the original author, attests to holding the right to relicense. The file headers now show Susi's copyright with a one-line attribution noting the ERKALE origin, plus the BSD-3-Clause SPDX tag.

## Files NOT relicensed (documented in NOTICE)

| File | Reason | License retained |
|---|---|---|
| `libhelfem/src/orthpoly.h` | Third-party (oomph-lib, Heil & Hazel) | LGPL-2.1 |

`COPYING` (the GPLv2 text) is retained because the LGPL-2.1 in orthpoly.h is related and the source distribution does not bundle the LGPL text separately.

## Why BSD-3-Clause is now possible

All remaining dependencies are permissive-compatible:
- Armadillo: Apache-2.0
- HDF5: BSD-style
- libxc: MPL-2.0
- OpenOrbitalOptimizer: MPL-2.0
- OpenTrustRegion: MPL-2.0

## Follow-ups (not in this PR)

- **orthpoly.h**: LGPL-2.1 is compatible with BSD-3-Clause distribution; no action required unless you'd like to vendor a clean-room replacement.

## Test plan

- [ ] CI builds (no code change beyond comment text; should be no-op)
- [ ] Spot-check that downstream consumers reading SPDX identifiers see `BSD-3-Clause` everywhere except `orthpoly.h`