### PR TITLE
v2: BasisKind dispatcher + generic matrix_element on FEMRadialBasis (PoC)

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -84,6 +84,8 @@ namespace helfem {
 
         /// Get polynomial basis
         std::shared_ptr<polynomial_basis::PolynomialBasis> get_poly() const;
+        /// Get the underlying FE basis (read-only).
+        const polynomial_basis::FiniteElementBasis & get_fem() const { return fem; }
 
         /// Get number of quadrature points
         int get_nquad() const;
@@ -128,6 +130,33 @@ namespace helfem {
         arma::mat bessel_il_integral(int L, double lambda, size_t iel) const;
         /// Compute Bessel k_L integral
         arma::mat bessel_kl_integral(int L, double lambda, size_t iel) const;
+
+        /// Identifies which representation of the radial basis to use when
+        /// evaluating bra/ket factors in a matrix element. Bn is the raw FE
+        /// polynomial B(r) = r*R(r) (or its n-th r-derivative); Rn is the
+        /// physical radial wavefunction R(r) = B(r)/r (or its n-th derivative),
+        /// computed via the analytic eval_over_r deflation on the first
+        /// element and direct division elsewhere. Both are first-class:
+        /// pick whichever makes the integrand smooth for the weight function
+        /// in question.
+        enum class BasisKind { B0, B1, B2, R0, R1, R2 };
+
+        /// Generic single-element matrix element
+        ///     M_ij = integral  bra_i(r) * weight(r) * ket_j(r)  dr
+        /// over element `iel`, with bra/ket chosen via BasisKind. Mirrors
+        /// FiniteElementBasis::matrix_element and is the engine that the
+        /// named matrix-element methods below (overlap, kinetic, nuclear, ...)
+        /// can be composed from. Default weight is identity (1).
+        arma::mat matrix_element(
+            size_t iel, BasisKind bra, BasisKind ket,
+            const std::function<double(double)> & weight =
+                std::function<double(double)>()) const;
+
+        /// Same as above, summed over every element of the basis.
+        arma::mat matrix_element(
+            BasisKind bra, BasisKind ket,
+            const std::function<double(double)> & weight =
+                std::function<double(double)>()) const;
 
         /// Compute overlap matrix
         arma::mat overlap() const override;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -107,6 +107,52 @@ namespace helfem {
         return ret;
       }
 
+      // Pre-bound evaluator for each BasisKind: a callable (x, iel) -> arma::mat
+      // suitable for FiniteElementBasis::matrix_element. The evaluator captures
+      // `this` only; it does not allocate per call beyond what fem.eval_*/get_*
+      // already does.
+      static std::function<arma::mat(const arma::vec &, size_t)>
+      make_evaluator(const FEMRadialBasis * rb, FEMRadialBasis::BasisKind k) {
+        using BK = FEMRadialBasis::BasisKind;
+        switch (k) {
+          case BK::B0: return [rb](const arma::vec & x, size_t iel) {
+            return rb->get_fem().eval_f(x, iel);
+          };
+          case BK::B1: return [rb](const arma::vec & x, size_t iel) {
+            return rb->get_fem().eval_df(x, iel);
+          };
+          case BK::B2: return [rb](const arma::vec & x, size_t iel) {
+            return rb->get_fem().eval_d2f(x, iel);
+          };
+          case BK::R0: return [rb](const arma::vec & x, size_t iel) {
+            return rb->get_bf(x, iel);
+          };
+          case BK::R1: return [rb](const arma::vec & x, size_t iel) {
+            return rb->get_df(x, iel);
+          };
+          case BK::R2: return [rb](const arma::vec & x, size_t iel) {
+            return rb->get_lf(x, iel);
+          };
+        }
+        throw std::logic_error("FEMRadialBasis::matrix_element: unknown BasisKind\n");
+      }
+
+      arma::mat FEMRadialBasis::matrix_element(
+          size_t iel, BasisKind bra, BasisKind ket,
+          const std::function<double(double)> & weight) const {
+        auto lhs = make_evaluator(this, bra);
+        auto rhs = make_evaluator(this, ket);
+        return fem.matrix_element(iel, lhs, rhs, xq, wq, weight);
+      }
+
+      arma::mat FEMRadialBasis::matrix_element(
+          BasisKind bra, BasisKind ket,
+          const std::function<double(double)> & weight) const {
+        auto lhs = make_evaluator(this, bra);
+        auto rhs = make_evaluator(this, ket);
+        return fem.matrix_element(lhs, rhs, xq, wq, weight);
+      }
+
       arma::mat FEMRadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {
         std::function<double(double)> besselil = [L, lambda](double r) { return utils::bessel_il(r*lambda, L); };
         return fem.matrix_element(iel, false, false, xq, wq, besselil);
@@ -217,55 +263,32 @@ namespace helfem {
         return radial_integral(rh, 0);
       }
 
-      arma::mat FEMRadialBasis::overlap(size_t iel) const {
-        std::function<double(double)> dummy;
-        return fem.matrix_element(iel, false, false, xq, wq, dummy);
-      }
+      // The four named matrix elements below are the proof-of-concept
+      // migration onto the BasisKind dispatcher introduced above. Math is
+      // unchanged; each routine collapses to a single composition of
+      // (bra evaluator, ket evaluator, weight function).
+      //
+      //   overlap     = integral B(r) B(r) dr                    -> B0 * B0 * 1
+      //   kinetic     = (1/2) integral B'(r) B'(r) dr            -> B1 * B1 * 1
+      //   kinetic_l   = (1/2) integral R(r) R(r) dr              -> R0 * R0 * 1
+      //                (= (1/2) <u | 1/r^2 | u> = half-centrifugal per l(l+1))
+      //   nuclear     = - integral R(r) * r * R(r) dr            -> R0 * R0 * r
+      //                (= - <u | 1/r | u>; sign included, Z=1 implicit)
 
-      arma::mat FEMRadialBasis::overlap() const {
-        std::function<double(double)> dummy;
-        return fem.matrix_element(false, false, xq, wq, dummy);
-      }
+      static const std::function<double(double)> kNoWeight;  // default-constructed = identity
+      static const std::function<double(double)> kRWeight = [](double r){ return r; };
 
-      arma::mat FEMRadialBasis::kinetic() const {
-        std::function<double(double)> dummy;
-        return 0.5*fem.matrix_element(true, true, xq, wq, dummy);
-      }
+      arma::mat FEMRadialBasis::overlap()         const { return matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight); }
+      arma::mat FEMRadialBasis::overlap(size_t iel) const { return matrix_element(iel, BasisKind::B0, BasisKind::B0, kNoWeight); }
 
-      arma::mat FEMRadialBasis::kinetic(size_t iel) const {
-        std::function<double(double)> dummy;
-        return 0.5*fem.matrix_element(iel, true, true, xq, wq, dummy);
-      }
+      arma::mat FEMRadialBasis::kinetic()         const { return 0.5 * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight); }
+      arma::mat FEMRadialBasis::kinetic(size_t iel) const { return 0.5 * matrix_element(iel, BasisKind::B1, BasisKind::B1, kNoWeight); }
 
-      arma::mat FEMRadialBasis::kinetic_l() const {
-        std::function<double(double)> dummy;
-        std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
-        radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
+      arma::mat FEMRadialBasis::kinetic_l()       const { return 0.5 * matrix_element(BasisKind::R0, BasisKind::R0, kNoWeight); }
+      arma::mat FEMRadialBasis::kinetic_l(size_t iel) const { return 0.5 * matrix_element(iel, BasisKind::R0, BasisKind::R0, kNoWeight); }
 
-        return 0.5 * fem.matrix_element(radial_bf, radial_bf, xq, wq, dummy);
-      }
-
-      arma::mat FEMRadialBasis::kinetic_l(size_t iel) const {
-        std::function<double(double)> dummy;
-        std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
-        radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
-
-        return 0.5 * fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, dummy);
-      }
-
-      arma::mat FEMRadialBasis::nuclear() const {
-        std::function<double(double)> r = [](double r){return r;};
-        std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
-        radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
-        return -fem.matrix_element(radial_bf, radial_bf, xq, wq, r);
-      }
-
-      arma::mat FEMRadialBasis::nuclear(size_t iel) const {
-        std::function<double(double)> r = [](double r){return r;};
-        std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
-        radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
-        return -fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, r);
-      }
+      arma::mat FEMRadialBasis::nuclear()         const { return -matrix_element(BasisKind::R0, BasisKind::R0, kRWeight); }
+      arma::mat FEMRadialBasis::nuclear(size_t iel) const { return -matrix_element(iel, BasisKind::R0, BasisKind::R0, kRWeight); }
 
       arma::mat FEMRadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {
 	std::function<double(double)> rpow = [N, shift_pot](double r){


### PR DESCRIPTION
## Summary

The first step in the eval_over_r-thread cleanup we discussed: introduce a single generic matrix-element routine on `FEMRadialBasis`, dispatched by a small `BasisKind` enum, so the 15+ near-duplicate named matrix-element methods (`overlap`, `kinetic`, `kinetic_l`, `nuclear`, `bessel_*_integral`, `model_potential`, `*_confinement`, ...) can all collapse to one-line compositions of three knobs: **(bra evaluator, ket evaluator, weight function)**.

### New API

```cpp
enum class FEMRadialBasis::BasisKind { B0, B1, B2, R0, R1, R2 };

arma::mat FEMRadialBasis::matrix_element(
    [size_t iel,] BasisKind bra, BasisKind ket,
    const std::function<double(double)> & weight = {}) const;
```

- `Bn` selects the raw FE polynomial B(r) = r·R(r) and its n-th r-derivative (delegates to `fem.eval_f/df/d2f`).
- `Rn` selects the physical radial wavefunction R(r) and its n-th r-derivative (delegates to `get_bf/df/lf`, which use the analytic `eval_over_r` deflation at iel=0 and direct division elsewhere).
- Default weight = identity.
- Per-element overload and the sum-over-all-elements overload, mirroring the existing `FiniteElementBasis::matrix_element` shape.

Also exposes a public `const FiniteElementBasis & get_fem() const` accessor so the dispatcher can hand the FEM to its evaluator lambdas — and so downstream code can do the same composition itself.

### Proof of concept

Migrated the four most-used named methods (8 functions total counting `(iel)` variants):

```cpp
// Before
arma::mat FEMRadialBasis::kinetic_l(size_t iel) const {
    std::function<double(double)> dummy;
    std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
    radial_bf = [this](const arma::vec & xq_, size_t iel_) {
        return this->get_bf(xq_, iel_); };
    return 0.5 * fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, dummy);
}

// After
arma::mat FEMRadialBasis::kinetic_l(size_t iel) const {
    return 0.5 * matrix_element(iel, BasisKind::R0, BasisKind::R0, kNoWeight);
}
```

Math is unchanged; the dispatcher just routes the bra/ket evaluator choice and the weight function into the existing `FiniteElementBasis::matrix_element` engine.

### What's still ahead (separate follow-up PR)

The remaining named methods (`bessel_*_integral`, `radial_integral(int, iel, ...)`, `model_potential`, the four confinement potentials, `nuclear_offcenter`, `spherical_potential`, ...) are left unchanged in this PR. They all reduce to one-line dispatcher calls with a tailored weight function — mechanical to migrate, but easier to review separately once this foundation lands.

The cross-basis variants (`radial_integral(const FEMRadialBasis &rh, ...)` etc.) follow the same pattern but need a two-basis dispatcher; that's a third small PR.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit**: He HF = −2.86167999561 Eh, err 3.59e-12; hydrogenic H 1s/2p/3d and He+ 1s/2p match `-Z²/(2n²)` to ~1e-12 (same noise floor as before the dispatcher)