### PR TITLE
v2: CASSCF support via install_full_eri + Be Froese-Fischer MC-HF demo

### DIFF
--- a/python/helfem/pyscf_driver.py
+++ b/python/helfem/pyscf_driver.py
@@ -228,19 +228,52 @@ def install_eri_builder(mc, basis):
 
 def helfem_casci(mf, basis, ncas, nelecas):
     """Build a pyscf.mcscf.CASCI driven by HelFEM integrals on top of an
-    `mf` from helfem_scf. Wraps `install_eri_builder` so the user gets a
-    ready-to-call CASCI object.
+    `mf` from helfem_scf. Auto-installs the full AO ERI on mf if not
+    already present, then constructs a standard pyscf CASCI -- no
+    custom mc.ao2mo override needed, all of pyscf's downstream
+    machinery (FCI solver, etc.) flows on top.
     """
     from pyscf import mcscf
-    mc = mcscf.CASCI(mf, ncas, nelecas)
-    return install_eri_builder(mc, basis)
+    if getattr(mf, "_eri", None) is None:
+        install_full_eri(mf, basis)
+    return mcscf.CASCI(mf, ncas, nelecas)
 
 
 def helfem_casscf(mf, basis, ncas, nelecas):
-    """Same as helfem_casci but with orbital optimisation (CASSCF)."""
+    """Same as helfem_casci but with orbital optimisation (CASSCF).
+
+    Requires mf._eri to have been pre-populated with the AO ERI tensor
+    (use install_full_eri below). CASSCF uses PySCF's _ERIS internals
+    which need the AO ERI; the install_eri_builder shim works for
+    CASCI but not CASSCF (CASSCF needs vhf_c, ppaa, papa, ... beyond
+    what install_eri_builder provides).
+    """
     from pyscf import mcscf
-    mc = mcscf.CASSCF(mf, ncas, nelecas)
-    return install_eri_builder(mc, basis)
+    if getattr(mf, "_eri", None) is None:
+        install_full_eri(mf, basis)
+    return mcscf.CASSCF(mf, ncas, nelecas)
+
+
+def install_full_eri(mf, basis):
+    """Pre-compute the full Nbf^4 AO ERI tensor for `basis` and store it
+    on mf._eri (8-fold packed form). Once installed, PySCF's
+    standard ao2mo / CASCI / CASSCF / MP2 / CCSD etc. machinery works
+    against the HelFEM basis through normal code paths -- no per-method
+    overrides needed.
+
+    Cost: Nbf*(Nbf+1)/2 J builds + O(Nbf^4) storage. For a compact NAO
+    basis (Nbf ~ 10-30) this is trivial (Nbf^4 ~ 10k-800k entries).
+    For larger Nbf the storage blows up -- use DF/Cholesky or stick to
+    the per-multipole install_eri_builder path instead. Typical NAO
+    workflows are small enough that this is the path of least
+    resistance for CASSCF.
+    """
+    Nbf = basis.Nbf()
+    # build_active_eri with identity coefficients returns the AO ERI.
+    eri_unpacked = build_active_eri(basis, np.eye(Nbf))
+    # Store in 8-fold-packed form (the format PySCF uses internally).
+    mf._eri = ao2mo.restore('s8', eri_unpacked, Nbf)
+    return mf
 
 
 # -- NAO basis (projection of an FE AtomicBasis onto its physical

--- a/python/test_pyscf_be_mchf.py
+++ b/python/test_pyscf_be_mchf.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Be 1s^2(2s^2 + 2p^2) multi-configuration HF via PySCF + HelFEM.
+
+The original Froese-Fischer MC-HF calculation: Be ground state with
+the 1s shell frozen as core, the 2s + 2p valence as a 4-orbital
+active space holding the 2 valence electrons. CASSCF reoptimises
+both the active-orbital shapes and the CI coefficients.
+
+Reference: experimental Be ground state energy = -14.6674 Eh.
+HF/basis-limit Be = -14.5730 Eh, so correlation ~ 94 mEh.
+The 1s^2(2s^2 + 2p^2) MC-HF captures the dominant near-degeneracy
+correlation (~50 mEh), the rest comes from dynamical correlation
+needing higher excitations / larger active spaces.
+"""
+import sys
+import numpy as np
+
+from helfem.pyscf_driver import (
+    helfem_scf, helfem_nao_scf, helfem_casci, helfem_casscf,
+    install_full_eri,
+)
+
+REF_BE_HF       = -14.573023
+REF_BE_MCHF_2s2p = -14.6172    # approximate Froese-Fischer MC-HF result
+REF_BE_EXACT    = -14.66736
+
+def main():
+    print("=== HF for Be (Z=4, lmax=1, mmax=1) -- compact FE basis ===")
+    mf_fe, basis_fe = helfem_scf(
+        Z=4, lmax=1, mmax=1,
+        primbas=4, nnodes=8, nelem=5, Rmax=10.0,
+        verbose=0,
+    )
+    print(f"  FE Nbf = {basis_fe.Nbf()}, shells = {list(zip(basis_fe.lvals(), basis_fe.mvals()))}")
+    e_hf_fe = mf_fe.kernel()
+    print(f"  RHF (full FE) = {e_hf_fe:.10f} Eh   (ref ~{REF_BE_HF})")
+    print()
+
+    print("=== Extract NAOs: 2 s + 1 each (p_-1, p_0, p_+1) = 5 NAOs ===")
+    # Angular shell order from angular_basis(lmax=1, mmax=1):
+    # likely (0,0), (1,-1), (1,0), (1,+1).  Keep 2 from s, 1 from each p.
+    keep = []
+    for (l, m) in zip(basis_fe.lvals(), basis_fe.mvals()):
+        if l == 0:
+            keep.append(2)
+        elif l == 1:
+            keep.append(1)
+        else:
+            keep.append(0)
+    print(f"  keep_per_shell = {keep}")
+    mf_nao, basis_nao = helfem_nao_scf(mf_fe, basis_fe, keep_per_shell=keep)
+    e_hf_nao = mf_nao.kernel()
+    print(f"  NAO Nbf = {basis_nao.Nbf()}")
+    print(f"  RHF (NAO) = {e_hf_nao:.10f} Eh   (matches FE: delta = {e_hf_nao - e_hf_fe:+.3e})")
+    print(f"  NAO MO energies: {mf_nao.mo_energy}")
+    print()
+
+    print("=== Install full AO ERI in NAO basis ===")
+    install_full_eri(mf_nao, basis_nao)
+    print(f"  mf._eri.shape = {mf_nao._eri.shape}")
+    print()
+
+    # For Be: 4 electrons, ncore = (4 - 2) / 2 = 1 (auto from CASCI).
+    # active = 2s + 2p_-1 + 2p_0 + 2p_+1 = 4 orbitals.
+    # 2 active electrons -> CASCI(2, 4) is exactly Froese-Fischer's
+    # 1s^2(2s^2 + 2p^2) (the 2p^2 part covers all three p orientations
+    # by symmetry).
+    print("=== CASCI(2, 4)  -- 1s^2 frozen, 2s+2p active ===")
+    mc_ci = helfem_casci(mf_nao, basis_nao, ncas=4, nelecas=2)
+    mc_ci.verbose = 0
+    e_ci = mc_ci.kernel()[0]
+    print(f"  ncore = {mc_ci.ncore} (PySCF auto-set)")
+    print(f"  CASCI = {e_ci:.10f}   corr = {e_ci - e_hf_nao:+.6f} Eh")
+    print()
+
+    print("=== CASSCF(2, 4) -- the Froese-Fischer MC-HF calc ===")
+    mc_scf = helfem_casscf(mf_nao, basis_nao, ncas=4, nelecas=2)
+    mc_scf.verbose = 0
+    e_scf = mc_scf.kernel()[0]
+    print(f"  CASSCF = {e_scf:.10f}   corr = {e_scf - e_hf_nao:+.6f} Eh")
+    print()
+
+    print("--- Summary (Be ground state) ---")
+    print(f"  HF (NAO)              = {e_hf_nao:.6f}")
+    print(f"  CASCI(2, 4)           = {e_ci:.6f}")
+    print(f"  CASSCF(2, 4) (MC-HF)  = {e_scf:.6f}")
+    print(f"  Froese-Fischer ref    = {REF_BE_MCHF_2s2p:.6f}")
+    print(f"  Exact (FCI extrap.)   = {REF_BE_EXACT:.6f}")
+    print(f"  HF/basis-limit ref    = {REF_BE_HF:.6f}")
+    print()
+    print(f"  MC-HF correlation captured: {abs(e_scf - e_hf_nao)*1000:.2f} mEh")
+    print(f"  Total Be corr ~94 mEh; MC-HF captures the near-degeneracy piece (~50 mEh).")
+    print(f"  Remaining ~40 mEh = dynamical correlation, needs higher excitations.")
+    assert e_scf <= e_ci + 1e-10, "CASSCF should be at or below CASCI"
+    print("\nPASS")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/test_pyscf_he_casscf.py
+++ b/python/test_pyscf_he_casscf.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""He CASSCF via PySCF + HelFEM (full PySCF interop arc done).
+
+Same setup as test_pyscf_he_nao.py but adds CASSCF on top of CASCI.
+CASSCF reoptimises the active orbitals; for He with a 10-NAO basis
+it should give the same or better correlation than CASCI.
+"""
+import sys
+import numpy as np
+
+from helfem.pyscf_driver import (
+    helfem_scf, helfem_nao_scf, helfem_casci, helfem_casscf,
+    install_full_eri,
+)
+
+def main():
+    print("=== HF for He at lmax=1, compact FE basis ===")
+    mf_fe, basis_fe = helfem_scf(
+        Z=2, lmax=1, mmax=0,
+        primbas=4, nnodes=8, nelem=5, Rmax=10.0,
+        verbose=0,
+    )
+    mf_fe.kernel()
+    print()
+
+    print("=== Extract per-shell NAOs ===")
+    mf_nao, basis_nao = helfem_nao_scf(
+        mf_fe, basis_fe, keep_per_shell=[5, 5],
+    )
+    e_hf = mf_nao.kernel()
+    print(f"  NAO Nbf = {basis_nao.Nbf()}")
+    print(f"  HF (NAO) = {e_hf:.10f} Eh")
+    print()
+
+    print("=== Pre-compute full ERI on NAO basis (for CASSCF) ===")
+    install_full_eri(mf_nao, basis_nao)
+    print(f"  mf._eri.shape = {mf_nao._eri.shape}")
+    print()
+
+    print("=== CASCI(2, 10) ===")
+    mc_ci = helfem_casci(mf_nao, basis_nao, ncas=10, nelecas=2)
+    mc_ci.verbose = 0
+    e_casci = mc_ci.kernel()[0]
+    print(f"  CASCI = {e_casci:.10f}   corr = {e_casci - e_hf:+.6f}")
+    print()
+
+    print("=== CASSCF(2, 10) ===")
+    mc_scf = helfem_casscf(mf_nao, basis_nao, ncas=10, nelecas=2)
+    mc_scf.verbose = 0
+    e_casscf = mc_scf.kernel()[0]
+    print(f"  CASSCF = {e_casscf:.10f}   corr = {e_casscf - e_hf:+.6f}")
+    print()
+
+    print("--- Summary ---")
+    print(f"  HF      = {e_hf:.6f}")
+    print(f"  CASCI   = {e_casci:.6f}  corr {e_casci - e_hf:+.4e}")
+    print(f"  CASSCF  = {e_casscf:.6f}  corr {e_casscf - e_hf:+.4e}")
+    print(f"  FCI ref = -2.903724 (basis-limit, Pekeris)")
+
+    # CASSCF >= CASCI is NOT guaranteed in general (PySCF picks orbitals
+    # different from CASCI's natural set). But for full active space
+    # (ncas = full basis), CASSCF == CASCI.
+    print("\nPASS")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds **CASSCF support** through PySCF (closing follow-on #1 from PR #92's list) and the **Be 1s²(2s² + 2p²) MC-HF demo** (#4).

### `install_full_eri(mf, basis)`

Pre-computes the full `Nbf⁴` AO ERI tensor for the given basis and stores it on `mf._eri` in 8-fold-packed form. Once installed, **all of PySCF's post-HF machinery — CASCI, CASSCF, MP2, CCSD, etc. — runs against HelFEM through standard PySCF code paths.** No custom `mc.ao2mo` overrides needed.

This subsumes `install_eri_builder` from PR #91 for typical NAO-scale use:
- NAO basis size 10-30 → ERI size 10k-800k entries, trivial.
- For larger bases (Nbf ~ 500, ERI ~ 62 GB), use `install_eri_builder` for CASCI on the fly, or wait for the DF/Cholesky path using PR #88's `twoe_integral_cholesky`.

`helfem_casci` and `helfem_casscf` both **auto-install the full ERI** on `mf` if not already present. CASCI still works as before; **CASSCF is new** — the `AttributeError: numpy.ndarray has no attribute 'vhf_c'` that blocked CASSCF in PR #91 is fixed because PySCF builds the proper `_ERIS` internally from `mf._eri`.

## End-to-end demos

### He CAS(2, 10)

```
HF      = -2.861680
CASCI   = -2.866206  corr -4.526 mEh
CASSCF  = -2.866206  corr -4.526 mEh  (= CASCI for full active space)
```

### Be 1s²(2s² + 2p²) MC-HF (the original Froese-Fischer calculation)

```
HF (NAO 5)            = -14.572877
CASCI(2, 4)           = -14.585970   corr -13.09 mEh
CASSCF(2, 4)          = -14.585996   corr -13.12 mEh
ncore = 1 (auto-set: 1s² frozen)
ncas  = 4 (2s + 2p_-1 + 2p_0 + 2p_+1 active)

Froese-Fischer ref     = -14.6172   (full MC-HF in larger basis)
Exact (FCI extrap.)    = -14.66736  (total correlation ~94 mEh)
```

The Be demo captures 13 of the ~44 mEh near-degeneracy correlation Froese-Fischer's larger-basis MC-HF gets. The shortfall is basis-side: the compact FE basis here (`nelem=5, nnodes=8, Rmax=10`) gives HF = −14.5729 vs basis-limit −14.5730 (already 0.1 mEh from limit), and the NAO truncation to 5 orbitals limits CASSCF's reach. A larger FE basis + more NAOs per shell would close the gap.

## One-line usage

```python
from helfem.pyscf_driver import helfem_scf, helfem_nao_scf, helfem_casscf

mf_fe, basis_fe = helfem_scf(Z=4, lmax=1, mmax=1)
mf_fe.kernel()
mf_nao, basis_nao = helfem_nao_scf(mf_fe, basis_fe, keep_per_shell=[2, 1, 1, 1])
mf_nao.kernel()
mc = helfem_casscf(mf_nao, basis_nao, ncas=4, nelecas=2)
mc.kernel()   # Froese-Fischer Be MC-HF, one line.
```

## Test plan (verified)

- [x] Full build clean with `HELFEM_PYTHON=ON`
- [x] He CASSCF(2, 10) converges (= CASCI for full active space)
- [x] Be CASSCF(2, 4) reproduces the Froese-Fischer MC-HF setup with ncore=1
- [x] Both CASCI/CASSCF run end-to-end via standard PySCF code paths

## Status of the PySCF interop arc

- [x] (a) Cholesky J/K helpers — PR #88
- [x] (b) pybind11 wrappers — PR #89
- [x] (c) PySCF HF driver — PR #90
- [x] (d) ERI provider + CASCI — PR #91
- [x] (e) NAO Python factory — PR #92
- [x] (f) CASSCF + Be MC-HF demo — **this PR**

## Open follow-ons

- **Natural-orbital iteration** — CASCI → diagonalise 1RDM → use NOs as new basis → iterate. Principled fix for the He virtual-quality problem.
- **DF/Cholesky ERI for large active spaces** — uses PR #88's `twoe_integral_cholesky` to avoid materialising the full `Nbf⁴` tensor.
- **Sadatom energy fix** (per your suggestion) — use the Hund-rule high-L, high-S single-determinant energy expression instead of the averaged-occupation one. Separate from the PySCF arc but a clean improvement to HelFEM's in-tree atomic code.