### PR TITLE
v2: drop dead Taylor zombies (ctor param, accessor shims, CLI flag)

### DIFF
--- a/examples/atomic_radial_export.cpp
+++ b/examples/atomic_radial_export.cpp
@@ -61,7 +61,6 @@ namespace {
 //   igrid         = 4         (exponential)
 //   zexp          = 2.0
 //   n_quad        = 5 * poly->get_nbf()
-//   taylor_order  = poly->get_nprim() - 1
 //
 // FEM boundary flags match TwoDBasis exactly:
 //   zero_func_left=true (Dirichlet at r=0)
@@ -78,9 +77,8 @@ atomic::basis::FEMRadialBasis make_radial(const Defaults & d = DEF) {
   polynomial_basis::FiniteElementBasis fem(poly, bval,
       /*zero_func_left*/true,  /*zero_deriv_left*/false,
       /*zero_func_right*/true, /*zero_deriv_right*/false);
-  int n_quad       = 5 * poly->get_nbf();
-  int taylor_order = poly->get_nprim() - 1;
-  return atomic::basis::FEMRadialBasis(fem, n_quad, taylor_order);
+  int n_quad = 5 * poly->get_nbf();
+  return atomic::basis::FEMRadialBasis(fem, n_quad);
 }
 
 double diag_lowest(const arma::mat & H, const arma::mat & S) {
@@ -127,7 +125,7 @@ bool he_hf_test() {
   arma::ivec lval = {0}, mval = {0};
   atomic::basis::TwoDBasis basis(Z, modelpotential::POINT_NUCLEUS, /*Rrms*/0.0,
       poly, /*zeroder*/false,
-      5*poly->get_nbf(), bval, poly->get_nprim()-1,
+      5*poly->get_nbf(), bval,
       lval, mval, /*Zl*/0, /*Zr*/0, /*Rhalf*/0.0);
   basis.compute_tei(/*exchange*/true);
 

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -65,17 +65,11 @@ namespace helfem {
         /// Finite element basis
         polynomial_basis::FiniteElementBasis fem;
 
-        // The Taylor pipeline used in earlier HelFEM versions to handle
-        // B(r)/r near r=0 has been replaced by an analytic deflation in
-        // PolynomialBasis::eval_over_r (called via FiniteElementBasis).
-        // The small_r_taylor_cutoff / taylor_order / taylor_diff state and
-        // the set_small_r_taylor_cutoff() helper are no longer needed.
-
       public:
         /// Dummy constructor
         FEMRadialBasis();
         /// Construct radial basis
-        FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem, int n_quad, int taylor_order);
+        FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem, int n_quad);
         /// Explicit destructor
         ~FEMRadialBasis() override;
 
@@ -97,12 +91,6 @@ namespace helfem {
         int get_poly_id() const;
         /// Get number of nodes in polynomial basis
         int get_poly_nnodes() const;
-        /// Get small r Taylor cutoff
-        double get_small_r_taylor_cutoff() const;
-        /// Get the order of the Taylor series
-        int get_taylor_order() const;
-        /// Get the error in the Taylor series
-        double get_taylor_diff() const;
 
         /// Get number of overlapping functions
         size_t get_noverlap() const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -28,15 +28,7 @@ namespace helfem {
     namespace basis {
       FEMRadialBasis::FEMRadialBasis() {}
 
-      FEMRadialBasis::FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad, int taylor_order_) : fem(fem_) {
-        // taylor_order is a vestigial parameter from the pre-eval_over_r days.
-        // The Taylor expansion near r=0 has been retired in favour of the
-        // analytic deflation in PolynomialBasis::eval_over_r; the value is
-        // ignored but accepted for API back-compatibility. Stored as 0 so the
-        // (also vestigial) get_taylor_order() accessor returns something
-        // bounded.
-        (void)taylor_order_;
-
+      FEMRadialBasis::FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad) : fem(fem_) {
         // Get quadrature rule
         chebyshev::chebyshev(n_quad, xq, wq);
         for (size_t i = 0; i < xq.n_elem; i++) {
@@ -88,13 +80,6 @@ namespace helfem {
       int FEMRadialBasis::get_poly_nnodes() const {
         return fem.get_poly_nnodes();
       }
-
-      // The Taylor pipeline has been retired in favour of PolynomialBasis::eval_over_r.
-      // These accessors stay for API back-compatibility but return 0.
-      double FEMRadialBasis::get_small_r_taylor_cutoff() const { return 0.0; }
-      int    FEMRadialBasis::get_taylor_order()         const { return 0;   }
-      double FEMRadialBasis::get_taylor_diff()          const { return 0.0; }
-
 
       arma::mat FEMRadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
         // <R | r^Rexp | R> with the FE-natural dr measure means weight r^(Rexp+2):

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -34,7 +34,7 @@ namespace helfem {
       TwoDBasis::TwoDBasis() {
       }
 
-      TwoDBasis::TwoDBasis(int Z_, modelpotential::nuclear_model_t model_, double Rrms_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder_, int n_quad, const arma::vec & bval, int taylor_order, const arma::ivec & lval_, const arma::ivec & mval_, int Zl_, int Zr_, double Rhalf_) {
+      TwoDBasis::TwoDBasis(int Z_, modelpotential::nuclear_model_t model_, double Rrms_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder_, int n_quad, const arma::vec & bval, const arma::ivec & lval_, const arma::ivec & mval_, int Zl_, int Zr_, double Rhalf_) {
         // Nuclear charge
         Z=Z_;
         Zl=Zl_;
@@ -49,7 +49,7 @@ namespace helfem {
         bool zero_func_right=true;
         zeroder=zeroder_;
         polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
-        radial=FEMRadialBasis(fem, n_quad, taylor_order);
+        radial=FEMRadialBasis(fem, n_quad);
 
         // Construct angular basis
         lval=lval_;
@@ -125,18 +125,6 @@ namespace helfem {
 
       size_t TwoDBasis::Nang() const {
         return lval.n_elem;
-      }
-
-      double TwoDBasis::get_small_r_taylor_cutoff() const {
-        return radial.get_small_r_taylor_cutoff();
-      }
-
-      int TwoDBasis::get_taylor_order() const {
-        return radial.get_taylor_order();
-      }
-
-      double TwoDBasis::get_taylor_diff() const {
-        return radial.get_taylor_diff();
       }
 
       arma::uvec TwoDBasis::pure_indices() const {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -74,7 +74,7 @@ namespace helfem {
       public:
         TwoDBasis();
         /// Constructor
-        TwoDBasis(int Z, modelpotential::nuclear_model_t model, double Rrms, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int n_quad, const arma::vec & bval, int taylor_order, const arma::ivec & lval, const arma::ivec & mval, int Zl, int Zr, double Rhalf);
+        TwoDBasis(int Z, modelpotential::nuclear_model_t model, double Rrms, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int n_quad, const arma::vec & bval, const arma::ivec & lval, const arma::ivec & mval, int Zl, int Zr, double Rhalf);
         /// Destructor
         ~TwoDBasis();
 
@@ -138,12 +138,6 @@ namespace helfem {
         size_t Nrad() const;
         /// Number of angular shells
         size_t Nang() const;
-        /// Get small r Taylor cutoff
-        double get_small_r_taylor_cutoff() const;
-        /// Get order of Taylor expansion
-        int get_taylor_order() const;
-        /// Get order of Taylor expansion
-        double get_taylor_diff() const;
 
         /// Form half-overlap matrix
         arma::mat Shalf(bool chol, int sym) const;

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -109,7 +109,6 @@ int main(int argc, char **argv) {
   parser.add<double>("dampfock", 0, "damping factor for off-diagonal elents", false, 0.7);
   parser.add<double>("dampthr", 0, "damping threshold", false, 0.1);
   parser.add<bool>("zeroder", 0, "zero derivative at Rmax?", false, false);
-  parser.add<int>("taylor_order", 0, "order of Taylor expansion near the nucleus", false, -1);
   parser.add<int>("iconf", 0, "Confinement potential: 1 for polynomial, 2 for exponential, 3 for barrier, 4 for Junquera et al.", false, 0);
   parser.add<int>("conf_N", 0, "Exponent in confinement potential", false, 0);
   parser.add<double>("conf_R", 0, "Confinement radius", false, 0.0);
@@ -143,7 +142,6 @@ int main(int argc, char **argv) {
   int Nelem(parser.get<int>("nelem"));
   // Number of nodes
   int Nnodes(parser.get<int>("nnodes"));
-  int taylor_order(parser.get<int>("taylor_order"));
 
   // Order of quadrature rule
   int Nquad(parser.get<int>("nquad"));
@@ -247,10 +245,6 @@ int main(int argc, char **argv) {
   else if(Nquad<2*poly->get_nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
 
-  // Set default order of Taylor expansion
-  if(taylor_order==-1)
-    taylor_order = poly->get_nprim()-1;
-
   printf("Using %i point quadrature rule.\n",Nquad);
   printf("Angular grid spanning from l=0..%i, m=%i..%i.\n",lmax,-mmax,mmax);
 
@@ -269,10 +263,9 @@ int main(int argc, char **argv) {
   arma::vec bval=atomic::basis::form_grid((modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax, igrid, zexp, Nelem0, igrid0, zexp0, Z, Zl, Zr, Rhalf, add_conf, shift_conf);
 
   atomic::basis::TwoDBasis basis;
-  basis=atomic::basis::TwoDBasis(Z, (modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, Nquad, bval, taylor_order, lval, mval, Zl, Zr, Rhalf);
+  basis=atomic::basis::TwoDBasis(Z, (modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, Nquad, bval, lval, mval, Zl, Zr, Rhalf);
   chkpt.write(basis);
   printf("Basis set consists of %i angular shells composed of %i radial functions, totaling %i basis functions\n",(int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf());
-  printf("%ith order Taylor series used to evaluate basis functions for r <= %e, error %e\n",taylor_order, basis.get_small_r_taylor_cutoff(), basis.get_taylor_diff());
 
   printf("One-electron matrix requires %s\n",scf::memory_size(basis.mem_1el()).c_str());
   printf("Auxiliary one-electron integrals require %s\n",scf::memory_size(basis.mem_1el_aux()).c_str());

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -532,7 +532,6 @@ namespace helfem {
         int Nnodes=15;
         auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::get_basis(primbas,Nnodes)));
         int Nquad=5*poly->get_nbf();
-        int taylor_order = poly->get_nprim()-1;
 
         // PBE xc
         int x_func = 101;
@@ -578,7 +577,7 @@ namespace helfem {
         int iguess=2;
 
         if(Zl>0) {
-          sadatom::solver::SCFSolver lsolver(Zl, finitenuc, Rrms, lmax(Zl), poly, zeroder, Nquad, blval, taylor_order, x_func, c_func, maxit, shift, convthr, dftthr, diiseps, diisthr, diisorder);
+          sadatom::solver::SCFSolver lsolver(Zl, finitenuc, Rrms, lmax(Zl), poly, zeroder, Nquad, blval, x_func, c_func, maxit, shift, convthr, dftthr, diiseps, diisthr, diisorder);
           helfem::sadatom::solver::rconf_t lconf;
           lconf.orbs=sadatom::solver::OrbitalChannel(true);
           lsolver.Initialize(lconf.orbs,iguess);
@@ -589,7 +588,7 @@ namespace helfem {
           lh_occs = lconf.orbs.Occs();
         }
         if(Zr>0) {
-          sadatom::solver::SCFSolver rsolver(Zr, finitenuc, Rrms, lmax(Zr), poly, zeroder, Nquad, brval, taylor_order, x_func, c_func, maxit, shift, convthr, dftthr, diiseps, diisthr, diisorder);
+          sadatom::solver::SCFSolver rsolver(Zr, finitenuc, Rrms, lmax(Zr), poly, zeroder, Nquad, brval, x_func, c_func, maxit, shift, convthr, dftthr, diiseps, diisthr, diisorder);
           helfem::sadatom::solver::rconf_t rconf;
           rconf.orbs=sadatom::solver::OrbitalChannel(true);
           rsolver.Initialize(rconf.orbs,iguess);

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -513,7 +513,6 @@ void Checkpoint::write(const helfem::atomic::basis::TwoDBasis & basis) {
   write("poly_id",basis.get_poly_id());
   write("poly_nnodes",basis.get_poly_nnodes());
   write("zeroder",basis.get_zeroder());
-  write("taylor_order",basis.get_taylor_order());
 
   write("lval",basis.get_lval());
   write("mval",basis.get_mval());
@@ -558,15 +557,13 @@ void Checkpoint::read(helfem::atomic::basis::TwoDBasis & basis) {
   read("poly_nnodes",poly_nnodes);
   int zeroder;
   read("zeroder", zeroder);
-  int taylor_order;
-  read("taylor_order", taylor_order);
 
   arma::ivec lval, mval;
   read("lval", lval);
   read("mval", mval);
 
   auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(poly_id,poly_nnodes)));
-  basis=helfem::atomic::basis::TwoDBasis(Z, (helfem::modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, n_quad, bval, taylor_order, lval, mval, Zl, Zr, Rhalf);
+  basis=helfem::atomic::basis::TwoDBasis(Z, (helfem::modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, n_quad, bval, lval, mval, Zl, Zr, Rhalf);
   
   if(cl) close();
 }

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -89,9 +89,6 @@ int main(int argc, char **argv) {
   // Order of quadrature rule
   printf("Using %i point quadrature rule.\n",Nquad);
 
-  // Set default order of Taylor expansion
-  int taylor_order = poly->get_nprim()-1;
-
   // Radial basis
   arma::vec bval=atomic::basis::form_grid((modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax, igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0);
 
@@ -100,7 +97,7 @@ int main(int argc, char **argv) {
   bool zero_deriv_left=false;
   bool zero_func_right=true;
   polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
-  atomic::basis::FEMRadialBasis radial(fem, Nquad, taylor_order);
+  atomic::basis::FEMRadialBasis radial(fem, Nquad);
 
   // Compute matrices
   arma::mat S(radial.overlap());

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -36,7 +36,7 @@ namespace helfem {
       TwoDBasis::TwoDBasis() {
       }
 
-      TwoDBasis::TwoDBasis(int Z_, modelpotential::nuclear_model_t model_, double Rrms_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder, int n_quad, const arma::vec & bval, int taylor_order, int lmax) {
+      TwoDBasis::TwoDBasis(int Z_, modelpotential::nuclear_model_t model_, double Rrms_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder, int n_quad, const arma::vec & bval, int lmax) {
         // Nuclear charge
         Z=Z_;
         model=model_;
@@ -46,7 +46,7 @@ namespace helfem {
         bool zero_deriv_left=false;
         bool zero_func_right=true;
         polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
-        radial=atomic::basis::FEMRadialBasis(fem, n_quad, taylor_order);
+        radial=atomic::basis::FEMRadialBasis(fem, n_quad);
         // Angular basis
         lval=arma::linspace<arma::ivec>(0,lmax,lmax+1);
       }
@@ -740,14 +740,6 @@ namespace helfem {
 
       arma::vec TwoDBasis::get_r(size_t iel) const {
         return radial.get_r(iel);
-      }
-
-      double TwoDBasis::get_small_r_taylor_cutoff() const {
-        return radial.get_small_r_taylor_cutoff();
-      }
-
-      double TwoDBasis::get_taylor_diff() const {
-        return radial.get_taylor_diff();
       }
 
       double TwoDBasis::nuclear_density(const arma::mat & P) const {

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -54,7 +54,7 @@ namespace helfem {
       public:
         TwoDBasis();
         /// Constructor
-        TwoDBasis(int Z, modelpotential::nuclear_model_t model, double Rrms, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int n_quad, const arma::vec & bval, int taylor_order, int lmax);
+        TwoDBasis(int Z, modelpotential::nuclear_model_t model, double Rrms, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int n_quad, const arma::vec & bval, int lmax);
         /// Destructor
         ~TwoDBasis();
 
@@ -111,10 +111,6 @@ namespace helfem {
         arma::vec get_wrad(size_t iel) const;
         /// Get r values
         arma::vec get_r(size_t iel) const;
-        /// Get small r Taylor cutoff
-        double get_small_r_taylor_cutoff() const;
-        /// Get small r Taylor cutoff
-        double get_taylor_diff() const;
 
         /// Get primitive integrals
         std::vector<arma::mat> get_prim_tei() const;

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -124,7 +124,6 @@ int main(int argc, char **argv) {
   parser.add<double>("diiseps", 0, "when to start mixing in diis", false, 1e-2);
   parser.add<double>("diisthr", 0, "when to switch over fully to diis", false, 1e-3);
   parser.add<int>("diisorder", 0, "length of diis history", false, 10);
-  parser.add<int>("taylor_order", 0, "order of Taylor expansion near the nucleus", false, -1);
   parser.add<bool>("saveorb", 0, "save radial orbitals to disk?", false, false);
   parser.add<bool>("savepot", 0, "save xc potential to disk?", false, false);
   parser.add<bool>("saveing", 0, "save xc ingredients to disk?", false, false);
@@ -162,7 +161,6 @@ int main(int argc, char **argv) {
   int Nelem0(parser.get<int>("nelem0"));
   // Number of nodes
   int Nnodes(parser.get<int>("nnodes"));
-  int taylor_order(parser.get<int>("taylor_order"));
 
   double shift(parser.get<double>("shift"));
 
@@ -214,10 +212,6 @@ int main(int argc, char **argv) {
   // Order of quadrature rule
   printf("Using %i point quadrature rule.\n",Nquad);
 
-  // Set default order of Taylor expansion
-  if(taylor_order==-1)
-    taylor_order = poly->get_nprim()-1;
-
   // Total number of electrons is
   arma::sword numel=Z-Q;
 
@@ -264,7 +258,7 @@ int main(int argc, char **argv) {
   arma::vec bval=atomic::basis::form_grid((modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax, igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0, add_conf, shift_conf);
 
   // Initialize solver
-  sadatom::solver::SCFSolver solver(Z, finitenuc, Rrms, lmax, poly, zeroder, Nquad, bval, taylor_order, x_func, c_func, maxit, shift, convthr, dftthr, diiseps, diisthr, diisorder, iconf, conf_N, conf_R, conf_barrier, shift_conf);
+  sadatom::solver::SCFSolver solver(Z, finitenuc, Rrms, lmax, poly, zeroder, Nquad, bval, x_func, c_func, maxit, shift, convthr, dftthr, diiseps, diisthr, diisorder, iconf, conf_N, conf_R, conf_barrier, shift_conf);
 
   // Set parameters if necessary
   arma::vec xpars, cpars;

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -619,17 +619,16 @@ namespace helfem {
         return lh.Econf < rh.Econf;
       }
 
-      SCFSolver::SCFSolver(int Z, int finitenuc, double Rrms, int lmax_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder, int Nquad, const arma::vec & bval, int taylor_order, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_) : lmax(lmax_), maxit(maxit_), shift(shift_), convthr(convthr_), dftthr(dftthr_), diiseps(diiseps_), diisthr(diisthr_), diisorder(diisorder_), iconf(0), conf_N(0), conf_R(0.0), conf_barrier(0.0), shift_pot(0.0) {}
+      SCFSolver::SCFSolver(int Z, int finitenuc, double Rrms, int lmax_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder, int Nquad, const arma::vec & bval, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_) : lmax(lmax_), maxit(maxit_), shift(shift_), convthr(convthr_), dftthr(dftthr_), diiseps(diiseps_), diisthr(diisthr_), diisorder(diisorder_), iconf(0), conf_N(0), conf_R(0.0), conf_barrier(0.0), shift_pot(0.0) {}
 
-      SCFSolver::SCFSolver(int Z, int finitenuc, double Rrms, int lmax_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder, int Nquad, const arma::vec & bval, int taylor_order, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_, int iconf_, int conf_N_, double conf_R_, double conf_barrier_, double shift_pot_) : lmax(lmax_), maxit(maxit_), shift(shift_), convthr(convthr_), dftthr(dftthr_), diiseps(diiseps_), diisthr(diisthr_), diisorder(diisorder_), iconf(iconf_), conf_N(conf_N_), conf_R(conf_R_), conf_barrier(conf_barrier_), shift_pot(shift_pot_) {
+      SCFSolver::SCFSolver(int Z, int finitenuc, double Rrms, int lmax_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder, int Nquad, const arma::vec & bval, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_, int iconf_, int conf_N_, double conf_R_, double conf_barrier_, double shift_pot_) : lmax(lmax_), maxit(maxit_), shift(shift_), convthr(convthr_), dftthr(dftthr_), diiseps(diiseps_), diisthr(diisthr_), diisorder(diisorder_), iconf(iconf_), conf_N(conf_N_), conf_R(conf_R_), conf_barrier(conf_barrier_), shift_pot(shift_pot_) {
 
         // Construct the angular basis
         arma::ivec lval, mval;
         atomic::basis::angular_basis(lmax,lmax,lval,mval);
 
-        basis=sadatom::basis::TwoDBasis(Z, (modelpotential::nuclear_model_t) (finitenuc), Rrms, poly, zeroder, Nquad, bval, taylor_order, lmax);
+        basis=sadatom::basis::TwoDBasis(Z, (modelpotential::nuclear_model_t) (finitenuc), Rrms, poly, zeroder, Nquad, bval, lmax);
         printf("Basis set has %i radial functions\n",(int) basis.Nbf());
-        printf("%ith order Taylor series used to evaluate basis functions for r <= %e, error %e\n",taylor_order, basis.get_small_r_taylor_cutoff(), basis.get_taylor_diff());
 
         // Form overlap matrix
         S=basis.overlap();

--- a/src/sadatom/solver.h
+++ b/src/sadatom/solver.h
@@ -253,10 +253,10 @@ namespace helfem {
         arma::mat ao_importance_profile(const rconf_t & conf, const arma::vec & expn, const std::function<arma::mat(int l, const arma::vec &r)> & eval_ao) const;
       public:
         /// Constructor
-        SCFSolver(int Z, int finitenuc, double Rrms, int lmax, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int Nquad, const arma::vec & bval, int taylor_order, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_);
+        SCFSolver(int Z, int finitenuc, double Rrms, int lmax, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int Nquad, const arma::vec & bval, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_);
 
 
-	SCFSolver(int Z, int finitenuc, double Rrms, int lmax, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int Nquad, const arma::vec & bval, int taylor_order, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_, int iconf_, int conf_N_, double conf_R_, double conf_barrier_, double shift_pot_);
+	SCFSolver(int Z, int finitenuc, double Rrms, int lmax, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int Nquad, const arma::vec & bval, int x_func_, int c_func_, int maxit_, double shift_, double convthr_, double dftthr_, double diiseps_, double diisthr_, int diisorder_, int iconf_, int conf_N_, double conf_R_, double conf_barrier_, double shift_pot_);
         /// Destructor
         ~SCFSolver();
 


### PR DESCRIPTION
## Summary

Completes the cleanup begun when the small-r Taylor pipeline in `RadialBasis` was retired in PR #69 in favour of analytic `eval_over_r`. The Taylor ctor parameter and accessor shims on `FEMRadialBasis`, the `TwoDBasis` wrappers on top of them, the `--taylor_order` CLI flag on the `atomic` and `sadatom` binaries, the diatomic-side pass-through, and the HDF5 checkpoint key are all removed.

Net diff: **+22 / −102** across 14 files.

### Removed

**`libhelfem/include/RadialBasis.{h,cpp}`** (`FEMRadialBasis`)
- ctor signature drops the trailing `int taylor_order` arg
- `get_small_r_taylor_cutoff() / get_taylor_order() / get_taylor_diff()` (no-op shims returning 0 / 0 / 0.0) deleted

**`src/atomic/TwoDBasis.{h,cpp}`**
- ctor drops `int taylor_order`
- `get_small_r_taylor_cutoff() / get_taylor_order() / get_taylor_diff()` forwarders deleted

**`src/sadatom/basis.{h,cpp}`**
- ctor drops `int taylor_order`
- `get_small_r_taylor_cutoff() / get_taylor_diff()` deleted

**`src/sadatom/solver.{h,cpp}`**
- `SCFSolver` ctor (both overloads) drops `int taylor_order`
- dead `"Nth order Taylor series used..."` print removed

**CLI binaries (`atomic`, `sadatom`)**
- `--taylor_order` parser entry removed
- local `taylor_order` variable + the `if (==-1) default` branch removed
- corresponding `"Nth order Taylor series used..."` print line removed

**Other callers**
- `src/sadatom/1e.cpp` and `src/diatomic/twodquadrature.cpp` drop the local `taylor_order` and pass updated arg lists to `FEMRadialBasis` / `SCFSolver`
- `src/general/checkpoint.cpp` drops write/read of `"taylor_order"` HDF5 key and the trailing arg from the `TwoDBasis` ctor call in `read()`
- `examples/atomic_radial_export.cpp` drops the local and ctor arg

### HDF5 backward compatibility

Existing checkpoints that still carry a stray `"taylor_order"` field will continue to load (the read call is gone; HDF5's per-key access leaves unused fields untouched). Newer checkpoints simply don't have the field.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit** (He HF = −2.86167999561 Eh, err 3.59e-12)
- [x] `atomic --help` no longer lists `--taylor_order`

## V2 refactor — closing out

After this PR the analytic eval_over_r / FEM cleanup arc is fully done:

- All five FE polynomial bases (LIP, HIP, HIP2, HIP3, Legendre) live in lib1dfem as templated headers with analytic eval_over_r
- All radial integrals on `FEMRadialBasis` flow through the `BasisKind` matrix-element dispatcher
- The Taylor pipeline is gone — code, ctor param, accessors, CLI flag, HDF5 key
- `GeneralHIPBasis` is gone; obsolete `primbas` values throw with explanatory errors
- HelFEM is BSD-3-Clause, GSL-free, with optional external BLAS linkage for libatomscf-style consumers