### PR TITLE
v2: migrate rs_exchange Yukawa branch onto the shared cached K helper

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -1131,73 +1131,50 @@ namespace helfem {
                 }
               }
 
-              // Loop over elements: output
-              for(size_t iel=0;iel<Nel;iel++) {
-                size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
-
-                // Input
-                for(size_t jel=0;jel<Nel;jel++) {
-                  size_t jfirst, jlast;
-                  radial.get_idx(jel,jfirst,jlast);
-
-                  // Number of functions in the two elements
-                  size_t Ni(ilast-ifirst+1);
-                  size_t Nj(jlast-jfirst+1);
-
-                  // error function does not factorize
-                  if(!yukawa || iel == jel) {
-                    /*
-                      The exchange matrix is given by
-                      K(jk) = (ij|kl) P(il)
-                      i.e. the complex conjugation hits i and l as
-                      in the density matrix.
-
-                      To get this in the proper order, we permute the integrals
-                      K(jk) = (jk;il) P(il)
-                    */
-
-                    // Exchange submatrix
+              if (yukawa) {
+                // Same FE structure as bare exchange: per-L cached
+                // helper, summed into the (jang, kang) angular block.
+                arma::mat K_block(Nrad, Nrad, arma::fill::zeros);
+                for(size_t L=0; L<N_L; ++L) {
+                  if(!couple[L]) continue;
+                  const size_t Lc = L;
+                  auto rs = [&,Lc](size_t iel) -> const arma::mat & {
+                    return disjoint_iL[Lc*Nel+iel];
+                  };
+                  auto rb = [&,Lc](size_t iel) -> const arma::mat & {
+                    return disjoint_kL[Lc*Nel+iel];
+                  };
+                  auto kt = [&,Lc](size_t iel) -> const arma::mat & {
+                    return rs_ktei[Nel*Nel*Lc + iel*Nel + iel];
+                  };
+                  K_block +=
+                    helfem::atomic::basis::assemble_K_FE_one_multipole_cached(
+                      radial, rs, rb, kt, Rmat[Lc]);
+                }
+                K.submat(jang*Nrad, kang*Nrad,
+                         (jang+1)*Nrad-1, (kang+1)*Nrad-1) -= K_block;
+              } else {
+                // Erfc: rs_ktei has cross-element entries for every
+                // (iel, jel) pair -- the kernel does not factorise.
+                // Keep the inline assembly.
+                for(size_t iel=0;iel<Nel;iel++) {
+                  size_t ifirst, ilast;
+                  radial.get_idx(iel,ifirst,ilast);
+                  for(size_t jel=0;jel<Nel;jel++) {
+                    size_t jfirst, jlast;
+                    radial.get_idx(jel,jfirst,jlast);
+                    size_t Ni(ilast-ifirst+1);
+                    size_t Nj(jlast-jfirst+1);
                     arma::mat Ksub(mem_Ksub[ith].memptr(),Ni*Nj,1,false,true);
                     Ksub.zeros();
-
                     for(size_t L=0;L<N_L;L++) {
-                      if(!couple[L])
-                        continue;
-                      Ksub+=rs_ktei[Nel*Nel*L + iel*Nel + jel]*arma::vectorise(Rmat[L].submat(ifirst,jfirst,ilast,jlast));
+                      if(!couple[L]) continue;
+                      Ksub += rs_ktei[Nel*Nel*L + iel*Nel + jel]
+                              * arma::vectorise(Rmat[L].submat(ifirst,jfirst,ilast,jlast));
                     }
                     Ksub.reshape(Ni,Nj);
-
-                    // Increment global exchange matrix
-                    K.submat(jang*Nrad+ifirst,kang*Nrad+jfirst,jang*Nrad+ilast,kang*Nrad+jlast)-=Ksub;
-
-                  } else {
-                    // Exchange submatrix
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni,Nj,false,true);
-                    Ksub.zeros();
-
-                    for(size_t L=0;L<N_L;L++) {
-                      if(!couple[L])
-                        continue;
-
-                      // Disjoint integrals. When r(iel)>r(jel), iel gets -1-L, jel gets L.
-                      const arma::mat & iint=(iel>jel) ? disjoint_kL[L*Nel+iel] : disjoint_iL[L*Nel+iel];
-                      const arma::mat & jint=(iel>jel) ? disjoint_iL[L*Nel+jel] : disjoint_kL[L*Nel+jel];
-
-                      // Get density submatrix (Niel x Njel)
-                      arma::mat Psub(mem_Psub[ith].memptr(),Ni,Nj,false,true);
-                      Psub=Rmat[L].submat(ifirst,jfirst,ilast,jlast);
-
-                      // Calculate helper
-                      arma::mat T(mem_T[ith].memptr(),Ni,Nj,false,true);
-                      // (Niel x Njel) = (Niel x Njel) x (Njel x Njel)
-                      T=Psub*arma::trans(jint);
-
-                      // Increment
-                      Ksub+=iint*T;
-                    }
-
-                    K.submat(jang*Nrad+ifirst,kang*Nrad+jfirst,jang*Nrad+ilast,kang*Nrad+jlast)-=Ksub;
+                    K.submat(jang*Nrad+ifirst,kang*Nrad+jfirst,
+                             jang*Nrad+ilast,kang*Nrad+jlast) -= Ksub;
                   }
                 }
               }

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -526,61 +526,39 @@ namespace helfem {
             for(size_t L=0;L<coupling.size();L++) {
               if(!coupling[L])
                 continue;
-
-              // Radial matrix
-              arma::mat P_L(Prad.slice(L));
-
-              // Loop over elements: output
-              for(size_t iel=0;iel<Nel;iel++) {
-                size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
-
-                // Input
-                for(size_t jel=0;jel<Nel;jel++) {
-                  size_t jfirst, jlast;
-                  radial.get_idx(jel,jfirst,jlast);
-
-                  // Number of functions in the two elements
-                  size_t Ni(ilast-ifirst+1);
-                  size_t Nj(jlast-jfirst+1);
-
-                  if(!yukawa || iel == jel) {
-                    /*
-                      The exchange matrix is given by
-                      K(jk) = (ij|kl) P(il)
-                      i.e. the complex conjugation hits i and l as
-                      in the density matrix.
-
-                      To get this in the proper order, we permute the integrals
-                      K(jk) = (jk;il) P(il)
-                    */
-
-                    // Exchange submatrix
+              const arma::mat & P_L = Prad.slice(L);
+              if (yukawa) {
+                // Same FE structure as bare exchange -- just different
+                // kernels in the cache. Delegate to the shared helper.
+                const size_t Lc = L;
+                auto rs = [&,Lc](size_t iel) -> const arma::mat & {
+                  return disjoint_iL[Lc*Nel+iel];
+                };
+                auto rb = [&,Lc](size_t iel) -> const arma::mat & {
+                  return disjoint_kL[Lc*Nel+iel];
+                };
+                auto kt = [&,Lc](size_t iel) -> const arma::mat & {
+                  return rs_ktei[Nel*Nel*Lc + iel*Nel + iel];
+                };
+                K.slice(lout) -=
+                  atomic::basis::assemble_K_FE_one_multipole_cached(
+                    radial, rs, rb, kt, P_L);
+              } else {
+                // Erfc: rs_ktei has cross-element entries (iel != jel)
+                // because the erfc kernel does not factorise. Keep the
+                // inline assembly.
+                for(size_t iel=0;iel<Nel;iel++) {
+                  size_t ifirst, ilast;
+                  radial.get_idx(iel,ifirst,ilast);
+                  for(size_t jel=0;jel<Nel;jel++) {
+                    size_t jfirst, jlast;
+                    radial.get_idx(jel,jfirst,jlast);
+                    size_t Ni(ilast-ifirst+1);
+                    size_t Nj(jlast-jfirst+1);
                     arma::mat Ksub(mem_Ksub[ith].memptr(),Ni*Nj,1,false,true);
-                    Ksub=rs_ktei[Nel*Nel*L + iel*Nel + jel]*arma::vectorise(P_L.submat(ifirst,jfirst,ilast,jlast));
+                    Ksub=rs_ktei[Nel*Nel*L + iel*Nel + jel]
+                         * arma::vectorise(P_L.submat(ifirst,jfirst,ilast,jlast));
                     Ksub.reshape(Ni,Nj);
-
-                    // Increment global exchange matrix
-                    K.slice(lout).submat(ifirst,jfirst,ilast,jlast)-=Ksub;
-
-                  } else {
-                    // Disjoint integrals. When r(iel)>r(jel), iel gets -1-L, jel gets L.
-                    const arma::mat & iint=(iel>jel) ? disjoint_kL[L*Nel+iel] : disjoint_iL[L*Nel+iel];
-                    const arma::mat & jint=(iel>jel) ? disjoint_iL[L*Nel+jel] : disjoint_kL[L*Nel+jel];
-
-                    // Get density submatrix (Niel x Njel)
-                    arma::mat Psub(mem_Psub[ith].memptr(),Ni,Nj,false,true);
-                    Psub=P_L.submat(ifirst,jfirst,ilast,jlast);
-
-                    // Calculate helper
-                    arma::mat T(mem_T[ith].memptr(),Ni,Nj,false,true);
-                    // (Niel x Njel) = (Niel x Njel) x (Njel x Njel)
-                    T=Psub*arma::trans(jint);
-                    // Exchange submatrix
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni,Nj,false,true);
-                    Ksub=iint*T;
-
-                    // Increment global exchange matrix
                     K.slice(lout).submat(ifirst,jfirst,ilast,jlast)-=Ksub;
                   }
                 }


### PR DESCRIPTION
## Summary

Follow-on to PR #85. The range-separated exchange `rs_exchange` (in both `sadatom::TwoDBasis` and `atomic::TwoDBasis`) Yukawa branch now routes through the same `assemble_K_FE_one_multipole_cached` helper that backs bare exchange — it has identical FE structure (in-element diagonal + cross-element disjoint factorisation), only the per-element accessors return Bessel-flavored integrals instead of polynomial ones.

**The cached helper itself is unchanged.**

## What the migration does

| routine | Yukawa LOC before | Yukawa LOC after |
|---|---|---|
| `sadatom::TwoDBasis::rs_exchange` | ~60 LOC of inline (jel, iel) assembly | ~15 LOC of accessor lambdas + cached helper |
| `atomic::TwoDBasis::rs_exchange` | ~70 LOC of inline per-L per-(iel, jel) accumulation | ~20 LOC of K_block accumulator over per-L cached-K calls (same shape as the bare exchange migration in PR #85) |

**Net diff: −115 / +70 LOC.**

## What's kept inline: erfc

The erfc branch in both routines is **not** migrated. erfc's `rs_ktei` is indexed by every (iel, jel) pair — the kernel does not factorise into a per-element small/big product — so it doesn't fit the disjoint helper pattern. Migrating it would need a separate helper that takes a full `(iel, jel)` tensor accessor, which is a different shape.

The `mem_Ksub` scratch buffer in both routines is preserved (still used by the erfc inline path).

## Validation

Yukawa λ=0.5 on a small sadatom basis for Z=2 with He-1s-ish density:

| | observed | expected |
|---|---|---|
| `‖K_yuk‖_F` | **4.08e-01** | finite, non-zero |
| has any NaN/Inf? | **no** | no |
| `‖K_sad + λ·K_nao_yuk‖_∞` | **5.55e-17** | machine eps |

The cross-check exploits the angular relationship:
- `K_sad` carries the HF minus sign + sadatom Yukawa `Lfac = 4π·λ`.
- Sadatom s-only angular: `totcoup(0)/(2·0+1) = (1/(4π))/1 = 1/(4π)`.
- So `K_sad = −(4π·λ)·(1/(4π))·K_nao_yuk_bare = −λ·K_nao_yuk_bare`.

**Both code paths agree to machine epsilon** — sadatom `rs_exchange` (Yukawa) and `NAORadialBasis::exchange_radial_yukawa` go through the same cached helper.

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test` pass
- [x] Yukawa `rs_exchange` produces finite output, matches NAO Yukawa K to machine eps
- [x] NAO export example (PR #55) matches prior numerics (He HF = −2.86167999561 Eh, err 3.43e-12; unchanged since PR #85)

## Still deferred

1. **erfc `rs_exchange`** — cross-element `rs_ktei[iel*Nel+kel]` doesn't factorise; needs a different helper.
2. **Cholesky integration** (#82) — once that lands, the in-element 4-index tensor in the cached K helper can use the Cholesky-factored form, retiring the direct `O(Ni⁴)` path. Same machinery — only the in-element accessor returns the Cholesky factor instead of the full tensor.