### PR TITLE
v2: SCF -> NAO export helpers (sadatom path)

### DIFF
--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -87,6 +87,17 @@ namespace helfem {
 
         ~NAORadialBasis() override = default;
 
+        /// Convenience factory: wrap an existing concrete RadialBasis
+        /// (typically a FEMRadialBasis fresh out of a TwoDBasis) in a
+        /// shared_ptr by copy, then construct. Useful when the caller
+        /// holds the underlying basis by value and does not want to
+        /// manage the shared_ptr themselves.
+        template <typename RB>
+        static NAORadialBasis from_owned_radial(RB underlying, arma::mat C) {
+          return NAORadialBasis(
+              std::make_shared<RB>(std::move(underlying)), std::move(C));
+        }
+
         /// Access the underlying basis.
         const RadialBasis & underlying() const { return *underlying_; }
         /// Access the orbital coefficient matrix.

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -22,6 +22,7 @@
 #include "../general/dftfuncs.h"
 #include <cassert>
 #include <cfloat>
+#include <sstream>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -1440,6 +1441,39 @@ namespace helfem {
           vxc.col(ic)%=r;
 
         return vxc;
+      }
+
+      std::vector<std::pair<int, atomic::basis::NAORadialBasis>>
+      extract_naos_per_l(const TwoDBasis & sad_basis,
+                         const arma::cube & Ccube,
+                         const std::vector<int> & keep_per_l) {
+        const int lmax = static_cast<int>(Ccube.n_slices) - 1;
+        if (static_cast<int>(keep_per_l.size()) != lmax + 1) {
+          std::ostringstream oss;
+          oss << "extract_naos_per_l: keep_per_l has size " << keep_per_l.size()
+              << " but Ccube has " << Ccube.n_slices
+              << " slices (expected " << lmax + 1 << ").\n";
+          throw std::logic_error(oss.str());
+        }
+        std::vector<std::pair<int, atomic::basis::NAORadialBasis>> out;
+        out.reserve(lmax + 1);
+        for (int l = 0; l <= lmax; ++l) {
+          const int keep = keep_per_l[l];
+          if (keep == 0) continue;
+          const arma::mat & Cl = Ccube.slice(l);
+          if (keep > static_cast<int>(Cl.n_cols)) {
+            std::ostringstream oss;
+            oss << "extract_naos_per_l: requested " << keep
+                << " NAOs for l=" << l << " but only "
+                << Cl.n_cols << " orbitals available.\n";
+            throw std::logic_error(oss.str());
+          }
+          const arma::mat Ckeep = (keep < 0) ? Cl
+                                             : arma::mat(Cl.cols(0, keep - 1));
+          out.emplace_back(l, atomic::basis::NAORadialBasis::from_owned_radial(
+              sad_basis.get_radial(), Ckeep));
+        }
+        return out;
       }
     }
   }

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -17,6 +17,7 @@
 
 #include <armadillo>
 #include "../atomic/basis.h"
+#include <NAORadialBasis.h>
 
 namespace helfem {
   namespace sadatom {
@@ -112,6 +113,11 @@ namespace helfem {
         /// Get r values
         arma::vec get_r(size_t iel) const;
 
+        /// Read-only access to the underlying radial basis. Useful for
+        /// callers that want to build an NAORadialBasis on top of a
+        /// converged sadatom SCF (see extract_naos_per_l below).
+        const atomic::basis::FEMRadialBasis & get_radial() const { return radial; }
+
         /// Get primitive integrals
         std::vector<arma::mat> get_prim_tei() const;
 
@@ -162,6 +168,24 @@ namespace helfem {
         /// Compute the exchange-correlation screening
         arma::mat xc_screening(const arma::mat & Parad, const arma::mat & Pbrad, int x_func, int c_func) const;
       };
+
+      /// Extract per-l NAOs from a converged sadatom SCF result.
+      ///
+      /// `Ccube` is the OrbitalChannel coefficient cube returned by
+      /// `sadatom::solver::OrbitalChannel::Coeffs()`; `Ccube.slice(l)`
+      /// has shape (Nrad x N_orb_l) and holds the l-channel MOs in
+      /// ascending eigenvalue order. `keep_per_l[l]` is how many of the
+      /// lowest-energy columns to retain (use -1 to keep all of slice l;
+      /// use 0 to skip that l-channel).
+      ///
+      /// Returns one (l, NAORadialBasis) pair per kept l-channel, in
+      /// order of l. Each NAORadialBasis owns its own copy of the
+      /// underlying FEMRadialBasis (shared internally via shared_ptr);
+      /// the returned basis objects can outlive `sad_basis`.
+      std::vector<std::pair<int, atomic::basis::NAORadialBasis>>
+      extract_naos_per_l(const TwoDBasis & sad_basis,
+                         const arma::cube & Ccube,
+                         const std::vector<int> & keep_per_l);
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes the loop on PR #78 — adds the plumbing needed to take a converged sadatom SCF and pack its per-l MOs into `NAORadialBasis` objects ready for downstream consumption.

### Three small pieces (+69 / −0 LOC)

**(1) `NAORadialBasis::from_owned_radial<RB>(underlying, C)`** — static factory in `libhelfem/include/NAORadialBasis.h`. Wraps a copy of an existing concrete `RadialBasis` into a fresh `shared_ptr` and constructs. Lets callers that hold the underlying basis by value skip the `shared_ptr` boilerplate.

**(2) `sadatom::basis::TwoDBasis::get_radial()`** — read-only accessor returning `const FEMRadialBasis &`. Just exposes the private `radial` member so the export helper can reach it without a friend declaration.

**(3) `sadatom::basis::extract_naos_per_l(sad_basis, Ccube, keep_per_l)`** — free function in `sadatom::basis`. Takes the `OrbitalChannel` coefficient cube (`Coeffs()` return value) and a per-l keep count:

| `keep_per_l[l]` | meaning |
|---|---|
| `-1` | keep all orbitals for that l |
| `0` | skip that l-channel entirely |
| `N > 0` | keep the first `N` columns (lowest-energy orbitals) |

Returns a `vector<pair<int, NAORadialBasis>>` in order of `l`. Each NAO basis owns a copy of the underlying radial shared via `shared_ptr`, so the returned bases can outlive `sad_basis`.

### Usage sketch

```cpp
sadatom::solver::SCFSolver solver(...);
solver.Solve(conf);
arma::cube C_cube = conf.orbs.Coeffs();
auto naos = sadatom::basis::extract_naos_per_l(
    solver.Basis(), C_cube, {/*l=0*/ 2, /*l=1*/ 1});
// naos[0] = (0, NAO with the two lowest s-channel orbitals)
// naos[1] = (1, NAO with the lowest p-channel orbital)
```

### Round-trip validation

Skipping the full SCF for simplicity — just solving the bare H-atom radial Hamiltonian per `l` in a sadatom basis, packing the eigenvectors into an `OrbitalChannel`-style cube, and going through `extract_naos_per_l`:

15-node-LIP, 20-element exponential FE basis, `l_max = 1`:

| | FE eigval | analytic |
|---|---|---|
| l=0 1s | `-0.5000000000` | `-0.5` |
| l=1 2p | `-0.1250000000` | `-0.125` |

After `extract_naos_per_l` with `keep_per_l = {1, 1}`:

| l | `S_NAO(0,0)` | `<NAO\|H\|NAO>` | `\|diff vs FE\|` |
|---|---|---|---|
| 0 | `1.00000000000000` | `-0.49999999999999` | **1.2e-14** |
| 1 | `1.00000000000000` | `-0.12499999999985` | **1.3e-14** |

i.e. machine epsilon — extraction is lossless.

Plus the corner cases: `keep=-1` returns all FE orbitals per l, `keep=[1,0]` correctly returns only the l=0 pair, over-keep throws an explanatory `logic_error`.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] End-to-end round trip: FE-resolve → cube → `extract_naos_per_l` → reproject H → recover FE eigenvalues to 1.2e-14
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit** (He HF = −2.86167999561 Eh, err 3.59e-12)

## Not in this PR

- **Atomic (non-sadatom) `TwoDBasis` extraction.** The full atomic `TwoDBasis` allows MOs to mix angular shells; principled per-l extraction would need to project each MO onto each l-channel first. Will add when the use case lands.
- **High-level "run an SCF and extract NAOs in one call" wrapper.** Out of scope for libhelfem — belongs in a downstream driver.