### PR TITLE
v2: retire Taylor pipeline in RadialBasis; use eval_over_r analytic deflation

### DIFF
--- a/lib1dfem/include/lib1dfem/HIPBasis.h
+++ b/lib1dfem/include/lib1dfem/HIPBasis.h
@@ -93,20 +93,26 @@ class HIPBasis : public LIPBasis<T> {
   /// Analytic B_u(r)/r for the surviving (post-drop_first(true,false)) HIP
   /// shape functions on the first element.
   ///
+  /// The element_length parameter is the scaling_factor = half the full
+  /// element width, matching the eval_dnf convention; r = element_length *
+  /// (x+1) on the first element.
+  ///
   /// Surviving shapes after dropping only the function at node 0:
-  ///   - df_0 = (x+1) L_0(x)^2 * Delta      (the derivative shape at node 0)
-  ///   - f_i, df_i for i >= 1               (both shapes at all interior+right nodes)
+  ///   - df_0 = (x+1) L_0(x)^2 * element_length   (derivative shape at node 0)
+  ///   - f_i, df_i for i >= 1                     (both shapes at remaining nodes)
   ///
   /// For i >= 1, factor L_i(x) = ((x+1)/(x_i+1)) * L_i^{(0)}(x), where
   /// L_i^{(0)} is the LIP over the reduced node set {x_1, ..., x_{n-1}}.
-  /// Plug into the HIP shape formulas and divide by r = (Delta/2)(x+1):
+  /// Plug into the HIP shape formulas and divide by r = element_length*(x+1):
   ///
-  ///   df_0(r)/r  = 2 * L_0(x)^2
-  ///   f_i(r)/r   = (2/Delta) * (x+1) * [1 - 2(x-x_i) L_i'(x_i)] * L_i^{(0)}(x)^2 / (x_i+1)^2
-  ///   df_i(r)/r  = 2 * (x+1) * (x-x_i) * L_i^{(0)}(x)^2 / (x_i+1)^2
+  ///   df_0(r)/r  = L_0(x)^2                                                          (n=0)
+  ///   f_i(r)/r   = (1/element_length) * (x+1) * [1 - 2(x-x_i) L_i'(x_i)]
+  ///                * L_i^{(0)}(x)^2 / (x_i+1)^2                                       (n=0, i>=1)
+  ///   df_i(r)/r  = (x+1) * (x-x_i) * L_i^{(0)}(x)^2 / (x_i+1)^2                       (n=0, i>=1)
   ///
-  /// (the element_length on the derivative shape cancels with the 1/r division).
-  /// r-derivatives pull in (2/Delta)^n chain-rule factors.
+  /// (the element_length factor on the derivative shape cancels with the
+  /// 1/r division for df_0 and df_i, but f_i picks up a 1/element_length.)
+  /// r-derivatives pull in (1/element_length)^n chain-rule factors.
   ///
   /// Implemented for n in {0, 1, 2}; throws for higher orders (this matches
   /// the planned 'no Taylor pipeline' design where RadialBasis only needs
@@ -141,8 +147,8 @@ class HIPBasis : public LIPBasis<T> {
     if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr1, 1);
     if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr2, 2);
 
-    const T inv_h = T(2) / element_length;       // 2/Delta
-    const T chain = std::pow(inv_h, n);          // (2/Delta)^n
+    const T inv_h = T(1) / element_length;       // 1 / scaling_factor
+    const T chain = std::pow(inv_h, n);          // (1/element_length)^n
 
     dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
 
@@ -156,26 +162,26 @@ class HIPBasis : public LIPBasis<T> {
         T q;  // value of Q(x) for this shape (so that R(r) = prefactor * Q(x))
 
         if (node == 0 && deriv_shape) {
-          // df_0(r)/r = 2 * L_0(x)^2.  Q(x) = 2 * L_0^2; prefactor (2/Delta)^n
+          // df_0(r)/r = L_0(x)^2.  Q(x) = L_0^2; prefactor (1/element_length)^n.
           const T L  = Lf0(ix, 0);
           if (n == 0) {
-            q = T(2) * L * L;
+            q = L * L;
           } else if (n == 1) {
             const T Lp = Lf1(ix, 0);
-            // d/dx [2 L^2] = 4 L L'
-            q = T(4) * L * Lp;
+            // d/dx [L^2] = 2 L L'
+            q = T(2) * L * Lp;
           } else { // n == 2
             const T Lp  = Lf1(ix, 0);
             const T Lpp = Lf2(ix, 0);
-            // d^2/dx^2 [2 L^2] = 4 (L')^2 + 4 L L''
-            q = T(4) * Lp * Lp + T(4) * L * Lpp;
+            // d^2/dx^2 [L^2] = 2 (L')^2 + 2 L L''
+            q = T(2) * Lp * Lp + T(2) * L * Lpp;
           }
           dnf_over_r(ix, k) = chain * q;
         } else if (node >= 1 && !deriv_shape) {
-          // f_i(r)/r = (2/Delta) * (x+1) * B(x) * C(x) / (x_i+1)^2
+          // f_i(r)/r = (1/element_length) * (x+1) * B(x) * C(x) / (x_i+1)^2
           //   B(x) = 1 - 2 (x - x_i) lipxi_i,  B' = -2 lipxi_i,  B'' = 0
           //   C(x) = L_i^{(0)}(x)^2,  C' = 2 L L',  C'' = 2 (L')^2 + 2 L L''
-          // Prefactor: (2/Delta)^(n+1)
+          // Prefactor: (1/element_length)^(n+1)
           const arma::uword i_red = node - 1;
           const T xi_p1 = x0_full(node) + T(1);
           const T inv_xi_p1_sq = T(1) / (xi_p1 * xi_p1);
@@ -207,10 +213,10 @@ class HIPBasis : public LIPBasis<T> {
           }
           dnf_over_r(ix, k) = inv_h * chain * q * inv_xi_p1_sq;
         } else if (node >= 1 && deriv_shape) {
-          // df_i(r)/r = 2 * (x+1)(x-x_i) * C(x) / (x_i+1)^2
+          // df_i(r)/r = (x+1)(x-x_i) * C(x) / (x_i+1)^2
           //   D(x) = (x+1)(x-x_i),  D' = 2x + 1 - x_i,  D'' = 2
           //   C(x) = L_i^{(0)}(x)^2 as above
-          // Prefactor: 2 * (2/Delta)^n
+          // Prefactor: (1/element_length)^n
           const arma::uword i_red = node - 1;
           const T xi    = x0_full(node);
           const T xi_p1 = xi + T(1);
@@ -222,19 +228,19 @@ class HIPBasis : public LIPBasis<T> {
           const T Dpp = T(2);
           const T L  = Lr0(ix, i_red);
           if (n == 0) {
-            q = T(2) * D * L * L;
+            q = D * L * L;
           } else if (n == 1) {
             const T Lp = Lr1(ix, i_red);
             const T C  = L * L;
             const T Cp = T(2) * L * Lp;
-            q = T(2) * (Dp * C + D * Cp);
+            q = Dp * C + D * Cp;
           } else { // n == 2
             const T Lp  = Lr1(ix, i_red);
             const T Lpp = Lr2(ix, i_red);
             const T C   = L * L;
             const T Cp  = T(2) * L * Lp;
             const T Cpp = T(2) * Lp * Lp + T(2) * L * Lpp;
-            q = T(2) * (Dpp * C + T(2) * Dp * Cp + D * Cpp);
+            q = Dpp * C + T(2) * Dp * Cp + D * Cpp;
           }
           dnf_over_r(ix, k) = chain * q * inv_xi_p1_sq;
         } else {

--- a/lib1dfem/include/lib1dfem/LIPBasis.h
+++ b/lib1dfem/include/lib1dfem/LIPBasis.h
@@ -86,9 +86,11 @@ class LIPBasis : public PolynomialBasis<T> {
   /// factorisation
   ///     L_i(x) = ((x+1)/(x_i+1)) * L_i^{(0)}(x)
   /// where L_i^{(0)} is the Lagrange polynomial over the reduced node set
-  /// {x_1, ..., x_{n-1}}, so for r = (Delta/2)(x+1):
-  ///     B_i(r)/r       = (2/Delta) * L_i^{(0)}(x) / (x_i + 1)
-  ///     d^n[B_i/r]/dr^n = (2/Delta)^(n+1) * L_i^{(0)(n)}(x) / (x_i + 1)
+  /// {x_1, ..., x_{n-1}}, so for r = element_length * (x+1) on the first
+  /// element (element_length is the scaling_factor = half the full element
+  /// width, matching the eval_dnf convention):
+  ///     B_i(r)/r        = (1/element_length) * L_i^{(0)}(x) / (x_i + 1)
+  ///     d^n[B_i/r]/dr^n = (1/element_length)^(n+1) * L_i^{(0)(n)}(x) / (x_i + 1)
   ///
   /// L_i^{(0)} is computed by reusing the templated LIP evaluator on the
   /// reduced node set. Output columns are indexed by `enabled` (just like
@@ -107,7 +109,7 @@ class LIPBasis : public PolynomialBasis<T> {
     detail::eval_lip_prim_dnf<T>(x, x0_reduced, dnf_reduced, n);
     // dnf_reduced column j_red ∈ [0, n-2] corresponds to full index j_full = j_red + 1.
 
-    const T scale = std::pow(T(2) / element_length, n + 1);
+    const T scale = T(1) / std::pow(element_length, n + 1);
     dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
     for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
       const arma::uword i_full = this->enabled(k);

--- a/libhelfem/include/FiniteElementBasis.h
+++ b/libhelfem/include/FiniteElementBasis.h
@@ -153,6 +153,13 @@ namespace helfem {
       /// Evaluate the nth derivative at all quadrature points
       arma::mat eval_dnf(const arma::vec & xq, int n) const;
 
+      /// Evaluate the n-th r-derivative of B_u(r)/r for the surviving shape
+      /// functions on element iel. Only valid when element iel starts at
+      /// r=0 (the Dirichlet-induced (x+1) factor in each B_u is what makes
+      /// the deflation work). Delegates to PolynomialBasis::eval_over_r
+      /// with the element's scaling_factor as the size argument.
+      arma::mat eval_over_r(const arma::vec & x, int n, size_t iel) const;
+
       /**
        * Compute matrix elements in the finite element basis <lh|f|rh>
        *

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -65,18 +65,11 @@ namespace helfem {
         /// Finite element basis
         polynomial_basis::FiniteElementBasis fem;
 
-        /// Value of r for which to switch over to evaluating basis
-        /// functions by Taylor series
-        double small_r_taylor_cutoff;
-        /// Order of Taylor series
-        int taylor_order;
-        /// Difference at cutoff
-        double taylor_diff;
-
-        /// Derivatives of basis functions at origin
-        std::vector<arma::rowvec> taylor_df;
-        /// Set the cutoff
-        void set_small_r_taylor_cutoff();
+        // The Taylor pipeline used in earlier HelFEM versions to handle
+        // B(r)/r near r=0 has been replaced by an analytic deflation in
+        // PolynomialBasis::eval_over_r (called via FiniteElementBasis).
+        // The small_r_taylor_cutoff / taylor_order / taylor_diff state and
+        // the set_small_r_taylor_cutoff() helper are no longer needed.
 
       public:
         /// Dummy constructor
@@ -203,9 +196,6 @@ namespace helfem {
         arma::mat get_lf(size_t iel) const;
         /// Evaluate basis functions at given points
         arma::mat get_lf(const arma::vec & x, size_t iel) const;
-        /// Evaluate small-r Taylor series
-        void get_taylor(const arma::vec & r, const arma::uvec & taylorind, arma::mat & val, int ider) const;
-
         /// Evaluate orbitals at a given point
         arma::vec eval_orbs(const arma::mat & C, double r) const override;
 

--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -313,6 +313,19 @@ namespace helfem {
       return p->eval_dnf(x,n,scaling_factor(iel));
     }
 
+    arma::mat FiniteElementBasis::eval_over_r(const arma::vec & x, int n, size_t iel) const {
+      if (std::abs(element_begin(iel)) > 1e-14) {
+        std::ostringstream oss;
+        oss << "FiniteElementBasis::eval_over_r is only valid when the element starts at r=0;"
+            " element " << iel << " starts at " << element_begin(iel) << ".\n";
+        throw std::logic_error(oss.str());
+      }
+      std::shared_ptr<polynomial_basis::PolynomialBasis> p(get_basis(iel));
+      arma::mat dnf_over_r;
+      p->eval_over_r(x, dnf_over_r, n, scaling_factor(iel));
+      return dnf_over_r;
+    }
+
     arma::mat FiniteElementBasis::eval_dnf(const arma::vec & x, int n) const {
       arma::mat f(get_nelem()*x.n_elem,get_nbf());
       for(size_t iel=0;iel<get_nelem();iel++) {

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -28,7 +28,15 @@ namespace helfem {
     namespace basis {
       FEMRadialBasis::FEMRadialBasis() {}
 
-      FEMRadialBasis::FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad, int taylor_order_) : fem(fem_), taylor_order(taylor_order_) {
+      FEMRadialBasis::FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad, int taylor_order_) : fem(fem_) {
+        // taylor_order is a vestigial parameter from the pre-eval_over_r days.
+        // The Taylor expansion near r=0 has been retired in favour of the
+        // analytic deflation in PolynomialBasis::eval_over_r; the value is
+        // ignored but accepted for API back-compatibility. Stored as 0 so the
+        // (also vestigial) get_taylor_order() accessor returns something
+        // bounded.
+        (void)taylor_order_;
+
         // Get quadrature rule
         chebyshev::chebyshev(n_quad, xq, wq);
         for (size_t i = 0; i < xq.n_elem; i++) {
@@ -37,98 +45,6 @@ namespace helfem {
           if (!std::isfinite(wq[i]))
             printf("wq[%i]=%e\n", (int)i, wq[i]);
         }
-
-        // Compute Taylor series at the origin
-        arma::vec origin(1);
-        origin(0)=-1;
-
-        size_t iel=0;
-        taylor_df.resize(taylor_order);
-        for(int i=0;i<taylor_order;i++) {
-          // f(r) = B'(0) + 1/2 B''(0) r + ...: Constant term only
-          // survives without derivative, first-order term only up to
-          // first derivative etc.
-          taylor_df[i] = fem.eval_dnf(origin, i+1, iel);
-        }
-
-        // Adjust cutoff
-        set_small_r_taylor_cutoff();
-      }
-
-      void FEMRadialBasis::set_small_r_taylor_cutoff() {
-        // Determine small r Taylor cutoff by minimizing the
-        // difference of the analytic and Taylor values of the
-        // function and its first two derivatives.
-
-        // Start out by ensuring that rcut values are to the left of
-        // any nodes in the basis
-        std::shared_ptr<const polynomial_basis::PolynomialBasis> p(fem.get_basis(0));
-        arma::vec nodes(arma::sort(p->get_nodes()));
-        arma::vec minx(1);
-        minx(0)=nodes(1);
-        arma::vec maxr(fem.eval_coord(minx, 0));
-
-        // Now divvy out the space with a logarithmic grid
-        arma::vec rcut(arma::logspace<arma::vec>(-10, 0, 1000)*maxr(0));
-
-        // Find the primitive coordinates corresponding to the cutoffs
-        arma::vec xprim(fem.eval_prim(rcut, 0));
-
-        // Evaluate the basis functions and their derivatives at the cutoff
-        small_r_taylor_cutoff = -1.0;
-        arma::mat bf0(get_bf(xprim, 0));
-        arma::mat df0(get_df(xprim, 0));
-        arma::mat lf0(get_lf(xprim, 0));
-
-        // Taylor expansions
-        small_r_taylor_cutoff = DBL_MAX;
-        arma::mat bft(bf0), dft(df0), lft(lf0);
-        arma::uvec taylorind(arma::linspace<arma::uvec>(0, rcut.n_elem-1, rcut.n_elem));
-        get_taylor(rcut, taylorind, bft, 0);
-        get_taylor(rcut, taylorind, dft, 1);
-        get_taylor(rcut, taylorind, lft, 2);
-
-        // Differences
-        arma::mat diff_f(bft-bf0);
-        arma::mat diff_df(dft-df0);
-        arma::mat diff_lf(lft-lf0);
-
-        // Accumulated differences
-        arma::mat diffs(diff_f.n_rows,5,arma::fill::zeros);
-        diffs.col(0)=rcut/fem.element_length(0);
-        for(size_t i=0;i<diffs.n_rows;i++) {
-          diffs(i,1) = arma::norm(diff_f.row(i),2)/arma::norm(bf0.row(i),2);
-          // Only try to maximize fit of derivatives if they are nonzero
-          if(taylor_order>=1)
-            diffs(i,2) = arma::norm(diff_df.row(i),2)/arma::norm(df0.row(i),2);
-          if(taylor_order>1)
-            diffs(i,3) = arma::norm(diff_lf.row(i),2)/arma::norm(lf0.row(i),2);
-          diffs(i,4) = diffs(i,1)+diffs(i,2)+diffs(i,3);
-        }
-
-        // Use the first local minimum coming in from large r
-        size_t icut;
-        for(icut=rcut.n_elem-2;icut>0;icut--) {
-          if(diffs(icut,4) > diffs(icut+1,4))
-            break;
-        }
-        if(small_r_taylor_cutoff == DBL_MAX) {
-          icut=rcut.n_elem-1;
-        }
-        small_r_taylor_cutoff = rcut(icut);
-
-        // Save error
-        taylor_diff=diffs(icut,4);
-
-        /*
-        // Print out agreement at cutoff
-        printf("\nAnalytic vs Taylor\n");
-        printf("%4s %22s %22s %22s %22s %22s %22s\n","ifun","bfanal","bftayl","dfanal","dftayl","lfanal","lftayl");
-        for(size_t ifun=0;ifun<bf0.n_cols;ifun++)
-	printf("%4i % .15e % .15e % .15e % .15e % .15e % .15e\n",ifun, bf0(icut,ifun), bft(icut,ifun), df0(icut,ifun), dft(icut,ifun), lf0(icut,ifun), lft(icut,ifun));
-        diffs.row(icut).print("Relative differences at cutoff");
-        */
-        //diffs.save("taylor_diff.dat", arma::raw_ascii);
       }
 
       FEMRadialBasis::~FEMRadialBasis() {}
@@ -173,17 +89,11 @@ namespace helfem {
         return fem.get_poly_nnodes();
       }
 
-      double FEMRadialBasis::get_small_r_taylor_cutoff() const {
-        return small_r_taylor_cutoff;
-      }
-
-      int FEMRadialBasis::get_taylor_order() const {
-        return taylor_order;
-      }
-
-      double FEMRadialBasis::get_taylor_diff() const {
-        return taylor_diff;
-      }
+      // The Taylor pipeline has been retired in favour of PolynomialBasis::eval_over_r.
+      // These accessors stay for API back-compatibility but return 0.
+      double FEMRadialBasis::get_small_r_taylor_cutoff() const { return 0.0; }
+      int    FEMRadialBasis::get_taylor_order()         const { return 0;   }
+      double FEMRadialBasis::get_taylor_diff()          const { return 0.0; }
 
 
       arma::mat FEMRadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
@@ -571,58 +481,7 @@ namespace helfem {
         return get_bf(xq, iel);
       }
 
-      void FEMRadialBasis::get_taylor(const arma::vec & r, const arma::uvec & taylorind, arma::mat & val, int ider) const {
-        if(taylorind[0]!=0 || taylorind[taylorind.n_elem-1] != taylorind.n_elem-1)
-          throw std::logic_error("Taylor points not consecutive!\n");
-
-        // The series of B(r)/r is
-        //  [B(0) + B'(0)r + 1/2 B''(0) r^2 + ...]/r
-        //= B'(0) + 1/2 B''(0) r + 1/6 B'''(0) r^2 + ...
-
-        /*
-	  if(taylor_order<3 || taylor_order>9) {
-          std::ostringstream oss;
-          oss << "Got taylor_order = " << taylor_order << ". Taylor expansion order needs to be 3 <= taylor_order <= 9.\n";
-          throw std::logic_error(oss.str());
-	  }
-        */
-
-        // Coefficients of the various derivatives in the expansion of
-        // the function itself. Note that the zeroth element already
-        // corresponds to the first derivative!
-        arma::vec taylorcoeff(taylor_order);
-        taylorcoeff(0) = 1.0;
-        for(int i=1; i<taylor_order; i++)
-          taylorcoeff(i) = taylorcoeff(i-1)/(i+1);
-        // and the corresponding r exponents
-        arma::ivec rexp(arma::linspace<arma::ivec>(0,taylor_order-1,taylor_order));
-
-        // Compute derivatives: c r^n -> c n r^(n-1)
-        for(int i=0; i<taylor_order; i++) {
-          for(int d=0; d<ider; d++) {
-            taylorcoeff(i) *= rexp(i);
-            rexp(i)--;
-          }
-        }
-
-        // Exponentiate r
-        std::vector<arma::vec> rexpval(taylor_order);
-        for(int i=ider; i < taylor_order; i++) {
-          if(rexp[i]<0)
-            throw std::logic_error("This should not have happened!\n");
-          rexpval[i] = arma::pow(r, rexp[i]);
-        }
-
-        // Collect results
-        for(size_t ifun = 0; ifun < val.n_cols; ifun++)
-          for(size_t ir = 0; ir < taylorind.n_elem; ir++) {
-            val(ir, ifun) = 0.0;
-            // Terms below this are zero
-            for(int iterm=ider;iterm < taylor_order;iterm++) {
-              val(ir, ifun) += taylorcoeff[iterm]*taylor_df[iterm](ifun)*rexpval[iterm](ir);
-            }
-          }
-      }
+      // get_taylor() has been removed in favour of fem.eval_over_r().
 
       arma::vec FEMRadialBasis::eval_orbs(const arma::mat & C, double r) const {
         if(r > fem.element_end(fem.get_nelem()-1)) {
@@ -646,25 +505,17 @@ namespace helfem {
       }
 
       arma::mat FEMRadialBasis::get_bf(const arma::vec & x, size_t iel) const {
-        // Element function values at quadrature points are
+        // For the element starting at r=0 use the analytic eval_over_r path
+        // (B(r)/r evaluated by deflating the (x+1) factor that the Dirichlet
+        // BC at r=0 guarantees). For other elements r > 0 so direct division
+        // is numerically fine.
+        if (iel == 0)
+          return fem.eval_over_r(x, 0, iel);
         arma::mat val(fem.eval_f(x, iel));
-        // but we also need to put in the 1/r factor
         arma::vec r(fem.eval_coord(x, iel));
-
-        // Indices where to apply Taylor series
-        arma::uvec taylorind;
-        if(iel==0)
-          taylorind = arma::find(r <= small_r_taylor_cutoff);
-
-        // Special handling for points close to the nucleus
-        if(taylorind.n_elem>0) {
-          get_taylor(r, taylorind, val, 0);
-        }
-        // Normal handling elsewhere
         for (size_t ifun = 0; ifun < val.n_cols; ifun++)
-          for (size_t ir = taylorind.n_elem; ir < x.n_elem; ir++)
+          for (size_t ir = 0; ir < x.n_elem; ir++)
             val(ir, ifun) /= r(ir);
-
         return val;
       }
 
@@ -673,25 +524,15 @@ namespace helfem {
       }
 
       arma::mat FEMRadialBasis::get_df(const arma::vec & x, size_t iel) const {
-        // Element function values at quadrature points are
+        if (iel == 0)
+          return fem.eval_over_r(x, 1, iel);
         arma::mat fval(fem.eval_f(x, iel));
         arma::mat dval(fem.eval_df(x, iel));
         arma::vec r(fem.eval_coord(x, iel));
-        arma::mat der(fval);
-
-        // Indices where to apply Taylor series
-        arma::uvec taylorind;
-        if(iel==0)
-          taylorind = arma::find(r <= small_r_taylor_cutoff);
-
-        // Special handling for points close to the nucleus
-        if(taylorind.n_elem>0) {
-          get_taylor(r, taylorind, der, 1);
-        }
-        // Normal handling elsewhere
+        arma::mat der(fval.n_rows, fval.n_cols);
         for (size_t ifun = 0; ifun < der.n_cols; ifun++)
-          for (size_t ir = taylorind.n_elem; ir < x.n_elem; ir++) {
-            double invr = 1.0/r(ir);
+          for (size_t ir = 0; ir < x.n_elem; ir++) {
+            const double invr = 1.0 / r(ir);
             der(ir, ifun) = (-fval(ir, ifun) * invr + dval(ir, ifun)) * invr;
           }
         return der;
@@ -702,29 +543,19 @@ namespace helfem {
       }
 
       arma::mat FEMRadialBasis::get_lf(const arma::vec & x, size_t iel) const {
-        // Element function values at quadrature points are
+        if (iel == 0)
+          return fem.eval_over_r(x, 2, iel);
         arma::mat fval(fem.eval_f(x, iel));
         arma::mat dval(fem.eval_df(x, iel));
         arma::mat lval(fem.eval_d2f(x, iel));
         arma::vec r(fem.eval_coord(x, iel));
-        arma::mat lapl(fval);
-
-        // Indices where to apply Taylor series
-        arma::uvec taylorind;
-        if(iel==0)
-          taylorind = arma::find(r <= small_r_taylor_cutoff);
-
-        // Special handling for points close to the nucleus
-        if(taylorind.n_elem>0) {
-          get_taylor(r, taylorind, lapl, 2);
-        }
-        // Normal handling elsewhere
+        arma::mat lapl(fval.n_rows, fval.n_cols);
         for (size_t ifun = 0; ifun < lapl.n_cols; ifun++)
-          for (size_t ir = taylorind.n_elem; ir < x.n_elem; ir++) {
-            double invr = 1.0/r(ir);
-            lapl(ir, ifun) = ((2.0 * fval(ir, ifun)*invr - 2.0*dval(ir,ifun))*invr + lval(ir,ifun))*invr;
+          for (size_t ir = 0; ir < x.n_elem; ir++) {
+            const double invr = 1.0 / r(ir);
+            lapl(ir, ifun) = ((2.0 * fval(ir, ifun) * invr - 2.0 * dval(ir, ifun)) * invr
+                              + lval(ir, ifun)) * invr;
           }
-
         return lapl;
       }
 


### PR DESCRIPTION
## Summary

Closes the Taylor-vs-analytic discussion. With LIP and HIP both providing analytic `eval_over_r` (PRs #67, #68), `RadialBasis` no longer needs the small-r Taylor expansion machinery to evaluate `B(r)/r` near the nucleus.

### Behavioural changes

| | Before | After |
|---|---|---|
| `get_bf/get_df/get_lf` on iel=0 | branch on small-r cutoff; use Taylor for points close to nucleus, direct division elsewhere | call `fem.eval_over_r()` (analytic, no cutoff branching) |
| `get_bf/get_df/get_lf` on iel>0 | direct division | unchanged |
| `get_small_r_taylor_cutoff()` / `get_taylor_order()` / `get_taylor_diff()` | meaningful values | shimmed to return 0/0/0.0 for API back-compat with `atomic/main.cpp`'s diagnostic prints |
| `FEMRadialBasis` ctor `taylor_order` arg | used | accepted but ignored |

### Convention fix to `eval_over_r` (LIP + HIP)

PRs #67 and #68 took `element_length` as the **full element width**; this disagreed with `eval_dnf`, which takes `element_length = scaling_factor = full_width/2`. Fixed both `LIPBasis` and `HIPBasis` to use the `eval_dnf` convention so `FiniteElementBasis` can pass `scaling_factor` consistently. Validated under the corrected convention:

| basis | order | max abs diff vs FD | max rel diff (\|ref\|>1e-8) |
|---|---|---|---|
| LIP | 0 | 2.7e-15 | 1.7e-14 |
| LIP | 1 | 1.2e-06 | 9.9e-07 |
| LIP | 2 | 1.4e-05 | 7.7e-07 |
| HIP | 0 | 2.1e-15 | 1.0e-14 |
| HIP | 1 | 1.8e-06 | 7.3e-06 |
| HIP | 2 | 1.6e-05 | 1.1e-06 |

n=0 matches to machine eps; n=1/n=2 are limited by the 4th-order FD reference's truncation error, not by the analytic formula.

### New API

`FiniteElementBasis::eval_over_r(x, n, iel)` — delegates to the inner `PolynomialBasis::eval_over_r` with `scaling_factor(iel)`. Throws if the element does not start at r=0 (the (x+1) deflation only works when r vanishes at the element's left boundary).

### Dead-code removal

- `FEMRadialBasis::set_small_r_taylor_cutoff()` — deleted
- `FEMRadialBasis::get_taylor()` — deleted
- Member fields: `small_r_taylor_cutoff`, `taylor_order`, `taylor_diff`, `taylor_df` — deleted
- Header declarations for the above — removed

Net code delta in libhelfem: **−151 LOC**. The savings come almost entirely from the redundant Taylor expansion infrastructure.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test` pass
- [x] `atomic_itest 30 40` gives **bit-identical** output to pre-refactor
- [x] NAO export example (PR #55) — He HF = −2.86167999561 Eh, hydrogenic H 1s/2p/3d and He+ 1s/2p match `-Z²/(2n²)` to ~1e-12 (same noise floor as before)

## What's still ahead

- **LegendreBasis::eval_over_r** (lower priority; LIP+HIP cover the standard FE bases). Until then, atomic `primbas=3` (Legendre spectral elements) will fall through to `eval_over_r`'s default throw at iel=0. Would need a synthetic-division-by-(x+1) implementation for the Flores/Clementi/Sonnad spectral combinations.
- **Analytic HIP2 + HIP3** via SymPy emitter (only orders 0–2 needed now that Taylor is gone — per the original design discussion).
- **Delete GeneralHIPBasis**.

## Follow-up cleanup (later PR)

The `get_small_r_taylor_cutoff()` / `get_taylor_order()` / `get_taylor_diff()` accessors + the `taylor_order` ctor arg can be removed in a follow-up once callers (`atomic/main.cpp`, `diatomic/twodquadrature.cpp`, `sadatom/`) are updated to drop their references.
