### PR TITLE
v2: migrate remaining same-basis named matrix-element methods onto BasisKind dispatcher

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -158,6 +158,15 @@ namespace helfem {
             const std::function<double(double)> & weight =
                 std::function<double(double)>()) const;
 
+        /// Per-element matrix element restricted to a sub-range of the
+        /// reference element [x_left, x_right] (defaults to the full range
+        /// [-1, +1]). Useful for two-electron inner integrals and other
+        /// piecewise integrations.
+        arma::mat matrix_element(
+            size_t iel, BasisKind bra, BasisKind ket,
+            const std::function<double(double)> & weight,
+            double x_left, double x_right) const;
+
         /// Compute overlap matrix
         arma::mat overlap() const override;
         /// Compute overlap matrix in element

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -97,13 +97,15 @@ namespace helfem {
 
 
       arma::mat FEMRadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
-        std::function<double(double)> rpowL = [Rexp](double r){return std::pow(r,Rexp+2);};
-        std::function<arma::mat(const arma::vec &,size_t)> radial_bf;
-        radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
-        arma::mat ret(fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, rpowL, x_left, x_right));
-        if(ret.has_nan()) {
-          printf("radial_integral(%i,%i) has NaN!\n",Rexp,(int) iel);
-        }
+        // <R | r^Rexp | R> with the FE-natural dr measure means weight r^(Rexp+2):
+        //   integral B(r)^2 r^(Rexp+2) / r^2  dr  =  integral R(r)^2 r^(Rexp+2)  dr
+        // = QM <r^Rexp> = integral R^2 r^Rexp r^2 dr.
+        const std::function<double(double)> rpowL =
+            [Rexp](double r){ return std::pow(r, Rexp + 2); };
+        arma::mat ret = matrix_element(iel, BasisKind::R0, BasisKind::R0,
+                                       rpowL, x_left, x_right);
+        if (ret.has_nan())
+          printf("radial_integral(%i,%i) has NaN!\n", Rexp, (int)iel);
         return ret;
       }
 
@@ -153,14 +155,23 @@ namespace helfem {
         return fem.matrix_element(lhs, rhs, xq, wq, weight);
       }
 
+      arma::mat FEMRadialBasis::matrix_element(
+          size_t iel, BasisKind bra, BasisKind ket,
+          const std::function<double(double)> & weight,
+          double x_left, double x_right) const {
+        auto lhs = make_evaluator(this, bra);
+        auto rhs = make_evaluator(this, ket);
+        return fem.matrix_element(iel, lhs, rhs, xq, wq, weight, x_left, x_right);
+      }
+
       arma::mat FEMRadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {
-        std::function<double(double)> besselil = [L, lambda](double r) { return utils::bessel_il(r*lambda, L); };
-        return fem.matrix_element(iel, false, false, xq, wq, besselil);
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [L, lambda](double r){ return utils::bessel_il(r * lambda, L); });
       }
 
       arma::mat FEMRadialBasis::bessel_kl_integral(int L, double lambda, size_t iel) const {
-        std::function<double(double)> besselkl = [L, lambda](double r) { return utils::bessel_kl(r*lambda, L); };
-        return fem.matrix_element(iel, false, false, xq, wq, besselkl);
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [L, lambda](double r){ return utils::bessel_kl(r * lambda, L); });
       }
 
       arma::mat FEMRadialBasis::radial_integral(const FEMRadialBasis &rh, int n, bool lhder,
@@ -291,54 +302,48 @@ namespace helfem {
       arma::mat FEMRadialBasis::nuclear(size_t iel) const { return -matrix_element(iel, BasisKind::R0, BasisKind::R0, kRWeight); }
 
       arma::mat FEMRadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {
-	std::function<double(double)> rpow = [N, shift_pot](double r){
-	  if(r<shift_pot)
-	    return 0.0;
-	  return std::pow(r-shift_pot,N+2);
-	};
-	std::function<arma::mat(const arma::vec &,size_t)> radial_bf = [this](const arma::vec & xq_, size_t iel_) { return this->get_bf(xq_, iel_); };
-        return fem.matrix_element(iel, radial_bf, radial_bf, xq, wq, rpow);
+        return matrix_element(iel, BasisKind::R0, BasisKind::R0,
+                              [N, shift_pot](double r) {
+                                return (r < shift_pot)
+                                    ? 0.0
+                                    : std::pow(r - shift_pot, N + 2);
+                              });
       }
 
       arma::mat FEMRadialBasis::exponential_confinement(size_t iel, int N, double r_0, double shift_pot) const {
-	std::function<double(double)> r_exp = [r_0, N, shift_pot](double r) {
-	  if(r<shift_pot)
-	    return 0.0;
-	  const double r_ratio = (r-shift_pot)/r_0;
-	  double fact = 1.0;
-
-	  double V=0.0;
-	  double r_ratio_pow_k = 1.0;
-	  for (int k=0; k<N; k++) {
-	    // r^k / k!
-	    V -= r_ratio_pow_k / fact;
-	    // Prepare values for next iteration
-	    fact *= k+1;
-	    r_ratio_pow_k *= r_ratio;
-	  }
-	  V += std::exp(r_ratio);
-	  V *= fact;
-	  return V;
-	};
-        return fem.matrix_element(iel, false, false, xq, wq, r_exp);
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [r_0, N, shift_pot](double r) {
+                                if (r < shift_pot) return 0.0;
+                                const double r_ratio = (r - shift_pot) / r_0;
+                                double fact = 1.0;
+                                double V = 0.0;
+                                double r_ratio_pow_k = 1.0;
+                                for (int k = 0; k < N; ++k) {
+                                  V -= r_ratio_pow_k / fact;
+                                  fact *= k + 1;
+                                  r_ratio_pow_k *= r_ratio;
+                                }
+                                V += std::exp(r_ratio);
+                                V *= fact;
+                                return V;
+                              });
       }
 
       arma::mat FEMRadialBasis::barrier_confinement(size_t iel, double V, double shift_pot) const {
-	std::function<double(double)> barrier = [V, shift_pot](double r) {
-          return (r<shift_pot) ? 0.0 : V;
-	};
-        return fem.matrix_element(iel, false, false, xq, wq, barrier);
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [V, shift_pot](double r) {
+                                return (r < shift_pot) ? 0.0 : V;
+                              });
       }
 
       arma::mat FEMRadialBasis::junq_confinement(size_t iel, int N, double V0, double r_c, double shift_pot) const {
-	std::function<double(double)> r_exp = [N, r_c, V0, shift_pot](double r) {
-	  if(r<shift_pot)
-	    return 0.0;
-	  const double denominator = std::pow(r_c-r,N);
-	  const double exponential = std::exp(-(r_c - shift_pot) / (r - shift_pot));
-	  return V0 * exponential / denominator;
-	};
-        return fem.matrix_element(iel, false, false, xq, wq, r_exp);
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [N, r_c, V0, shift_pot](double r) {
+                                if (r < shift_pot) return 0.0;
+                                const double denominator  = std::pow(r_c - r, N);
+                                const double exponential  = std::exp(-(r_c - shift_pot) / (r - shift_pot));
+                                return V0 * exponential / denominator;
+                              });
       }
 
       arma::mat FEMRadialBasis::confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const {
@@ -388,9 +393,9 @@ namespace helfem {
 
 
       arma::mat FEMRadialBasis::model_potential(const modelpotential::ModelPotential *model,
-                                             size_t iel) const {
-        std::function<double(double)> modelpot = [model](double r) { return model->V(r); };
-        return fem.matrix_element(iel, false, false, xq, wq, modelpot);
+                                                size_t iel) const {
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [model](double r){ return model->V(r); });
       }
 
       arma::mat FEMRadialBasis::nuclear_offcenter(size_t iel, double Rhalf, int L) const {


### PR DESCRIPTION
## Summary

Follow-up to PR #70. Migrates the remaining single-basis named methods on `FEMRadialBasis` to the dispatcher pattern. Each method collapses to a one-line composition of `(bra evaluator, ket evaluator, weight)`.

### Migrated

| Method | bra/ket | weight |
|---|---|---|
| `bessel_il_integral(L, λ, iel)` | B0 / B0 | `bessel_il(λr, L)` |
| `bessel_kl_integral(L, λ, iel)` | B0 / B0 | `bessel_kl(λr, L)` |
| `polynomial_confinement` | R0 / R0 | piecewise `(r−shift)^(N+2)` |
| `exponential_confinement` | B0 / B0 | piecewise exponential remainder |
| `barrier_confinement` | B0 / B0 | piecewise constant `V` |
| `junq_confinement` | B0 / B0 | Junquera form |
| `model_potential(modelpot, iel)` | B0 / B0 | `model->V(r)` |
| `radial_integral(int Rexp, iel, x_left, x_right)` | R0 / R0 | `r^(Rexp+2)` |

### New dispatcher overload

```cpp
arma::mat matrix_element(
    size_t iel, BasisKind bra, BasisKind ket,
    const std::function<double(double)> & weight,
    double x_left, double x_right) const;
```

Enables `radial_integral` (the only same-basis caller that needs a sub-range integration on the reference element) to use the dispatcher cleanly.

### Intentionally not migrated this PR

- `nuclear_offcenter` — calls `radial_integral` internally; the `sqrt(4π/(2L+1)) · r^L` closed-form factoring reads more cleanly as-is.
- `spherical_potential` — uses `twoe_inner_integral`, a different quadrature engine (not a matrix-element wrapper).
- All cross-basis variants (`radial_integral(const FEMRadialBasis&, ...)`, `model_potential(const FEMRadialBasis&, ...)`, `overlap(const FEMRadialBasis&)`) — need a two-basis dispatcher, will land separately.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit**: He HF = −2.86167999561 Eh, err 3.59e-12; hydrogenic H 1s, He+ 1s, H 2p, He+ 2p, H 3d match `-Z²/(2n²)` to ~1e-12 (same noise as before).