### PR TITLE
v2: NAORadialBasis -- view over an underlying RadialBasis + orbital coeffs

### DIFF
--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -1,0 +1,135 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef ATOMIC_BASIS_NAORADIALBASIS_H
+#define ATOMIC_BASIS_NAORADIALBASIS_H
+
+#include "RadialBasis.h"
+#include <armadillo>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+
+namespace helfem {
+  namespace atomic {
+    namespace basis {
+
+      /// Numerical-Atomic-Orbital (NAO) radial basis. Each NAO is a linear
+      /// combination of the shape functions of an underlying RadialBasis
+      /// (typically a high-resolution FEMRadialBasis using LIP/HIP/HIP2/
+      /// HIP3/Legendre primitives). The class is just a thin view: it
+      /// holds a shared_ptr to the underlying basis and a coefficient
+      /// matrix C (shape Nbf_underlying x Nbf_NAO) defining each NAO as
+      ///
+      ///     |NAO_alpha> = sum_i C(i, alpha) |underlying_i>
+      ///
+      /// Every one-electron integral reduces to a basis transform of the
+      /// underlying matrix:
+      ///
+      ///     M_NAO  =  C^T  M_underlying  C
+      ///
+      /// so the NAO basis automatically inherits the underlying basis's
+      /// quadrature accuracy. No tabulation, no interpolation, no log-grid
+      /// reweighting; the underlying basis already integrates everything
+      /// to its own (typically near-machine-precision) standard.
+      ///
+      /// Typical usage:
+      ///   1. Run an atomic SCF in a high-resolution FEMRadialBasis.
+      ///   2. Pick the C columns to keep (e.g. the occupied orbitals plus
+      ///      a handful of virtuals, per (n, l) channel).
+      ///   3. Hand the (underlying, C) pair to NAORadialBasis; use the
+      ///      result wherever a RadialBasis* is expected (e.g. as the
+      ///      atomic-centre basis in a downstream diatomic calculation).
+      ///
+      /// The underlying basis is held by shared_ptr so the NAO basis can
+      /// outlive the constructing scope, and so the same underlying FE
+      /// basis can back multiple NAO projections (e.g. one per (n, l)).
+      ///
+      /// Currently non-templated (operates on arma::mat = double) to
+      /// match the non-templated RadialBasis base; the broader
+      /// templated-precision migration is a follow-up.
+      class NAORadialBasis : public RadialBasis {
+       protected:
+        /// Underlying radial basis (typically a FEMRadialBasis).
+        std::shared_ptr<const RadialBasis> underlying_;
+        /// Orbital coefficient matrix, shape (Nbf_underlying x Nbf_NAO).
+        arma::mat C_;
+
+       public:
+        /// Constructor. `C` must have `underlying->Nbf()` rows and at
+        /// least one column (one column = one NAO).
+        NAORadialBasis(std::shared_ptr<const RadialBasis> underlying,
+                       arma::mat C)
+            : underlying_(std::move(underlying)), C_(std::move(C)) {
+          if (!underlying_)
+            throw std::logic_error("NAORadialBasis: null underlying basis.\n");
+          if (C_.n_rows != underlying_->Nbf()) {
+            std::ostringstream oss;
+            oss << "NAORadialBasis: C has " << C_.n_rows
+                << " rows but underlying basis has " << underlying_->Nbf()
+                << " basis functions.\n";
+            throw std::logic_error(oss.str());
+          }
+          if (C_.n_cols == 0)
+            throw std::logic_error("NAORadialBasis: C has zero columns (no NAOs).\n");
+        }
+
+        ~NAORadialBasis() override = default;
+
+        /// Access the underlying basis.
+        const RadialBasis & underlying() const { return *underlying_; }
+        /// Access the orbital coefficient matrix.
+        const arma::mat & coeffs() const { return C_; }
+
+        size_t Nbf() const override { return C_.n_cols; }
+
+        /// S_NAO = C^T S_underlying C.
+        arma::mat overlap() const override {
+          return C_.t() * underlying_->overlap() * C_;
+        }
+
+        /// T_NAO = C^T T_underlying C.
+        arma::mat kinetic() const override {
+          return C_.t() * underlying_->kinetic() * C_;
+        }
+
+        /// (Centrifugal-per-l(l+1))_NAO = C^T (...)_underlying C.
+        arma::mat kinetic_l() const override {
+          return C_.t() * underlying_->kinetic_l() * C_;
+        }
+
+        /// V_NAO = C^T V_underlying C (Z=1; caller multiplies by +Z).
+        arma::mat nuclear() const override {
+          return C_.t() * underlying_->nuclear() * C_;
+        }
+
+        /// Evaluate the NAO orbitals (columns of C_orb in the NAO basis)
+        /// at radius r. Internally promotes to the underlying basis via
+        /// C_promoted = C * C_orb and delegates to underlying.eval_orbs.
+        arma::vec eval_orbs(const arma::mat & C_orb, double r) const override {
+          if (C_orb.n_rows != Nbf()) {
+            std::ostringstream oss;
+            oss << "NAORadialBasis::eval_orbs: C_orb has " << C_orb.n_rows
+                << " rows but NAO Nbf() = " << Nbf() << "\n";
+            throw std::logic_error(oss.str());
+          }
+          return underlying_->eval_orbs(C_ * C_orb, r);
+        }
+      };
+
+    } // namespace basis
+  } // namespace atomic
+} // namespace helfem
+
+#endif


### PR DESCRIPTION
## Summary

First concrete `RadialBasis` subclass beyond `FEMRadialBasis`. Each NAO is a **linear combination of the shape functions of an underlying RadialBasis** (typically a high-resolution `FEMRadialBasis` using LIP/HIP/HIP2/HIP3/Legendre primitives):

```
|NAO_α⟩ = Σᵢ C(i, α) |underlying_i⟩
```

The class is a thin view: it holds a `shared_ptr<const RadialBasis>` to the underlying basis and a coefficient matrix `C` of shape `(Nbf_underlying × Nbf_NAO)`. Every one-electron integral reduces to a basis transform:

```
M_NAO = Cᵀ M_underlying C
```

so the NAO basis automatically inherits the underlying basis's quadrature accuracy. **No tabulation, no interpolation, no log-grid reweighting** — the underlying basis already integrates everything to its own (near-machine-precision) standard.

### Typical usage

1. Run an atomic SCF in a high-resolution `FEMRadialBasis`.
2. Pick the `C` columns to keep (e.g. occupied orbitals plus a handful of virtuals, per (n, l) channel).
3. Hand the `(underlying, C)` pair to `NAORadialBasis`; use the result wherever a `RadialBasis*` is expected (e.g. as the atomic-centre basis in a downstream diatomic calculation).

`shared_ptr` ownership lets the NAO basis outlive the constructing scope, and lets the same underlying FE basis back multiple NAO projections (one per (n, l) channel, say).

### Interface implemented

| method | formula |
|---|---|
| `Nbf()` | `C.n_cols` |
| `overlap()` | `Cᵀ S_underlying C` |
| `kinetic()` | `Cᵀ T_underlying C` |
| `kinetic_l()` | `Cᵀ (centrifugal-per-l(l+1))_underlying C` |
| `nuclear()` | `Cᵀ V_underlying C` |
| `eval_orbs(C_orb, r)` | promotes `C_orb` to the underlying basis via `C · C_orb` and delegates to `underlying.eval_orbs` |

Plus `underlying()` / `coeffs()` read-only accessors.

### Constructor guards

- non-null underlying
- `C.n_rows == underlying->Nbf()`
- `C.n_cols >= 1`

### Validation (end-to-end)

1. Build a 15-node-LIP, 20-element exponential FE basis for H (l=0).
2. Solve the 1s eigenproblem via `S^{-1/2} H S^{-1/2}` canonical orthogonalisation; FE eigenvalue = `-0.5000000000` (10 digits vs analytic).
3. Construct `NAORadialBasis` with the single column = FE coefficients of the 1s orbital.

| | value |
|---|---|
| `S_NAO(0,0)` | `1.00000000000000` (orbital is S-orthonormal in FE basis) |
| `⟨NAO\|H\|NAO⟩` | `-0.49999999999999` |
| `\|⟨NAO\|H\|NAO⟩ − FE eigval\|` | **1.1e-14** |

i.e. machine epsilon. An NAO basis containing exactly the 1s eigenstate gives back the FE 1s eigenvalue to roundoff, as it must.

### Implementation notes

- Header-only, `libhelfem/include/NAORadialBasis.h` (~140 LOC).
- Currently **non-templated** (operates on `arma::mat = double`) to match the non-templated `RadialBasis` base. The broader templated-precision migration (`RadialBasis<T>`, `FEMRadialBasis<T>`, `NAORadialBasis<T>`) is a follow-up.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] H 1s round-trip: FE-resolve → NAO-project → H back to 1.1e-14 of FE eigval
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit** (He HF = −2.86167999561 Eh, err 3.59e-12)

## Followups

This is the first slice. Staged for later PRs:

1. **`NAORadialBasis<T>` templated** — along with the broader `RadialBasis<T>` / `FEMRadialBasis<T>` migration.
2. **HelFEM SCF → NAO export helper** — extract the per-(n, l) `C` columns from a converged FEM atomic SCF and pack them into ready-to-use `NAORadialBasis` objects.
3. **STO/GTO subclasses** — analytic STO/GTO subclasses for standard QC basis interop (these stay analytic; they do NOT need an "underlying" basis since their matrix elements have closed forms).

## Note on the prior commit (force-pushed)

The first version of this PR had a tabulated-on-a-grid implementation, which was the wrong design — it threw away the high-quality FE integration the user had already paid for and re-tabulated on a separate radial grid. This is the correct view-over-underlying design.