### PR TITLE
v2: STORadialBasis + GTORadialBasis -- analytic STO/GTO subclasses

### DIFF
--- a/libhelfem/include/GTORadialBasis.h
+++ b/libhelfem/include/GTORadialBasis.h
@@ -1,0 +1,178 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef ATOMIC_BASIS_GTORADIALBASIS_H
+#define ATOMIC_BASIS_GTORADIALBASIS_H
+
+#include "RadialBasis.h"
+#include <armadillo>
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+namespace helfem {
+  namespace atomic {
+    namespace basis {
+
+      /// Primitive Gaussian-type-orbital (GTO) radial basis. Each
+      /// function is characterised by an integer power n_i >= 0 (usually
+      /// n_i = l for a primitive of angular momentum l) and a positive
+      /// exponent alpha_i:
+      ///
+      ///     R_i(r) = N_i * r^{n_i} * exp(-alpha_i * r^2)
+      ///     u_i(r) = r * R_i(r) = N_i * r^{n_i + 1} * exp(-alpha_i * r^2)
+      ///
+      /// (u convention matches FEMRadialBasis / NAORadialBasis;
+      /// u_i(0) = 0 for any n_i >= 0).
+      ///
+      /// Functions are normalised individually:
+      ///     N_i = 1 / sqrt( I(2 n_i + 2, 2 alpha_i) )
+      /// so the diagonal of the overlap matrix is 1 (off-diagonals are
+      /// nonzero -- GTOs at distinct (n, alpha) are NOT orthogonal).
+      ///
+      /// All one-electron matrix elements have closed forms via
+      ///     I(p, alpha) := integral_0^inf r^p exp(-alpha r^2) dr
+      ///                  = (1/2) Gamma((p+1)/2) / alpha^{(p+1)/2}
+      /// implemented with std::tgamma so any non-negative integer p works.
+      ///
+      /// Contracted GTOs (fixed linear combinations of primitives) are
+      /// handled by composing with NAORadialBasis (just like for
+      /// STORadialBasis).
+      ///
+      /// Currently non-templated (operates on arma::mat = double) to
+      /// match the non-templated RadialBasis base.
+      class GTORadialBasis : public RadialBasis {
+       protected:
+        arma::ivec n_;       ///< powers (n_i >= 0; typically n_i = l)
+        arma::vec  alpha_;   ///< exponents (alpha_i > 0)
+        arma::vec  norm_;    ///< per-function normalisation constants
+
+        /// I(p, a) = (1/2) Gamma((p+1)/2) / a^{(p+1)/2}; p >= 0.
+        static double I(int p, double a) {
+          if (p < 0)
+            throw std::logic_error("GTORadialBasis: I called with negative p.\n");
+          const double half = 0.5 * (p + 1);
+          return 0.5 * std::tgamma(half) / std::pow(a, half);
+        }
+
+       public:
+        /// Construct from per-function (n, alpha). Both vectors must have
+        /// the same nonzero length; all n_i >= 0; all alpha_i > 0.
+        GTORadialBasis(arma::ivec n, arma::vec alpha)
+            : n_(std::move(n)), alpha_(std::move(alpha)) {
+          if (n_.n_elem != alpha_.n_elem)
+            throw std::logic_error("GTORadialBasis: n and alpha sizes differ.\n");
+          if (n_.n_elem == 0)
+            throw std::logic_error("GTORadialBasis: empty basis.\n");
+          if (arma::any(n_ < 0))
+            throw std::logic_error("GTORadialBasis: every n_i must be >= 0.\n");
+          if (arma::any(alpha_ <= 0.0))
+            throw std::logic_error("GTORadialBasis: every alpha_i must be positive.\n");
+          norm_.set_size(n_.n_elem);
+          for (arma::uword i = 0; i < n_.n_elem; ++i)
+            norm_(i) = 1.0 / std::sqrt(I(2 * n_(i) + 2, 2.0 * alpha_(i)));
+        }
+
+        ~GTORadialBasis() override = default;
+
+        const arma::ivec & n_powers() const { return n_; }
+        const arma::vec  & alphas()   const { return alpha_; }
+        const arma::vec  & norms()    const { return norm_; }
+
+        size_t Nbf() const override { return n_.n_elem; }
+
+        /// S_ij = N_i N_j I(n_i + n_j + 2, alpha_i + alpha_j).
+        arma::mat overlap() const override {
+          const arma::uword N = Nbf();
+          arma::mat S(N, N);
+          for (arma::uword j = 0; j < N; ++j)
+            for (arma::uword i = 0; i < N; ++i)
+              S(i, j) = norm_(i) * norm_(j) *
+                        I(n_(i) + n_(j) + 2, alpha_(i) + alpha_(j));
+          return S;
+        }
+
+        /// T_ij = (1/2) integral u'_i u'_j dr.
+        /// u'_i = N_i [(n_i + 1) r^{n_i} - 2 alpha_i r^{n_i + 2}] exp(-alpha_i r^2)
+        /// u'_i u'_j = N_i N_j r^{p} [A - 2 B r^2 + 4 alpha_i alpha_j r^4] exp(-beta r^2)
+        ///   with p = n_i + n_j, A = (n_i + 1)(n_j + 1),
+        ///        B = (n_i + 1) alpha_j + (n_j + 1) alpha_i,
+        ///        beta = alpha_i + alpha_j.
+        arma::mat kinetic() const override {
+          const arma::uword N = Nbf();
+          arma::mat T(N, N);
+          for (arma::uword j = 0; j < N; ++j) {
+            for (arma::uword i = 0; i < N; ++i) {
+              const int    ni = n_(i);
+              const int    nj = n_(j);
+              const double ai = alpha_(i);
+              const double aj = alpha_(j);
+              const int    p  = ni + nj;
+              const double b  = ai + aj;
+              const double A  = double(ni + 1) * (nj + 1);
+              const double B  = (ni + 1) * aj + (nj + 1) * ai;
+              const double term = A * I(p, b)
+                                - 2.0 * B * I(p + 2, b)
+                                + 4.0 * ai * aj * I(p + 4, b);
+              T(i, j) = 0.5 * norm_(i) * norm_(j) * term;
+            }
+          }
+          return T;
+        }
+
+        /// (Centrifugal)_ij = (1/2) integral u_i u_j / r^2 dr
+        ///                  = (1/2) N_i N_j I(n_i + n_j, alpha_i + alpha_j).
+        arma::mat kinetic_l() const override {
+          const arma::uword N = Nbf();
+          arma::mat L(N, N);
+          for (arma::uword j = 0; j < N; ++j)
+            for (arma::uword i = 0; i < N; ++i)
+              L(i, j) = 0.5 * norm_(i) * norm_(j) *
+                        I(n_(i) + n_(j), alpha_(i) + alpha_(j));
+          return L;
+        }
+
+        /// V_ij = -integral u_i u_j / r dr
+        ///      = -N_i N_j I(n_i + n_j + 1, alpha_i + alpha_j)  (Z=1).
+        arma::mat nuclear() const override {
+          const arma::uword N = Nbf();
+          arma::mat V(N, N);
+          for (arma::uword j = 0; j < N; ++j)
+            for (arma::uword i = 0; i < N; ++i)
+              V(i, j) = -norm_(i) * norm_(j) *
+                         I(n_(i) + n_(j) + 1, alpha_(i) + alpha_(j));
+          return V;
+        }
+
+        /// psi_alpha(r) = sum_i C_{i,alpha} N_i r^{n_i} exp(-alpha_i r^2).
+        arma::vec eval_orbs(const arma::mat & C, double r) const override {
+          if (C.n_rows != Nbf()) {
+            std::ostringstream oss;
+            oss << "GTORadialBasis::eval_orbs: C has " << C.n_rows
+                << " rows but Nbf() = " << Nbf() << "\n";
+            throw std::logic_error(oss.str());
+          }
+          arma::rowvec R_at_r(Nbf());
+          for (arma::uword i = 0; i < Nbf(); ++i)
+            R_at_r(i) = norm_(i) * std::pow(r, n_(i)) *
+                        std::exp(-alpha_(i) * r * r);
+          return (R_at_r * C).t();
+        }
+      };
+
+    } // namespace basis
+  } // namespace atomic
+} // namespace helfem
+
+#endif

--- a/libhelfem/include/STORadialBasis.h
+++ b/libhelfem/include/STORadialBasis.h
@@ -1,0 +1,190 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef ATOMIC_BASIS_STORADIALBASIS_H
+#define ATOMIC_BASIS_STORADIALBASIS_H
+
+#include "RadialBasis.h"
+#include <armadillo>
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+namespace helfem {
+  namespace atomic {
+    namespace basis {
+
+      /// Primitive Slater-type-orbital (STO) radial basis. Each function
+      /// is characterised by an integer power n_i >= 1 and a positive
+      /// exponent zeta_i:
+      ///
+      ///     R_i(r) = N_i * r^{n_i - 1} * exp(-zeta_i * r)
+      ///     u_i(r) = r * R_i(r) = N_i * r^{n_i} * exp(-zeta_i * r)
+      ///
+      /// (the u convention matches FEMRadialBasis and NAORadialBasis,
+      /// so u_i(0) = 0 and all matrix elements are in dr measure).
+      ///
+      /// Functions are normalised individually:
+      ///     N_i = sqrt( (2*zeta_i)^{2 n_i + 1} / (2 n_i)! )
+      /// so the diagonal of the overlap matrix is 1 (off-diagonals are
+      /// nonzero -- STOs at distinct (n, zeta) are NOT orthogonal).
+      ///
+      /// All one-electron matrix elements have closed forms via
+      ///     I(p, alpha) := integral_0^inf r^p exp(-alpha r) dr
+      ///                  = p! / alpha^{p+1}    (integer p >= 0).
+      ///
+      /// Contracted STOs (fixed linear combinations of primitives) are
+      /// handled by composing this class with NAORadialBasis: build the
+      /// primitive STORadialBasis once, then wrap with NAORadialBasis
+      /// carrying the contraction coefficients.
+      ///
+      /// Currently non-templated (operates on arma::mat = double) to
+      /// match the non-templated RadialBasis base.
+      class STORadialBasis : public RadialBasis {
+       protected:
+        arma::ivec n_;       ///< principal powers (n_i >= 1)
+        arma::vec  zeta_;    ///< exponents (zeta_i > 0)
+        arma::vec  norm_;    ///< per-function normalisation constants
+
+        /// Integer factorial; STOs typically need p <= 2*max(n_i), small.
+        static double fact(int p) {
+          if (p < 0)
+            throw std::logic_error("STORadialBasis: factorial of negative argument.\n");
+          double f = 1.0;
+          for (int k = 2; k <= p; ++k) f *= k;
+          return f;
+        }
+
+        /// Convenience: I(p, alpha) = p! / alpha^{p+1}.
+        static double I(int p, double alpha) {
+          return fact(p) / std::pow(alpha, p + 1);
+        }
+
+       public:
+        /// Construct from per-function (n, zeta). Both vectors must have
+        /// the same nonzero length; all n_i >= 1; all zeta_i > 0.
+        STORadialBasis(arma::ivec n, arma::vec zeta)
+            : n_(std::move(n)), zeta_(std::move(zeta)) {
+          if (n_.n_elem != zeta_.n_elem)
+            throw std::logic_error("STORadialBasis: n and zeta sizes differ.\n");
+          if (n_.n_elem == 0)
+            throw std::logic_error("STORadialBasis: empty basis.\n");
+          if (arma::any(n_ < 1))
+            throw std::logic_error("STORadialBasis: every n_i must be >= 1 "
+                                    "(to enforce u(0)=0).\n");
+          if (arma::any(zeta_ <= 0.0))
+            throw std::logic_error("STORadialBasis: every zeta_i must be positive.\n");
+          norm_.set_size(n_.n_elem);
+          for (arma::uword i = 0; i < n_.n_elem; ++i) {
+            const int    ni = n_(i);
+            const double zi = zeta_(i);
+            // N_i^2 = (2 zeta_i)^{2 n_i + 1} / (2 n_i)!
+            norm_(i) = std::sqrt(std::pow(2.0 * zi, 2 * ni + 1) / fact(2 * ni));
+          }
+        }
+
+        ~STORadialBasis() override = default;
+
+        /// Read-only accessors.
+        const arma::ivec & n_powers() const { return n_; }
+        const arma::vec  & zetas()   const { return zeta_; }
+        const arma::vec  & norms()   const { return norm_; }
+
+        size_t Nbf() const override { return n_.n_elem; }
+
+        /// S_ij = N_i N_j (n_i + n_j)! / (zeta_i + zeta_j)^{n_i + n_j + 1}
+        arma::mat overlap() const override {
+          const arma::uword N = Nbf();
+          arma::mat S(N, N);
+          for (arma::uword j = 0; j < N; ++j)
+            for (arma::uword i = 0; i < N; ++i)
+              S(i, j) = norm_(i) * norm_(j) *
+                        I(n_(i) + n_(j), zeta_(i) + zeta_(j));
+          return S;
+        }
+
+        /// T_ij = (1/2) integral u'_i u'_j dr.
+        /// With u'_i = N_i r^{n_i - 1} (n_i - zeta_i r) exp(-zeta_i r),
+        ///   u'_i u'_j = N_i N_j r^{p-2} [n_i n_j
+        ///                                - (n_i zeta_j + n_j zeta_i) r
+        ///                                + zeta_i zeta_j r^2] exp(-alpha r)
+        /// where p = n_i + n_j, alpha = zeta_i + zeta_j.
+        arma::mat kinetic() const override {
+          const arma::uword N = Nbf();
+          arma::mat T(N, N);
+          for (arma::uword j = 0; j < N; ++j) {
+            for (arma::uword i = 0; i < N; ++i) {
+              const int    ni = n_(i);
+              const int    nj = n_(j);
+              const double zi = zeta_(i);
+              const double zj = zeta_(j);
+              const int    p  = ni + nj;
+              const double a  = zi + zj;
+              const double term = double(ni * nj) * I(p - 2, a)
+                                - (ni * zj + nj * zi) * I(p - 1, a)
+                                + zi * zj * I(p, a);
+              T(i, j) = 0.5 * norm_(i) * norm_(j) * term;
+            }
+          }
+          return T;
+        }
+
+        /// (Centrifugal)_ij = (1/2) integral u_i u_j / r^2 dr
+        ///                  = (1/2) N_i N_j (p-2)! / alpha^{p-1}
+        ///                  (well-defined since p = n_i + n_j >= 2).
+        arma::mat kinetic_l() const override {
+          const arma::uword N = Nbf();
+          arma::mat L(N, N);
+          for (arma::uword j = 0; j < N; ++j)
+            for (arma::uword i = 0; i < N; ++i)
+              L(i, j) = 0.5 * norm_(i) * norm_(j) *
+                        I(n_(i) + n_(j) - 2, zeta_(i) + zeta_(j));
+          return L;
+        }
+
+        /// V_ij = -integral u_i u_j / r dr
+        ///      = -N_i N_j (p-1)! / alpha^p     (Z=1; caller multiplies by Z).
+        arma::mat nuclear() const override {
+          const arma::uword N = Nbf();
+          arma::mat V(N, N);
+          for (arma::uword j = 0; j < N; ++j)
+            for (arma::uword i = 0; i < N; ++i)
+              V(i, j) = -norm_(i) * norm_(j) *
+                         I(n_(i) + n_(j) - 1, zeta_(i) + zeta_(j));
+          return V;
+        }
+
+        /// psi_alpha(r) = sum_i C_{i,alpha} R_i(r)
+        ///              = sum_i C_{i,alpha} N_i r^{n_i - 1} exp(-zeta_i r).
+        /// Finite at r=0 (n_i >= 1 guarantees r^{n_i - 1} bounded).
+        arma::vec eval_orbs(const arma::mat & C, double r) const override {
+          if (C.n_rows != Nbf()) {
+            std::ostringstream oss;
+            oss << "STORadialBasis::eval_orbs: C has " << C.n_rows
+                << " rows but Nbf() = " << Nbf() << "\n";
+            throw std::logic_error(oss.str());
+          }
+          arma::rowvec R_at_r(Nbf());
+          for (arma::uword i = 0; i < Nbf(); ++i)
+            R_at_r(i) = norm_(i) * std::pow(r, n_(i) - 1) *
+                        std::exp(-zeta_(i) * r);
+          return (R_at_r * C).t();
+        }
+      };
+
+    } // namespace basis
+  } // namespace atomic
+} // namespace helfem
+
+#endif


### PR DESCRIPTION
## Summary

Completes the `RadialBasis` subclass roster: **FEM, NAO, STO, GTO**. Each new class is a primitive (uncontracted) radial basis where every function carries its own `(n, exponent)` and all one-electron matrix elements have closed forms.

### `STORadialBasis`

Functions: `R_i(r) = N_i · r^{n_i − 1} · exp(−ζ_i · r)`, `u_i(r) = N_i · r^{n_i} · exp(−ζ_i · r)`.

All four required matrix elements via

```
I(p, α) = p! / α^{p+1}    (integer p ≥ 0)
```

`n_i ≥ 1` enforced (so `u(0) = 0`, the Dirichlet condition). `N_i` normalised so the overlap diagonal is 1.

### `GTORadialBasis`

Functions: `R_i(r) = N_i · r^{n_i} · exp(−α_i · r²)`, `u_i(r) = N_i · r^{n_i + 1} · exp(−α_i · r²)`.

Matrix elements via

```
I(p, a) = (1/2) Γ((p+1)/2) / a^{(p+1)/2}
```

implemented with `std::tgamma` (any non-negative integer `p` works). `n_i ≥ 0` enforced; typically `n_i = l` for a primitive of angular momentum `l`. `N_i` normalised so the overlap diagonal is 1.

### Contracted bases compose with NAORadialBasis

Standard quantum-chemistry contracted STO/GTO bases (fixed linear combinations of primitives per basis function) compose trivially: build the primitive STO/GTO basis, then wrap with `NAORadialBasis` carrying the contraction matrix. Same pattern used for SCF-MO-on-top-of-FEM in PR #79.

### Validation

| test | observed | reference |
|---|---|---|
| **STO single H 1s** (n=1, ζ=1) — exact H eigenstate | E = −0.50000000000000 | −0.5 (analytic, exact to 14 digits) |
| **STO 2-fn basis** {n=1, ζ ∈ (1, 2)} | E_low = −0.50000000000000 | −0.5 (variational bound saturated; ζ=1 is exact) |
| **GTO STO-3G H 1s** (3 GTOs + NAO contraction) | T + V = −0.46658184955727 | −0.4666 (textbook STO-3G, 7-digit match) |
| **GTO 4-prim even-tempered s** for H | E_low = −0.49832685508795 | variational improvement over STO-3G |

## RadialBasis ecosystem after this PR

| class | functions | matrix elements |
|---|---|---|
| `FEMRadialBasis` | FE primitives (LIP, HIP, HIP2, HIP3, Legendre) | numerical (Chebyshev / Lobatto) |
| `NAORadialBasis` | view over underlying basis + coefficient matrix | inherits underlying accuracy |
| `STORadialBasis` | analytic Slater primitives | closed form |
| `GTORadialBasis` | analytic Gaussian primitives | closed form |

Contracted STO/GTO = primitive STO/GTO + `NAORadialBasis` wrapper.

Both new classes are header-only at `libhelfem/include/`, ~170 LOC each, non-templated (matches the non-templated `RadialBasis` base).

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] STO + GTO matrix elements vs analytic limits (see table)
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit** (He HF = −2.86167999561 Eh, err 3.59e-12)