### PR TITLE
v2: LegendreBasis::eval_over_r via analytic Q_n deflation

### DIFF
--- a/lib1dfem/include/lib1dfem/LegendreBasis.h
+++ b/lib1dfem/include/lib1dfem/LegendreBasis.h
@@ -108,6 +108,95 @@ class LegendreBasis : public PolynomialBasis<T> {
       }
     }
   }
+
+  // Pull the base's 3-arg eval_over_r overload back into scope.
+  using PolynomialBasis<T>::eval_over_r;
+
+  /// Analytic B_u(r)/r and r-derivatives for the surviving Legendre shape
+  /// functions on the first element (r = element_length * (x+1)).
+  ///
+  /// After drop_first(zero_func=true) the value-shape (P_0 - P_1)/2 =
+  /// (1-x)/2 is dropped (it has B(-1)=1). The remaining shapes (last
+  /// shape (P_0+P_1)/2 = (1+x)/2, and interior shapes (P_{j+1} - P_{j-1})
+  /// / sqrt(4j+2)) all vanish at x=-1 so B/r is finite.
+  ///
+  /// Deflation: define Q_n(x) := (P_n(x) - (-1)^n) / (x+1). It's a
+  /// polynomial because P_n(-1) = (-1)^n. From the standard Legendre
+  /// recurrence one gets
+  ///   (n+1) Q_{n+1}(x) = (2n+1) x Q_n(x) - n Q_{n-1}(x) + (-1)^n (2n+1)
+  /// with Q_0 = 0, Q_1 = 1. The first two x-derivatives obey
+  ///   (n+1) Q'_{n+1}(x)  = (2n+1)(Q_n + x Q'_n)     - n Q'_{n-1}
+  ///   (n+1) Q''_{n+1}(x) = (2n+1)(2 Q'_n + x Q''_n) - n Q''_{n-1}
+  /// Then the surviving shapes are linear combinations of Q's:
+  ///   last shape j=lmax:    R(r)  = 1 / (2 * element_length)    (constant)
+  ///   interior j in [1, lmax-1]:
+  ///                         R(x)  = (Q_{j+1}(x) - Q_{j-1}(x))
+  ///                                 / (element_length * sqrt(4j+2))
+  /// r-derivatives pull in (1/element_length)^n via the chain rule.
+  ///
+  /// Implemented for n in {0, 1, 2}; throws for higher orders.
+  void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r, int n,
+                   T element_length) const override {
+    if (n < 0 || n > 2) {
+      std::ostringstream oss;
+      oss << "LegendreBasis::eval_over_r: derivative order " << n
+          << " not implemented (only 0, 1, 2 supported).\n";
+      throw std::logic_error(oss.str());
+    }
+    if (this->enabled.n_elem == 0)
+      throw std::logic_error("LegendreBasis::eval_over_r: no surviving basis functions.\n");
+    if (this->enabled(0) == 0)
+      throw std::logic_error(
+          "LegendreBasis::eval_over_r requires drop_first(zero_func=true): "
+          "the value-shape (1-x)/2 has B(-1)=1 and B/r is singular at the origin.\n");
+
+    // Build Q_n, Q'_n, Q''_n for n = 0..lmax at every integration point.
+    arma::Mat<T> Q  (x.n_elem, lmax + 1, arma::fill::zeros);
+    arma::Mat<T> Qp (x.n_elem, lmax + 1, arma::fill::zeros);
+    arma::Mat<T> Qpp(x.n_elem, lmax + 1, arma::fill::zeros);
+    if (lmax >= 1)
+      for (arma::uword ix = 0; ix < x.n_elem; ++ix)
+        Q(ix, 1) = T(1);
+    for (int k = 1; k < lmax; ++k) {
+      const T inv_kp1  = T(1) / T(k + 1);
+      const T two_k_p1 = T(2 * k + 1);
+      const T k_T      = T(k);
+      const T sign_k   = (k % 2 == 0) ? T(1) : T(-1);
+      for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+        const T xv = x(ix);
+        Q  (ix, k + 1) = (two_k_p1 * xv * Q  (ix, k) - k_T * Q  (ix, k - 1)
+                          + sign_k * two_k_p1) * inv_kp1;
+        Qp (ix, k + 1) = (two_k_p1 * (Q (ix, k) + xv * Qp (ix, k))
+                          - k_T * Qp (ix, k - 1)) * inv_kp1;
+        Qpp(ix, k + 1) = (two_k_p1 * (T(2) * Qp(ix, k) + xv * Qpp(ix, k))
+                          - k_T * Qpp(ix, k - 1)) * inv_kp1;
+      }
+    }
+
+    const T inv_e   = T(1) / element_length;
+    const T chain_n = std::pow(inv_e, n);
+
+    dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
+    for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
+      const arma::uword j = this->enabled(k);
+      if (j == static_cast<arma::uword>(lmax)) {
+        // Last shape: R(r) = 1/(2 e); derivatives vanish.
+        const T val0 = T(1) / (T(2) * element_length);
+        for (arma::uword ix = 0; ix < x.n_elem; ++ix)
+          dnf_over_r(ix, k) = (n == 0) ? val0 : T(0);
+      } else {
+        // Interior j in [1, lmax-1].
+        const T inv_norm = T(1) / std::sqrt(T(4) * T(j) + T(2));
+        for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+          T R;
+          if      (n == 0) R = (Q  (ix, j + 1) - Q  (ix, j - 1)) * inv_norm * inv_e;
+          else if (n == 1) R = (Qp (ix, j + 1) - Qp (ix, j - 1)) * inv_norm * inv_e;
+          else             R = (Qpp(ix, j + 1) - Qpp(ix, j - 1)) * inv_norm * inv_e;
+          dnf_over_r(ix, k) = chain_n * R;
+        }
+      }
+    }
+  }
 };
 
 } // namespace polynomial_basis


### PR DESCRIPTION
## Summary

Last polynomial-basis subclass to get `eval_over_r`. The deflation is the cleanest of all the bases because Legendre shapes are already linear combinations of `P_n`, so dividing by `(x+1)` reduces to dividing each `P_n` by `(x+1)` with the constant offset `(−1)^n` exactly cancelling the boundary value.

### Deflation

Define `Q_n(x) := (P_n(x) − (−1)^n) / (x+1)`. It's a polynomial since `P_n(−1) = (−1)^n`. From the Legendre recurrence:

```
(n+1) Q_{n+1}(x) = (2n+1) x Q_n(x) − n Q_{n−1}(x) + (−1)^n (2n+1)
```

with `Q_0 = 0`, `Q_1 = 1`. Differentiating gives matching recurrences for `Q'_n` and `Q''_n`.

### Surviving shapes

After `drop_first(zero_func=true)`:

- last shape `φ_{lmax}(x) = (1+x)/2` → `R(r) = 1 / (2e)` (constant; r-derivatives vanish)
- interior `φ_j = (P_{j+1} − P_{j−1}) / √(4j+2)` for `j ∈ [1, lmax−1]` → `R(x) = (Q_{j+1}(x) − Q_{j−1}(x)) / (e · √(4j+2))`

with `e = element_length`. r-derivatives pull `(1/e)^n` via the chain rule. Implemented for `n ∈ {0, 1, 2}`; higher orders throw.

### Validation

Compared against 4th-order central FD of `B(r)/r` at moderate r (lmax=7, e=0.75):

| order | max abs diff |
|---|---|
| 0 | 2.8e-16  (sub-machine eps) |
| 1 | 1.9e-10  (FD-truncation-limited) |
| 2 | 1.2e-09  (FD-truncation-limited) |

n=0 is essentially exact — Legendre shapes are linear combinations of polynomials in x so the analytic and direct divisions agree to roundoff. n=1/n=2 are much tighter than HIP{2,3} validation because Legendre shapes are smooth (no high-order spike behavior).

## Status of `eval_over_r` after this PR

| Basis | `eval_over_r` |
|---|---|
| LIPBasis (primbas=4) | ✅ PR #67 |
| HIPBasis (primbas=5) | ✅ PR #68 |
| HIP2Basis (primbas=8) | ✅ PR #75 |
| HIP3Basis (primbas=9) | ✅ PR #75 |
| LegendreBasis (primbas=3) | ✅ this PR |

**All standard polynomial-basis subclasses now provide analytic eval_over_r at orders 0..2;** every supported `primbas` value (3, 4, 5, 8, 9) is usable in atomic SCF.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit** (He HF = −2.86167999561 Eh, err 3.59e-12)
- [x] Standalone LegendreBasis eval_over_r vs FD — n=0 sub-machine eps, n=1/2 FD-truncation-limited

## Next (the one cleanup left)

The dead `taylor_order` ctor param + `get_small_r_taylor_cutoff` / `get_taylor_order` / `get_taylor_diff` accessor shims still exist as no-ops across `FEMRadialBasis`, `TwoDBasis`, and the `atomic` / `diatomic` / `sadatom` callers (and the HDF5 checkpoint). Single mechanical PR to drop them.