### PR TITLE
v2 Phase 0: RadialBasis abstract base + FEMRadialBasis rename + lib1dfem skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ endif()
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/libhelfem/include")
 
 # Compile code
+add_subdirectory(lib1dfem)   # v2 Phase 1 destination (currently empty INTERFACE target)
 add_subdirectory(libhelfem)
 if(HELFEM_BINARIES)
     add_subdirectory(src)

--- a/examples/atomic_radial_export.cpp
+++ b/examples/atomic_radial_export.cpp
@@ -71,7 +71,7 @@ namespace {
 struct Defaults { int primbas, Nnodes, Nelem, igrid; double Rmax, zexp; };
 constexpr Defaults DEF{4, 15, 20, 4, 40.0, 2.0};
 
-atomic::basis::RadialBasis make_radial(const Defaults & d = DEF) {
+atomic::basis::FEMRadialBasis make_radial(const Defaults & d = DEF) {
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
       polynomial_basis::get_basis(d.primbas, d.Nnodes));
   arma::vec bval = utils::get_grid(d.Rmax, d.Nelem, d.igrid, d.zexp);
@@ -80,7 +80,7 @@ atomic::basis::RadialBasis make_radial(const Defaults & d = DEF) {
       /*zero_func_right*/true, /*zero_deriv_right*/false);
   int n_quad       = 5 * poly->get_nbf();
   int taylor_order = poly->get_nprim() - 1;
-  return atomic::basis::RadialBasis(fem, n_quad, taylor_order);
+  return atomic::basis::FEMRadialBasis(fem, n_quad, taylor_order);
 }
 
 double diag_lowest(const arma::mat & H, const arma::mat & S) {
@@ -93,7 +93,7 @@ double diag_lowest(const arma::mat & H, const arma::mat & S) {
 }
 
 // Returns false on failure (any test off by more than `tol`).
-bool one_electron_tests(const atomic::basis::RadialBasis & radial) {
+bool one_electron_tests(const atomic::basis::FEMRadialBasis & radial) {
   arma::mat S = radial.overlap();
   arma::mat T = radial.kinetic();
   arma::mat Tl = radial.kinetic_l();

--- a/lib1dfem/CMakeLists.txt
+++ b/lib1dfem/CMakeLists.txt
@@ -1,0 +1,23 @@
+# lib1dfem -- generic 1D finite-element method library
+#
+# Placeholder for the v2 refactor (Phase 1). Populated incrementally:
+# files that are strictly 1D-FEM-generic (no quantum-chemistry assumptions)
+# are migrated here from libhelfem/, templated on the scalar type T.
+#
+# The target is exposed as `helfem::lib1dfem` and is currently an empty
+# INTERFACE library -- it adds no sources or include directories until the
+# first migration lands. Linking against it is a no-op today; once Phase 1
+# starts, downstream targets (libhelfem, helfem-common) will rebase onto it.
+
+add_library(lib1dfem INTERFACE)
+add_library(helfem::lib1dfem ALIAS lib1dfem)
+
+target_include_directories(lib1dfem INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
+)
+
+# When Phase 1 starts, this is the point where the migrated source files
+# (PolynomialBasis, LIPBasis, HIPBasis, FiniteElementBasis, lobatto,
+# chebyshev, quadrature, grid, math half of utils) will be added as a
+# templated header-only or compiled implementation.

--- a/lib1dfem/include/lib1dfem.h
+++ b/lib1dfem/include/lib1dfem.h
@@ -1,0 +1,38 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef LIB1DFEM_H
+#define LIB1DFEM_H
+
+// lib1dfem -- generic 1D finite-element method library.
+//
+// This umbrella header is a stub. It will gain pulls of the migrated
+// templated APIs as the v2 refactor (Phase 1) populates lib1dfem from
+// libhelfem/. Until then, including this header is a no-op.
+//
+// Planned umbrella includes (Phase 1):
+//   #include <lib1dfem/PolynomialBasis.h>      // templated<T>
+//   #include <lib1dfem/LIPBasis.h>
+//   #include <lib1dfem/HIPBasis.h>
+//   #include <lib1dfem/FiniteElementBasis.h>
+//   #include <lib1dfem/Quadrature.h>           // lobatto, chebyshev, adaptive
+//   #include <lib1dfem/Grid.h>
+
+namespace helfem {
+namespace lib1dfem {
+  // Reserved namespace for the migrated templated 1D-FEM API.
+}
+}
+
+#endif

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -22,8 +22,42 @@
 namespace helfem {
   namespace atomic {
     namespace basis {
-      /// Radial basis set
+      /// Abstract radial basis interface. Implementations provide the
+      /// global one-electron matrices in the u = r * R(r) representation
+      /// (integration measure dr; the r^2 volume element is absorbed in u^2).
+      /// Concrete subclasses: FEMRadialBasis (this file); future
+      /// NAORadialBasis, STORadialBasis, GTORadialBasis.
       class RadialBasis {
+       public:
+        virtual ~RadialBasis() = default;
+
+        /// Number of basis functions
+        virtual size_t Nbf() const = 0;
+
+        /// Overlap matrix S_{ij} = integral u_i(r) u_j(r) dr
+        virtual arma::mat overlap() const = 0;
+        /// Radial kinetic matrix (1/2) integral u'_i(r) u'_j(r) dr.
+        /// EXCLUDES the centrifugal term -- caller adds l*(l+1) * kinetic_l().
+        virtual arma::mat kinetic() const = 0;
+        /// Half the centrifugal-per-l(l+1) matrix:
+        /// (1/2) integral u_i(r) u_j(r) / r^2 dr.
+        /// Full centrifugal contribution is l*(l+1) * kinetic_l().
+        virtual arma::mat kinetic_l() const = 0;
+        /// Nuclear attraction at Z=1 (sign included):
+        /// - integral u_i(r) u_j(r) / r dr.
+        /// For arbitrary Z, the caller multiplies by +Z.
+        virtual arma::mat nuclear() const = 0;
+
+        /// Evaluate orbitals (columns of C) at a given r.
+        virtual arma::vec eval_orbs(const arma::mat & C, double r) const = 0;
+      };
+
+      /// Finite-element radial basis set.
+      ///
+      /// Implements RadialBasis using a Lagrange/Hermite finite-element basis
+      /// on a user-supplied radial grid; this is HelFEM's original concrete
+      /// implementation (formerly named RadialBasis prior to the v2 refactor).
+      class FEMRadialBasis : public RadialBasis {
         /// Quadrature points
         arma::vec xq;
         /// Quadrature weights
@@ -46,11 +80,11 @@ namespace helfem {
 
       public:
         /// Dummy constructor
-        RadialBasis();
+        FEMRadialBasis();
         /// Construct radial basis
-        RadialBasis(const polynomial_basis::FiniteElementBasis & fem, int n_quad, int taylor_order);
+        FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem, int n_quad, int taylor_order);
         /// Explicit destructor
-        ~RadialBasis();
+        ~FEMRadialBasis() override;
 
         /// Add an element boundary
         void add_boundary(double r);
@@ -78,7 +112,7 @@ namespace helfem {
         /// Get number of overlapping functions
         size_t get_noverlap() const;
         /// Number of basis functions
-        size_t Nbf() const;
+        size_t Nbf() const override;
         /// Number of primitive functions in element
         size_t Nprim(size_t iel) const;
         /// Number of primitive functions in element
@@ -88,10 +122,6 @@ namespace helfem {
         size_t Nel() const;
         /// Get function indices
         void get_idx(size_t iel, size_t &ifirst, size_t &ilast) const;
-
-        /// Form density matrix
-        arma::mat form_density(const arma::mat &Cl, const arma::mat &Cr,
-                               size_t nocc) const;
 
         /// Compute radial matrix elements <r^n> in element (overlap is n=0,
         /// nuclear is n=-1)
@@ -107,21 +137,21 @@ namespace helfem {
         arma::mat bessel_kl_integral(int L, double lambda, size_t iel) const;
 
         /// Compute overlap matrix
-        arma::mat overlap() const;
+        arma::mat overlap() const override;
         /// Compute overlap matrix in element
         arma::mat overlap(size_t iel) const;
 
         /// Compute primitive kinetic energy matrix (excluding l part)
-        arma::mat kinetic() const;
+        arma::mat kinetic() const override;
         /// Compute primitive kinetic energy matrix in element (excluding l
         /// part)
         arma::mat kinetic(size_t iel) const;
         /// Compute l part of kinetic energy matrix
-        arma::mat kinetic_l() const;
+        arma::mat kinetic_l() const override;
         /// Compute l part of kinetic energy matrix in element
         arma::mat kinetic_l(size_t iel) const;
         /// Compute nuclear attraction matrix
-        arma::mat nuclear() const;
+        arma::mat nuclear() const override;
         /// Compute nuclear attraction matrix in element
         arma::mat nuclear(size_t iel) const;
 	/// Compute polynomial confinement potential matrix in element
@@ -152,14 +182,14 @@ namespace helfem {
         arma::mat spherical_potential(size_t iel) const;
 
         /// Compute cross-basis integral
-        arma::mat radial_integral(const RadialBasis &rh, int n,
+        arma::mat radial_integral(const FEMRadialBasis &rh, int n,
                                   bool lhder = false, bool rhder = false) const;
         /// Compute cross-basis model potential integral
-        arma::mat model_potential(const RadialBasis &rh,
+        arma::mat model_potential(const FEMRadialBasis &rh,
                                   const modelpotential::ModelPotential *model,
                                   bool lhder = false, bool rhder = false) const;
         /// Compute projection
-        arma::mat overlap(const RadialBasis &rh) const;
+        arma::mat overlap(const FEMRadialBasis &rh) const;
 
         /// Evaluate basis functions at quadrature points
         arma::mat get_bf(size_t iel) const;
@@ -177,7 +207,7 @@ namespace helfem {
         void get_taylor(const arma::vec & r, const arma::uvec & taylorind, arma::mat & val, int ider) const;
 
         /// Evaluate orbitals at a given point
-        arma::vec eval_orbs(const arma::mat & C, double r) const;
+        arma::vec eval_orbs(const arma::mat & C, double r) const override;
 
         /// Get quadrature weights
         arma::vec get_wrad(size_t iel) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -26,9 +26,9 @@
 namespace helfem {
   namespace atomic {
     namespace basis {
-      RadialBasis::RadialBasis() {}
+      FEMRadialBasis::FEMRadialBasis() {}
 
-      RadialBasis::RadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad, int taylor_order_) : fem(fem_), taylor_order(taylor_order_) {
+      FEMRadialBasis::FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad, int taylor_order_) : fem(fem_), taylor_order(taylor_order_) {
         // Get quadrature rule
         chebyshev::chebyshev(n_quad, xq, wq);
         for (size_t i = 0; i < xq.n_elem; i++) {
@@ -55,7 +55,7 @@ namespace helfem {
         set_small_r_taylor_cutoff();
       }
 
-      void RadialBasis::set_small_r_taylor_cutoff() {
+      void FEMRadialBasis::set_small_r_taylor_cutoff() {
         // Determine small r Taylor cutoff by minimizing the
         // difference of the analytic and Taylor values of the
         // function and its first two derivatives.
@@ -131,62 +131,62 @@ namespace helfem {
         //diffs.save("taylor_diff.dat", arma::raw_ascii);
       }
 
-      RadialBasis::~RadialBasis() {}
+      FEMRadialBasis::~FEMRadialBasis() {}
 
-      int RadialBasis::get_nquad() const {
+      int FEMRadialBasis::get_nquad() const {
         return (int)xq.n_elem;
       }
 
-      arma::vec RadialBasis::get_xq() const {
+      arma::vec FEMRadialBasis::get_xq() const {
         return xq;
       }
 
-      size_t RadialBasis::Nbf() const {
+      size_t FEMRadialBasis::Nbf() const {
         return fem.get_nbf();
       }
 
-      size_t RadialBasis::Nel() const {
+      size_t FEMRadialBasis::Nel() const {
         return fem.get_nelem();
       }
 
-      size_t RadialBasis::Nprim(size_t iel) const {
+      size_t FEMRadialBasis::Nprim(size_t iel) const {
         return fem.get_nprim(iel);
       }
 
-      size_t RadialBasis::max_Nprim() const {
+      size_t FEMRadialBasis::max_Nprim() const {
         return fem.get_max_nprim();
       }
 
-      void RadialBasis::get_idx(size_t iel, size_t &ifirst, size_t &ilast) const {
+      void FEMRadialBasis::get_idx(size_t iel, size_t &ifirst, size_t &ilast) const {
         fem.get_idx(iel, ifirst, ilast);
       }
 
-      arma::vec RadialBasis::get_bval() const {
+      arma::vec FEMRadialBasis::get_bval() const {
         return fem.get_bval();
       }
 
-      int RadialBasis::get_poly_id() const {
+      int FEMRadialBasis::get_poly_id() const {
         return fem.get_poly_id();
       }
 
-      int RadialBasis::get_poly_nnodes() const {
+      int FEMRadialBasis::get_poly_nnodes() const {
         return fem.get_poly_nnodes();
       }
 
-      double RadialBasis::get_small_r_taylor_cutoff() const {
+      double FEMRadialBasis::get_small_r_taylor_cutoff() const {
         return small_r_taylor_cutoff;
       }
 
-      int RadialBasis::get_taylor_order() const {
+      int FEMRadialBasis::get_taylor_order() const {
         return taylor_order;
       }
 
-      double RadialBasis::get_taylor_diff() const {
+      double FEMRadialBasis::get_taylor_diff() const {
         return taylor_diff;
       }
 
 
-      arma::mat RadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
+      arma::mat FEMRadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
         std::function<double(double)> rpowL = [Rexp](double r){return std::pow(r,Rexp+2);};
         std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
         radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
@@ -197,23 +197,23 @@ namespace helfem {
         return ret;
       }
 
-      arma::mat RadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {
+      arma::mat FEMRadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {
         std::function<double(double)> besselil = [L, lambda](double r) { return utils::bessel_il(r*lambda, L); };
         return fem.matrix_element(iel, false, false, xq, wq, besselil);
       }
 
-      arma::mat RadialBasis::bessel_kl_integral(int L, double lambda, size_t iel) const {
+      arma::mat FEMRadialBasis::bessel_kl_integral(int L, double lambda, size_t iel) const {
         std::function<double(double)> besselkl = [L, lambda](double r) { return utils::bessel_kl(r*lambda, L); };
         return fem.matrix_element(iel, false, false, xq, wq, besselkl);
       }
 
-      arma::mat RadialBasis::radial_integral(const RadialBasis &rh, int n, bool lhder,
+      arma::mat FEMRadialBasis::radial_integral(const FEMRadialBasis &rh, int n, bool lhder,
                                              bool rhder) const {
         modelpotential::RadialPotential rad(n);
         return model_potential(rh, &rad, lhder, rhder);
       }
 
-      arma::mat RadialBasis::model_potential(const RadialBasis &rh,
+      arma::mat FEMRadialBasis::model_potential(const FEMRadialBasis &rh,
                                              const modelpotential::ModelPotential *model,
                                              bool lhder, bool rhder) const {
         // Use the larger number of quadrature points to assure
@@ -303,31 +303,31 @@ namespace helfem {
         return S;
       }
 
-      arma::mat RadialBasis::overlap(const RadialBasis &rh) const {
+      arma::mat FEMRadialBasis::overlap(const FEMRadialBasis &rh) const {
         return radial_integral(rh, 0);
       }
 
-      arma::mat RadialBasis::overlap(size_t iel) const {
+      arma::mat FEMRadialBasis::overlap(size_t iel) const {
         std::function<double(double)> dummy;
         return fem.matrix_element(iel, false, false, xq, wq, dummy);
       }
 
-      arma::mat RadialBasis::overlap() const {
+      arma::mat FEMRadialBasis::overlap() const {
         std::function<double(double)> dummy;
         return fem.matrix_element(false, false, xq, wq, dummy);
       }
 
-      arma::mat RadialBasis::kinetic() const {
+      arma::mat FEMRadialBasis::kinetic() const {
         std::function<double(double)> dummy;
         return 0.5*fem.matrix_element(true, true, xq, wq, dummy);
       }
 
-      arma::mat RadialBasis::kinetic(size_t iel) const {
+      arma::mat FEMRadialBasis::kinetic(size_t iel) const {
         std::function<double(double)> dummy;
         return 0.5*fem.matrix_element(iel, true, true, xq, wq, dummy);
       }
 
-      arma::mat RadialBasis::kinetic_l() const {
+      arma::mat FEMRadialBasis::kinetic_l() const {
         std::function<double(double)> dummy;
         std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
         radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
@@ -335,7 +335,7 @@ namespace helfem {
         return 0.5 * fem.matrix_element(radial_bf, radial_bf, xq, wq, dummy);
       }
 
-      arma::mat RadialBasis::kinetic_l(size_t iel) const {
+      arma::mat FEMRadialBasis::kinetic_l(size_t iel) const {
         std::function<double(double)> dummy;
         std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
         radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
@@ -343,21 +343,21 @@ namespace helfem {
         return 0.5 * fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, dummy);
       }
 
-      arma::mat RadialBasis::nuclear() const {
+      arma::mat FEMRadialBasis::nuclear() const {
         std::function<double(double)> r = [](double r){return r;};
         std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
         radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
         return -fem.matrix_element(radial_bf, radial_bf, xq, wq, r);
       }
 
-      arma::mat RadialBasis::nuclear(size_t iel) const {
+      arma::mat FEMRadialBasis::nuclear(size_t iel) const {
         std::function<double(double)> r = [](double r){return r;};
         std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
         radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
         return -fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, r);
       }
 
-      arma::mat RadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {
+      arma::mat FEMRadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {
 	std::function<double(double)> rpow = [N, shift_pot](double r){
 	  if(r<shift_pot)
 	    return 0.0;
@@ -367,7 +367,7 @@ namespace helfem {
         return fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, rpow);
       }
 
-      arma::mat RadialBasis::exponential_confinement(size_t iel, int N, double r_0, double shift_pot) const {
+      arma::mat FEMRadialBasis::exponential_confinement(size_t iel, int N, double r_0, double shift_pot) const {
 	std::function<double(double)> r_exp = [r_0, N, shift_pot](double r) {
 	  if(r<shift_pot)
 	    return 0.0;
@@ -390,14 +390,14 @@ namespace helfem {
         return fem.matrix_element(iel, false, false, xq, wq, r_exp);
       }
 
-      arma::mat RadialBasis::barrier_confinement(size_t iel, double V, double shift_pot) const {
+      arma::mat FEMRadialBasis::barrier_confinement(size_t iel, double V, double shift_pot) const {
 	std::function<double(double)> barrier = [V, shift_pot](double r) {
           return (r<shift_pot) ? 0.0 : V;
 	};
         return fem.matrix_element(iel, false, false, xq, wq, barrier);
       }
 
-      arma::mat RadialBasis::junq_confinement(size_t iel, int N, double V0, double r_c, double shift_pot) const {
+      arma::mat FEMRadialBasis::junq_confinement(size_t iel, int N, double V0, double r_c, double shift_pot) const {
 	std::function<double(double)> r_exp = [N, r_c, V0, shift_pot](double r) {
 	  if(r<shift_pot)
 	    return 0.0;
@@ -408,7 +408,7 @@ namespace helfem {
         return fem.matrix_element(iel, false, false, xq, wq, r_exp);
       }
 
-      arma::mat RadialBasis::confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const {
+      arma::mat FEMRadialBasis::confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const {
 	// Attractive potential does not make sense for shift_pot != 0
 
 	// sign of r0 controls if the potential is attractive or repulsive
@@ -454,13 +454,13 @@ namespace helfem {
       }
 
 
-      arma::mat RadialBasis::model_potential(const modelpotential::ModelPotential *model,
+      arma::mat FEMRadialBasis::model_potential(const modelpotential::ModelPotential *model,
                                              size_t iel) const {
         std::function<double(double)> modelpot = [model](double r) { return model->V(r); };
         return fem.matrix_element(iel, false, false, xq, wq, modelpot);
       }
 
-      arma::mat RadialBasis::nuclear_offcenter(size_t iel, double Rhalf, int L) const {
+      arma::mat FEMRadialBasis::nuclear_offcenter(size_t iel, double Rhalf, int L) const {
         if (fem.element_begin(iel) <= Rhalf)
           return -sqrt(4.0 * M_PI / (2 * L + 1)) * radial_integral(-L - 1, iel) *
             std::pow(Rhalf, L);
@@ -474,7 +474,7 @@ namespace helfem {
         }
       }
 
-      arma::mat RadialBasis::twoe_integral(int L, size_t iel) const {
+      arma::mat FEMRadialBasis::twoe_integral(int L, size_t iel) const {
         double Rmin(fem.element_begin(iel));
         double Rmax(fem.element_end(iel));
 
@@ -487,7 +487,7 @@ namespace helfem {
         return tei;
       }
 
-      arma::mat RadialBasis::yukawa_integral(int L, double lambda, size_t iel) const {
+      arma::mat FEMRadialBasis::yukawa_integral(int L, double lambda, size_t iel) const {
         double Rmin(fem.element_begin(iel));
         double Rmax(fem.element_end(iel));
 
@@ -498,7 +498,7 @@ namespace helfem {
         return tei;
       }
 
-      arma::mat RadialBasis::erfc_integral(int L, double mu, size_t iel, size_t kel) const {
+      arma::mat FEMRadialBasis::erfc_integral(int L, double mu, size_t iel, size_t kel) const {
         // Number of quadrature points
         size_t Nq = xq.n_elem;
         // Number of subintervals
@@ -556,7 +556,7 @@ namespace helfem {
         return tei;
       }
 
-      arma::mat RadialBasis::spherical_potential(size_t iel) const {
+      arma::mat FEMRadialBasis::spherical_potential(size_t iel) const {
         double Rmin(fem.element_begin(iel));
         double Rmax(fem.element_end(iel));
 
@@ -567,11 +567,11 @@ namespace helfem {
         return pot;
       }
 
-      arma::mat RadialBasis::get_bf(size_t iel) const {
+      arma::mat FEMRadialBasis::get_bf(size_t iel) const {
         return get_bf(xq, iel);
       }
 
-      void RadialBasis::get_taylor(const arma::vec & r, const arma::uvec & taylorind, arma::mat & val, int ider) const {
+      void FEMRadialBasis::get_taylor(const arma::vec & r, const arma::uvec & taylorind, arma::mat & val, int ider) const {
         if(taylorind[0]!=0 || taylorind[taylorind.n_elem-1] != taylorind.n_elem-1)
           throw std::logic_error("Taylor points not consecutive!\n");
 
@@ -624,7 +624,7 @@ namespace helfem {
           }
       }
 
-      arma::vec RadialBasis::eval_orbs(const arma::mat & C, double r) const {
+      arma::vec FEMRadialBasis::eval_orbs(const arma::mat & C, double r) const {
         if(r > fem.element_end(fem.get_nelem()-1)) {
           // The wave function is zero here
           arma::vec val(C.n_cols, arma::fill::zeros);
@@ -645,7 +645,7 @@ namespace helfem {
         }
       }
 
-      arma::mat RadialBasis::get_bf(const arma::vec & x, size_t iel) const {
+      arma::mat FEMRadialBasis::get_bf(const arma::vec & x, size_t iel) const {
         // Element function values at quadrature points are
         arma::mat val(fem.eval_f(x, iel));
         // but we also need to put in the 1/r factor
@@ -668,11 +668,11 @@ namespace helfem {
         return val;
       }
 
-      arma::mat RadialBasis::get_df(size_t iel) const {
+      arma::mat FEMRadialBasis::get_df(size_t iel) const {
         return get_df(xq ,iel);
       }
 
-      arma::mat RadialBasis::get_df(const arma::vec & x, size_t iel) const {
+      arma::mat FEMRadialBasis::get_df(const arma::vec & x, size_t iel) const {
         // Element function values at quadrature points are
         arma::mat fval(fem.eval_f(x, iel));
         arma::mat dval(fem.eval_df(x, iel));
@@ -697,11 +697,11 @@ namespace helfem {
         return der;
       }
 
-      arma::mat RadialBasis::get_lf(size_t iel) const {
+      arma::mat FEMRadialBasis::get_lf(size_t iel) const {
         return get_lf(xq, iel);
       }
 
-      arma::mat RadialBasis::get_lf(const arma::vec & x, size_t iel) const {
+      arma::mat FEMRadialBasis::get_lf(const arma::vec & x, size_t iel) const {
         // Element function values at quadrature points are
         arma::mat fval(fem.eval_f(x, iel));
         arma::mat dval(fem.eval_df(x, iel));
@@ -728,28 +728,28 @@ namespace helfem {
         return lapl;
       }
 
-      arma::vec RadialBasis::get_wrad(size_t iel) const {
+      arma::vec FEMRadialBasis::get_wrad(size_t iel) const {
         return get_wrad(wq, iel);
       }
 
-      arma::vec RadialBasis::get_wrad(const arma::vec & w, size_t iel) const {
+      arma::vec FEMRadialBasis::get_wrad(const arma::vec & w, size_t iel) const {
         // This is just the radial rule, no r^2 factor included here
         return fem.scaling_factor(iel) * w;
       }
 
-      arma::vec RadialBasis::get_r(size_t iel) const {
+      arma::vec FEMRadialBasis::get_r(size_t iel) const {
         return get_r(xq, iel);
       }
 
-      arma::vec RadialBasis::get_r(const arma::vec & x, size_t iel) const {
+      arma::vec FEMRadialBasis::get_r(const arma::vec & x, size_t iel) const {
         return fem.eval_coord(x, iel);
       }
 
-      double RadialBasis::get_r(double x, size_t iel) const {
+      double FEMRadialBasis::get_r(double x, size_t iel) const {
         return fem.eval_coord(x, iel);
       }
 
-      double RadialBasis::nuclear_density(const arma::mat &Prad) const {
+      double FEMRadialBasis::nuclear_density(const arma::mat &Prad) const {
         if (Prad.n_rows != Nbf() || Prad.n_cols != Nbf())
           throw std::logic_error("nuclear_density expects a radial density matrix\n");
 
@@ -772,7 +772,7 @@ namespace helfem {
         return den;
       }
 
-      double RadialBasis::nuclear_density_gradient(const arma::mat &Prad) const {
+      double FEMRadialBasis::nuclear_density_gradient(const arma::mat &Prad) const {
         if (Prad.n_rows != Nbf() || Prad.n_cols != Nbf())
           throw std::logic_error("nuclear_density_gradient expects a radial density matrix\n");
 
@@ -796,7 +796,7 @@ namespace helfem {
         return den;
       }
 
-      arma::rowvec RadialBasis::nuclear_orbital(const arma::mat &C) const {
+      arma::rowvec FEMRadialBasis::nuclear_orbital(const arma::mat &C) const {
         // Nuclear coordinate
         arma::vec x(1);
         // Remember that the primitive basis polynomials belong to [-1,1]

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -49,7 +49,7 @@ namespace helfem {
         bool zero_func_right=true;
         zeroder=zeroder_;
         polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
-        radial=RadialBasis(fem, n_quad, taylor_order);
+        radial=FEMRadialBasis(fem, n_quad, taylor_order);
 
         // Construct angular basis
         lval=lval_;

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -45,7 +45,7 @@ namespace helfem {
         double lambda;
 
         /// Radial basis set
-        RadialBasis radial;
+        FEMRadialBasis radial;
         /// Angular basis set: function l values
         arma::ivec lval;
         /// Angular basis set: function m values

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
   bool zero_deriv_left=false;
   bool zero_func_right=true;
   polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
-  atomic::basis::RadialBasis radial(fem, Nquad, taylor_order);
+  atomic::basis::FEMRadialBasis radial(fem, Nquad, taylor_order);
 
   // Compute matrices
   arma::mat S(radial.overlap());

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -46,7 +46,7 @@ namespace helfem {
         bool zero_deriv_left=false;
         bool zero_func_right=true;
         polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
-        radial=atomic::basis::RadialBasis(fem, n_quad, taylor_order);
+        radial=atomic::basis::FEMRadialBasis(fem, n_quad, taylor_order);
         // Angular basis
         lval=arma::linspace<arma::ivec>(0,lmax,lmax+1);
       }

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -36,7 +36,7 @@ namespace helfem {
         double lambda;
 
         /// Radial basis set
-        atomic::basis::RadialBasis radial;
+        atomic::basis::FEMRadialBasis radial;
         /// Angular basis set: function l values
         arma::ivec lval;
 


### PR DESCRIPTION
## Summary

Phase 0 of the v2 refactor plan: lay the foundation for the radial-basis abstraction (FEM today, NAO/STO/GTO later) and the planned `lib1dfem` extraction. Two commits, both fully backward-compatible.

### Commit 1 — Abstract `RadialBasis` + rename concrete to `FEMRadialBasis`
- New abstract base `helfem::atomic::basis::RadialBasis` with the **global one-electron matrix API** as pure virtuals: `Nbf`, `overlap`, `kinetic`, `kinetic_l`, `nuclear`, `eval_orbs`. This is the API any radial-basis backend can implement.
- Existing concrete class renamed `RadialBasis → FEMRadialBasis`. All method bodies and signatures preserved — pure rename for the concrete path.
- Element-level / quadrature / Taylor machinery (`overlap(iel)`, `twoe_integral(L,iel)`, `get_bf`, `get_taylor`, …) stays concrete on `FEMRadialBasis`. These are FEM-specific concepts that don't generalise to NAO/STO/GTO.
- Cross-basis methods (`radial_integral(const, n, ...)`, `model_potential(const, ...)`, `overlap(const)`) now take `const FEMRadialBasis &` — they use the FEM element-overlap machinery and have no meaning for non-FEM backends.
- Call-site updates: `src/atomic/TwoDBasis`, `src/sadatom/basis`, `src/sadatom/1e.cpp`, `examples/atomic_radial_export.cpp` switch direct constructions/members to `FEMRadialBasis`.
- Dropped a dead `form_density` declaration on `RadialBasis` that had no implementation in libhelfem; production code uses `scf::form_density` and `TwoDBasis::form_density` instead.

### Commit 2 — `lib1dfem/` skeleton directory
- Adds `lib1dfem/CMakeLists.txt` declaring `helfem::lib1dfem` as an INTERFACE library (empty, no sources or headers yet).
- Stub umbrella header at `lib1dfem/include/lib1dfem.h`.
- Wired into top-level CMakeLists.txt before `libhelfem`.
- Phase 1 will populate this with the strictly-generic-1D-FEM files migrated from `libhelfem/` (PolynomialBasis, LIPBasis, HIPBasis, GeneralHIPBasis, LegendreBasis, FiniteElementBasis, lobatto, chebyshev, quadrature, grid, math half of utils — ~5800 LOC), templated on the scalar type `T`.

## Test plan (verified locally)

- [x] Default build (`HELFEM_FIND_DEPS=ON`, shared libs) clean
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] `examples/atomic_radial_export` (PR #55) passes with **identical numerics**: H 1s/2p/3d, He+ 1s/2p match `-Z²/(2n²)` to ~1e-12; He HF = −2.86167999561 Eh (err 3e-12) — unchanged from pre-refactor

## What's next (separate PRs)

- **Phase 1**: extract the generic-FEM files into `lib1dfem/` and template on `T = double`. Multi-week effort; will land incrementally.
- **Phase 2**: implement `NAORadialBasis` deriving from the new abstract base.

This PR is intentionally a small foundation — no behavioural change, just scaffolding so the bigger phases can build on it.