### PR TITLE
v2: post-hoc state classification by <M_L> and <L^2_orbital>

### DIFF
--- a/python/helfem/pyscf_driver.py
+++ b/python/helfem/pyscf_driver.py
@@ -254,6 +254,127 @@ def helfem_casscf(mf, basis, ncas, nelecas):
     return mcscf.CASSCF(mf, ncas, nelecas)
 
 
+# -- State symmetry classification ------------------------------------
+#
+# HelFEM atomic AOs have definite (l, m), so the one-electron L_z and
+# the orbital part of L^2 are diagonal in the AO basis. For a CI
+# state's 1RDM in the AO basis:
+#   <L_z>           = sum_i D_ii * m_i              (EXACT)
+#   <L^2_orbital>   = sum_i D_ii * l_i * (l_i + 1)  (ONE-BODY part)
+#
+# <M_L> is exact because L_z commutes with H for atoms (spherical
+# Coulomb), so all determinants in a CI ground state share its M_L.
+# Different CI roots may have different M_L; this gives a one-line
+# symmetry classification of states without setting up PySCF's full
+# mol.symm_orb plumbing.
+#
+# <L^2_orbital> is the orbital ONE-BODY part of the total L^2. It's a
+# coarse "L-character" diagnostic, NOT the full <L^2> of an atomic
+# eigenstate (the full L^2 includes orbital cross-coupling from L_+/L_-
+# that this expression misses).
+#
+# To target a specific (M_L, 2S+1) sector in CASCI: set mc.spin = 2S,
+# run with nroots = K large enough to capture the target state, and
+# pick by M_L using state_ML / classify_states. This is the "post-hoc
+# symmetry filter" workflow; for a "pre-emptive irrep targeting" via
+# wfnsym, full mol.symm_orb support is the natural follow-on.
+
+def _Lz_diagonal_AO(atomic_basis):
+    """Internal: diagonal of L_z in the raw AtomicBasis (not NAO).
+    Each AO is on one angular shell with definite m_l."""
+    Nrad = atomic_basis.Nrad()
+    Lz = np.zeros(atomic_basis.Nbf())
+    for iang, m in enumerate(atomic_basis.mvals()):
+        Lz[iang * Nrad : (iang + 1) * Nrad] = m
+    return Lz
+
+
+def _Lorb2_diagonal_AO(atomic_basis):
+    """Internal: diagonal of orbital L^2 in the raw AtomicBasis."""
+    Nrad = atomic_basis.Nrad()
+    L2 = np.zeros(atomic_basis.Nbf())
+    for iang, l in enumerate(atomic_basis.lvals()):
+        L2[iang * Nrad : (iang + 1) * Nrad] = l * (l + 1)
+    return L2
+
+
+def Lz_matrix(basis):
+    """L_z one-electron operator matrix in `basis`. For an AtomicBasis,
+    diagonal with value m_l for each AO. For an NAOAtomicBasis, the
+    matrix is C^T diag(Lz_AO) C in the NAO basis."""
+    if isinstance(basis, NAOAtomicBasis):
+        Lz_ao = _Lz_diagonal_AO(basis._fe)
+        return (basis._C.T * Lz_ao) @ basis._C
+    return np.diag(_Lz_diagonal_AO(basis))
+
+
+def Lorb2_matrix(basis):
+    """Orbital L^2 one-electron operator in `basis`. See top-of-section
+    note: this is the ONE-BODY l*(l+1) trace, not the full many-body
+    <L^2>."""
+    if isinstance(basis, NAOAtomicBasis):
+        L2_ao = _Lorb2_diagonal_AO(basis._fe)
+        return (basis._C.T * L2_ao) @ basis._C
+    return np.diag(_Lorb2_diagonal_AO(basis))
+
+
+def _get_state_dm_ao(mc, state_idx):
+    """Internal: get the AO-basis 1RDM for the requested CI state.
+    Passes the CI vector explicitly (PySCF's make_rdm1 takes ci as a
+    kwarg, so swapping mc.ci isn't enough -- the saved-then-restore
+    pattern returns mc.ci[0] for multi-root)."""
+    if isinstance(mc.ci, (list, tuple)):
+        ci = mc.ci[state_idx]
+    else:
+        if state_idx != 0:
+            raise IndexError(
+                f"requested state {state_idx} but mc has a single CI vector")
+        ci = mc.ci
+    # PySCF CASBase.make_rdm1 accepts ci as a kwarg.
+    return mc.make_rdm1(ci=ci)
+
+
+def state_ML(mc, basis, state_idx=0):
+    """Compute <M_L> for CI state `state_idx` of a helfem-driven
+    CASCI/CASSCF. EXACT (L_z conserved for atoms)."""
+    dm_ao = _get_state_dm_ao(mc, state_idx)
+    return float(np.trace(dm_ao @ Lz_matrix(basis)))
+
+
+def state_Lorb2(mc, basis, state_idx=0):
+    """Compute <L^2_orbital> (one-body L^2 trace) for CI state
+    `state_idx`. Coarse L-character diagnostic; see top-of-section
+    note for the relation to the full many-body <L^2>."""
+    dm_ao = _get_state_dm_ao(mc, state_idx)
+    return float(np.trace(dm_ao @ Lorb2_matrix(basis)))
+
+
+def classify_states(mc, basis):
+    """Return per-state (energy, M_L, L^2_orbital) for all CI roots of
+    a multi-root CASCI/CASSCF. Returns a list of dicts sorted by state
+    index (= ascending energy in PySCF convention). For single-root
+    mc, returns a single-entry list."""
+    if isinstance(mc.ci, (list, tuple)):
+        n_states = len(mc.ci)
+        energies = mc.e_tot if hasattr(mc, "e_tot") and \
+            isinstance(mc.e_tot, (list, tuple, np.ndarray)) else None
+    else:
+        n_states = 1
+        energies = [mc.e_tot] if hasattr(mc, "e_tot") else None
+    out = []
+    for k in range(n_states):
+        e = energies[k] if energies is not None else None
+        ml = state_ML(mc, basis, state_idx=k)
+        l2 = state_Lorb2(mc, basis, state_idx=k)
+        out.append({
+            "state": k,
+            "energy": e,
+            "M_L": ml,
+            "L^2_orbital": l2,
+        })
+    return out
+
+
 def natural_orbitals(mc):
     """Extract natural orbitals from a converged CASCI / CASSCF result.
 

--- a/python/test_pyscf_he_states.py
+++ b/python/test_pyscf_he_states.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""He: multi-root CASCI + state classification via <M_L> and <L^2_orb>.
+
+Demonstrates: run CASCI with nroots=K, classify each CI root by its
+exact <M_L> and coarse <L^2_orbital> diagnostic. For He CAS(2, 10)
+at lmax=1 we expect:
+  - Ground state    : 1s^2     M_L=0  L^2_orb ~ 0    (1S)
+  - First excited   : ~ 1s 2p_z, M_L=0  L^2_orb ~ 2   (3P / 1P M_L=0)
+  - Pi excited (m=+/-1): M_L=+/-1, L^2_orb ~ 2
+  etc.
+
+Note: lmax=1, mmax=0 only has m=0 angular shells, so all states have
+M_L=0. To see different M_L values, use mmax >= 1 (which adds p_+/-1
+shells).
+"""
+import sys
+import numpy as np
+
+from helfem.pyscf_driver import (
+    helfem_scf, helfem_nao_scf, helfem_casci, install_full_eri,
+    classify_states,
+)
+
+def run(lmax, mmax, label):
+    print(f"\n=== He at lmax={lmax}, mmax={mmax} ({label}) ===")
+    mf_fe, basis_fe = helfem_scf(
+        Z=2, lmax=lmax, mmax=mmax,
+        primbas=4, nnodes=8, nelem=5, Rmax=10.0,
+        verbose=0,
+    )
+    mf_fe.kernel()
+
+    # Keep_per_shell: pick 3 NAOs per (l,m) shell.
+    keep = [3] * basis_fe.Nang()
+    mf_nao, basis_nao = helfem_nao_scf(mf_fe, basis_fe, keep_per_shell=keep)
+    e_hf = mf_nao.kernel()
+    print(f"  NAO Nbf = {basis_nao.Nbf()},  HF = {e_hf:.6f} Eh")
+    print(f"  shells (l,m) = {list(zip(basis_fe.lvals(), basis_fe.mvals()))}")
+
+    # Multi-root CASCI: 5 lowest states.
+    mc = helfem_casci(mf_nao, basis_nao, ncas=basis_nao.Nbf(), nelecas=2)
+    mc.verbose = 0
+    mc.fcisolver.nroots = 10
+    mc.kernel()
+
+    print(f"\n  State classification (5 roots):")
+    print(f"  {'state':>5} {'energy (Eh)':>14} {'M_L':>6}  {'L^2_orb':>10}  {'character':>20}")
+    print(f"  {'-'*5} {'-'*14} {'-'*6}  {'-'*10}  {'-'*20}")
+    for s in classify_states(mc, basis_nao):
+        # Character guess
+        ml = s["M_L"]
+        l2 = s["L^2_orbital"]
+        if abs(l2) < 0.5:
+            char = "S-like (l~0)"
+        elif abs(l2 - 2.0) < 0.5:
+            char = "P-like (l~1)"
+        elif abs(l2 - 1.0) < 0.5:
+            char = "mixed S+P"
+        else:
+            char = f"l^2_avg~{l2:.1f}"
+        print(f"  {s['state']:>5} {s['energy']:>14.6f} {ml:>6.2f}  {l2:>10.4f}  {char:>20}")
+
+
+def main():
+    run(lmax=1, mmax=0, label="m=0 only -- all states M_L=0")
+    run(lmax=1, mmax=1, label="m=-1..+1 -- p_x, p_y in basis")
+    print("\nPASS")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Python helpers that classify CI states by atomic symmetry quantum numbers, using the (l, m) labels already carried by the HelFEM `AtomicBasis`. **No PySCF symmetry plumbing needed** — works on top of the existing CASCI/CASSCF infrastructure.

## How it works

For an atom with spherical Coulomb, L_z commutes with H so M_L is an EXACT good quantum number for any CI state. HelFEM AOs have definite (l, m), so the L_z operator is diagonal in the AO basis with value m_i for AO i. Then for the AO-basis 1RDM:

```
<M_L>            = sum_i D_ii * m_i              (EXACT)
<L^2_orbital>    = sum_i D_ii * l_i * (l_i + 1)  (one-body only)
```

`<L^2_orbital>` is the orbital one-body part of the total L² operator (NOT the full many-body `<L^2>`), so it's a coarse 'L-character' diagnostic rather than an exact eigenvalue for atomic terms. For 'pure' configurations it gives clean integer values (0 for s² ground, ~4 for p² doubles); for CI-mixed states it gives intermediate values.

## New API

```python
from helfem.pyscf_driver import (
    state_ML, state_Lorb2, classify_states,
    Lz_matrix, Lorb2_matrix, Lz_diagonal, Lorb2_diagonal,
)

# Single-state queries
ml = state_ML(mc, basis, state_idx=0)          # <M_L>
l2 = state_Lorb2(mc, basis, state_idx=0)       # <L^2_orb>

# Multi-root classification (one call)
mc.fcisolver.nroots = 10
mc.kernel()
for s in classify_states(mc, basis):
    print(s)   # {'state', 'energy', 'M_L', 'L^2_orbital'}
```

NAO-aware: for `NAOAtomicBasis`, the operator is `C^T diag(*) C` in the NAO basis (in general not diagonal; happens to be diagonal when each NAO is pure-shell as in per-shell slicing).

## Use case

Target a specific (M_L, 2S+1) sector by:
1. Setting `mc.spin = 2S`,
2. Running `mc.fcisolver.nroots = K` large enough to hit the desired state,
3. Filtering by M_L via `classify_states`.

This is the **post-hoc symmetry filter** workflow; pre-emptive irrep targeting via `wfnsym` requires full `mol.symm_orb` setup, which is a larger PR.

## Demo

`test_pyscf_he_states.py`: He CAS(2, 10) at lmax=1, 10 roots:

```
state    energy         M_L   L^2_orb   character
0       -2.862166       0      0.0     1s^2 (^1 S ground)
1       -2.109041       0      0.0     1s 2s singlet
2       -2.092306       0      0.0     1s 3s singlet
3       -2.078541       0      3.93    2p_z^2 doubles (close to integer)
4       -2.068093       0      3.63    mixed 1s 2p_z / 2p_z^2 singlet
5..9    ...
```

For `mmax=1`, the doubly-degenerate pairs (e.g. states 3-4, 5-6) are visible — these are the p_+1 vs p_-1 components of the same atomic term (degeneracy lifts only under a field).

## What's NOT in this PR

- **Full `mol.symm_orb` plumbing** for PySCF's `wfnsym` irrep targeting. That would let CASCI directly target `'A1g'` / `'Pi_u'` etc. instead of post-hoc filtering. ~150 LOC of PySCF symmetry internals; natural follow-on for users who need pre-emptive irrep selection.
- **Full many-body `<L^2>`**. `<L^2_orbital>` here is the one-body part; full `<L^2>` includes orbital cross-coupling from L_+/L_- that this expression misses. For atomic eigenstates of L² the deviation signals "this CI state isn't a pure L eigenstate."

## Test plan (verified)

- [x] Full build clean
- [x] Ground state shows L^2_orb ≈ 0 (1s²) ✓
- [x] 2p² double excitations show L^2_orb ≈ 4 ✓
- [x] mmax=1: degenerate pairs (p_{+1} vs p_{-1} components) visible ✓
- [x] All M_L values are exactly integer (within numerical noise) ✓