### PR TITLE
v2: <S^2> in state classification + MP2/CCSD/FCI wrappers

### DIFF
--- a/python/helfem/pyscf_driver.py
+++ b/python/helfem/pyscf_driver.py
@@ -341,6 +341,19 @@ def state_ML(mc, basis, state_idx=0):
     return float(np.trace(dm_ao @ Lz_matrix(basis)))
 
 
+def state_S2(mc, state_idx=0):
+    """Compute <S^2> for CI state `state_idx`. Uses PySCF's
+    fcisolver.spin_square. Returns (S^2, 2S+1) as PySCF does."""
+    if isinstance(mc.ci, (list, tuple)):
+        ci = mc.ci[state_idx]
+    else:
+        if state_idx != 0:
+            raise IndexError(
+                f"requested state {state_idx} but mc has a single CI vector")
+        ci = mc.ci
+    return mc.fcisolver.spin_square(ci, mc.ncas, mc.nelecas)
+
+
 def state_Lorb2(mc, basis, state_idx=0):
     """Compute <L^2_orbital> (one-body L^2 trace) for CI state
     `state_idx`. Coarse L-character diagnostic; see top-of-section
@@ -366,13 +379,51 @@ def classify_states(mc, basis):
         e = energies[k] if energies is not None else None
         ml = state_ML(mc, basis, state_idx=k)
         l2 = state_Lorb2(mc, basis, state_idx=k)
+        s2, mult = state_S2(mc, state_idx=k)
         out.append({
             "state": k,
             "energy": e,
             "M_L": ml,
             "L^2_orbital": l2,
+            "S^2": s2,
+            "2S+1": mult,
         })
     return out
+
+
+# -- Post-HF convenience wrappers (MP2, CCSD, FCI) -------------------
+#
+# install_full_eri makes any of PySCF's post-HF methods Just Work on
+# top of a helfem-driven mf. These wrappers provide a uniform one-line
+# API alongside helfem_casci / helfem_casscf, and auto-install the AO
+# ERI tensor on mf if not already there.
+
+def helfem_mp2(mf, basis):
+    """MP2 on top of HelFEM SCF. Auto-installs the AO ERI on mf."""
+    from pyscf import mp
+    if getattr(mf, "_eri", None) is None:
+        install_full_eri(mf, basis)
+    return mp.MP2(mf)
+
+
+def helfem_ccsd(mf, basis):
+    """CCSD on top of HelFEM SCF. Auto-installs the AO ERI on mf."""
+    from pyscf import cc
+    if getattr(mf, "_eri", None) is None:
+        install_full_eri(mf, basis)
+    return cc.CCSD(mf)
+
+
+def helfem_fci(mf, basis):
+    """Full CI on top of HelFEM SCF. Returns a pyscf CASCI driver
+    configured for the full basis (ncas = Nbf, nelecas from mf.mol).
+
+    For small NAO bases (Nbf <= ~16) FCI is tractable and gives the
+    exact basis-set energy. For larger bases use CASCI on a chosen
+    active space instead.
+    """
+    nelectron = int(mf.mol.nelectron)
+    return helfem_casci(mf, basis, ncas=basis.Nbf(), nelecas=nelectron)
 
 
 def natural_orbitals(mc):

--- a/python/test_pyscf_he_method_ladder.py
+++ b/python/test_pyscf_he_method_ladder.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""He on a small NAO basis, running through the full PySCF post-HF
+method ladder via helfem: HF -> MP2 -> CCSD -> FCI.
+
+Demonstrates the install_full_eri pattern works for all of PySCF's
+correlated methods (not just CASCI/CASSCF), and exercises the
+classify_states helper with the new S^2 / 2S+1 entries.
+"""
+import sys
+from helfem.pyscf_driver import (
+    helfem_scf, helfem_nao_scf, helfem_casci, helfem_mp2, helfem_ccsd,
+    helfem_fci, install_full_eri, classify_states,
+)
+
+def main():
+    print("=== He at lmax=1 compact basis, NAO subset ===")
+    mf_fe, basis_fe = helfem_scf(
+        Z=2, lmax=1, mmax=0,
+        primbas=4, nnodes=8, nelem=5, Rmax=10.0,
+        verbose=0,
+    )
+    mf_fe.kernel()
+    mf, basis = helfem_nao_scf(mf_fe, basis_fe, keep_per_shell=[5, 5])
+    e_hf = mf.kernel()
+    print(f"  Nbf(NAO) = {basis.Nbf()},  HF = {e_hf:.10f} Eh")
+
+    print("\n=== MP2 ===")
+    mp2 = helfem_mp2(mf, basis)
+    e_corr_mp2, _ = mp2.kernel()
+    print(f"  MP2 correlation = {e_corr_mp2:+.6f} Eh")
+    print(f"  HF + MP2        = {e_hf + e_corr_mp2:.10f} Eh")
+
+    print("\n=== CCSD ===")
+    ccsd = helfem_ccsd(mf, basis)
+    ccsd.verbose = 0
+    e_corr_ccsd, _, _ = ccsd.kernel()
+    print(f"  CCSD correlation = {e_corr_ccsd:+.6f} Eh")
+    print(f"  HF + CCSD        = {e_hf + e_corr_ccsd:.10f} Eh")
+
+    print("\n=== FCI (full basis) ===")
+    fci = helfem_fci(mf, basis)
+    fci.verbose = 0
+    e_fci = fci.kernel()[0]
+    print(f"  FCI energy      = {e_fci:.10f} Eh")
+    print(f"  FCI correlation = {e_fci - e_hf:+.6f} Eh")
+
+    # State classification (S^2 included).
+    print("\n=== State classification (FCI, 3 lowest roots) ===")
+    fci3 = helfem_fci(mf, basis)
+    fci3.verbose = 0
+    fci3.fcisolver.nroots = 3
+    fci3.kernel()
+    print(f"  {'state':>5} {'energy':>14} {'M_L':>6} {'L^2_orb':>9} {'S^2':>6} {'2S+1':>5}")
+    for s in classify_states(fci3, basis):
+        print(f"  {s['state']:>5} {s['energy']:>14.6f} {s['M_L']:>6.2f} "
+              f"{s['L^2_orbital']:>9.4f} {s['S^2']:>6.3f} {s['2S+1']:>5.2f}")
+
+    print("\n--- Summary ---")
+    print(f"  HF        = {e_hf:.6f}")
+    print(f"  HF + MP2  = {e_hf + e_corr_mp2:.6f}  corr {e_corr_mp2:+.4e}")
+    print(f"  HF + CCSD = {e_hf + e_corr_ccsd:.6f}  corr {e_corr_ccsd:+.4e}")
+    print(f"  FCI       = {e_fci:.6f}  corr {e_fci - e_hf:+.4e}")
+    print(f"  Expected: MP2 < CCSD <= FCI (in magnitude of correlation)")
+
+    # Sanity: For 2-electron systems CCSD == FCI (CCSD is exact for 2e).
+    assert abs((e_hf + e_corr_ccsd) - e_fci) < 1e-7, \
+        "CCSD should equal FCI for a 2-electron system"
+    print("\nPASS (CCSD == FCI for 2-electron He, as expected)")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two small extensions to the PySCF interop:

### 1. `<S²>` in state classification

`state_S2(mc, state_idx)` computes `<S²>` for a CI state via PySCF's `fcisolver.spin_square`. `classify_states()` now includes `S^2` and `2S+1` columns alongside `M_L` and `L^2_orbital`, giving a complete (S, M_L) symmetry classification.

### 2. Convenience wrappers: `helfem_mp2`, `helfem_ccsd`, `helfem_fci`

All one-liners on top of `install_full_eri` — PySCF's standard post-HF code paths Just Work once the AO ERI is installed. These provide a uniform one-line API alongside the existing `helfem_casci` / `helfem_casscf`:

```python
mp2 = helfem_mp2(mf, basis)
ccsd = helfem_ccsd(mf, basis)
fci  = helfem_fci(mf, basis)
```

## Demo (`test_pyscf_he_method_ladder.py`)

He on NAO basis (Nbf=10) through HF → MP2 → CCSD → FCI:

| Method | Energy | Correlation |
|---|---|---|
| HF | −2.861680 | — |
| HF + MP2 | −2.865510 | −3.83 mEh (partial) |
| HF + CCSD | −2.866206 | −4.53 mEh |
| FCI | −2.866206 | −4.53 mEh **(= CCSD, exact for 2-e)** |

State classification (FCI, 3 roots) with the new S² entries:

| state | energy | M_L | L²_orb | S² | 2S+1 | character |
|---|---|---|---|---|---|---|
| 0 | −2.866206 | 0 | 0.01 | 0.0 | 1.0 | ¹S ground |
| 1 | −2.142456 | 0 | 0.00 | 2.0 | 3.0 | **³S triplet** (1s 2s) |
| 2 | −2.113943 | 0 | 0.00 | 0.0 | 1.0 | ¹S excited (1s 2s) |

The new S²/2S+1 columns correctly distinguish the 1s2s **triplet** (state 1) from the 1s2s **singlet** (state 2) — previously these would have looked identical in the (M_L, L²_orb) classification.

## Test plan (verified)

- [x] Full build clean
- [x] He method ladder: HF → MP2 → CCSD → FCI all converge and give expected energies
- [x] CCSD energy == FCI energy for 2-electron He (within 1e-7; CCSD is exact for 2 electrons)
- [x] S²/2S+1 correctly distinguishes ³S from ¹S excited states

## Open follow-ons (unchanged)

- **Full `mol.symm_orb` plumbing** for `wfnsym` pre-emptive irrep targeting
- **d-shell Hund corrections** for transition metals (needs F²+F⁴ + d^n coupling tables)
- **DF/Cholesky ERI for large active spaces** (uses PR #88's `twoe_integral_cholesky`)
- Bigger v2 arcs: templated precision, OOO SCF, diatomic axial-symmetry, adaptive quadrature