### PR TITLE
v2 Phase 1 slice 3: migrate radial grid generator to lib1dfem (templated)

### DIFF
--- a/lib1dfem/CMakeLists.txt
+++ b/lib1dfem/CMakeLists.txt
@@ -11,6 +11,9 @@
 #                Newton iteration on Legendre polynomial derivatives,
 #                replaces the hardcoded double-precision tables that
 #                lived in libhelfem prior to v2).
+#   - grid:      Radial element-boundary grid generator (linear / quadratic /
+#                generalised polynomial / generalised exponential / geometric;
+#                templated on T, header-only).
 
 add_library(lib1dfem INTERFACE)
 add_library(helfem::lib1dfem ALIAS lib1dfem)

--- a/lib1dfem/include/lib1dfem/grid.h
+++ b/lib1dfem/include/lib1dfem/grid.h
@@ -1,0 +1,106 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef LIB1DFEM_GRID_H
+#define LIB1DFEM_GRID_H
+
+#include <armadillo>
+#include <cmath>
+#include <cstdio>
+#include <stdexcept>
+
+namespace helfem {
+namespace lib1dfem {
+namespace grid {
+
+/// Form a 1D grid of element boundaries on [0, rmax] with `num_el`
+/// elements. The shape is selected by `igrid`:
+///
+///   1: linear
+///   2: quadratic (Schweizer et al. 1999)
+///   3: generalised polynomial   r_i = rmax * (i/num_el)^zexp
+///   4: generalised exponential  built from exp(linspace^zexp) - 1
+///   5: geometric (Cancès & Mourad 2018; 0 < zexp < 1)
+///
+/// Endpoints are snapped to exactly 0 and rmax to avoid floating-point
+/// roundoff. Templated on the scalar type T.
+template <typename T>
+arma::Col<T> get_grid(T rmax, int num_el, int igrid, T zexp,
+                      bool verbose = false) {
+  arma::Col<T> bval;
+
+  switch (igrid) {
+    case 1: { // linear
+      if (verbose) std::printf("Using linear grid\n");
+      bval = arma::linspace<arma::Col<T>>(T(0), rmax, num_el + 1);
+      break;
+    }
+    case 2: { // quadratic
+      if (verbose) std::printf("Using quadratic grid\n");
+      bval.zeros(num_el + 1);
+      const T inv_n2 = T(1) / (T(num_el) * T(num_el));
+      for (int i = 0; i <= num_el; ++i)
+        bval(i) = T(i) * T(i) * rmax * inv_n2;
+      break;
+    }
+    case 3: { // generalised polynomial
+      if (verbose)
+        std::printf("Using generalized polynomial grid, zexp = %e\n",
+                    static_cast<double>(zexp));
+      bval.zeros(num_el + 1);
+      const T inv_n = T(1) / T(num_el);
+      for (int i = 0; i <= num_el; ++i)
+        bval(i) = rmax * std::pow(T(i) * inv_n, zexp);
+      break;
+    }
+    case 4: { // generalised exponential
+      if (verbose)
+        std::printf("Using generalized exponential grid, zexp = %e\n",
+                    static_cast<double>(zexp));
+      const T upper = std::pow(std::log(rmax + T(1)), T(1) / zexp);
+      auto t = arma::linspace<arma::Col<T>>(T(0), upper, num_el + 1);
+      bval = arma::exp(arma::pow(t, zexp)) - arma::ones<arma::Col<T>>(num_el + 1);
+      break;
+    }
+    case 5: { // geometric
+      if (verbose)
+        std::printf("Using geometric grid of doi:10.2140/camcos.2018.13.139, "
+                    "s = %e\n", static_cast<double>(zexp));
+      if (zexp <= T(0) || zexp >= T(1))
+        throw std::logic_error("Invalid value for s parameter!\n");
+      // h_k from p.158 of the Cancès-Mourad paper:
+      arma::Col<T> hk(num_el);
+      hk(num_el - 1) = (T(1) - zexp) / (T(1) - std::pow(zexp, num_el)) * rmax;
+      for (int iel = num_el - 2; iel >= 0; --iel)
+        hk(iel) = zexp * hk(iel + 1);
+      bval.zeros(num_el + 1);
+      for (int iel = 0; iel < num_el; ++iel)
+        bval(iel + 1) = bval(iel) + hk(iel);
+      break;
+    }
+    default:
+      throw std::logic_error("Invalid choice for grid\n");
+  }
+
+  // Make endpoints numerically exact.
+  bval(0) = T(0);
+  bval(bval.n_elem - 1) = rmax;
+  return bval;
+}
+
+} // namespace grid
+} // namespace lib1dfem
+} // namespace helfem
+
+#endif

--- a/libhelfem/src/grid.cpp
+++ b/libhelfem/src/grid.cpp
@@ -12,75 +12,17 @@
  * See the LICENSE file at the root of this source distribution
  * for the full license text.
  */
+
+// v2 refactor (Phase 1): the grid-builder implementation now lives in
+// lib1dfem as a templated header. This translation unit is the double-only
+// compatibility shim that keeps the libhelfem public API (declared in
+// helfem.source.h) source-compatible during the migration.
+
 #include <helfem.h>
+#include <lib1dfem/grid.h>
 
-arma::vec helfem::utils::get_grid(double rmax, int num_el, int igrid, double zexp) {
-  // Boundary values
-  arma::vec bval;
-
-  // Get boundary values
-  switch (igrid) {
-  // linear grid
-  case (1):
-    if (helfem::verbose)
-      printf("Using linear grid\n");
-    bval = arma::linspace<arma::vec>(0, rmax, num_el + 1);
-    break;
-
-  // quadratic grid (Schweizer et al 1999)
-  case (2):
-    if (helfem::verbose)
-      printf("Using quadratic grid\n");
-    bval.zeros(num_el + 1);
-    for (int i = 0; i <= num_el; i++)
-      bval(i) = i * i * rmax / (num_el * num_el);
-    break;
-
-  case (3):
-    // generalized polynomial grid, monotonic decrease till zexp~3, after that fails to work
-    if (helfem::verbose)
-      printf("Using generalized polynomial grid, zexp = %e\n", zexp);
-    bval.zeros(num_el + 1);
-    for (int i = 0; i <= num_el; i++)
-      bval(i) = rmax * std::pow(i * 1.0 / num_el, zexp);
-    break;
-
-  // generalized exponential grid, monotonic decrease till zexp~2, after that fails to work
-  case (4):
-    if (helfem::verbose)
-      printf("Using generalized exponential grid, zexp = %e\n", zexp);
-    bval = arma::exp(arma::pow(arma::linspace<arma::vec>(
-                                   0, std::pow(log(rmax + 1), 1.0 / zexp), num_el + 1),
-                               zexp)) -
-           arma::ones<arma::vec>(num_el + 1);
-    break;
-
-  // geometric grid, Cancès and Mourad 2018
-  case (5):
-    if (helfem::verbose)
-      printf("Using geometric grid of doi:10.2140/camcos.2018.13.139, s = %e\n", zexp);
-    if(zexp<=0.0 or zexp>=1.0)
-      throw std::logic_error("Invalid value for s parameter!\n");
-    // We compute the h_k, see p. 158
-    {
-      arma::vec hk(num_el);
-      hk(num_el-1) = (1.0-zexp)/(1.0-std::pow(zexp,num_el))*rmax;
-      for(int iel=num_el-2;iel>=0;iel--)
-        hk(iel)=zexp*hk(iel+1);
-      // and then set the nodes
-      bval.zeros(num_el+1);
-      for(int iel=0;iel<num_el;iel++)
-        bval(iel+1) = bval(iel) + hk(iel);
-    }
-    break;
-
-  default:
-    throw std::logic_error("Invalid choice for grid\n");
-  }
-
-  // Make sure start and end points are numerically exact
-  bval(0) = 0.0;
-  bval(bval.n_elem - 1) = rmax;
-
-  return bval;
+arma::vec helfem::utils::get_grid(double rmax, int num_el, int igrid,
+                                  double zexp) {
+  return helfem::lib1dfem::grid::get_grid<double>(rmax, num_el, igrid, zexp,
+                                                  helfem::verbose);
 }


### PR DESCRIPTION
## Summary

Third slice of v2 Phase 1. Moves the `helfem::utils::get_grid` implementation into `lib1dfem/include/lib1dfem/grid.h` as a templated header-only function `lib1dfem::grid::get_grid<T>(rmax, num_el, igrid, zexp, verbose=false)`.

### What changed
- All five grid types preserved with identical algorithms, parameterised on T:
  - `igrid=1` linear (`arma::linspace<arma::Col<T>>`)
  - `igrid=2` quadratic (Schweizer 1999)
  - `igrid=3` generalised polynomial (`r_i = rmax * (i/n)^zexp`)
  - `igrid=4` generalised exponential (`exp(linspace^zexp) - 1`)
  - `igrid=5` geometric (Cancès & Mourad 2018)
- `arma::vec` → `arma::Col<T>`; numeric literals lifted with `T(…)`; `std::pow`/`std::log`/`std::exp` auto-dispatch on T.
- Endpoint-snap to exactly 0 and `rmax` preserved (avoids floating-point roundoff in callers that compare to those values).
- Verbose diagnostic prints now controlled by a defaulted `bool verbose` argument (the libhelfem shim passes `helfem::verbose` so user-visible behaviour is unchanged).

### Source-compatibility shim
`libhelfem/src/grid.cpp` shrinks from ~80 LOC to a 4-line forwarding function that calls into `lib1dfem::grid::get_grid<double>` and passes `helfem::verbose`. The `helfem::utils::get_grid(double rmax, int num_el, int igrid, double zexp)` API declared in `helfem.source.h` is unchanged — every caller (`src/atomic`, `src/diatomic`, `src/sadatom`, etc.) compiles untouched.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`, no CMake.system)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) passes with **identical numerics**: hydrogenic energies match to ~1e-12; He HF = −2.86167999561 Eh (err 3.6e-12)

## Next Phase 1 slices

- `quadrature.cpp` (~280 LOC, depends on chebyshev) — radial integral helpers.
- Math half of `utils.cpp` (Bessel functions, hyperbolic inverse) — needs splitting from the QC-flavoured helpers in the same file.
- Then the bigger move: `PolynomialBasis` + `LIPBasis(+eval)` + `HIPBasis(+eval)` + `GeneralHIPBasis` + `LegendreBasis` (the auto-generated eval tables need a templated emitter), then `FiniteElementBasis`.