### PR TITLE
v2: HIPBasis::eval_over_r — analytic B(r)/r deflation for HIP shape functions

### DIFF
--- a/lib1dfem/include/lib1dfem/HIPBasis.h
+++ b/lib1dfem/include/lib1dfem/HIPBasis.h
@@ -85,6 +85,168 @@ class HIPBasis : public LIPBasis<T> {
                      T element_length) const override {
     detail::eval_hip_prim_dnf<T>(x, this->x0, lipxi, dnf, n, element_length);
   }
+
+  // Pull the base's 3-arg matrix-returning eval_over_r overload back into
+  // scope (overriding the 4-arg virtual below would otherwise hide it).
+  using PolynomialBasis<T>::eval_over_r;
+
+  /// Analytic B_u(r)/r for the surviving (post-drop_first(true,false)) HIP
+  /// shape functions on the first element.
+  ///
+  /// Surviving shapes after dropping only the function at node 0:
+  ///   - df_0 = (x+1) L_0(x)^2 * Delta      (the derivative shape at node 0)
+  ///   - f_i, df_i for i >= 1               (both shapes at all interior+right nodes)
+  ///
+  /// For i >= 1, factor L_i(x) = ((x+1)/(x_i+1)) * L_i^{(0)}(x), where
+  /// L_i^{(0)} is the LIP over the reduced node set {x_1, ..., x_{n-1}}.
+  /// Plug into the HIP shape formulas and divide by r = (Delta/2)(x+1):
+  ///
+  ///   df_0(r)/r  = 2 * L_0(x)^2
+  ///   f_i(r)/r   = (2/Delta) * (x+1) * [1 - 2(x-x_i) L_i'(x_i)] * L_i^{(0)}(x)^2 / (x_i+1)^2
+  ///   df_i(r)/r  = 2 * (x+1) * (x-x_i) * L_i^{(0)}(x)^2 / (x_i+1)^2
+  ///
+  /// (the element_length on the derivative shape cancels with the 1/r division).
+  /// r-derivatives pull in (2/Delta)^n chain-rule factors.
+  ///
+  /// Implemented for n in {0, 1, 2}; throws for higher orders (this matches
+  /// the planned 'no Taylor pipeline' design where RadialBasis only needs
+  /// these three orders).
+  void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r, int n,
+                   T element_length) const override {
+    if (n < 0 || n > 2) {
+      std::ostringstream oss;
+      oss << "HIPBasis::eval_over_r: derivative order " << n
+          << " not implemented (only 0, 1, 2 supported).\n";
+      throw std::logic_error(oss.str());
+    }
+    if (this->enabled.n_elem == 0)
+      throw std::logic_error("HIPBasis::eval_over_r: no surviving basis functions.\n");
+    if (this->enabled(0) == 0)
+      throw std::logic_error(
+          "HIPBasis::eval_over_r requires drop_first(func=true, deriv=false): the "
+          "function shape at x=-1 has B(-1) != 0 and B/r is singular at the origin.\n");
+
+    const arma::Col<T> & x0_full = this->x0;
+    const arma::Col<T> x0_red    = x0_full.subvec(1, x0_full.n_elem - 1);
+
+    // Full LIP values+derivatives (for L_0)
+    arma::Mat<T> Lf0, Lf1, Lf2;
+    detail::eval_lip_prim_dnf<T>(x, x0_full, Lf0, 0);
+    if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf1, 1);
+    if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf2, 2);
+
+    // Reduced LIP values+derivatives (for L_i^{(0)}, i >= 1)
+    arma::Mat<T> Lr0, Lr1, Lr2;
+    detail::eval_lip_prim_dnf<T>(x, x0_red, Lr0, 0);
+    if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr1, 1);
+    if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr2, 2);
+
+    const T inv_h = T(2) / element_length;       // 2/Delta
+    const T chain = std::pow(inv_h, n);          // (2/Delta)^n
+
+    dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
+
+    for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
+      const arma::uword idx  = this->enabled(k);
+      const arma::uword node = idx / 2;
+      const bool        deriv_shape = (idx % 2) == 1;
+
+      for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+        const T xv = x(ix);
+        T q;  // value of Q(x) for this shape (so that R(r) = prefactor * Q(x))
+
+        if (node == 0 && deriv_shape) {
+          // df_0(r)/r = 2 * L_0(x)^2.  Q(x) = 2 * L_0^2; prefactor (2/Delta)^n
+          const T L  = Lf0(ix, 0);
+          if (n == 0) {
+            q = T(2) * L * L;
+          } else if (n == 1) {
+            const T Lp = Lf1(ix, 0);
+            // d/dx [2 L^2] = 4 L L'
+            q = T(4) * L * Lp;
+          } else { // n == 2
+            const T Lp  = Lf1(ix, 0);
+            const T Lpp = Lf2(ix, 0);
+            // d^2/dx^2 [2 L^2] = 4 (L')^2 + 4 L L''
+            q = T(4) * Lp * Lp + T(4) * L * Lpp;
+          }
+          dnf_over_r(ix, k) = chain * q;
+        } else if (node >= 1 && !deriv_shape) {
+          // f_i(r)/r = (2/Delta) * (x+1) * B(x) * C(x) / (x_i+1)^2
+          //   B(x) = 1 - 2 (x - x_i) lipxi_i,  B' = -2 lipxi_i,  B'' = 0
+          //   C(x) = L_i^{(0)}(x)^2,  C' = 2 L L',  C'' = 2 (L')^2 + 2 L L''
+          // Prefactor: (2/Delta)^(n+1)
+          const arma::uword i_red = node - 1;
+          const T xi_p1 = x0_full(node) + T(1);
+          const T inv_xi_p1_sq = T(1) / (xi_p1 * xi_p1);
+          const T xpx1 = xv + T(1);
+          const T xmxi = xv - x0_full(node);
+          const T lipxi_i = lipxi(node);
+          const T B  = T(1) - T(2) * xmxi * lipxi_i;
+          const T Bp = -T(2) * lipxi_i;
+          const T L  = Lr0(ix, i_red);
+          if (n == 0) {
+            const T C = L * L;
+            q = xpx1 * B * C;
+          } else if (n == 1) {
+            const T Lp = Lr1(ix, i_red);
+            const T C  = L * L;
+            const T Cp = T(2) * L * Lp;
+            // d/dx [(x+1) B C] = 1*B*C + (x+1)*Bp*C + (x+1)*B*Cp
+            q = B * C + xpx1 * Bp * C + xpx1 * B * Cp;
+          } else { // n == 2
+            const T Lp  = Lr1(ix, i_red);
+            const T Lpp = Lr2(ix, i_red);
+            const T C   = L * L;
+            const T Cp  = T(2) * L * Lp;
+            const T Cpp = T(2) * Lp * Lp + T(2) * L * Lpp;
+            // d^2/dx^2 [(x+1) B C] with A=x+1, A''=0, A'=1, B''=0:
+            //   = 2*A'*Bp*C + 2*A'*B*Cp + (x+1)*0*C + 2*(x+1)*Bp*Cp + (x+1)*B*Cpp
+            //   = 2 Bp C + 2 B Cp + 2 (x+1) Bp Cp + (x+1) B Cpp
+            q = T(2) * Bp * C + T(2) * B * Cp + T(2) * xpx1 * Bp * Cp + xpx1 * B * Cpp;
+          }
+          dnf_over_r(ix, k) = inv_h * chain * q * inv_xi_p1_sq;
+        } else if (node >= 1 && deriv_shape) {
+          // df_i(r)/r = 2 * (x+1)(x-x_i) * C(x) / (x_i+1)^2
+          //   D(x) = (x+1)(x-x_i),  D' = 2x + 1 - x_i,  D'' = 2
+          //   C(x) = L_i^{(0)}(x)^2 as above
+          // Prefactor: 2 * (2/Delta)^n
+          const arma::uword i_red = node - 1;
+          const T xi    = x0_full(node);
+          const T xi_p1 = xi + T(1);
+          const T inv_xi_p1_sq = T(1) / (xi_p1 * xi_p1);
+          const T xpx1 = xv + T(1);
+          const T xmxi = xv - xi;
+          const T D  = xpx1 * xmxi;
+          const T Dp = T(2) * xv + T(1) - xi;
+          const T Dpp = T(2);
+          const T L  = Lr0(ix, i_red);
+          if (n == 0) {
+            q = T(2) * D * L * L;
+          } else if (n == 1) {
+            const T Lp = Lr1(ix, i_red);
+            const T C  = L * L;
+            const T Cp = T(2) * L * Lp;
+            q = T(2) * (Dp * C + D * Cp);
+          } else { // n == 2
+            const T Lp  = Lr1(ix, i_red);
+            const T Lpp = Lr2(ix, i_red);
+            const T C   = L * L;
+            const T Cp  = T(2) * L * Lp;
+            const T Cpp = T(2) * Lp * Lp + T(2) * L * Lpp;
+            q = T(2) * (Dpp * C + T(2) * Dp * Cp + D * Cpp);
+          }
+          dnf_over_r(ix, k) = chain * q * inv_xi_p1_sq;
+        } else {
+          // node == 0 && !deriv_shape: function shape at node 0 was supposed to
+          // be dropped (the enabled(0)==0 check above guards this).
+          throw std::logic_error(
+              "HIPBasis::eval_over_r: encountered the function shape at node 0 "
+              "in enabled set; drop_first(true, false) must be called.\n");
+        }
+      }
+    }
+  }
 };
 
 } // namespace polynomial_basis


### PR DESCRIPTION
## Summary

Follow-up to PR #67. Implements the analytic `B(r)/r` deflation for the HIP shape-function class so the Taylor pipeline can be retired for HIP-based atomic radial bases too (LIP was done in #67).

### What changed

`HIPBasis<T>::eval_over_r(x, dnf_over_r, n, element_length)`:
- After `drop_first(zero_func=true, zero_deriv=false)` the surviving shapes are `df_0` plus `f_i, df_i` for i≥1.
- For i≥1, factor `L_i(x) = ((x+1)/(x_i+1)) · L_i^{(0)}(x)` using the reduced LIP over `{x_1,…,x_{n-1}}`, then divide by `r = (Δ/2)(x+1)`. The closed forms are:
  - `df_0(r)/r  = 2 · L_0(x)^2`
  - `f_i(r)/r   = (2/Δ) · (x+1) · [1 − 2(x−x_i) L_i'(x_i)] · L_i^{(0)}(x)^2 / (x_i+1)^2`
  - `df_i(r)/r  = 2 · (x+1) · (x−x_i) · L_i^{(0)}(x)^2 / (x_i+1)^2`
- The `element_length` factor on the derivative shape cancels with the `1/r` division. r-derivatives pull in `(2/Δ)^n` chain-rule factors.
- Derivative orders 0, 1, 2 implemented analytically via closed-form Leibniz expansions of the relevant product chains. Higher orders throw — they're not needed once the Taylor pipeline is retired (per the planned `RadialBasis` refactor that's the next step).

### Validation

Compared `eval_over_r` against 4th-order central FD of `B(r)/r` at moderate `r` (n=10 Lobatto nodes, Δ=1.5):

| order | max abs diff | max rel diff (|ref|>1e-8) |
|---|---|---|
| 0 | 2.1e-15 | 1.0e-14 |
| 1 | 1.8e-06 | 7.3e-06 |
| 2 | 1.6e-05 | 1.1e-06 |
| 3 | — | throws (as designed) |

n=0 matches to machine eps; n=1/n=2 limited by the FD reference's truncation error at h=1.5e-3, **not** by the analytic formula.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`, no CMake.system)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) matches prior numerics (He HF = −2.86167999561 Eh, err 3.6e-12)
- [x] Standalone HIP validation matrix above

## Next in the eval_over_r thread

1. **LegendreBasis::eval_over_r** — synthetic division by `(x+1)` of the Flores/Clementi/Sonnad spectral combinations. (Lower priority since LIP+HIP cover the standard FE bases.)
2. **`RadialBasis` refactor** to call `eval_over_r` instead of the Taylor pipeline; deletes `get_taylor`, `set_small_r_taylor_cutoff`, `taylor_order` / `taylor_diff` machinery.
3. **Analytic HIP2 / HIP3** via SymPy emitter (only orders 0–2 needed once Taylor is gone).
4. **Delete GeneralHIPBasis**.