### PR TITLE
v2 Phase 1 slice 5: template PolynomialBasis abstract base, move to lib1dfem

### DIFF
--- a/lib1dfem/CMakeLists.txt
+++ b/lib1dfem/CMakeLists.txt
@@ -19,6 +19,11 @@
 #                use std::cyl_bessel_i/k for the standard float/double/long
 #                double overloads, plus an explicit Taylor series at small |x|
 #                that works at any precision.
+#   - PolynomialBasis: abstract templated base for primitive polynomial bases
+#                on the reference element [-1, 1]. Concrete subclasses
+#                (LIPBasis, HIPBasis, GeneralHIPBasis, LegendreBasis) still
+#                live in libhelfem during the migration; they derive from
+#                lib1dfem::polynomial_basis::PolynomialBasis<double>.
 
 add_library(lib1dfem INTERFACE)
 add_library(helfem::lib1dfem ALIAS lib1dfem)

--- a/lib1dfem/include/lib1dfem/PolynomialBasis.h
+++ b/lib1dfem/include/lib1dfem/PolynomialBasis.h
@@ -1,0 +1,120 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef LIB1DFEM_POLYNOMIALBASIS_H
+#define LIB1DFEM_POLYNOMIALBASIS_H
+
+#include <armadillo>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+namespace helfem {
+namespace lib1dfem {
+namespace polynomial_basis {
+
+/// Abstract template for a primitive polynomial basis defined on the
+/// reference element [-1, 1]. Concrete subclasses (LIPBasis, HIPBasis,
+/// GeneralHIPBasis, LegendreBasis) implement eval_prim_dnf, copy,
+/// drop_first, drop_last and may override get_nodes.
+///
+/// Templated on the scalar type T. The integer `enabled` index list
+/// stays a plain arma::uvec since it indexes columns, not floats.
+template <typename T>
+class PolynomialBasis {
+ protected:
+  /// Number of primitive functions
+  int nprim = 0;
+  /// List of enabled functions
+  arma::uvec enabled;
+  /// Number of overlapping functions (between adjacent elements)
+  int noverlap = 0;
+  /// Identifier (used by factories and downstream metadata)
+  int id = 0;
+  /// Number of nodes
+  int nnodes = 0;
+
+  /// Evaluate nth derivatives of primitive polynomials at given points.
+  /// Default throws -- concrete subclasses must override.
+  virtual void eval_prim_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf,
+                             int n, T element_length) const {
+    (void)x; (void)dnf; (void)n; (void)element_length;
+    throw std::logic_error(
+        "Values haven't been implemented for the used family of basis polynomials.\n");
+  }
+
+ public:
+  PolynomialBasis() = default;
+  virtual ~PolynomialBasis() = default;
+
+  /// Polymorphic clone.
+  virtual PolynomialBasis * copy() const = 0;
+
+  int get_nprim()    const { return nprim; }
+  int get_nbf()      const { return static_cast<int>(enabled.n_elem); }
+  int get_noverlap() const { return noverlap; }
+  int get_id()       const { return id; }
+  int get_nnodes()   const { return nnodes; }
+
+  /// Default node set is the reference element boundary {-1, +1};
+  /// concrete subclasses (LIP/HIP) override with the actual node set.
+  virtual arma::Col<T> get_nodes() const {
+    arma::Col<T> n(2);
+    n(0) = T(-1);
+    n(1) = T(1);
+    return n;
+  }
+
+  arma::uvec get_enabled() const { return enabled; }
+
+  /// Drop first function(s); zero_deriv: also set derivatives to zero.
+  virtual void drop_first(bool zero_func, bool zero_deriv) = 0;
+  /// Drop last function(s); zero_deriv: also set derivatives to zero.
+  virtual void drop_last(bool zero_func, bool zero_deriv) = 0;
+
+  /// Evaluate nth derivatives of polynomials at given points; applies the
+  /// element_length^-n chain-rule scaling and restricts to enabled
+  /// functions.
+  void eval_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf, int n,
+                T element_length) const {
+    eval_prim_dnf(x, dnf, n, element_length);
+    dnf = dnf.cols(enabled) / std::pow(element_length, n);
+  }
+
+  arma::Mat<T> eval_dnf(const arma::Col<T> & x, int n,
+                        T element_length) const {
+    arma::Mat<T> dnf;
+    eval_dnf(x, dnf, n, element_length);
+    return dnf;
+  }
+
+  /// Diagnostic dump of basis functions (and first derivatives) sampled
+  /// on a fine grid; writes "bf<str>.dat" / "df<str>.dat".
+  void print(const std::string & str = "") const {
+    arma::Col<T> x = arma::linspace<arma::Col<T>>(T(-1), T(1), 1001);
+    arma::Mat<T> bf, df;
+    eval_dnf(x, bf, 0, T(1));
+    eval_dnf(x, df, 1, T(1));
+    bf.insert_cols(0, x);
+    df.insert_cols(0, x);
+    bf.save("bf" + str + ".dat", arma::raw_ascii);
+    df.save("df" + str + ".dat", arma::raw_ascii);
+  }
+};
+
+} // namespace polynomial_basis
+} // namespace lib1dfem
+} // namespace helfem
+
+#endif

--- a/libhelfem/include/PolynomialBasis.h
+++ b/libhelfem/include/PolynomialBasis.h
@@ -15,67 +15,23 @@
 #ifndef POLYNOMIAL_BASIS_POLYNOMIALBASIS_H
 #define POLYNOMIAL_BASIS_POLYNOMIALBASIS_H
 
-#include <armadillo>
+// v2 refactor (Phase 1): the abstract PolynomialBasis class is now a
+// template living in lib1dfem. libhelfem is compiled at T = double, so
+// this header exposes the double-only instantiation under the original
+// helfem::polynomial_basis::PolynomialBasis name -- existing concrete
+// subclasses (LIPBasis, HIPBasis, GeneralHIPBasis, LegendreBasis) and
+// downstream callers continue to compile without source changes.
+
+#include <lib1dfem/PolynomialBasis.h>
 
 namespace helfem {
   namespace polynomial_basis {
-    /// Template for a primitive basis
-    class PolynomialBasis {
-    protected:
-      /// Number of primitive functions
-      int nprim;
-      /// List of enabled functions
-      arma::uvec enabled;
-      /// Number of overlapping functions
-      int noverlap;
-      /// Identifier
-      int id;
-      /// Number of nodes
-      int nnodes;
+    /// Alias for the lib1dfem template at T = double.
+    using PolynomialBasis = helfem::lib1dfem::polynomial_basis::PolynomialBasis<double>;
 
-      /// Evaluate nth derivatives of primitive polynomials at given points
-      virtual void eval_prim_dnf(const arma::vec & x, arma::mat & dnf, int n, double element_length) const;
-
-    public:
-      /// Constructor
-      PolynomialBasis();
-      /// Destructor
-      virtual ~PolynomialBasis();
-      /// Get a copy
-      virtual PolynomialBasis * copy() const=0;
-
-      /// Get number of primitive functions
-      int get_nprim() const;
-      /// Get number of basis functions
-      int get_nbf() const;
-      /// Get number of overlapping functions
-      int get_noverlap() const;
-
-      /// Get identifier
-      int get_id() const;
-      /// Get number of nodes
-      int get_nnodes() const;
-      /// Get nodes
-      virtual arma::vec get_nodes() const;
-
-      /// Get list of enabled primitives
-      arma::uvec get_enabled() const;
-      /// Drop first function(s); zero_deriv: also set derivatives to zero
-      virtual void drop_first(bool zero_func, bool zero_deriv)=0;
-      /// Drop last function(s); zero_deriv: also set derivatives to zero
-      virtual void drop_last(bool zero_func, bool zero_deriv)=0;
-
-      /// Evaluate nth derivatives of polynomials at given points
-      void eval_dnf(const arma::vec & x, arma::mat & dnf, int n, double element_length) const;
-      /// Evaluate nth derivatives of polynomials at given points
-      arma::mat eval_dnf(const arma::vec & x, int n, double element_length) const;
-
-      /// Print out the basis functions
-      void print(const std::string & str="") const;
-    };
-
-    /// Get the wanted polynomial basis
+    /// Factory: construct a primitive polynomial basis by ID.
     PolynomialBasis * get_basis(int primbas, int Nnodes);
   }
 }
+
 #endif

--- a/libhelfem/src/PolynomialBasis.cpp
+++ b/libhelfem/src/PolynomialBasis.cpp
@@ -13,6 +13,11 @@
  * for the full license text.
  */
 
+// v2 refactor (Phase 1): the abstract PolynomialBasis base class definitions
+// have moved into lib1dfem/include/lib1dfem/PolynomialBasis.h (templated,
+// header-only). This translation unit now only holds the factory that
+// constructs the concrete libhelfem-side polynomial bases by primitive ID.
+
 #include "PolynomialBasis.h"
 #include "lobatto.h"
 #include "LIPBasis.h"
@@ -99,82 +104,7 @@ namespace helfem {
         throw std::logic_error("Unsupported primitive basis.\n");
       }
 
-      // Print out
-      //poly->print();
-
       return poly;
-    }
-
-    PolynomialBasis::PolynomialBasis() {
-    }
-
-    PolynomialBasis::~PolynomialBasis() {
-    }
-
-    int PolynomialBasis::get_nprim() const {
-      return nprim;
-    }
-
-    int PolynomialBasis::get_nbf() const {
-      return enabled.n_elem;
-    }
-
-    int PolynomialBasis::get_noverlap() const {
-      return noverlap;
-    }
-
-    int PolynomialBasis::get_id() const {
-      return id;
-    }
-
-    int PolynomialBasis::get_nnodes() const {
-      return nnodes;
-    }
-
-    arma::vec PolynomialBasis::get_nodes() const {
-      arma::vec n(2);
-      n(0)=-1.0;
-      n(1)=1.0;
-      return n;
-    }
-
-    arma::uvec PolynomialBasis::get_enabled() const {
-      return enabled;
-    }
-
-    void PolynomialBasis::print(const std::string & str) const {
-      arma::vec x(arma::linspace<arma::vec>(-1.0,1.0,1001));
-      arma::mat bf, df;
-      eval_dnf(x,bf,0,1.0);
-      eval_dnf(x,df,1,1.0);
-
-      bf.insert_cols(0,x);
-      df.insert_cols(0,x);
-
-      std::string fname("bf" + str + ".dat");
-      std::string dname("df" + str + ".dat");
-      bf.save(fname,arma::raw_ascii);
-      df.save(dname,arma::raw_ascii);
-    }
-
-    arma::mat PolynomialBasis::eval_dnf(const arma::vec & x, int n, double element_length) const {
-      arma::mat dnf;
-      eval_dnf(x, dnf, n, element_length);
-      return dnf;
-    }
-
-    void PolynomialBasis::eval_prim_dnf(const arma::vec & x, arma::mat & dnf, int n, double element_length) const {
-      (void) x;
-      (void) dnf;
-      (void) n;
-      (void) element_length;
-      throw std::logic_error("Values haven't been implemented for the used family of basis polynomials.\n");
-    }
-
-    void PolynomialBasis::eval_dnf(const arma::vec & x, arma::mat & dnf, int n, double element_length) const {
-      eval_prim_dnf(x, dnf, n, element_length);
-      // Apply scaling
-      dnf = dnf.cols(enabled) / std::pow(element_length, n);
     }
   }
 }


### PR DESCRIPTION
## Summary

Lifts the abstract polynomial-basis base class into lib1dfem as a header-only template, leaving the concrete subclasses (LIPBasis, HIPBasis, GeneralHIPBasis, LegendreBasis) in place. This is the smallest validating slice for the **template-the-base-keep-subclasses-as-T=double-concrete** pattern that the remaining Phase 1 slices will reuse.

### New
```
helfem::lib1dfem::polynomial_basis::PolynomialBasis<T>
```
Templated on the scalar type T. The integer `enabled` index list stays `arma::uvec` (it indexes columns, not floats). All other numeric fields and virtual signatures (`eval_prim_dnf`, `get_nodes`, `eval_dnf`) key off T.

### Compat alias
```cpp
namespace helfem::polynomial_basis {
  using PolynomialBasis = helfem::lib1dfem::polynomial_basis::PolynomialBasis<double>;
}
```

The concrete subclass overrides in libhelfem (e.g. `void eval_prim_dnf(const arma::vec&, arma::mat&, int, double) const override;`) match the templated base's `<double>` instantiation byte-for-byte (`arma::vec` *is* `arma::Col<double>`, etc.), so the subclass headers and the call sites need no source change.

### libhelfem-side cleanup
`libhelfem/src/PolynomialBasis.cpp` shrinks from 180 LOC to 80 LOC — all the base-class method bodies moved to the templated header, leaving only the `get_basis()` factory that constructs concrete subclasses by primitive ID.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`, no CMake.system)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) passes with **identical numerics**: hydrogenic energies match to ~1e-12; He HF = −2.86167999561 Eh (err 3.6e-12)

## Next Phase 1 slices

Now that the templated base is in place, the concrete subclasses can migrate one at a time:
- **LegendreBasis** (~109 LOC, no auto-generated eval tables) — easy next slice
- **GeneralHIPBasis** (~148 LOC) — also no eval-table generator
- **LIPBasis / HIPBasis** — bigger lift; the auto-generated eval-table CPPs (2200 LOC for LIP, 1200 for HIP) need a templated emitter (Python scripts at `libhelfem/src/generate_*_code.py`)

Then `quadrature.cpp` can move (was blocked on PolynomialBasis), and finally `FiniteElementBasis`.