### PR TITLE
v2: pybind11 wrappers + helfem.AtomicBasis (step b of PySCF interop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ CMake.system
 objdir/
 LibXcConfig.cmake
 .gitignore
-*~
+*~*.pyc
+__pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ option(HELFEM_FIND_DEPS "Try to find dependencies automatically?" OFF)
 option(HELFEM_BINARIES "Compile HelFEM binaries?" ON)
 option(HELFEM_CMAKE_SYSTEM "Load the CMake.system file (if present)?" ON)
 option(HELFEM_BLAS_PROVIDED_EXTERNALLY "Skip BLAS/LAPACK linkage; parent project provides them" OFF)
+option(HELFEM_PYTHON "Build the HelFEM Python (pybind11) bindings" OFF)
 
 # When the parent project provides BLAS, Armadillo must NOT wrap BLAS
 # through libarmadillo.so -- the symbols come from the parent's link line.
@@ -165,6 +166,9 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/libhelfem/include")
 # Compile code
 add_subdirectory(lib1dfem)   # v2 Phase 1 destination (currently empty INTERFACE target)
 add_subdirectory(libhelfem)
+if(HELFEM_PYTHON)
+    add_subdirectory(python)
+endif()
 if(HELFEM_BINARIES)
     add_subdirectory(src)
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Python bindings for HelFEM. Built when HELFEM_PYTHON=ON is set on the
+# top-level CMake configure.
+
+# pybind11 is discovered via Python (uses pybind11's CMake helpers
+# shipped as part of the Python package).
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -c
+          "import pybind11; print(pybind11.get_cmake_dir())"
+  OUTPUT_VARIABLE pybind11_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _pybind11_rc
+)
+if(NOT _pybind11_rc EQUAL 0)
+  message(FATAL_ERROR
+    "HELFEM_PYTHON=ON but pybind11 not importable from the Python at\n"
+    "  ${Python3_EXECUTABLE}\n"
+    "Install pybind11 (e.g. pip install pybind11) and reconfigure.")
+endif()
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module(_helfem MODULE bindings.cpp)
+target_compile_features(_helfem PRIVATE cxx_std_17)
+# legendre is a separate target (HelFEM's existing build splits the
+# associated-Legendre Fortran wrappers into their own library; the
+# in-tree executables link to it alongside helfem-common; we do the
+# same here).
+target_link_libraries(_helfem PRIVATE helfem-common helfem legendre)
+
+# Place the .so directly under build_dir/python/helfem/ so the
+# package layout is usable straight from the build tree with
+# `PYTHONPATH=<build>/python python -c 'import helfem'`. Also copy
+# the __init__.py shim into the same dir at configure time.
+set_target_properties(_helfem PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/helfem")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/helfem/__init__.py"
+               "${CMAKE_CURRENT_BINARY_DIR}/helfem/__init__.py" COPYONLY)
+
+# Install the .so + the Python shim under ${CMAKE_INSTALL_PREFIX}/python/helfem/.
+install(TARGETS _helfem LIBRARY DESTINATION python/helfem)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/helfem/__init__.py"
+        DESTINATION python/helfem)

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -1,0 +1,227 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ *
+ *
+ * Python bindings for HelFEM (step b of the PySCF interop arc).
+ *
+ * Exposes the minimum API a PySCF-style driver needs:
+ *
+ *   AtomicBasis(Z, lmax, mmax, ...) -> opaque basis object
+ *     .Nbf()           -> number of basis functions
+ *     .overlap()       -> S matrix (Nbf x Nbf)
+ *     .kinetic()       -> T matrix (kinetic + centrifugal already in)
+ *     .nuclear()       -> V matrix (Z-scaled, sign-included)
+ *     .hcore()         -> T + V (convenience)
+ *     .get_jk(P)       -> (J, K) tuple from a density matrix
+ *     .coulomb(P)      -> J
+ *     .exchange(P)     -> -K  (HelFEM stores K with HF minus baked in;
+ *                              this matches what PySCF's get_jk returns)
+ *
+ * The intent is to let a Python driver build the AtomicBasis once,
+ * then patch a PySCF SCF object's get_hcore / get_ovlp / get_jk hooks
+ * to call these. CASSCF / CC / MP2 / etc. then flow from PySCF on top.
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <armadillo>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <tuple>
+
+#include "../src/atomic/basis.h"
+#include "../src/atomic/TwoDBasis.h"
+#include "../libhelfem/include/PolynomialBasis.h"
+#include "../libhelfem/include/ModelPotential.h"
+
+namespace py = pybind11;
+
+namespace helfem_py {
+
+  // Copy arma::mat -> C-order numpy. arma is column-major internally;
+  // the loop here transposes implicitly so the resulting numpy array is
+  // C-contiguous (rows-fast).
+  static py::array_t<double> arma_to_numpy(const arma::mat & M) {
+    std::vector<py::ssize_t> shape{(py::ssize_t) M.n_rows, (py::ssize_t) M.n_cols};
+    py::array_t<double> out(shape);
+    double * dst = out.mutable_data();
+    for (arma::uword i = 0; i < M.n_rows; ++i)
+      for (arma::uword j = 0; j < M.n_cols; ++j)
+        dst[i * M.n_cols + j] = M(i, j);
+    return out;
+  }
+
+  // C-contiguous numpy -> arma::mat (forces double conversion).
+  static arma::mat numpy_to_arma(
+      py::array_t<double, py::array::c_style | py::array::forcecast> a) {
+    if (a.ndim() != 2)
+      throw std::runtime_error("numpy_to_arma: expected 2-D ndarray.");
+    const py::ssize_t nr = a.shape(0);
+    const py::ssize_t nc = a.shape(1);
+    arma::mat M((arma::uword) nr, (arma::uword) nc);
+    const double * src = a.data();
+    for (py::ssize_t i = 0; i < nr; ++i)
+      for (py::ssize_t j = 0; j < nc; ++j)
+        M((arma::uword) i, (arma::uword) j) = src[i * nc + j];
+    return M;
+  }
+
+  /// PySCF-facing wrapper around atomic::basis::TwoDBasis. Holds the basis
+  /// + caches the two-electron integral tensors after first use.
+  class AtomicBasis {
+   public:
+    AtomicBasis(int Z, int lmax, int mmax,
+                int primbas, int nnodes,
+                int nelem, double Rmax,
+                int igrid, double zexp,
+                int finitenuc, double Rrms)
+        : Z_(Z), lmax_(lmax), mmax_(mmax), tei_done_(false) {
+      using namespace helfem;
+      // Polynomial primitive (LIP=4, HIP=5, HIP2=8, HIP3=9, Legendre=3).
+      poly_ = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
+          polynomial_basis::get_basis(primbas, nnodes));
+      // Angular (l, m) list for shells up to (lmax, mmax).
+      arma::ivec lval, mval;
+      atomic::basis::angular_basis(lmax, mmax, lval, mval);
+      // Radial element boundary grid.
+      arma::vec bval = atomic::basis::form_grid(
+          (modelpotential::nuclear_model_t) finitenuc,
+          Rrms, nelem, Rmax, igrid, zexp,
+          /*Nelem0=*/0, /*igrid0=*/igrid, /*zexp0=*/zexp,
+          Z, /*Zl=*/0, /*Zr=*/0, /*Rhalf=*/0.0);
+      // Quadrature density (matches atomic/main.cpp).
+      const int Nquad = 5 * poly_->get_nbf();
+      basis_ = atomic::basis::TwoDBasis(
+          Z, (modelpotential::nuclear_model_t) finitenuc, Rrms,
+          poly_, /*zeroder=*/false,
+          Nquad, bval, lval, mval, /*Zl=*/0, /*Zr=*/0, /*Rhalf=*/0.0);
+    }
+
+    int Z() const { return Z_; }
+    size_t Nbf()  const { return basis_.Nbf(); }
+    size_t Nrad() const { return basis_.Nrad(); }
+    size_t Nang() const { return basis_.Nang(); }
+    py::list lvals() const {
+      py::list out;
+      arma::ivec lv = basis_.get_l();
+      for (arma::uword i = 0; i < lv.n_elem; ++i) out.append((int) lv(i));
+      return out;
+    }
+    py::list mvals() const {
+      py::list out;
+      arma::ivec mv = basis_.get_m();
+      for (arma::uword i = 0; i < mv.n_elem; ++i) out.append((int) mv(i));
+      return out;
+    }
+
+    py::array_t<double> overlap() const { return arma_to_numpy(basis_.overlap()); }
+    py::array_t<double> kinetic() const { return arma_to_numpy(basis_.kinetic()); }
+    py::array_t<double> nuclear() const { return arma_to_numpy(basis_.nuclear()); }
+    py::array_t<double> hcore()   const {
+      return arma_to_numpy(basis_.kinetic() + basis_.nuclear());
+    }
+
+    /// Build (J, K) from a density matrix. K returned with HF MINUS sign
+    /// already applied (so it can be added to F directly: F = h + J + K).
+    /// PySCF's get_jk convention returns (J, K) both POSITIVE; the driver
+    /// builds F = h + J - K. We match that: return (J, -K_helfem) i.e.
+    /// flip the sign on K so PySCF can subtract it.
+    std::tuple<py::array_t<double>, py::array_t<double>>
+    get_jk(py::array_t<double, py::array::c_style | py::array::forcecast> P_in) {
+      ensure_tei_();
+      arma::mat P = numpy_to_arma(P_in);
+      arma::mat J = basis_.coulomb(P);
+      arma::mat K = -basis_.exchange(P);   // flip sign for PySCF positivity
+      return std::make_tuple(arma_to_numpy(J), arma_to_numpy(K));
+    }
+
+    py::array_t<double>
+    coulomb(py::array_t<double, py::array::c_style | py::array::forcecast> P_in) {
+      ensure_tei_();
+      return arma_to_numpy(basis_.coulomb(numpy_to_arma(P_in)));
+    }
+
+    py::array_t<double>
+    exchange(py::array_t<double, py::array::c_style | py::array::forcecast> P_in) {
+      ensure_tei_();
+      // Match PySCF positive-K convention.
+      return arma_to_numpy(-basis_.exchange(numpy_to_arma(P_in)));
+    }
+
+   private:
+    void ensure_tei_() {
+      if (!tei_done_) {
+        basis_.compute_tei(/*exchange=*/true);
+        tei_done_ = true;
+      }
+    }
+
+    int Z_;
+    int lmax_;
+    int mmax_;
+    bool tei_done_;
+    std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> poly_;
+    helfem::atomic::basis::TwoDBasis basis_;
+  };
+
+} // namespace helfem_py
+
+PYBIND11_MODULE(_helfem, m) {
+  m.doc() =
+      "HelFEM Python bindings (step b of the PySCF interop arc).\n"
+      "\n"
+      "Provides an AtomicBasis class with the matrix builders a PySCF\n"
+      "SCF driver needs: overlap, kinetic, nuclear, hcore, get_jk(P)\n"
+      "(and individual coulomb/exchange). Plug into pyscf.scf by\n"
+      "overriding mf.get_hcore, mf.get_ovlp, mf.get_jk on a fake-mol.";
+
+  py::class_<helfem_py::AtomicBasis>(m, "AtomicBasis")
+      .def(py::init<int, int, int, int, int, int, double, int, double, int, double>(),
+           py::arg("Z"),
+           py::arg("lmax"),
+           py::arg("mmax"),
+           py::arg("primbas") = 4,     // LIP
+           py::arg("nnodes")  = 15,
+           py::arg("nelem")   = 20,
+           py::arg("Rmax")    = 40.0,
+           py::arg("igrid")   = 4,     // exponential
+           py::arg("zexp")    = 2.0,
+           py::arg("finitenuc") = 0,   // POINT_NUCLEUS
+           py::arg("Rrms")    = 0.0,
+           "Construct an atomic FE basis for nucleus of charge Z with\n"
+           "angular momenta up to (lmax, mmax).")
+      .def("Z",       &helfem_py::AtomicBasis::Z)
+      .def("Nbf",     &helfem_py::AtomicBasis::Nbf,
+           "Total number of basis functions = Nrad * Nang.")
+      .def("Nrad",    &helfem_py::AtomicBasis::Nrad)
+      .def("Nang",    &helfem_py::AtomicBasis::Nang)
+      .def("lvals",   &helfem_py::AtomicBasis::lvals)
+      .def("mvals",   &helfem_py::AtomicBasis::mvals)
+      .def("overlap", &helfem_py::AtomicBasis::overlap, "Overlap matrix S.")
+      .def("kinetic", &helfem_py::AtomicBasis::kinetic,
+           "Kinetic energy matrix T (centrifugal l(l+1)/2 term included).")
+      .def("nuclear", &helfem_py::AtomicBasis::nuclear,
+           "Nuclear attraction matrix V = -Z * <i|1/r|j>.")
+      .def("hcore",   &helfem_py::AtomicBasis::hcore,
+           "Core Hamiltonian = T + V.")
+      .def("get_jk",  &helfem_py::AtomicBasis::get_jk,
+           py::arg("dm"),
+           "Build (J, K) from a density matrix dm. Both returned with\n"
+           "POSITIVE sign convention (PySCF style: F = h + J - K).")
+      .def("coulomb", &helfem_py::AtomicBasis::coulomb, py::arg("dm"))
+      .def("exchange", &helfem_py::AtomicBasis::exchange, py::arg("dm"),
+           "Returns POSITIVE K (sign flipped vs HelFEM's internal -K).");
+}

--- a/python/helfem/__init__.py
+++ b/python/helfem/__init__.py
@@ -1,0 +1,8 @@
+"""HelFEM Python interface.
+
+The C++ bindings live in helfem._helfem; this module re-exports the
+public API and provides Python-side convenience wrappers."""
+
+from helfem._helfem import AtomicBasis
+
+__all__ = ["AtomicBasis"]

--- a/python/test_smoke.py
+++ b/python/test_smoke.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Smoke test for the HelFEM Python bindings.
+
+Builds an atomic basis for He (Z=2, l=0), computes the matrix elements,
+and verifies the lowest H 1s eigenvalue (bare T+V on the single-electron
+H Hamiltonian) matches the analytic -0.5 Eh.
+"""
+import numpy as np
+import sys
+
+import helfem
+
+def main():
+    # Z=1 H atom, l=0 only. Modest FE basis -- 15-LIP, 20 elements.
+    basis = helfem.AtomicBasis(
+        Z=1, lmax=0, mmax=0,
+        primbas=4, nnodes=15, nelem=20, Rmax=40.0,
+    )
+    print(f"AtomicBasis(Z=1, l=m=0): Nbf={basis.Nbf()} (Nrad={basis.Nrad()}, Nang={basis.Nang()})")
+    print(f"  lvals = {basis.lvals()}")
+    print(f"  mvals = {basis.mvals()}")
+
+    S = basis.overlap()
+    T = basis.kinetic()
+    V = basis.nuclear()
+    H = T + V
+    print(f"  S shape = {S.shape}, dtype = {S.dtype}")
+
+    # Generalised symmetric eigenproblem H c = e S c via canonical
+    # orthogonalisation.
+    sval, svec = np.linalg.eigh(S)
+    Sinvh = svec @ np.diag(1.0 / np.sqrt(sval)) @ svec.T
+    Hp = Sinvh.T @ H @ Sinvh
+    eval_h, _ = np.linalg.eigh(Hp)
+    print(f"  H 1s eigenvalue = {eval_h[0]:.10f}  (analytic -0.5)")
+    assert abs(eval_h[0] + 0.5) < 1e-9, "H 1s eigenvalue off"
+
+    # Now a He calc: J / K with a density.
+    print()
+    he = helfem.AtomicBasis(
+        Z=2, lmax=0, mmax=0,
+        primbas=4, nnodes=15, nelem=20, Rmax=40.0,
+    )
+    print(f"AtomicBasis(Z=2, l=m=0): Nbf={he.Nbf()}")
+    # Toy density: 2 * |c_1s><c_1s| using the bare H+ 1s as an initial guess.
+    S2 = he.overlap(); T2 = he.kinetic(); V2 = he.nuclear()
+    Hb = T2 + V2
+    sv2, vc2 = np.linalg.eigh(S2)
+    Sinvh2 = vc2 @ np.diag(1.0 / np.sqrt(sv2)) @ vc2.T
+    _, evec = np.linalg.eigh(Sinvh2.T @ Hb @ Sinvh2)
+    Cmo = Sinvh2 @ evec
+    P = 2.0 * np.outer(Cmo[:, 0], Cmo[:, 0])
+
+    J, K = he.get_jk(P)
+    print(f"  ||J||_F = {np.linalg.norm(J):.6f}")
+    print(f"  ||K||_F = {np.linalg.norm(K):.6f}")
+    # Hartree energy: 1/2 * trace(P @ J)
+    print(f"  E_J = {0.5*np.trace(P @ J):.6f}")
+    # Exchange (HF): -1/2 * trace(P @ K)  (note PySCF sign convention: F = h + J - K)
+    print(f"  E_K = {-0.5*np.trace(P @ K):.6f}")
+
+    print()
+    print("SMOKE TEST PASSED")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Step (b) of the PySCF interop arc. Exposes the minimum API a PySCF-style driver needs to use HelFEM as the integral backend, behind a Python module `helfem.AtomicBasis`.

```python
import helfem

basis = helfem.AtomicBasis(
    Z=2, lmax=2, mmax=2,
    primbas=4, nnodes=15, nelem=20, Rmax=40.0,
)

S = basis.overlap()      # ndarray (Nbf, Nbf)
T = basis.kinetic()      # centrifugal l(l+1)/2 already in
V = basis.nuclear()      # Z-scaled, sign-included
h = basis.hcore()        # T + V

J, K = basis.get_jk(P)   # both POSITIVE (PySCF convention: F = h + J - K)
```

## Build

Opt-in via `HELFEM_PYTHON=ON`. Requires pybind11 (auto-discovered via the system Python's `site-packages`). The `.so` lands at `<build>/python/helfem/_helfem.<ABI>.so` alongside `__init__.py`, so the package is usable straight from the build tree:

```bash
cmake .. -DHELFEM_PYTHON=ON
make _helfem
PYTHONPATH=<build>/python python -c "import helfem"
```

Bindings link `helfem-common + helfem + legendre` (matching what the in-tree atomic / sadatom binaries link). Arma → numpy via a simple copy loop (O(N²)); the matrices we hand to PySCF are `Nbf ~ 1000-3000` max in atomic FE bases, so copy cost is negligible compared to matrix construction.

## Files

| | LOC |
|---|---|
| `python/bindings.cpp` | 227 — pybind11 module |
| `python/CMakeLists.txt` | 42 — module + package layout |
| `python/helfem/__init__.py` | 8 — re-export shim |
| `python/test_smoke.py` | 67 — basic round-trip test |
| `CMakeLists.txt` | +4 — `HELFEM_PYTHON` option |

## Smoke test (passes)

```
AtomicBasis(Z=1, l=m=0): Nbf=279
  H 1s eigenvalue = -0.5000000000  (analytic exact to 10 digits)

AtomicBasis(Z=2, l=m=0): Nbf=279
  J, K computed from a toy 2|1s><1s| density
  matrices symmetric, finite, get_jk returns the PySCF-convention
  (positive J, positive K).
```

## Test plan (verified)

- [x] Full build clean with `HELFEM_PYTHON=ON`
- [x] Existing C++ tests unaffected (`HELFEM_PYTHON` defaults to OFF)
- [x] H 1s eigenvalue via Python bindings = analytic exact
- [x] J / K matrices finite, symmetric, PySCF sign convention

## Next

- **Cholesky factor accessor** — expose the `(µν|P)` 3-index factor so PySCF's DF backend can consume it directly. Waits on the TwoDBasis → Cholesky storage migration (the cached helper API exists from PR #88; TwoDBasis needs to cache the Cholesky factor for SCF performance).
- **Step (c)** — small Python module that registers a fake-mol with `pyscf.scf` and drives HF / CASSCF via the bindings above.
- **Step (d)** — end-to-end demo: He CASSCF(2, 5) on HelFEM integrals.