### PR TITLE
v2: extract FE 2e assembly into reusable free functions; route NAORadialBasis through them

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -1,0 +1,205 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef ATOMIC_BASIS_COULOMB_EXCHANGE_FE_H
+#define ATOMIC_BASIS_COULOMB_EXCHANGE_FE_H
+
+#include "RadialBasis.h"
+#include <armadillo>
+
+namespace helfem {
+  // Forward declaration of the existing in-tree helper from
+  // libhelfem/src/utils.cpp (its header is in libhelfem/src/, not on the
+  // public include path; the symbol is resolved at link time -- callers
+  // of these helpers link against libhelfem anyway).
+  namespace utils {
+    arma::mat exchange_tei(const arma::mat & tei, size_t Ni, size_t Nj,
+                            size_t Nk, size_t Nl);
+  }
+  namespace atomic {
+    namespace basis {
+
+      /// Free-function FE-basis assembly of the single-multipole
+      /// two-electron radial operators. These are the "BARE" operators in
+      /// the sense of TwoDBasis: no 4*pi/(2L+1) prefactor, no Gaunt
+      /// coefficient -- the caller (NAORadialBasis, TwoDBasis::coulomb
+      /// at one L, ...) applies whatever angular factor its own driver
+      /// demands.
+      ///
+      /// For the in-element 4-index tensor, the assembly uses
+      ///   FEMRadialBasis::twoe_integral(L, iel)         (bare Coulomb)
+      ///   FEMRadialBasis::yukawa_integral(L, lambda, iel) (Yukawa)
+      /// and contracts directly. For cross-element pairs the standard
+      /// disjoint factorisation is used:
+      ///   R^L(ab, cd) = r_small(iel)_{ab} * r_big(jel)_{cd}    (iel < jel)
+      ///              = r_big(iel)_{ab}   * r_small(jel)_{cd}   (iel > jel)
+      /// with
+      ///   r_small = radial.radial_integral(L, iel)         (bare Coulomb)
+      ///           = radial.bessel_il_integral(L, lambda, iel) (Yukawa)
+      ///   r_big   = radial.radial_integral(-L-1, iel)
+      ///           = radial.bessel_kl_integral(L, lambda, iel)
+      ///
+      /// Same assembly pattern that sadatom/atomic TwoDBasis::coulomb /
+      /// exchange use (single source of truth: the helpers below). The
+      /// existing TwoDBasis driver routines can rewrite themselves on
+      /// top of these (DRY); doing that migration is a separate PR.
+      ///
+      /// Sign convention: assemble_J_FE_one_multipole returns the
+      /// positive bare integral; assemble_K_FE_one_multipole returns the
+      /// positive bare K (no HF minus -- caller flips sign if needed,
+      /// matches NAORadialBasis::exchange_radial).
+      ///
+      /// Implementations recompute the per-element radial_integral /
+      /// twoe_integral on each call -- adequate for occasional NAO usage
+      /// but expensive for an SCF loop. TwoDBasis (which calls these
+      /// every SCF iteration) should cache per-element integrals
+      /// externally and... [follow-on PR will add caching-aware
+      /// overloads].
+
+      arma::mat assemble_J_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const arma::mat & P_FE);
+
+      arma::mat assemble_K_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const arma::mat & P_FE);
+
+      arma::mat assemble_J_FE_one_multipole_yukawa(
+          const FEMRadialBasis & radial, int L, double lambda,
+          const arma::mat & P_FE);
+
+      arma::mat assemble_K_FE_one_multipole_yukawa(
+          const FEMRadialBasis & radial, int L, double lambda,
+          const arma::mat & P_FE);
+
+      // Inline implementations -- header-only to match the rest of the
+      // libhelfem/include/ NAO surface. ~150 LOC total.
+
+      namespace detail_fe_2e {
+
+        inline arma::mat r_small(const FEMRadialBasis & fem, int L, size_t iel,
+                                  bool yukawa, double lambda) {
+          return yukawa ? fem.bessel_il_integral(L, lambda, iel)
+                        : fem.radial_integral(L, iel);
+        }
+        inline arma::mat r_big(const FEMRadialBasis & fem, int L, size_t iel,
+                                bool yukawa, double lambda) {
+          return yukawa ? fem.bessel_kl_integral(L, lambda, iel)
+                        : fem.radial_integral(-L - 1, iel);
+        }
+        inline arma::mat in_element_tei(const FEMRadialBasis & fem, int L,
+                                         size_t iel,
+                                         bool yukawa, double lambda) {
+          return yukawa ? fem.yukawa_integral(L, lambda, iel)
+                        : fem.twoe_integral(L, iel);
+        }
+
+        inline arma::mat assemble_J(const FEMRadialBasis & radial, int L,
+                                     const arma::mat & P_FE,
+                                     bool yukawa, double lambda) {
+          const size_t Nel  = radial.Nel();
+          const size_t Nrad = radial.Nbf();
+          arma::mat J_FE(Nrad, Nrad, arma::fill::zeros);
+          for (size_t jel = 0; jel < Nel; ++jel) {
+            size_t jfirst, jlast;
+            radial.get_idx(jel, jfirst, jlast);
+            const size_t Nj = jlast - jfirst + 1;
+            arma::mat Psub = P_FE.submat(jfirst, jfirst, jlast, jlast);
+            const arma::mat rs = r_small(radial, L, jel, yukawa, lambda);
+            const arma::mat rb = r_big  (radial, L, jel, yukawa, lambda);
+            const double jsmall = arma::trace(rs * Psub);
+            const double jbig   = arma::trace(rb * Psub);
+            for (size_t iel = 0; iel < jel; ++iel) {
+              size_t ifirst, ilast;
+              radial.get_idx(iel, ifirst, ilast);
+              J_FE.submat(ifirst, ifirst, ilast, ilast) +=
+                  jbig * r_small(radial, L, iel, yukawa, lambda);
+            }
+            for (size_t iel = jel + 1; iel < Nel; ++iel) {
+              size_t ifirst, ilast;
+              radial.get_idx(iel, ifirst, ilast);
+              J_FE.submat(ifirst, ifirst, ilast, ilast) +=
+                  jsmall * r_big(radial, L, iel, yukawa, lambda);
+            }
+            // In-element 4-index contribution.
+            arma::vec Psub_v = arma::vectorise(Psub);
+            arma::vec Jsub_v = in_element_tei(radial, L, jel, yukawa, lambda) * Psub_v;
+            J_FE.submat(jfirst, jfirst, jlast, jlast) +=
+                arma::reshape(Jsub_v, Nj, Nj);
+          }
+          return J_FE;
+        }
+
+        inline arma::mat assemble_K(const FEMRadialBasis & radial, int L,
+                                     const arma::mat & P_FE,
+                                     bool yukawa, double lambda) {
+          const size_t Nel  = radial.Nel();
+          const size_t Nrad = radial.Nbf();
+          arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
+          for (size_t iel = 0; iel < Nel; ++iel) {
+            size_t ifirst, ilast;
+            radial.get_idx(iel, ifirst, ilast);
+            const size_t Ni = ilast - ifirst + 1;
+            for (size_t jel = 0; jel < Nel; ++jel) {
+              size_t jfirst, jlast;
+              radial.get_idx(jel, jfirst, jlast);
+              const size_t Nj = jlast - jfirst + 1;
+              if (iel == jel) {
+                const arma::mat tei  = in_element_tei(radial, L, iel, yukawa, lambda);
+                const arma::mat ktei = utils::exchange_tei(tei, Ni, Ni, Ni, Ni);
+                arma::vec Psub_v = arma::vectorise(
+                    P_FE.submat(ifirst, jfirst, ilast, jlast));
+                arma::vec Ksub_v = ktei * Psub_v;
+                K_FE.submat(ifirst, jfirst, ilast, jlast) +=
+                    arma::reshape(Ksub_v, Ni, Nj);
+              } else {
+                const arma::mat iint = (iel > jel)
+                    ? r_big  (radial, L, iel, yukawa, lambda)
+                    : r_small(radial, L, iel, yukawa, lambda);
+                const arma::mat jint = (iel > jel)
+                    ? r_small(radial, L, jel, yukawa, lambda)
+                    : r_big  (radial, L, jel, yukawa, lambda);
+                const arma::mat Psub = P_FE.submat(ifirst, jfirst, ilast, jlast);
+                K_FE.submat(ifirst, jfirst, ilast, jlast) +=
+                    iint * (Psub * jint.t());
+              }
+            }
+          }
+          return K_FE;
+        }
+
+      } // namespace detail_fe_2e
+
+      inline arma::mat assemble_J_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
+        return detail_fe_2e::assemble_J(radial, L, P_FE, /*yukawa=*/false, 0.0);
+      }
+      inline arma::mat assemble_K_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
+        return detail_fe_2e::assemble_K(radial, L, P_FE, /*yukawa=*/false, 0.0);
+      }
+      inline arma::mat assemble_J_FE_one_multipole_yukawa(
+          const FEMRadialBasis & radial, int L, double lambda,
+          const arma::mat & P_FE) {
+        return detail_fe_2e::assemble_J(radial, L, P_FE, /*yukawa=*/true, lambda);
+      }
+      inline arma::mat assemble_K_FE_one_multipole_yukawa(
+          const FEMRadialBasis & radial, int L, double lambda,
+          const arma::mat & P_FE) {
+        return detail_fe_2e::assemble_K(radial, L, P_FE, /*yukawa=*/true, lambda);
+      }
+
+    } // namespace basis
+  } // namespace atomic
+} // namespace helfem
+
+#endif

--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -16,21 +16,13 @@
 #define ATOMIC_BASIS_NAORADIALBASIS_H
 
 #include "RadialBasis.h"
+#include "CoulombExchangeFE.h"
 #include <armadillo>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
 
 namespace helfem {
-  // Forward declaration of the existing in-tree helper from
-  // libhelfem/src/utils.cpp (its header is in libhelfem/src/ and is not
-  // part of the public include path, so we just resolve the symbol at
-  // link time -- callers of the NAO 2e methods link against libhelfem
-  // anyway because the FE matrix elements live there).
-  namespace utils {
-    arma::mat exchange_tei(const arma::mat & tei, size_t Ni, size_t Nj,
-                            size_t Nk, size_t Nl);
-  }
   namespace atomic {
     namespace basis {
 
@@ -197,9 +189,9 @@ namespace helfem {
                                  const arma::mat & D) const {
           require_shared_fe_(other, "coulomb_radial");
           require_density_shape_(other, D, "coulomb_radial");
+          const FEMRadialBasis & fem = underlying_fem_();
           const arma::mat P_FE = other.C_ * D * other.C_.t();
-          const arma::mat J_FE = assemble_J_fe_(k, P_FE, /*yukawa*/false, 0.0);
-          return C_.t() * J_FE * C_;
+          return C_.t() * assemble_J_FE_one_multipole(fem, k, P_FE) * C_;
         }
 
         /// K^k_NAO(D) := sum_{mn} D_{mn} R^k(a_i b_m, a_j b_n) (bare radial).
@@ -209,9 +201,9 @@ namespace helfem {
                                   const arma::mat & D) const {
           require_shared_fe_(other, "exchange_radial");
           require_density_shape_(other, D, "exchange_radial");
+          const FEMRadialBasis & fem = underlying_fem_();
           const arma::mat P_FE = other.C_ * D * other.C_.t();
-          const arma::mat K_FE = assemble_K_fe_(k, P_FE, /*yukawa*/false, 0.0);
-          return C_.t() * K_FE * C_;
+          return C_.t() * assemble_K_FE_one_multipole(fem, k, P_FE) * C_;
         }
 
         /// Yukawa-screened Coulomb at multipole k, screening lambda > 0:
@@ -225,9 +217,10 @@ namespace helfem {
           require_density_shape_(other, D, "coulomb_radial_yukawa");
           if (lambda <= 0.0)
             throw std::logic_error("coulomb_radial_yukawa: lambda must be positive.\n");
+          const FEMRadialBasis & fem = underlying_fem_();
           const arma::mat P_FE = other.C_ * D * other.C_.t();
-          const arma::mat J_FE = assemble_J_fe_(k, P_FE, /*yukawa*/true, lambda);
-          return C_.t() * J_FE * C_;
+          return C_.t() *
+                 assemble_J_FE_one_multipole_yukawa(fem, k, lambda, P_FE) * C_;
         }
 
         /// Yukawa-screened exchange at multipole k.
@@ -238,9 +231,10 @@ namespace helfem {
           require_density_shape_(other, D, "exchange_radial_yukawa");
           if (lambda <= 0.0)
             throw std::logic_error("exchange_radial_yukawa: lambda must be positive.\n");
+          const FEMRadialBasis & fem = underlying_fem_();
           const arma::mat P_FE = other.C_ * D * other.C_.t();
-          const arma::mat K_FE = assemble_K_fe_(k, P_FE, /*yukawa*/true, lambda);
-          return C_.t() * K_FE * C_;
+          return C_.t() *
+                 assemble_K_FE_one_multipole_yukawa(fem, k, lambda, P_FE) * C_;
         }
 
        protected:
@@ -282,107 +276,6 @@ namespace helfem {
                 "basis is not a FEMRadialBasis; per-multipole two-electron "
                 "operators are only implemented for FE-backed NAOs.\n");
           return *fem;
-        }
-
-        /// Return r_small(L, iel) -- either radial_integral(L, iel) (bare)
-        /// or bessel_il_integral(L, lambda, iel) (Yukawa).
-        static arma::mat r_small_(const FEMRadialBasis & fem, int L, size_t iel,
-                                  bool yukawa, double lambda) {
-          return yukawa ? fem.bessel_il_integral(L, lambda, iel)
-                        : fem.radial_integral(L, iel);
-        }
-        /// Return r_big(L, iel) -- radial_integral(-L-1, iel) (bare) or
-        /// bessel_kl_integral (Yukawa).
-        static arma::mat r_big_(const FEMRadialBasis & fem, int L, size_t iel,
-                                bool yukawa, double lambda) {
-          return yukawa ? fem.bessel_kl_integral(L, lambda, iel)
-                        : fem.radial_integral(-L - 1, iel);
-        }
-        /// In-element 4-index integral.
-        static arma::mat in_element_tei_(const FEMRadialBasis & fem, int L,
-                                         size_t iel,
-                                         bool yukawa, double lambda) {
-          return yukawa ? fem.yukawa_integral(L, lambda, iel)
-                        : fem.twoe_integral(L, iel);
-        }
-
-        /// Build the FE-basis Coulomb J^L_FE for a single multipole L,
-        /// without the 4 pi / (2L+1) prefactor.
-        arma::mat assemble_J_fe_(int L, const arma::mat & P_FE,
-                                 bool yukawa, double lambda) const {
-          const FEMRadialBasis & radial = underlying_fem_();
-          const size_t Nel  = radial.Nel();
-          const size_t Nrad = radial.Nbf();
-          arma::mat J_FE(Nrad, Nrad, arma::fill::zeros);
-          for (size_t jel = 0; jel < Nel; ++jel) {
-            size_t jfirst, jlast;
-            radial.get_idx(jel, jfirst, jlast);
-            const size_t Nj = jlast - jfirst + 1;
-            arma::mat Psub = P_FE.submat(jfirst, jfirst, jlast, jlast);
-            const arma::mat rs = r_small_(radial, L, jel, yukawa, lambda);
-            const arma::mat rb = r_big_  (radial, L, jel, yukawa, lambda);
-            const double jsmall = arma::trace(rs * Psub);
-            const double jbig   = arma::trace(rb * Psub);
-            for (size_t iel = 0; iel < jel; ++iel) {
-              size_t ifirst, ilast;
-              radial.get_idx(iel, ifirst, ilast);
-              J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                  jbig * r_small_(radial, L, iel, yukawa, lambda);
-            }
-            for (size_t iel = jel + 1; iel < Nel; ++iel) {
-              size_t ifirst, ilast;
-              radial.get_idx(iel, ifirst, ilast);
-              J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                  jsmall * r_big_(radial, L, iel, yukawa, lambda);
-            }
-            // In-element 4-index contribution.
-            arma::vec Psub_v = arma::vectorise(Psub);
-            arma::vec Jsub_v = in_element_tei_(radial, L, jel, yukawa, lambda) * Psub_v;
-            J_FE.submat(jfirst, jfirst, jlast, jlast) +=
-                arma::reshape(Jsub_v, Nj, Nj);
-          }
-          return J_FE;
-        }
-
-        /// Build the FE-basis exchange K^L_FE for a single multipole L,
-        /// without the 4 pi / (2L+1) prefactor. Sign: POSITIVE bare integral
-        /// (no HF minus).
-        arma::mat assemble_K_fe_(int L, const arma::mat & P_FE,
-                                 bool yukawa, double lambda) const {
-          const FEMRadialBasis & radial = underlying_fem_();
-          const size_t Nel  = radial.Nel();
-          const size_t Nrad = radial.Nbf();
-          arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
-          for (size_t iel = 0; iel < Nel; ++iel) {
-            size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
-            const size_t Ni = ilast - ifirst + 1;
-            for (size_t jel = 0; jel < Nel; ++jel) {
-              size_t jfirst, jlast;
-              radial.get_idx(jel, jfirst, jlast);
-              const size_t Nj = jlast - jfirst + 1;
-              if (iel == jel) {
-                const arma::mat tei  = in_element_tei_(radial, L, iel, yukawa, lambda);
-                const arma::mat ktei = utils::exchange_tei(tei, Ni, Ni, Ni, Ni);
-                arma::vec Psub_v = arma::vectorise(
-                    P_FE.submat(ifirst, jfirst, ilast, jlast));
-                arma::vec Ksub_v = ktei * Psub_v;
-                K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                    arma::reshape(Ksub_v, Ni, Nj);
-              } else {
-                const arma::mat iint = (iel > jel)
-                    ? r_big_  (radial, L, iel, yukawa, lambda)
-                    : r_small_(radial, L, iel, yukawa, lambda);
-                const arma::mat jint = (iel > jel)
-                    ? r_small_(radial, L, jel, yukawa, lambda)
-                    : r_big_  (radial, L, jel, yukawa, lambda);
-                const arma::mat Psub = P_FE.submat(ifirst, jfirst, ilast, jlast);
-                K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                    iint * (Psub * jint.t());
-              }
-            }
-          }
-          return K_FE;
         }
       };
 


### PR DESCRIPTION
## Summary

DRY follow-on to PR #81 (per your design feedback). The `NAORadialBasis::assemble_J_fe_` / `assemble_K_fe_` helpers were pure FE-level assembly that did not need NAO context. They are now promoted to free functions in `helfem::atomic::basis`, in a new header `libhelfem/include/CoulombExchangeFE.h`:

```cpp
arma::mat assemble_J_FE_one_multipole(
    const FEMRadialBasis & radial, int L, const arma::mat & P_FE);
arma::mat assemble_K_FE_one_multipole(
    const FEMRadialBasis & radial, int L, const arma::mat & P_FE);
arma::mat assemble_J_FE_one_multipole_yukawa(
    const FEMRadialBasis & radial, int L, double lambda,
    const arma::mat & P_FE);
arma::mat assemble_K_FE_one_multipole_yukawa(
    const FEMRadialBasis & radial, int L, double lambda,
    const arma::mat & P_FE);
```

Same semantics as before: bare radial operator at a single multipole `L` (no `4π/(2L+1)` prefactor, no Gaunt; sign convention positive bare integral). Header-only, ~180 LOC, takes the same inputs the `NAORadialBasis` methods used to take internally.

## NAORadialBasis simplification

`coulomb_radial` / `exchange_radial` / `coulomb_radial_yukawa` / `exchange_radial_yukawa` now collapse to one-line wrappers that C-transform around the free function:

```cpp
arma::mat coulomb_radial(int k, const NAORadialBasis & other,
                         const arma::mat & D) const {
  ...
  return C_.t() * assemble_J_FE_one_multipole(fem, k, P_FE) * C_;
}
```

**Net diff in NAORadialBasis.h: −113 LOC.** The `assemble_J_fe_` / `assemble_K_fe_` / `r_small_` / `r_big_` / `in_element_tei_` / `exchange_tei_` private helpers all go away, replaced by the free-function call. The `exchange_tei` forward-declaration also moves to the new header.

## Validation

Ran the same end-to-end test suite from PR #81 (8-LIP, 10 exponential elements, Z=2 He at l=0):

| test | observed | reference (pre-refactor) |
|---|---|---|
| **1.** `‖J_sadatom − 4π·J_nao‖_∞` (L=0) | **1.776e-15** | 1.776e-15 |
| **1.** rel err | **1.497e-16** | 1.497e-16 |
| **1b.** `‖K_sadatom + K_nao‖_∞` (L=0) | **5.551e-17** | 5.551e-17 |
| **2.** `‖J_small − Cᵀ J_FE C‖_∞` | **0.0** | 0.0 |
| **2.** `‖K_small − Cᵀ K_FE C‖_∞` | **0.0** | 0.0 |
| **3.** `‖J_L=2 − J_L=2ᵀ‖_∞` | **6.939e-18** | 6.939e-18 |
| **3.** `‖K_L=2 − K_L=2ᵀ‖_∞` | **6.939e-18** | 6.939e-18 |
| **4.** cross-channel (C_small, C_b) | **0.0** | 0.0 |
| **5.** Yukawa(λ=0.5) `‖J_yuk‖_F` | **1.841855e+00** | 1.841855e+00 |

**Bit-for-bit identical** to the pre-refactor results — pure code motion, no semantic change.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test`, `atomic_itest` pass
- [x] Full #81 validation suite: bit-for-bit identical to pre-refactor
- [x] NAO export example (PR #55) matches prior numerics **bit-for-bit** (He HF = −2.86167999561 Eh, err 3.59e-12)

## What this PR does NOT do (deferred)

- **sadatom and atomic `TwoDBasis::coulomb / exchange`** still carry their own inline per-multipole assembly with precomputed `disjoint` / `prim_tei` caches for SCF-loop performance. Migrating those onto the new free functions requires either (a) preserving the caching via a cache-aware overload, or (b) accepting the cache-free overhead — both doable but a separate refactor with SCF regression implications. Next PR.
- **Cholesky migration** (PR #82's `twoe_integral_cholesky`): once the free functions accept the in-element tensor in factored form, the unified contraction routine `Σ_p L_p · P · L_pᵀ` replaces the direct n⁴ path in both `NAORadialBasis` and `TwoDBasis`. Logical follow-on after the TwoDBasis migration.