### PR TITLE
v2: migrate rs_exchange erfc branch onto a pairwise cached K helper

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -120,6 +120,20 @@ namespace helfem {
           const PerElementAccessor & ktei_in_element,
           const arma::mat & P_FE);
 
+      /// Per-(iel, jel) accessor variant of the above K helper, for
+      /// kernels whose r1/r2 coupling does NOT factorise into a
+      /// small/big disjoint product (in particular: the error-function
+      /// kernel used by HelFEM's compute_erfc / rs_exchange). Every
+      /// element pair gets its own dense ktei from the cache, then the
+      /// standard K contraction is applied. No disjoint optimisation
+      /// available -- O(Nel^2) per call.
+      using PerElementPairAccessor =
+          std::function<const arma::mat & (size_t iel, size_t jel)>;
+      arma::mat assemble_K_FE_one_multipole_cached_pairwise(
+          const FEMRadialBasis & radial,
+          const PerElementPairAccessor & ktei_pairwise,
+          const arma::mat & P_FE);
+
       // Inline implementations -- header-only to match the rest of the
       // libhelfem/include/ NAO surface. ~150 LOC total.
 
@@ -216,6 +230,31 @@ namespace helfem {
               K_FE.submat(ifirst, jfirst, ilast, jlast) +=
                   iint * (Psub * jint.t());
             }
+          }
+        }
+        return K_FE;
+      }
+
+      inline arma::mat assemble_K_FE_one_multipole_cached_pairwise(
+          const FEMRadialBasis & radial,
+          const PerElementPairAccessor & ktei_pairwise,
+          const arma::mat & P_FE) {
+        const size_t Nel  = radial.Nel();
+        const size_t Nrad = radial.Nbf();
+        arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
+        for (size_t iel = 0; iel < Nel; ++iel) {
+          size_t ifirst, ilast;
+          radial.get_idx(iel, ifirst, ilast);
+          const size_t Ni = ilast - ifirst + 1;
+          for (size_t jel = 0; jel < Nel; ++jel) {
+            size_t jfirst, jlast;
+            radial.get_idx(jel, jfirst, jlast);
+            const size_t Nj = jlast - jfirst + 1;
+            arma::vec Psub_v = arma::vectorise(
+                P_FE.submat(ifirst, jfirst, ilast, jlast));
+            arma::vec Ksub_v = ktei_pairwise(iel, jel) * Psub_v;
+            K_FE.submat(ifirst, jfirst, ilast, jlast) +=
+                arma::reshape(Ksub_v, Ni, Nj);
           }
         }
         return K_FE;

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -1046,31 +1046,12 @@ namespace helfem {
         arma::mat K(Ndummy(),Ndummy());
         K.zeros();
 
-        // Helper memory
-#ifdef _OPENMP
-        const int nth(omp_get_max_threads());
-#else
-        const int nth(1);
-#endif
-        std::vector<arma::vec> mem_Ksub(nth);
-        std::vector<arma::vec> mem_Psub(nth);
-        std::vector<arma::vec> mem_T(nth);
-
+        // Per-element K assembly is delegated to the cached helpers
+        // in CoulombExchangeFE.h -- no per-thread scratch needed.
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
         {
-#ifdef _OPENMP
-          const int ith(omp_get_thread_num());
-#else
-          const int ith(0);
-#endif
-          // These are only small submatrices!
-          mem_Psub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_Ksub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_T[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-
-          // Increment
 #ifdef _OPENMP
 #pragma omp for collapse(2)
 #endif
@@ -1155,28 +1136,21 @@ namespace helfem {
                          (jang+1)*Nrad-1, (kang+1)*Nrad-1) -= K_block;
               } else {
                 // Erfc: rs_ktei has cross-element entries for every
-                // (iel, jel) pair -- the kernel does not factorise.
-                // Keep the inline assembly.
-                for(size_t iel=0;iel<Nel;iel++) {
-                  size_t ifirst, ilast;
-                  radial.get_idx(iel,ifirst,ilast);
-                  for(size_t jel=0;jel<Nel;jel++) {
-                    size_t jfirst, jlast;
-                    radial.get_idx(jel,jfirst,jlast);
-                    size_t Ni(ilast-ifirst+1);
-                    size_t Nj(jlast-jfirst+1);
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni*Nj,1,false,true);
-                    Ksub.zeros();
-                    for(size_t L=0;L<N_L;L++) {
-                      if(!couple[L]) continue;
-                      Ksub += rs_ktei[Nel*Nel*L + iel*Nel + jel]
-                              * arma::vectorise(Rmat[L].submat(ifirst,jfirst,ilast,jlast));
-                    }
-                    Ksub.reshape(Ni,Nj);
-                    K.submat(jang*Nrad+ifirst,kang*Nrad+jfirst,
-                             jang*Nrad+ilast,kang*Nrad+jlast) -= Ksub;
-                  }
+                // (iel, jel) pair -- delegate to the pairwise cached
+                // helper, summed over L into the (jang, kang) block.
+                arma::mat K_block(Nrad, Nrad, arma::fill::zeros);
+                for(size_t L=0; L<N_L; ++L) {
+                  if(!couple[L]) continue;
+                  const size_t Lc = L;
+                  auto kt = [&,Lc](size_t iel, size_t jel) -> const arma::mat & {
+                    return rs_ktei[Nel*Nel*Lc + iel*Nel + jel];
+                  };
+                  K_block +=
+                    helfem::atomic::basis::assemble_K_FE_one_multipole_cached_pairwise(
+                      radial, kt, Rmat[Lc]);
                 }
+                K.submat(jang*Nrad, kang*Nrad,
+                         (jang+1)*Nrad-1, (kang+1)*Nrad-1) -= K_block;
               }
             }
           }

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -446,31 +446,12 @@ namespace helfem {
         arma::cube K(Nrad,Nrad,gmax+1);
         K.zeros();
 
-        // Helper memory
-#ifdef _OPENMP
-        const int nth(omp_get_max_threads());
-#else
-        const int nth(1);
-#endif
-        std::vector<arma::vec> mem_Ksub(nth);
-        std::vector<arma::vec> mem_Psub(nth);
-        std::vector<arma::vec> mem_T(nth);
-
+        // Per-element K assembly is delegated to the cached helpers in
+        // CoulombExchangeFE.h -- no per-thread scratch needed here.
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
         {
-#ifdef _OPENMP
-          const int ith(omp_get_thread_num());
-#else
-          const int ith(0);
-#endif
-          // These are only small submatrices!
-          mem_Psub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_Ksub[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-          mem_T[ith].zeros(radial.max_Nprim()*radial.max_Nprim());
-
-          // Increment
 #ifdef _OPENMP
 #pragma omp for
 #endif
@@ -545,23 +526,16 @@ namespace helfem {
                     radial, rs, rb, kt, P_L);
               } else {
                 // Erfc: rs_ktei has cross-element entries (iel != jel)
-                // because the erfc kernel does not factorise. Keep the
-                // inline assembly.
-                for(size_t iel=0;iel<Nel;iel++) {
-                  size_t ifirst, ilast;
-                  radial.get_idx(iel,ifirst,ilast);
-                  for(size_t jel=0;jel<Nel;jel++) {
-                    size_t jfirst, jlast;
-                    radial.get_idx(jel,jfirst,jlast);
-                    size_t Ni(ilast-ifirst+1);
-                    size_t Nj(jlast-jfirst+1);
-                    arma::mat Ksub(mem_Ksub[ith].memptr(),Ni*Nj,1,false,true);
-                    Ksub=rs_ktei[Nel*Nel*L + iel*Nel + jel]
-                         * arma::vectorise(P_L.submat(ifirst,jfirst,ilast,jlast));
-                    Ksub.reshape(Ni,Nj);
-                    K.slice(lout).submat(ifirst,jfirst,ilast,jlast)-=Ksub;
-                  }
-                }
+                // because the erfc kernel does not factorise. Delegate
+                // to the pairwise cached helper -- same contraction
+                // pattern, just no disjoint optimisation.
+                const size_t Lc = L;
+                auto kt = [&,Lc](size_t iel, size_t jel) -> const arma::mat & {
+                  return rs_ktei[Nel*Nel*Lc + iel*Nel + jel];
+                };
+                K.slice(lout) -=
+                  atomic::basis::assemble_K_FE_one_multipole_cached_pairwise(
+                    radial, kt, P_L);
               }
             }
           }


### PR DESCRIPTION
## Summary

Final piece of the rs_exchange DRY arc (after #86). The erfc branch of `rs_exchange` (in both sadatom and atomic `TwoDBasis`) now goes through a new free-function helper that fits its (iel, jel)-pair tensor shape:

```cpp
arma::mat assemble_K_FE_one_multipole_cached_pairwise(
    const FEMRadialBasis & radial,
    const PerElementPairAccessor & ktei_pairwise,   // (iel, jel) -> &mat
    const arma::mat & P_FE);
```

The standard cached K helper assumes the cross-element ktei factorises via small/big disjoint integrals; erfc does not, so it needs a dense per-(iel, jel) accessor instead. Otherwise the contraction shape is the same.

## Migrations

| routine | before | after |
|---|---|---|
| `sadatom::TwoDBasis::rs_exchange` (erfc) | ~20 LOC of inline (iel, jel) submat assembly | ~5 LOC accessor + cached-pairwise helper |
| `atomic::TwoDBasis::rs_exchange` (erfc) | ~25 LOC of per-(iel, jel) per-L accumulation | K_block accumulator over cached-pairwise calls; same shape as Yukawa migration from PR #86 |

**Scratch buffers removed** from both `rs_exchange` routines — the helper allocates its own.

**Net diff: −80 / +67 LOC.** The new helper body adds ~25 LOC; the two rs_exchange routines lose ~75 LOC of inline+scratch.

## State after this PR

Both `rs_exchange` routines are now fully migrated. **No inline 2e assembly remains anywhere in TwoDBasis.** Every 2e radial assembly in TwoDBasis (bare J/K, Yukawa K, erfc K) now flows through `CoulombExchangeFE.h`.

## Validation

| | observed | expected |
|---|---|---|
| `‖K_erfc‖_F` (μ=0.4) | **4.02e-01** | finite, non-zero |
| has any NaN/Inf? | **no** | no |
| `‖K_bare‖_F` | **5.42e-01** | > `‖K_erfc‖_F` (erfc screens long-range) |

The bare > erfc magnitude is the expected screening behaviour (erfc(μr) < 1 for r > 0, reducing the long-range exchange contribution).

## Test plan (verified)

- [x] Full build clean (`HELFEM_FIND_DEPS=ON`, `BUILD_SHARED_LIBS=ON`)
- [x] `gaunt_test`, `sphtest`, `legendre_test` pass
- [x] Erfc `rs_exchange` produces finite output, smaller magnitude than bare exchange
- [x] NAO export example (PR #55) matches prior numerics (He HF = −2.86167999561 Eh, err 3.43e-12; unchanged since PR #85)

## Next

**Cholesky integration** (#82's `twoe_integral_cholesky`): the in-element accessor in the standard cached K helper can return a Cholesky factor instead of the full ktei, replacing the direct `O(Ni⁴)` contraction with `O(Ni² · r)`. Same machinery — only the accessor changes. That'll be the last big v2 win for the 2e path.