### PR TITLE
Add HELFEM_BLAS_PROVIDED_EXTERNALLY CMake option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ make -j9 install
 - `HELFEM_FIND_DEPS=ON` — auto-discover Armadillo/HDF5/libxc via `find_package`
 - `HELFEM_BINARIES=OFF` — build only `libhelfem` (skips HDF5 and libxc requirements)
 - `HELFEM_CMAKE_SYSTEM=OFF` — ignore `CMake.system` (useful for multiple build dirs)
+- `HELFEM_BLAS_PROVIDED_EXTERNALLY=ON` — don't link BLAS/LAPACK into libhelfem; parent project (e.g. an embedding application with its own MKL/OpenBLAS) must provide them. Sets `-DARMA_DONT_USE_WRAPPER`. The parent must match integer width — see ARMA_64BIT_WORD / ARMA_BLAS_LONG.
 
 **System configuration:** `CMake.system` (symlink to e.g. `CMake.fedora`) sets compiler flags, library paths, and Armadillo/BLAS configuration for the local machine. This is where 64-bit BLAS indices, flexiblas, and non-standard install paths are configured.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,30 @@ endif()
 #   different settings, some using CMake.system and some not. Primarily useful when
 #   developing the build scripts.
 #
+# - HELFEM_BLAS_PROVIDED_EXTERNALLY: if set to ON, HelFEM will NOT link BLAS/LAPACK itself
+#   when running under HELFEM_FIND_DEPS. Use this when embedding libhelfem in a parent
+#   project that already provides BLAS/LAPACK (e.g. its own MKL/OpenBLAS/flexiblas setup).
+#   When ON, only Armadillo headers are added (ARMADILLO_LIBRARIES is not linked, since on
+#   most distributions it brings in a BLAS dep), and -DARMA_DONT_USE_WRAPPER is set so
+#   Armadillo expects BLAS symbols to be resolved by the parent's final link. The parent
+#   project is responsible for matching the integer width libhelfem was compiled with
+#   (LP64 vs ILP64 -- see ARMA_64BIT_WORD / ARMA_BLAS_LONG). A mismatch silently corrupts
+#   the heap inside LAPACK routines like dsyevd, surfacing as "free(): invalid next size".
+#
 option(USE_OPENMP "Compile OpenMP enabled version (for parallel calculations)?" ON)
 option(HELFEM_FIND_DEPS "Try to find dependencies automatically?" OFF)
 option(HELFEM_BINARIES "Compile HelFEM binaries?" ON)
 option(HELFEM_CMAKE_SYSTEM "Load the CMake.system file (if present)?" ON)
+# When HelFEM is embedded in a parent project that already links its own
+# BLAS/LAPACK (e.g. an MKL/OpenBLAS/flexiblas build with a specific integer
+# width), enable this option to keep libhelfem from pulling in BLAS itself.
+# Effects: under HELFEM_FIND_DEPS, only Armadillo HEADERS are added
+# (ARMADILLO_LIBRARIES is NOT linked, since on most distributions it brings
+# in a BLAS dep). -DARMA_DONT_USE_WRAPPER is set automatically so Armadillo
+# expects the BLAS symbols to be resolved by the parent project's link line.
+# The parent project is then responsible for matching integer width
+# (LP64 vs ILP64 -- see ARMA_64BIT_WORD / ARMA_BLAS_LONG).
+option(HELFEM_BLAS_PROVIDED_EXTERNALLY "Skip BLAS/LAPACK linkage; parent project provides them" OFF)
 
 # System specific definitions
 if(HELFEM_CMAKE_SYSTEM AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMake.system")
@@ -70,9 +90,16 @@ if(HELFEM_FIND_DEPS)
     if(${ARMADILLO_VERSION_MAJOR} LESS "9")
         message(FATAL_ERROR "Armadillo too old, version 9 or above required.")
     endif()
-    # Globally link the Armadillo library to everything
+    # Globally link the Armadillo library to everything (or only include
+    # its headers, if the parent project provides BLAS/LAPACK).
     include_directories("${ARMADILLO_INCLUDE_DIRS}")
-    link_libraries("${ARMADILLO_LIBRARIES}")
+    if(HELFEM_BLAS_PROVIDED_EXTERNALLY)
+        message(STATUS "HELFEM_BLAS_PROVIDED_EXTERNALLY=ON: NOT linking ARMADILLO_LIBRARIES")
+        message(STATUS "  Parent project must provide BLAS/LAPACK symbols.")
+        add_definitions(-DARMA_DONT_USE_WRAPPER)
+    else()
+        link_libraries("${ARMADILLO_LIBRARIES}")
+    endif()
     # If we should also compile all the HelFEM binaries (under src/), we need also need to
     # set up the HDF5 and libxc dependencies:
     if(HELFEM_BINARIES)


### PR DESCRIPTION
## Summary

Adds a new CMake option `HELFEM_BLAS_PROVIDED_EXTERNALLY` (default `OFF`, fully backward-compatible) for parent projects that embed libhelfem and already provide their own BLAS/LAPACK linkage (e.g. an application built against MKL, OpenBLAS, or flexiblas at a specific integer width).

When `ON`:
- Under `HELFEM_FIND_DEPS=ON`, only Armadillo **headers** are added; `ARMADILLO_LIBRARIES` is **not** linked (since on most distributions Armadillo brings in a BLAS dep).
- `-DARMA_DONT_USE_WRAPPER` is set automatically, so Armadillo expects BLAS/LAPACK symbols to be resolved by the parent project's final link step.

When `OFF` (default), the behaviour is unchanged.

## Verified

```
=== default (OFF) ===
BLAS deps in libhelfem.so:
  libarmadillo.so.12 => /lib64/libarmadillo.so.12
  libflexiblas.so.3 => /lib64/libflexiblas.so.3

=== HELFEM_BLAS_PROVIDED_EXTERNALLY=ON ===
BLAS deps in libhelfem.so:
  (none — as expected, parent provides BLAS)
```

## Caveat

The parent project must match libhelfem's integer width (LP64 vs ILP64 — see `ARMA_64BIT_WORD` / `ARMA_BLAS_LONG`). A mismatch silently corrupts the heap inside LAPACK routines like `dsyevd`, surfacing as `free(): invalid next size`. This is the same trap documented in `examples/atomic_radial_export.cpp` (PR #55) and is now called out in the new option's help text and CLAUDE.md entry.

## Test plan

- [x] Configure + build verified in both modes against `BUILD_SHARED_LIBS=ON`
- [x] `ldd` of the resulting `libhelfem.so` confirms BLAS is present (default) / absent (external)
- [ ] CI builds default mode (should be a no-op since option defaults to OFF)