### PR TITLE
v2: Cholesky-factored in-element 2e tensor on FEMRadialBasis

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -209,6 +209,28 @@ namespace helfem {
         arma::mat twoe_integral(int L, size_t iel) const;
         /// Compute primitive Yukawa-screened two-electron integral
         arma::mat yukawa_integral(int L, double lambda, size_t iel) const;
+
+        /// Pivoted-Cholesky decomposition of the in-element 4-index
+        /// two-electron tensor twoe_integral(L, iel). Returns L of shape
+        /// (Ni^2 x r) such that L * L^T == twoe_integral(L, iel) to the
+        /// requested absolute tolerance on the residual diagonal (default
+        /// 1e-12). The rank r is determined by truncation; for smooth FE
+        /// kernels in a single element r is typically much smaller than
+        /// Ni^2 -- often O(Ni).
+        ///
+        /// Same factored representation as the cross-element disjoint
+        /// pieces (radial_integral(L)/(-L-1)), so a single contraction
+        /// routine over Sum_p L_p(ab) * L_p(cd) handles every (iel, jel)
+        /// case uniformly (in-element: r columns; disjoint: rank-1).
+        ///
+        /// Assumes the in-element tensor is positive semi-definite; this
+        /// holds for the bare Coulomb and Yukawa kernels (both PSD as
+        /// integral kernels).
+        arma::mat twoe_integral_cholesky(int L, size_t iel,
+                                         double tol = 1e-12) const;
+        /// Same as above for the Yukawa-screened tensor yukawa_integral.
+        arma::mat yukawa_integral_cholesky(int L, double lambda, size_t iel,
+                                           double tol = 1e-12) const;
         /// Compute primitive complementary error function two-electron integral
         arma::mat erfc_integral(int L, double lambda, size_t iel,
                                 size_t jel) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -410,6 +410,61 @@ namespace helfem {
         return tei;
       }
 
+      // Pivoted Cholesky with truncation. Returns Lout of shape
+      // (n x r) such that Lout * Lout^T == A up to abs tolerance on the
+      // residual diagonal. Standard textbook algorithm (Higham, Sec 10.3);
+      // pivots greedily on the largest remaining diagonal each step.
+      static arma::mat pivoted_cholesky_(const arma::mat & A, double tol) {
+        const arma::uword n = A.n_rows;
+        if (A.n_cols != n)
+          throw std::logic_error("pivoted_cholesky: input must be square.\n");
+        arma::vec  D    = A.diag();
+        arma::uvec done(n, arma::fill::zeros);
+        arma::mat  L(n, 0);
+        for (arma::uword k = 0; k < n; ++k) {
+          // Pivot on the largest remaining diagonal residual.
+          arma::uword pivot = n;
+          double pivot_val = tol;
+          for (arma::uword i = 0; i < n; ++i)
+            if (!done(i) && D(i) > pivot_val) {
+              pivot = i;
+              pivot_val = D(i);
+            }
+          if (pivot == n) break;            // truncated -- rank reached
+          done(pivot) = 1;
+          const double sqrt_d = std::sqrt(pivot_val);
+          arma::vec col(n);
+          // col(i) = (A(i, pivot) - sum_{j<k} L(i,j) L(pivot,j)) / sqrt_d.
+          // For already-pivoted rows (i with done(i)==1, i != pivot) the
+          // residual is 0 by construction; skip the computation cleanly
+          // by zeroing.
+          for (arma::uword i = 0; i < n; ++i) {
+            if (done(i) && i != pivot) { col(i) = 0.0; continue; }
+            double s = A(i, pivot);
+            if (L.n_cols > 0)
+              s -= arma::dot(L.row(i), L.row(pivot));
+            col(i) = s / sqrt_d;
+          }
+          col(pivot) = sqrt_d;
+          L.insert_cols(L.n_cols, col);
+          // Update residual diagonal for the not-yet-pivoted rows.
+          for (arma::uword i = 0; i < n; ++i)
+            if (!done(i)) D(i) -= col(i) * col(i);
+        }
+        return L;
+      }
+
+      arma::mat FEMRadialBasis::twoe_integral_cholesky(int L, size_t iel,
+                                                       double tol) const {
+        return pivoted_cholesky_(twoe_integral(L, iel), tol);
+      }
+
+      arma::mat FEMRadialBasis::yukawa_integral_cholesky(int L, double lambda,
+                                                         size_t iel,
+                                                         double tol) const {
+        return pivoted_cholesky_(yukawa_integral(L, lambda, iel), tol);
+      }
+
       arma::mat FEMRadialBasis::yukawa_integral(int L, double lambda, size_t iel) const {
         double Rmin(fem.element_begin(iel));
         double Rmax(fem.element_end(iel));


### PR DESCRIPTION
## Summary

Adds `twoe_integral_cholesky(L, iel, tol)` and `yukawa_integral_cholesky(...)` on `FEMRadialBasis`. Returns a pivoted-Cholesky factor `L` of shape `(Ni² × r)` such that

```
L · Lᵀ == twoe_integral(L, iel)
```

to the requested absolute tolerance on the residual diagonal (default `1e-12`). The rank `r` is determined by truncation; in practice for smooth FE kernels in a single element `r ≪ Ni²` — typically `O(Ni)`.

## Why

Foundation for a unified contraction path across the elemental 4-index two-electron operator. The cross-element "disjoint" factorisation

```
R^L_FE(ab, cd) = r_small(iel)_{ab} · r_big(jel)_{cd}    (iel ≠ jel)
```

is already a rank-1 outer-product representation. Cholesky-decomposing the in-element tensor turns it into the **same** representation, just at higher rank (`r` columns instead of 1). One contraction routine of the form

```
M = Σ_p A_p · P · B_pᵀ     (K-ordering)
M = Σ_p A_p · ⟨B_p, P⟩      (J-ordering)
```

then handles every `(iel, jel)` pair uniformly; the existing direct `O(Ni⁴)` in-element path becomes redundant.

**This PR adds the primitive only.** The migration of `TwoDBasis::coulomb / TwoDBasis::exchange` (sadatom + atomic), and of `NAORadialBasis::coulomb_radial / exchange_radial` (once PR #81 lands), to the unified path is a separate larger refactor.

## Implementation

`pivoted_cholesky_` helper in `RadialBasis.cpp` — standard greedy pivot-on-largest-residual-diagonal algorithm (Higham §10.3, ~35 LOC).

Assumes the in-element tensor is positive semi-definite, which holds for the bare Coulomb and Yukawa kernels (both PSD as integral kernels on functions). For erfc / indefinite kernels, the same algorithm could be replaced with a truncated eigendecomposition; out of scope here.

## Validation

15-LIP, 10 exponential elements:

### Reconstruction error and rank

| iel | Ni² | L | rank | tol | `‖L·Lᵀ − T‖_∞` |
|---:|---:|---:|---:|---:|---:|
| 0 | 196 | 0 | 26 | 1e-8 | **7.8e-9** |
| 0 | 196 | 0 | 27 | 1e-12 | **3.5e-18** |
| 0 | 196 | 0 | 27 | 1e-15 | **3.5e-18** ← numerical rank reached |
| 0 | 196 | 1 | 27 | 1e-12 | 3.5e-18 |
| 0 | 196 | 2 | 27 | 1e-12 | 3.5e-18 |
| 0 | 196 | 4 | 27 | 1e-12 | 3.5e-18 |
| 1–9 | 196–225 | 0 | 27 | 1e-8 | ~2e-9 |

**Cholesky rank 27 vs Ni² ≈ 200 → ~7-8× compression** in both memory (`Ni² · r` vs `Ni⁴`) and density-contraction FLOPs.

### Yukawa (λ=0.5)

Rank 27–29 (similar to bare Coulomb), reconstruction at machine eps (~1e-17).

### Direct vs Cholesky density contraction (random symmetric P)

| iel | Ni | rank | `‖direct − chol‖_∞` |
|---:|---:|---:|---:|
| 0 | 14 | 27 | **4.2e-17** |
| 1 | 15 | 29 | **2.1e-17** |
| 2 | 15 | 29 | **2.8e-17** |

i.e. machine epsilon.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit** (He HF = −2.86167999561 Eh, err 3.59e-12)
- [x] Cholesky reconstruction at requested tolerance (machine eps when rank reaches numerical rank)
- [x] Density contraction via Cholesky agrees with direct path to machine eps

## Next

A follow-on PR can wire:
- `TwoDBasis::compute_tei` / `coulomb` / `exchange` (sadatom + atomic) onto the unified contraction routine, replacing the dense `prim_tei` storage with Cholesky factors.
- `NAORadialBasis::coulomb_radial` / `exchange_radial` (once PR #81 lands) onto the same path.

Then benchmark vs the current direct `O(Ni⁴)` path on representative systems (He, Be, Ne) before deciding whether to retire the direct path entirely or keep it as a fallback for indefinite kernels.