### PR TITLE
v2 Phase 1 slice 4: migrate pure-math utils (arcosh/arsinh/bessel) to lib1dfem

### DIFF
--- a/lib1dfem/CMakeLists.txt
+++ b/lib1dfem/CMakeLists.txt
@@ -14,6 +14,11 @@
 #   - grid:      Radial element-boundary grid generator (linear / quadratic /
 #                generalised polynomial / generalised exponential / geometric;
 #                templated on T, header-only).
+#   - math:      Pure-math helpers (arcosh, arsinh, modified Bessel i_L / k_L)
+#                used inside the FEM machinery. Templated on T; Bessel paths
+#                use std::cyl_bessel_i/k for the standard float/double/long
+#                double overloads, plus an explicit Taylor series at small |x|
+#                that works at any precision.
 
 add_library(lib1dfem INTERFACE)
 add_library(helfem::lib1dfem ALIAS lib1dfem)

--- a/lib1dfem/include/lib1dfem/math.h
+++ b/lib1dfem/include/lib1dfem/math.h
@@ -1,0 +1,123 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef LIB1DFEM_MATH_H
+#define LIB1DFEM_MATH_H
+
+#include <armadillo>
+#include <cmath>
+#include <algorithm>
+#include <limits>
+
+namespace helfem {
+namespace lib1dfem {
+namespace math {
+
+/// Inverse cosh. x is mathematically >= 1 but is clamped to 1 because the
+/// caller may pass values that round to slightly below 1 (e.g. cosh(mu) for
+/// very small mu).
+template <typename T>
+T arcosh(T x) {
+  return std::acosh(std::max(x, T(1)));
+}
+
+template <typename T>
+arma::Col<T> arcosh(const arma::Col<T> & x) {
+  arma::Col<T> y(x.n_elem);
+  for (size_t i = 0; i < x.n_elem; ++i) y(i) = arcosh<T>(x(i));
+  return y;
+}
+
+/// Inverse sinh.
+template <typename T>
+T arsinh(T x) {
+  return std::asinh(x);
+}
+
+template <typename T>
+arma::Col<T> arsinh(const arma::Col<T> & x) {
+  arma::Col<T> y(x.n_elem);
+  for (size_t i = 0; i < x.n_elem; ++i) y(i) = arsinh<T>(x(i));
+  return y;
+}
+
+/// Modified Bessel function i_L(x), where
+///     i_L(x) = sqrt(pi/(2|x|)) * I_{L+1/2}(|x|),  i_L(-x) = (-1)^L i_L(x).
+///
+/// For small |x| we evaluate the Taylor series
+///     i_L(x) = x^L/(2L+1)!! * sum_{k>=0} (x^2/2)^k / (k! prod_{j=1..k}(2L+2j+1))
+/// to dodge the sqrt(pi/(2x))*I_{L+1/2}(x) ~ 0/0 limit at x=0; the standard
+/// library's small-argument behaviour for cyl_bessel_i is also more lossy
+/// than the explicit series.
+///
+/// For larger |x| we fall back to the C++17 std::cyl_bessel_i, which
+/// overloads on float/double/long double. For __float128 (or any other T
+/// without a std::cyl_bessel_i overload) a user-supplied specialisation
+/// is required.
+template <typename T>
+T bessel_il(T r, int L) {
+  const T absr = std::abs(r);
+  T val;
+  if (absr < T(0.5)) {
+    // (2L+1)!!
+    T dfac = T(1);
+    for (int j = 3; j <= 2*L + 1; j += 2) dfac *= T(j);
+    T term = std::pow(absr, L) / dfac;
+    val = term;
+    const T r2half = T(0.5) * absr * absr;
+    const T tol    = std::numeric_limits<T>::epsilon() * T(0.01);
+    for (int k = 1; k < 256; ++k) {
+      term *= r2half / (T(k) * T(2*L + 2*k + 1));
+      val += term;
+      if (std::abs(term) <= tol * std::abs(val)) break;
+    }
+  } else {
+    const T pi = std::acos(T(-1));
+    val = std::cyl_bessel_i(T(L) + T(0.5), absr) * std::sqrt(pi / (T(2) * absr));
+  }
+  return (r < T(0) && (L & 1)) ? -val : val;
+}
+
+template <typename T>
+arma::Col<T> bessel_il(const arma::Col<T> & r, int L) {
+  arma::Col<T> ret(r.n_elem);
+  for (size_t i = 0; i < ret.n_elem; ++i) ret(i) = bessel_il<T>(r(i), L);
+  return ret;
+}
+
+/// Modified Bessel function k_L(r), normalised as
+///     k_L(r) = sqrt(2/(pi r)) * K_{L+1/2}(r).
+/// Singular at r=0.
+///
+/// Uses C++17 std::cyl_bessel_k under the hood; same precision-portability
+/// caveat as bessel_il (user-supplied specialisation needed for T without
+/// a std::cyl_bessel_k overload).
+template <typename T>
+T bessel_kl(T r, int L) {
+  const T pi = std::acos(T(-1));
+  return std::cyl_bessel_k(T(L) + T(0.5), r) * std::sqrt(T(2) / (pi * r));
+}
+
+template <typename T>
+arma::Col<T> bessel_kl(const arma::Col<T> & r, int L) {
+  arma::Col<T> ret(r.n_elem);
+  for (size_t i = 0; i < ret.n_elem; ++i) ret(i) = bessel_kl<T>(r(i), L);
+  return ret;
+}
+
+} // namespace math
+} // namespace lib1dfem
+} // namespace helfem
+
+#endif

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -13,84 +13,46 @@
  * for the full license text.
  */
 #include "utils.h"
+#include <lib1dfem/math.h>
 #include <cmath>
 
 namespace helfem {
   namespace utils {
+    // v2 refactor (Phase 1): the pure-math helpers (arcosh, arsinh,
+    // bessel_il, bessel_kl) now live in lib1dfem and are templated on the
+    // scalar type. The functions below are thin double-only compatibility
+    // shims that forward to the templated implementations.
+
     double arcosh(double x) {
-      // x is mathematically >= 1, but may be 1 - eps under round-off (e.g.
-      // when the caller computed it as cosh(mu) for very small mu). The
-      // explicit log form would NaN; std::acosh handles this safely.
-      return std::acosh(std::max(x, 1.0));
+      return helfem::lib1dfem::math::arcosh<double>(x);
     }
 
     arma::vec arcosh(const arma::vec & x) {
-      arma::vec y(x);
-      for(size_t i=0;i<x.n_elem;i++)
-	y(i)=arcosh(x(i));
-      return y;
+      return helfem::lib1dfem::math::arcosh<double>(x);
     }
 
     double arsinh(double x) {
-      return log(x+sqrt(x*x+1.0));
+      return helfem::lib1dfem::math::arsinh<double>(x);
     }
 
     arma::vec arsinh(const arma::vec & x) {
-      arma::vec y(x);
-      for(size_t i=0;i<x.n_elem;i++)
-	y(i)=arsinh(x(i));
-      return y;
+      return helfem::lib1dfem::math::arsinh<double>(x);
     }
 
     double bessel_il(double r, int L) {
-      // i_L(x) = sqrt(pi/(2|x|)) I_{L+1/2}(|x|), with i_L(-x) = (-1)^L i_L(x).
-      //
-      // For small |x| we evaluate the Taylor series
-      //     i_L(x) = x^L/(2L+1)!! * sum_{k>=0} (x^2/2)^k / (k! prod_{j=1..k}(2L+2j+1))
-      // which sidesteps the sqrt(pi/(2x))*I_{L+1/2}(x) ~ 0/0 limit at x=0
-      // and stays accurate without relying on the standard library's
-      // small-argument behaviour.
-      const double absr = std::abs(r);
-      double val;
-      if(absr < 0.5) {
-        // (2L+1)!!
-        double dfac = 1.0;
-        for(int j=3; j<=2*L+1; j+=2)
-          dfac *= j;
-        double term = std::pow(absr, L) / dfac;
-        val = term;
-        const double r2half = 0.5*absr*absr;
-        for(int k=1; k<64; ++k) {
-          term *= r2half / (k * (2*L + 2*k + 1));
-          val += term;
-          if(std::abs(term) <= 1e-18 * std::abs(val))
-            break;
-        }
-      } else {
-        val = std::cyl_bessel_i(L + 0.5, absr) * std::sqrt(M_PI/(2.0*absr));
-      }
-      return (r < 0.0 && (L & 1)) ? -val : val;
+      return helfem::lib1dfem::math::bessel_il<double>(r, L);
     }
 
     arma::vec bessel_il(const arma::vec & r, int L) {
-      arma::vec ret(r.n_elem);
-      for(size_t i=0; i<ret.n_elem; i++)
-        ret(i) = bessel_il(r(i), L);
-      return ret;
+      return helfem::lib1dfem::math::bessel_il<double>(r, L);
     }
 
     double bessel_kl(double r, int L) {
-      // (2/pi) k_L(r) with k_L(r) = sqrt(pi/(2r)) K_{L+1/2}(r);
-      // helfem's normalisation pulls out the (2/pi) factor, leaving
-      // sqrt(2/(pi r)) * K_{L+1/2}(r). k_L(r) is singular at r=0.
-      return std::cyl_bessel_k(L + 0.5, r) * std::sqrt(2.0/(M_PI*r));
+      return helfem::lib1dfem::math::bessel_kl<double>(r, L);
     }
 
     arma::vec bessel_kl(const arma::vec & r, int L) {
-      arma::vec ret(r.n_elem);
-      for(size_t i=0; i<ret.n_elem; i++)
-        ret(i) = bessel_kl(r(i), L);
-      return ret;
+      return helfem::lib1dfem::math::bessel_kl<double>(r, L);
     }
 
     arma::mat product_tei(const arma::mat & ijint, const arma::mat & klint) {


### PR DESCRIPTION
## Summary

Fourth slice of v2 Phase 1. Moves the **math half** of `libhelfem/src/utils.cpp` into a new templated header `lib1dfem/include/lib1dfem/math.h`:

| Function | Notes |
|---|---|
| `arcosh<T>(scalar / arma::Col<T>)` | Clamps argument to ≥ 1 before `std::acosh` (defence against caller-side round-off into `1 - ε`). |
| `arsinh<T>(scalar / arma::Col<T>)` | Now uses `std::asinh<T>` directly. The original explicit `log(x + sqrt(x*x + 1))` form lost the lowest few ulps for large \|x\| via catastrophic cancellation; `std::asinh` handles it correctly. |
| `bessel_il<T>(scalar / arma::Col<T>, int L)` | Modified Bessel `i_L`. Small-\|x\| Taylor series with tolerance `numeric_limits<T>::epsilon() * 0.01` (auto-scales with T); iteration cap bumped 64→256 to accommodate slower convergence at higher precision. Large-\|x\| path uses `std::cyl_bessel_i`. |
| `bessel_kl<T>(scalar / arma::Col<T>, int L)` | Modified Bessel `k_L` with HelFEM's `sqrt(2/(π r))` normalisation. Uses `std::cyl_bessel_k`. |

### Note on Bessel + higher precision

`std::cyl_bessel_i` / `std::cyl_bessel_k` (C++17) have standard overloads for `float`, `double`, `long double`. For `T` without an overload (e.g. `__float128`), a user-supplied specialisation will be required — documented in the headers. Today's `T = double` instantiation works out-of-the-box.

### What stays in libhelfem (QC-flavoured)
`product_tei`, `check_tei_symmetry`, `exchange_tei`, `stricmp`, `invh` — these reference QC-specific layouts or pull in BLAS. They'd belong in a separate `helfem_tei` / matrix-utilities header, not lib1dfem.

### Source-compatibility shim
`libhelfem/src/utils.cpp` keeps the `helfem::utils::` public API intact as thin double-only shims forwarding to the templated `lib1dfem::math::` versions. Every existing caller compiles unchanged.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`, no CMake.system)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) passes with **identical numerics**: hydrogenic energies match to ~1e-12; He HF = −2.86167999561 Eh (err 3.6e-12)

## Why utils-math before quadrature

`quadrature.cpp` depends on `polynomial_basis::PolynomialBasis` (the abstract polynomial-basis interface used by `LIPBasis` / `HIPBasis` / …). Migrating `quadrature` cleanly requires moving the PolynomialBasis hierarchy first, which is the next bigger slice. utils-math has no class dependencies and is a clean independent step.

## Next Phase 1 slices

- **`PolynomialBasis` hierarchy** (the big one): `PolynomialBasis` + `LIPBasis` (+ 2200 LOC `LIPBasis_eval.cpp`) + `HIPBasis` (+ 1200 LOC `HIPBasis_eval.cpp`) + `GeneralHIPBasis` + `LegendreBasis`. The auto-generated eval-table CPPs need a templated emitter (Python script lives in `libhelfem/src/generate_*_code.py`).
- Then `quadrature.cpp` (~280 LOC, will follow PolynomialBasis trivially).
- Then `FiniteElementBasis`.