### PR TITLE
sadatom: extend Hund-rule correction to UHF + guard multi-open-shell

### DIFF
--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -722,6 +722,21 @@ int main(int argc, char **argv) {
     printf("Eenuc = % 18.9f\n",uconf.Epot);
     printf("Econf = % 18.9f\n",uconf.Econfinement);
     printf("Exc   = % 18.9f\n",uconf.Exc);
+
+    // Hund-rule correction (UHF). Combines orbsa + orbsb occupations
+    // for the total atomic configuration; uses alpha orbital
+    // coefficients for F^k (Hund-rule puts the open-shell electrons
+    // in the high-spin / alpha channel).
+    {
+      double dE_hund = sadatom::solver::hund_rule_correction(
+          uconf.orbsa, uconf.orbsb, solver.Basis());
+      if (dE_hund != 0.0) {
+        printf("Hund corr  = % 18.9f  (E(barycentre) -> E(ground term))\n",
+               dE_hund);
+        printf("Etot(Hund) = % 18.9f\n", uconf.Econf + dE_hund);
+      }
+    }
+
     printf("Alpha orbitals\n");
     uconf.orbsa.Print(solver.Basis());
     (HARTREEINEV*uconf.orbsa.GetGap()).t().print("Alpha HOMO-LUMO gap (eV)");

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -286,15 +286,35 @@ namespace helfem {
 	save_data(oss.str(), orblval);
       }
 
-      double hund_rule_correction(const OrbitalChannel & orbs,
-                                  const basis::TwoDBasis & basis) {
+      static double hund_rule_correction_impl(const arma::ivec & occs,
+                                              const arma::cube & C,
+                                              int lmax,
+                                              const basis::TwoDBasis & basis) {
         // Walk shells in order of l. For each, count the open-shell
         // occupation = occs(l) mod (4l + 2). The lowest partially-filled
         // orbital in that l-shell is the "open shell"; its orbital index
         // is occs(l) / (4l + 2).
-        const arma::ivec occs = orbs.Occs();
-        const int lmax = orbs.Lmax();
-        const arma::cube C = orbs.Coeffs();
+        //
+        // Only proceed if at most ONE open shell exists (so the
+        // configuration has a clean single-multiplet structure where
+        // our tabulated p^n / d^n coefficients are valid). For
+        // multi-open-shell configs (e.g. 2s^1 2p^3 in sadatom's UHF
+        // Aufbau for C), the term structure involves cross-shell
+        // (s-p, etc.) coupling integrals that the simple table does
+        // NOT cover; skip with a warning.
+        int n_open_shells = 0;
+        for (int l = 0; l <= lmax && l < (int) occs.n_elem; ++l) {
+          const int capacity = 4 * l + 2;
+          if (occs(l) % capacity != 0)
+            n_open_shells++;
+        }
+        if (n_open_shells > 1) {
+          printf("[hund_rule_correction] warning: %d open shells in this "
+                 "configuration; the tabulated p^n / d^n correction only "
+                 "covers single-open-shell configs. Skipping (returning 0).\n",
+                 n_open_shells);
+          return 0.0;
+        }
         double total_correction = 0.0;
         for (int l = 0; l <= lmax; ++l) {
           if (l >= (int) occs.n_elem) break;
@@ -349,6 +369,26 @@ namespace helfem {
           }
         }
         return total_correction;
+      }
+
+      double hund_rule_correction(const OrbitalChannel & orbs,
+                                  const basis::TwoDBasis & basis) {
+        return hund_rule_correction_impl(orbs.Occs(), orbs.Coeffs(),
+                                         orbs.Lmax(), basis);
+      }
+
+      double hund_rule_correction(const OrbitalChannel & orbsa,
+                                  const OrbitalChannel & orbsb,
+                                  const basis::TwoDBasis & basis) {
+        // UHF Hund-rule correction. Combine alpha + beta occupations
+        // to get the total atomic configuration. Use ALPHA coefficients
+        // for F^k -- under Hund's rule, the open-shell electrons live
+        // in the high-spin (alpha) channel, so the alpha orbital is the
+        // physical "open-shell" orbital for the Hund single determinant.
+        const arma::ivec occs_total = orbsa.Occs() + orbsb.Occs();
+        const int lmax = std::max(orbsa.Lmax(), orbsb.Lmax());
+        return hund_rule_correction_impl(occs_total, orbsa.Coeffs(),
+                                         lmax, basis);
       }
 
       bool OrbitalChannel::operator==(const OrbitalChannel & rh) const {

--- a/src/sadatom/solver.h
+++ b/src/sadatom/solver.h
@@ -54,6 +54,14 @@ namespace helfem {
       double hund_rule_correction(const class OrbitalChannel & orbs,
                                   const basis::TwoDBasis & basis);
 
+      /// UHF overload: combines alpha + beta occupations for the
+      /// total atomic configuration, uses alpha orbital coefficients
+      /// for the F^k integral (Hund-rule puts the open-shell electrons
+      /// in the high-spin / alpha channel).
+      double hund_rule_correction(const class OrbitalChannel & orbsa,
+                                  const class OrbitalChannel & orbsb,
+                                  const basis::TwoDBasis & basis);
+
       /// Helper for defining orbital channels
       class OrbitalChannel {
       protected:


### PR DESCRIPTION
## Summary

Follow-on to PR #95. Two additions:

### 1. UHF overload of `hund_rule_correction(orbsa, orbsb, basis)`

For UHF sadatom the open-shell electrons live in the high-spin (alpha) channel; this overload combines alpha + beta occupations for the total atomic configuration and uses alpha orbital coefficients for the F^k Slater integral.

### 2. Multi-open-shell guard

The tabulated p^n / d^n Hund-rule coefficients assume the configuration has at most ONE open shell (so a clean single-multiplet term structure). For configurations with two open shells — e.g. sadatom UHF's Aufbau on C, which converges to **1s² 2s¹ 2p³** (an excited ⁵S configuration, lower in spherical-averaging UHF than the true 1s² 2s² 2p² ³P ground state) — the correct correction involves cross-shell coupling integrals that the simple table does NOT cover. The guard prints a warning and skips the correction in that case.

### Refactor

The existing code now lives in a static `hund_rule_correction_impl(occs, C, lmax, basis)` helper; the RHF and UHF entry points both call it. **No behaviour change for the RHF path** from PR #95.

## Validation — side-by-side RHF/UHF Hund corrections on B–Ne

| Atom | RHF Etot | RHF Hund | UHF Etot | UHF Hund |
|---|---|---|---|---|
| B | −24.385 | 0 (²P) | −24.415 | 0 (²P) |
| C | −37.344 | −23 (³P) | −37.599 | **skipped** (sadatom UHF finds 1s² 2s¹ 2p³, 2 open shells) |
| N | −53.852 | −61 (⁴S) | −54.405 | −71 (⁴S) |
| O | −74.298 | −38 (³P) | −74.622 | −43 (³P) |
| F | −99.067 | 0 (²P) | −99.165 | 0 (²P) |
| Ne | −128.547 | 0 (¹S) | −128.547 | 0 (¹S) |

For N and O, **UHF + Hund correction** gives the most accurate Hund-rule ground state estimate available within sadatom (UHF breaks spin symmetry for additional variational freedom; the Hund correction then maps the spherically-averaged Coulomb energy to the high-L/high-S single-determinant energy).

For C, sadatom's UHF Aufbau finds the wrong configuration (excited ⁵S over the ³P ground state) because spherical averaging over-stabilises high-spin solutions. The guard correctly catches this and skips the correction rather than applying a wrong formula. Workaround: use `--restricted=1` for C, which gives the right 1s²2s²2p² ³P configuration.

## Test plan (verified)

- [x] B / F / Ne (unique terms): zero correction in both RHF and UHF ✓
- [x] N / O: meaningful corrections in both modes ✓
- [x] C: RHF gives clean correction; UHF correctly skips with warning ✓
- [x] Full build clean

## Open follow-ons (unchanged from #95 list)

- **d-shell Hund corrections** for transition metals — needs F² and F⁴ Slater integrals plus d^n term-coupling tables.
- **PySCF spatial symmetry support** (`mol.symm_orb` from (l, m) labels).
- **DF/Cholesky ERI for large active spaces** (uses PR #88's `twoe_integral_cholesky`).