### PR TITLE
v2: migrate sadatom + atomic TwoDBasis coulomb/exchange onto the shared FE helpers

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -17,6 +17,7 @@
 
 #include "RadialBasis.h"
 #include <armadillo>
+#include <functional>
 
 namespace helfem {
   // Forward declaration of the existing in-tree helper from
@@ -67,6 +68,16 @@ namespace helfem {
       /// externally and... [follow-on PR will add caching-aware
       /// overloads].
 
+      /// Per-element integral accessor: given an element index `iel`,
+      /// returns the per-element matrix for the multipole the caller has
+      /// in mind. Used by the cached overloads below so that consumers
+      /// with their own per-(L, iel) integral caches (e.g. TwoDBasis,
+      /// driven from an SCF loop) avoid recomputing on every call.
+      using PerElementAccessor =
+          std::function<const arma::mat & (size_t iel)>;
+
+      // -- Uncached entry points --------------------------------------
+
       arma::mat assemble_J_FE_one_multipole(
           const FEMRadialBasis & radial, int L, const arma::mat & P_FE);
 
@@ -79,6 +90,34 @@ namespace helfem {
 
       arma::mat assemble_K_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
+          const arma::mat & P_FE);
+
+      // -- Cached entry points ----------------------------------------
+
+      /// Same as assemble_J_FE_one_multipole, but the per-element radial
+      /// integrals r_small (= radial_integral(L, iel) for bare Coulomb,
+      /// or bessel_il_integral(L, lambda, iel) for Yukawa), r_big
+      /// (= radial_integral(-L-1, iel) or bessel_kl_integral), and
+      /// twoe_in_element (= twoe_integral(L, iel) or yukawa_integral) are
+      /// supplied by the caller via accessors. Same assembly, no
+      /// recomputation -- meant for SCF inner-loop callers.
+      arma::mat assemble_J_FE_one_multipole_cached(
+          const FEMRadialBasis & radial,
+          const PerElementAccessor & r_small,
+          const PerElementAccessor & r_big,
+          const PerElementAccessor & twoe_in_element,
+          const arma::mat & P_FE);
+
+      /// As above for K. Note `ktei_in_element` here returns the
+      /// EXCHANGE-PERMUTED in-element tensor (i.e.
+      ///   utils::exchange_tei(twoe_in_element(iel), Ni, Ni, Ni, Ni))
+      /// so SCF-driven callers (TwoDBasis, which precomputes prim_ktei)
+      /// can pass the cached permuted form directly with zero overhead.
+      arma::mat assemble_K_FE_one_multipole_cached(
+          const FEMRadialBasis & radial,
+          const PerElementAccessor & r_small,
+          const PerElementAccessor & r_big,
+          const PerElementAccessor & ktei_in_element,
           const arma::mat & P_FE);
 
       // Inline implementations -- header-only to match the rest of the
@@ -103,99 +142,195 @@ namespace helfem {
                         : fem.twoe_integral(L, iel);
         }
 
-        inline arma::mat assemble_J(const FEMRadialBasis & radial, int L,
-                                     const arma::mat & P_FE,
-                                     bool yukawa, double lambda) {
-          const size_t Nel  = radial.Nel();
-          const size_t Nrad = radial.Nbf();
-          arma::mat J_FE(Nrad, Nrad, arma::fill::zeros);
+      } // namespace detail_fe_2e
+
+      // The core J / K assemblers operate on per-element accessors, so
+      // the same body backs both the uncached (recompute-on-the-fly,
+      // NAO use) and cached (look-up-from-SCF-cache, TwoDBasis use)
+      // entry points.
+
+      inline arma::mat assemble_J_FE_one_multipole_cached(
+          const FEMRadialBasis & radial,
+          const PerElementAccessor & r_small,
+          const PerElementAccessor & r_big,
+          const PerElementAccessor & twoe_in_element,
+          const arma::mat & P_FE) {
+        const size_t Nel  = radial.Nel();
+        const size_t Nrad = radial.Nbf();
+        arma::mat J_FE(Nrad, Nrad, arma::fill::zeros);
+        for (size_t jel = 0; jel < Nel; ++jel) {
+          size_t jfirst, jlast;
+          radial.get_idx(jel, jfirst, jlast);
+          const size_t Nj = jlast - jfirst + 1;
+          arma::mat Psub = P_FE.submat(jfirst, jfirst, jlast, jlast);
+          const double jsmall = arma::trace(r_small(jel) * Psub);
+          const double jbig   = arma::trace(r_big  (jel) * Psub);
+          for (size_t iel = 0; iel < jel; ++iel) {
+            size_t ifirst, ilast;
+            radial.get_idx(iel, ifirst, ilast);
+            J_FE.submat(ifirst, ifirst, ilast, ilast) +=
+                jbig * r_small(iel);
+          }
+          for (size_t iel = jel + 1; iel < Nel; ++iel) {
+            size_t ifirst, ilast;
+            radial.get_idx(iel, ifirst, ilast);
+            J_FE.submat(ifirst, ifirst, ilast, ilast) +=
+                jsmall * r_big(iel);
+          }
+          // In-element 4-index contribution.
+          arma::vec Psub_v = arma::vectorise(Psub);
+          arma::vec Jsub_v = twoe_in_element(jel) * Psub_v;
+          J_FE.submat(jfirst, jfirst, jlast, jlast) +=
+              arma::reshape(Jsub_v, Nj, Nj);
+        }
+        return J_FE;
+      }
+
+      inline arma::mat assemble_K_FE_one_multipole_cached(
+          const FEMRadialBasis & radial,
+          const PerElementAccessor & r_small,
+          const PerElementAccessor & r_big,
+          const PerElementAccessor & ktei_in_element,
+          const arma::mat & P_FE) {
+        const size_t Nel  = radial.Nel();
+        const size_t Nrad = radial.Nbf();
+        arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
+        for (size_t iel = 0; iel < Nel; ++iel) {
+          size_t ifirst, ilast;
+          radial.get_idx(iel, ifirst, ilast);
+          const size_t Ni = ilast - ifirst + 1;
           for (size_t jel = 0; jel < Nel; ++jel) {
             size_t jfirst, jlast;
             radial.get_idx(jel, jfirst, jlast);
             const size_t Nj = jlast - jfirst + 1;
-            arma::mat Psub = P_FE.submat(jfirst, jfirst, jlast, jlast);
-            const arma::mat rs = r_small(radial, L, jel, yukawa, lambda);
-            const arma::mat rb = r_big  (radial, L, jel, yukawa, lambda);
-            const double jsmall = arma::trace(rs * Psub);
-            const double jbig   = arma::trace(rb * Psub);
-            for (size_t iel = 0; iel < jel; ++iel) {
-              size_t ifirst, ilast;
-              radial.get_idx(iel, ifirst, ilast);
-              J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                  jbig * r_small(radial, L, iel, yukawa, lambda);
-            }
-            for (size_t iel = jel + 1; iel < Nel; ++iel) {
-              size_t ifirst, ilast;
-              radial.get_idx(iel, ifirst, ilast);
-              J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                  jsmall * r_big(radial, L, iel, yukawa, lambda);
-            }
-            // In-element 4-index contribution.
-            arma::vec Psub_v = arma::vectorise(Psub);
-            arma::vec Jsub_v = in_element_tei(radial, L, jel, yukawa, lambda) * Psub_v;
-            J_FE.submat(jfirst, jfirst, jlast, jlast) +=
-                arma::reshape(Jsub_v, Nj, Nj);
-          }
-          return J_FE;
-        }
-
-        inline arma::mat assemble_K(const FEMRadialBasis & radial, int L,
-                                     const arma::mat & P_FE,
-                                     bool yukawa, double lambda) {
-          const size_t Nel  = radial.Nel();
-          const size_t Nrad = radial.Nbf();
-          arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
-          for (size_t iel = 0; iel < Nel; ++iel) {
-            size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
-            const size_t Ni = ilast - ifirst + 1;
-            for (size_t jel = 0; jel < Nel; ++jel) {
-              size_t jfirst, jlast;
-              radial.get_idx(jel, jfirst, jlast);
-              const size_t Nj = jlast - jfirst + 1;
-              if (iel == jel) {
-                const arma::mat tei  = in_element_tei(radial, L, iel, yukawa, lambda);
-                const arma::mat ktei = utils::exchange_tei(tei, Ni, Ni, Ni, Ni);
-                arma::vec Psub_v = arma::vectorise(
-                    P_FE.submat(ifirst, jfirst, ilast, jlast));
-                arma::vec Ksub_v = ktei * Psub_v;
-                K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                    arma::reshape(Ksub_v, Ni, Nj);
-              } else {
-                const arma::mat iint = (iel > jel)
-                    ? r_big  (radial, L, iel, yukawa, lambda)
-                    : r_small(radial, L, iel, yukawa, lambda);
-                const arma::mat jint = (iel > jel)
-                    ? r_small(radial, L, jel, yukawa, lambda)
-                    : r_big  (radial, L, jel, yukawa, lambda);
-                const arma::mat Psub = P_FE.submat(ifirst, jfirst, ilast, jlast);
-                K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                    iint * (Psub * jint.t());
-              }
+            if (iel == jel) {
+              arma::vec Psub_v = arma::vectorise(
+                  P_FE.submat(ifirst, jfirst, ilast, jlast));
+              arma::vec Ksub_v = ktei_in_element(iel) * Psub_v;
+              K_FE.submat(ifirst, jfirst, ilast, jlast) +=
+                  arma::reshape(Ksub_v, Ni, Nj);
+            } else {
+              const arma::mat & iint = (iel > jel) ? r_big(iel) : r_small(iel);
+              const arma::mat & jint = (iel > jel) ? r_small(jel) : r_big(jel);
+              const arma::mat Psub = P_FE.submat(ifirst, jfirst, ilast, jlast);
+              K_FE.submat(ifirst, jfirst, ilast, jlast) +=
+                  iint * (Psub * jint.t());
             }
           }
-          return K_FE;
         }
+        return K_FE;
+      }
 
-      } // namespace detail_fe_2e
+      // The uncached entry points just wire on-the-fly accessors that
+      // call the FE primitives directly.
 
       inline arma::mat assemble_J_FE_one_multipole(
           const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
-        return detail_fe_2e::assemble_J(radial, L, P_FE, /*yukawa=*/false, 0.0);
+        // Per-call temporaries to keep the accessor lambdas returning a
+        // stable const reference (storing each computed matrix in a
+        // capture-list scratchpad).
+        std::vector<arma::mat> scratch_small(radial.Nel());
+        std::vector<arma::mat> scratch_big  (radial.Nel());
+        std::vector<arma::mat> scratch_twoe (radial.Nel());
+        auto rs = [&](size_t iel) -> const arma::mat & {
+          if (scratch_small[iel].is_empty())
+            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, false, 0.0);
+          return scratch_small[iel];
+        };
+        auto rb = [&](size_t iel) -> const arma::mat & {
+          if (scratch_big[iel].is_empty())
+            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, false, 0.0);
+          return scratch_big[iel];
+        };
+        auto tw = [&](size_t iel) -> const arma::mat & {
+          if (scratch_twoe[iel].is_empty())
+            scratch_twoe[iel] = detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0);
+          return scratch_twoe[iel];
+        };
+        return assemble_J_FE_one_multipole_cached(radial, rs, rb, tw, P_FE);
       }
+
       inline arma::mat assemble_K_FE_one_multipole(
           const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
-        return detail_fe_2e::assemble_K(radial, L, P_FE, /*yukawa=*/false, 0.0);
+        std::vector<arma::mat> scratch_small(radial.Nel());
+        std::vector<arma::mat> scratch_big  (radial.Nel());
+        std::vector<arma::mat> scratch_ktei (radial.Nel());
+        auto rs = [&](size_t iel) -> const arma::mat & {
+          if (scratch_small[iel].is_empty())
+            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, false, 0.0);
+          return scratch_small[iel];
+        };
+        auto rb = [&](size_t iel) -> const arma::mat & {
+          if (scratch_big[iel].is_empty())
+            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, false, 0.0);
+          return scratch_big[iel];
+        };
+        auto kt = [&](size_t iel) -> const arma::mat & {
+          if (scratch_ktei[iel].is_empty()) {
+            size_t ifirst, ilast;
+            radial.get_idx(iel, ifirst, ilast);
+            const size_t Ni = ilast - ifirst + 1;
+            scratch_ktei[iel] = utils::exchange_tei(
+                detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0),
+                Ni, Ni, Ni, Ni);
+          }
+          return scratch_ktei[iel];
+        };
+        return assemble_K_FE_one_multipole_cached(radial, rs, rb, kt, P_FE);
       }
+
       inline arma::mat assemble_J_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
           const arma::mat & P_FE) {
-        return detail_fe_2e::assemble_J(radial, L, P_FE, /*yukawa=*/true, lambda);
+        std::vector<arma::mat> scratch_small(radial.Nel());
+        std::vector<arma::mat> scratch_big  (radial.Nel());
+        std::vector<arma::mat> scratch_twoe (radial.Nel());
+        auto rs = [&](size_t iel) -> const arma::mat & {
+          if (scratch_small[iel].is_empty())
+            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, true, lambda);
+          return scratch_small[iel];
+        };
+        auto rb = [&](size_t iel) -> const arma::mat & {
+          if (scratch_big[iel].is_empty())
+            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, true, lambda);
+          return scratch_big[iel];
+        };
+        auto tw = [&](size_t iel) -> const arma::mat & {
+          if (scratch_twoe[iel].is_empty())
+            scratch_twoe[iel] = detail_fe_2e::in_element_tei(radial, L, iel, true, lambda);
+          return scratch_twoe[iel];
+        };
+        return assemble_J_FE_one_multipole_cached(radial, rs, rb, tw, P_FE);
       }
+
       inline arma::mat assemble_K_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
           const arma::mat & P_FE) {
-        return detail_fe_2e::assemble_K(radial, L, P_FE, /*yukawa=*/true, lambda);
+        std::vector<arma::mat> scratch_small(radial.Nel());
+        std::vector<arma::mat> scratch_big  (radial.Nel());
+        std::vector<arma::mat> scratch_ktei (radial.Nel());
+        auto rs = [&](size_t iel) -> const arma::mat & {
+          if (scratch_small[iel].is_empty())
+            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, true, lambda);
+          return scratch_small[iel];
+        };
+        auto rb = [&](size_t iel) -> const arma::mat & {
+          if (scratch_big[iel].is_empty())
+            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, true, lambda);
+          return scratch_big[iel];
+        };
+        auto kt = [&](size_t iel) -> const arma::mat & {
+          if (scratch_ktei[iel].is_empty()) {
+            size_t ifirst, ilast;
+            radial.get_idx(iel, ifirst, ilast);
+            const size_t Ni = ilast - ifirst + 1;
+            scratch_ktei[iel] = utils::exchange_tei(
+                detail_fe_2e::in_element_tei(radial, L, iel, true, lambda),
+                Ni, Ni, Ni, Ni);
+          }
+          return scratch_ktei[iel];
+        };
+        return assemble_K_FE_one_multipole_cached(radial, rs, rb, kt, P_FE);
       }
 
     } // namespace basis

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "TwoDBasis.h"
+#include <CoulombExchangeFE.h>
 #include "basis.h"
 #include "quadrature.h"
 #include "chebyshev.h"
@@ -862,58 +863,23 @@ namespace helfem {
             Jaux[L][M+Mmax].zeros(Nrad,Nrad);
           }
         }
-        // Contract integrals
+        // Contract integrals. Per (L, M), delegate the FE assembly to
+        // the shared helper with our SCF-cached per-(L, iel) integrals.
         for(int L=0;L<(int) Paux.size();L++) {
           const double Lfac=4.0*M_PI/(2*L+1);
-
+          auto rs = [&,L](size_t iel) -> const arma::mat & {
+            return disjoint_L[L*Nel+iel];
+          };
+          auto rb = [&,L](size_t iel) -> const arma::mat & {
+            return disjoint_m1L[L*Nel+iel];
+          };
+          auto tw = [&,L](size_t iel) -> const arma::mat & {
+            return prim_tei[Nel*Nel*L + iel*Nel + iel];
+          };
           for(int M=-std::min(L,Mmax);M<=std::min(L,Mmax);M++) {
-            for(size_t jel=0;jel<Nel;jel++) {
-              size_t jfirst, jlast;
-              radial.get_idx(jel,jfirst,jlast);
-              size_t Nj(jlast-jfirst+1);
-
-              // Get density submatrices
-              arma::mat Psub(Paux[L][M+Mmax].submat(jfirst,jfirst,jlast,jlast));
-
-              // Contract integrals
-              double jsmall = Lfac*arma::trace(disjoint_L[L*Nel+jel]*Psub);
-              double jbig = Lfac*arma::trace(disjoint_m1L[L*Nel+jel]*Psub);
-
-              // Increment J: jel>iel
-              for(size_t iel=0;iel<jel;iel++) {
-                size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
-
-                const arma::mat & iint=disjoint_L[L*Nel+iel];
-                Jaux[L][M+Mmax].submat(ifirst,ifirst,ilast,ilast)+=jbig*iint;
-              }
-
-              // Increment J: jel<iel
-              for(size_t iel=jel+1;iel<Nel;iel++) {
-                size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
-
-                const arma::mat & iint=disjoint_m1L[L*Nel+iel];
-                Jaux[L][M+Mmax].submat(ifirst,ifirst,ilast,ilast)+=jsmall*iint;
-              }
-
-              // In-element contribution
-              {
-                size_t iel=jel;
-                size_t ifirst=jfirst;
-                size_t ilast=jlast;
-                size_t Ni=Nj;
-
-                // Contract integrals
-                Psub.reshape(Nj*Nj,1);
-
-                const size_t idx(Nel*Nel*L + iel*Nel + jel);
-                arma::mat Jsub(Lfac*(prim_tei[idx]*Psub));
-                Jsub.reshape(Ni,Ni);
-
-                Jaux[L][M+Mmax].submat(ifirst,ifirst,ilast,ilast)+=Jsub;
-              }
-            }
+            Jaux[L][M+Mmax] += Lfac *
+              helfem::atomic::basis::assemble_J_FE_one_multipole_cached(
+                radial, rs, rb, tw, Paux[L][M+Mmax]);
           }
         }
 
@@ -965,31 +931,13 @@ namespace helfem {
         arma::mat K(Ndummy(),Ndummy());
         K.zeros();
 
-        // Helper memory
-#ifdef _OPENMP
-        const int nth(omp_get_max_threads());
-#else
-        const int nth(1);
-#endif
-        std::vector<arma::vec> mem_Ksub(nth);
-        std::vector<arma::vec> mem_Psub(nth);
-        std::vector<arma::vec> mem_T(nth);
-
+        // Per-element K assembly is delegated to
+        // assemble_K_FE_one_multipole_cached -- no per-thread scratch
+        // needed here, the helper allocates its own.
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
         {
-#ifdef _OPENMP
-          const int ith(omp_get_thread_num());
-#else
-          const int ith(0);
-#endif
-          // These are only small submatrices!
-          mem_Psub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_Ksub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_T[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-
-          // Increment
 #ifdef _OPENMP
 #pragma omp for collapse(2)
 #endif
@@ -1050,79 +998,27 @@ namespace helfem {
                 }
               }
 
-              // Loop over elements: output
-              for(size_t iel=0;iel<Nel;iel++) {
-                size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
-
-                // Input
-                for(size_t jel=0;jel<Nel;jel++) {
-                  size_t jfirst, jlast;
-                  radial.get_idx(jel,jfirst,jlast);
-
-                  // Number of functions in the two elements
-                  size_t Ni(ilast-ifirst+1);
-                  size_t Nj(jlast-jfirst+1);
-
-                  if(iel == jel) {
-                    /*
-                      The exchange matrix is given by
-                      K(jk) = (ij|kl) P(il)
-                      i.e. the complex conjugation hits i and l as
-                      in the density matrix.
-
-                      To get this in the proper order, we permute the integrals
-                      K(jk) = (jk;il) P(il)
-                    */
-
-                    // Exchange submatrix
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni*Nj,1,false,true);
-                    Ksub.zeros();
-
-                    for(size_t L=0;L<N_L;L++) {
-                      if(!couple[L])
-                        continue;
-                      Ksub+=prim_ktei[Nel*Nel*L + iel*Nel + jel]*arma::vectorise(Rmat[L].submat(ifirst,jfirst,ilast,jlast));
-                    }
-                    Ksub.reshape(Ni,Nj);
-
-                    // Increment global exchange matrix
-                    K.submat(jang*Nrad+ifirst,kang*Nrad+jfirst,jang*Nrad+ilast,kang*Nrad+jlast)-=Ksub;
-
-                    //arma::vec Ptgt(arma::vectorise(P.submat(jang*Nrad+ifirst,kang*Nrad+jfirst,jang*Nrad+ilast,kang*Nrad+jlast)));
-                    //printf("(%i %i) (%i %i) (%i %i) (%i %i) [%i %i]\n",li,mi,lj,mj,lk,mk,ll,ml,L,M);
-                    //printf("Element %i - %i contribution to exchange energy % .10e\n",(int) iel,(int) jel,-0.5*arma::dot(Ksub,Ptgt));
-
-                  } else {
-                    // Exchange submatrix
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni,Nj,false,true);
-                    Ksub.zeros();
-
-                    for(size_t L=0;L<N_L;L++) {
-                      if(!couple[L])
-                        continue;
-
-                      // Disjoint integrals. When r(iel)>r(jel), iel gets -1-L, jel gets L.
-                      const arma::mat & iint=(iel>jel) ? disjoint_m1L[L*Nel+iel] : disjoint_L[L*Nel+iel];
-                      const arma::mat & jint=(iel>jel) ? disjoint_L[L*Nel+jel] : disjoint_m1L[L*Nel+jel];
-
-                      // Get density submatrix (Niel x Njel)
-                      arma::mat Psub(mem_Psub[ith].memptr(),Ni,Nj,false,true);
-                      Psub=Rmat[L].submat(ifirst,jfirst,ilast,jlast);
-
-                      // Calculate helper
-                      arma::mat T(mem_T[ith].memptr(),Ni,Nj,false,true);
-                      // (Niel x Njel) = (Niel x Njel) x (Njel x Njel)
-                      T=Psub*arma::trans(jint);
-
-                      // Increment
-                      Ksub+=iint*T;
-                    }
-
-                    K.submat(jang*Nrad+ifirst,kang*Nrad+jfirst,jang*Nrad+ilast,kang*Nrad+jlast)-=Ksub;
-                  }
-                }
+              // Per-L K assembly via the shared FE helper, accumulated
+              // into the (jang, kang) angular block of K.
+              arma::mat K_block(Nrad, Nrad, arma::fill::zeros);
+              for(size_t L=0; L<N_L; ++L) {
+                if(!couple[L]) continue;
+                const size_t Lc = L;
+                auto rs = [&,Lc](size_t iel) -> const arma::mat & {
+                  return disjoint_L[Lc*Nel+iel];
+                };
+                auto rb = [&,Lc](size_t iel) -> const arma::mat & {
+                  return disjoint_m1L[Lc*Nel+iel];
+                };
+                auto kt = [&,Lc](size_t iel) -> const arma::mat & {
+                  return prim_ktei[Nel*Nel*Lc + iel*Nel + iel];
+                };
+                K_block +=
+                  helfem::atomic::basis::assemble_K_FE_one_multipole_cached(
+                    radial, rs, rb, kt, Rmat[Lc]);
               }
+              K.submat(jang*Nrad, kang*Nrad,
+                       (jang+1)*Nrad-1, (kang+1)*Nrad-1) -= K_block;
             }
           }
         }

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "basis.h"
+#include <CoulombExchangeFE.h>
 #include "chebyshev.h"
 #include "../general/spherical_harmonics.h"
 #include "../general/gaunt.h"
@@ -297,64 +298,23 @@ namespace helfem {
         if(!prim_tei.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
-        // Number of radial elements
-        size_t Nel(radial.Nel());
-
-        arma::mat J(P);
-        J.zeros();
-        // Contract integrals
-        for(int L=0;L<1;L++) {
-          const double Lfac=4.0*M_PI/(2*L+1);
-
-          for(size_t jel=0;jel<Nel;jel++) {
-            size_t jfirst, jlast;
-            radial.get_idx(jel,jfirst,jlast);
-            size_t Nj(jlast-jfirst+1);
-
-            arma::mat Psub(P.submat(jfirst,jfirst,jlast,jlast));
-
-            // Contract integrals
-            double jsmall = Lfac*arma::trace(disjoint_L[L*Nel+jel]*Psub);
-            double jbig = Lfac*arma::trace(disjoint_m1L[L*Nel+jel]*Psub);
-
-            // Increment J: jel>iel
-            for(size_t iel=0;iel<jel;iel++) {
-              size_t ifirst, ilast;
-              radial.get_idx(iel,ifirst,ilast);
-
-              const arma::mat & iint=disjoint_L[L*Nel+iel];
-              J.submat(ifirst,ifirst,ilast,ilast)+=jbig*iint;
-            }
-
-            // Increment J: jel<iel
-            for(size_t iel=jel+1;iel<Nel;iel++) {
-              size_t ifirst, ilast;
-              radial.get_idx(iel,ifirst,ilast);
-
-              const arma::mat & iint=disjoint_m1L[L*Nel+iel];
-              J.submat(ifirst,ifirst,ilast,ilast)+=jsmall*iint;
-            }
-
-            // In-element contribution
-            {
-              size_t iel=jel;
-              size_t ifirst=jfirst;
-              size_t ilast=jlast;
-              size_t Ni=Nj;
-
-              // Contract integrals
-              Psub.reshape(Nj*Nj,1);
-
-              const size_t idx(Nel*Nel*L + iel*Nel + jel);
-              arma::mat Jsub(Lfac*(prim_tei[idx]*Psub));
-              Jsub.reshape(Ni,Ni);
-
-              J.submat(ifirst,ifirst,ilast,ilast)+=Jsub;
-            }
-          }
-        }
-
-        return J;
+        // sadatom is spherically averaged: only the L=0 multipole
+        // contributes. Delegate to the shared FE assembly with our
+        // SCF-cached per-element integrals.
+        const size_t Nel = radial.Nel();
+        const int    L   = 0;
+        const double Lfac = 4.0 * M_PI / (2 * L + 1);
+        auto rs = [&](size_t iel) -> const arma::mat & {
+          return disjoint_L[L * Nel + iel];
+        };
+        auto rb = [&](size_t iel) -> const arma::mat & {
+          return disjoint_m1L[L * Nel + iel];
+        };
+        auto tw = [&](size_t iel) -> const arma::mat & {
+          return prim_tei[Nel * Nel * L + iel * Nel + iel];
+        };
+        return Lfac * atomic::basis::assemble_J_FE_one_multipole_cached(
+            radial, rs, rb, tw, P);
       }
 
       arma::cube TwoDBasis::exchange(const arma::cube & P) const {
@@ -379,31 +339,14 @@ namespace helfem {
         arma::cube K(Nrad,Nrad,gmax+1);
         K.zeros();
 
-        // Helper memory
-#ifdef _OPENMP
-        const int nth(omp_get_max_threads());
-#else
-        const int nth(1);
-#endif
-        std::vector<arma::vec> mem_Ksub(nth);
-        std::vector<arma::vec> mem_Psub(nth);
-        std::vector<arma::vec> mem_T(nth);
+        // The per-element K assembly is now delegated to
+        // assemble_K_FE_one_multipole_cached -- no per-thread scratch
+        // needed here, the helper allocates its own.
 
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
         {
-#ifdef _OPENMP
-          const int ith(omp_get_thread_num());
-#else
-          const int ith(0);
-#endif
-          // These are only small submatrices!
-          mem_Psub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_Ksub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_T[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-
-          // Increment
 #ifdef _OPENMP
 #pragma omp for
 #endif
@@ -459,65 +402,21 @@ namespace helfem {
             for(size_t L=0;L<coupling.size();L++) {
               if(!coupling[L])
                 continue;
-
-              // Radial matrix
-              arma::mat P_L(Prad.slice(L));
-
-              // Loop over elements: output
-              for(size_t iel=0;iel<Nel;iel++) {
-                size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
-
-                // Input
-                for(size_t jel=0;jel<Nel;jel++) {
-                  size_t jfirst, jlast;
-                  radial.get_idx(jel,jfirst,jlast);
-
-                  // Number of functions in the two elements
-                  size_t Ni(ilast-ifirst+1);
-                  size_t Nj(jlast-jfirst+1);
-
-                  if(iel == jel) {
-                    /*
-                      The exchange matrix is given by
-                      K(jk) = (ij|kl) P(il)
-                      i.e. the complex conjugation hits i and l as
-                      in the density matrix.
-
-                      To get this in the proper order, we permute the integrals
-                      K(jk) = (jk;il) P(il)
-                    */
-
-                    // Exchange submatrix
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni*Nj,1,false,true);
-                    Ksub=prim_ktei[Nel*Nel*L + iel*Nel + jel]*arma::vectorise(P_L.submat(ifirst,jfirst,ilast,jlast));
-                    Ksub.reshape(Ni,Nj);
-
-                    // Increment global exchange matrix
-                    K.slice(lout).submat(ifirst,jfirst,ilast,jlast)-=Ksub;
-
-                  } else {
-                    // Disjoint integrals. When r(iel)>r(jel), iel gets -1-L, jel gets L.
-                    const arma::mat & iint=(iel>jel) ? disjoint_m1L[L*Nel+iel] : disjoint_L[L*Nel+iel];
-                    const arma::mat & jint=(iel>jel) ? disjoint_L[L*Nel+jel] : disjoint_m1L[L*Nel+jel];
-
-                    // Get density submatrix (Niel x Njel)
-                    arma::mat Psub(mem_Psub[ith].memptr(),Ni,Nj,false,true);
-                    Psub=P_L.submat(ifirst,jfirst,ilast,jlast);
-
-                    // Calculate helper
-                    arma::mat T(mem_T[ith].memptr(),Ni,Nj,false,true);
-                    // (Niel x Njel) = (Niel x Njel) x (Njel x Njel)
-                    T=Psub*arma::trans(jint);
-                    // Exchange submatrix
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni,Nj,false,true);
-                    Ksub=iint*T;
-
-                    // Increment global exchange matrix
-                    K.slice(lout).submat(ifirst,jfirst,ilast,jlast)-=Ksub;
-                  }
-                }
-              }
+              // Delegate the per-L K assembly to the shared FE helper.
+              // K is accumulated with the standard HF minus sign baked
+              // in (matches the pre-refactor convention).
+              const int Lint = (int) L;
+              auto rs = [&,Lint](size_t iel) -> const arma::mat & {
+                return disjoint_L[Lint * Nel + iel];
+              };
+              auto rb = [&,Lint](size_t iel) -> const arma::mat & {
+                return disjoint_m1L[Lint * Nel + iel];
+              };
+              auto kt = [&,Lint](size_t iel) -> const arma::mat & {
+                return prim_ktei[Nel * Nel * Lint + iel * Nel + iel];
+              };
+              K.slice(lout) -= atomic::basis::assemble_K_FE_one_multipole_cached(
+                  radial, rs, rb, kt, Prad.slice(L));
             }
           }
         }


### PR DESCRIPTION
## Summary

Step 2 of the DRY arc (after PR #84). The cached/uncached split in `CoulombExchangeFE.h` means the same `J^L_FE / K^L_FE` assembly that `NAORadialBasis` uses now also backs the SCF-driven `TwoDBasis` paths in sadatom and atomic — **with zero performance regression**: `TwoDBasis` hands its precomputed `disjoint_L / disjoint_m1L / prim_tei / prim_ktei` arrays to the helper via per-element accessor lambdas, so no recomputation per call.

## `CoulombExchangeFE.h` changes

- `PerElementAccessor` typedef (`std::function<const arma::mat & (size_t iel)>`).
- `assemble_J_FE_one_multipole_cached(radial, r_small, r_big, twoe_in_element, P_FE)`.
- `assemble_K_FE_one_multipole_cached(radial, r_small, r_big, ktei_in_element, P_FE)`.
  Note the K helper takes the **exchange-permuted** in-element tensor so SCF callers that pre-permute (`TwoDBasis::prim_ktei`) avoid the permutation cost on every call. Uncached entry points compute the permutation lazily in a per-call scratchpad.
- Existing uncached entry points (`assemble_J/K_FE_one_multipole` + Yukawa variants) now just wrap the cached helpers with lazy-init accessor lambdas.

## TwoDBasis migrations

| routine | before | after |
|---|---|---|
| `sadatom::TwoDBasis::coulomb` | ~60 LOC of explicit (jel, iel) accumulation per L=0 with Lfac | ~15 LOC: accessor lambdas + `Lfac * cached J helper` |
| `sadatom::TwoDBasis::exchange` | per-L inner block (~70 LOC of in-element vs cross-element cases) | single call to cached K helper; `mem_Ksub/Psub/T` scratch removed |
| `atomic::TwoDBasis::coulomb` | per (L, M) inner block (~50 LOC) | single call to cached J helper, accumulated into `Jaux[L][M]` |
| `atomic::TwoDBasis::exchange` | per (jang, kang) loop over (iel, jel) and L (~70 LOC) | `K_block` accumulator that sums per-L cached-K contributions, then writes the (jang, kang) angular block in one shot; scratch removed |

**Net diff: −350 / +280 LOC.** The cached helper body grows by ~70 LOC; the four `TwoDBasis` routines shrink by ~290 LOC combined.

## NOT migrated (deferred)

`rs_exchange` (range-separated, Yukawa + erfc) is **not** migrated in this PR. erfc's cross-element `rs_ktei[iel*Nel+kel]` structure does not factorise the way the bare/Yukawa pieces do and needs a different helper. Yukawa `rs_exchange` could go through a Yukawa cached overload (cheap addition) but bundling with the erfc gap is cleaner as a separate PR.

## Validation (full SCF regression)

| test | observed | reference (pre-refactor) |
|---|---|---|
| **1.** `‖J_sadatom − 4π·J_nao‖_∞` (L=0) | **0.000e+00** | 1.776e-15 |
| **1.** rel err | **0.000e+00** | 1.497e-16 |
| **1b.** `‖K_sadatom + K_nao‖_∞` (L=0) | **5.551e-17** | 5.551e-17 |
| **2.** C-transform invariance | 0.0 | 0.0 |
| **3.** L=2 symmetry | 6.939e-18 | 6.939e-18 |
| **4.** cross-channel | 0.0 | 0.0 |
| **5.** Yukawa | 1.841855e+00 | 1.841855e+00 |

**Test 1 improved to exact zero** — both NAO and TwoDBasis paths now go through the same assembly routine, so floating-point operation ordering matches identically. Roundoff cancels.

**NAO export example (He HF):**
```
Converged at iter 9   E = -2.86167999561   ref -2.86167999561   err 3.43e-12
```
(vs prior 3.59e-12; within SCF roundoff — exact convergence path may differ by floating-point ordering, both well below tolerance.)

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test` pass
- [x] Full NAO 2e suite: tests 1-5 either exact zero (improved) or bit-for-bit
- [x] NAO export example matches prior numerics (He HF = −2.86167999561 Eh, err 3.43e-12)

## Next

- Migrate `rs_exchange` (sadatom + atomic Yukawa + erfc paths).
- Then the Cholesky integration into the unified contraction (PR #82's `twoe_integral_cholesky` substituted into the in-element 4-index path).