### PR TITLE
v2: DRY TwoDBasis cache construction into CoulombExchangeFE helpers

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -204,6 +204,129 @@ namespace helfem {
 
       } // namespace detail_fe_2e
 
+      // -- Per-element cache construction helpers ---------------------
+      //
+      // The cached assembly helpers below
+      // (assemble_*_FE_one_multipole_cached) take per-(L, iel) integrals
+      // via accessor lambdas; SCF-driven callers (atomic::TwoDBasis,
+      // sadatom::TwoDBasis) populate those caches once per basis change.
+      // The fill loops are identical in structure between the two
+      // callers, so we share them here.
+      //
+      // Convention: caches are flat vectors with index = L*Nel + iel
+      // (or L*Nel*Nel + iel*Nel + jel for cross-element). Matches the
+      // existing TwoDBasis cache layouts exactly so the helpers below
+      // can be dropped into existing call sites without changing the
+      // surrounding accessor lambdas.
+
+      /// Per-(L, iel) disjoint radial integrals for the multipole
+      /// decomposition.
+      ///   bare:    disjoint_small[L*Nel+iel] = radial.radial_integral(L, iel)
+      ///            disjoint_big  [L*Nel+iel] = radial.radial_integral(-L-1, iel)
+      ///   Yukawa:  disjoint_small = radial.bessel_il_integral(L, lambda, iel)
+      ///            disjoint_big   = radial.bessel_kl_integral(L, lambda, iel)
+      inline void compute_disjoint_radial_integrals(
+          const FEMRadialBasis & radial,
+          int N_L,
+          std::vector<arma::mat> & disjoint_small,
+          std::vector<arma::mat> & disjoint_big,
+          bool yukawa = false,
+          double lambda = 0.0) {
+        const size_t Nel = radial.Nel();
+        disjoint_small.resize((size_t) N_L * Nel);
+        disjoint_big  .resize((size_t) N_L * Nel);
+        for (int L = 0; L < N_L; ++L) {
+          for (size_t iel = 0; iel < Nel; ++iel) {
+            disjoint_small[(size_t) L * Nel + iel] =
+                detail_fe_2e::r_small(radial, L, iel, yukawa, lambda);
+            disjoint_big  [(size_t) L * Nel + iel] =
+                detail_fe_2e::r_big  (radial, L, iel, yukawa, lambda);
+          }
+        }
+      }
+
+      /// Per-(L, iel) in-element 4-index 2e integrals. Only diagonal
+      /// (iel == iel) entries are populated; cross-element pieces are
+      /// assembled on the fly from the disjoint factors in the
+      /// assemble_*_FE_one_multipole_cached path. Layout:
+      ///   prim_tei[L*Nel*Nel + iel*Nel + iel] = in-element 4-index tensor
+      /// For bare Coulomb (default): radial.twoe_integral(L, iel).
+      /// For Yukawa: radial.yukawa_integral(L, lambda, iel).
+      inline void compute_in_element_tei(
+          const FEMRadialBasis & radial,
+          int N_L,
+          std::vector<arma::mat> & prim_tei,
+          bool yukawa = false,
+          double lambda = 0.0) {
+        const size_t Nel = radial.Nel();
+        prim_tei.resize(Nel * Nel * (size_t) N_L);
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2)
+#endif
+        for (int L = 0; L < N_L; ++L) {
+          for (size_t iel = 0; iel < Nel; ++iel) {
+            prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel] =
+                detail_fe_2e::in_element_tei(radial, L, iel, yukawa, lambda);
+          }
+        }
+      }
+
+      /// Apply utils::exchange_tei to each in-element prim_tei entry to
+      /// produce the exchange-permuted form (prim_ktei) used by the
+      /// cached K assembly. Only diagonal entries.
+      inline void compute_in_element_ktei_from_tei(
+          const FEMRadialBasis & radial,
+          int N_L,
+          const std::vector<arma::mat> & prim_tei,
+          std::vector<arma::mat> & prim_ktei) {
+        const size_t Nel = radial.Nel();
+        prim_ktei.resize(Nel * Nel * (size_t) N_L);
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2)
+#endif
+        for (int L = 0; L < N_L; ++L) {
+          for (size_t iel = 0; iel < Nel; ++iel) {
+            const size_t Ni = radial.Nprim(iel);
+            prim_ktei[Nel * Nel * (size_t) L + iel * Nel + iel] =
+                helfem::utils::exchange_tei(
+                    prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel],
+                    Ni, Ni, Ni, Ni);
+          }
+        }
+      }
+
+      /// Erfc-kernel cross-element ktei cache:
+      ///   rs_ktei[L*Nel*Nel + iel*Nel + jel]
+      ///     = exchange-permuted erfc 4-index tensor for (iel, jel).
+      /// The erfc kernel does NOT factorise into disjoint small/big
+      /// factors, so all Nel*Nel pairs are stored explicitly. The
+      /// pairwise K assembly path
+      /// (assemble_K_FE_one_multipole_cached_pairwise) consumes this
+      /// layout.
+      inline void compute_erfc_ktei(
+          const FEMRadialBasis & radial,
+          int N_L,
+          double mu,
+          std::vector<arma::mat> & rs_ktei) {
+        const size_t Nel = radial.Nel();
+        rs_ktei.resize(Nel * Nel * (size_t) N_L);
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2)
+#endif
+        for (int L = 0; L < N_L; ++L) {
+          for (size_t iel = 0; iel < Nel; ++iel) {
+            for (size_t jel = 0; jel < Nel; ++jel) {
+              const size_t Ni = radial.Nprim(iel);
+              const size_t Nj = radial.Nprim(jel);
+              rs_ktei[Nel * Nel * (size_t) L + iel * Nel + jel] =
+                  helfem::utils::exchange_tei(
+                      radial.erfc_integral(L, mu, iel, jel),
+                      Ni, Ni, Nj, Nj);
+            }
+          }
+        }
+      }
+
       // The core J / K assemblers operate on per-element accessors, so
       // the same body backs both the uncached (recompute-on-the-fly,
       // NAO use) and cached (look-up-from-SCF-cache, TwoDBasis use)

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -656,154 +656,49 @@ namespace helfem {
 
 
       void TwoDBasis::compute_tei(bool exchange) {
-        // Number of distinct L values is
-        size_t N_L(2*arma::max(lval)+1);
-        size_t Nel(radial.Nel());
-
-        // Compute disjoint integrals
-        disjoint_L.resize(Nel*N_L);
-        disjoint_m1L.resize(Nel*N_L);
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            disjoint_L[L*Nel+iel]=radial.radial_integral(L,iel);
-            disjoint_m1L[L*Nel+iel]=radial.radial_integral(-L-1,iel);
-          }
-
-        // Form two-electron integrals
-        prim_tei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-        for(size_t L=0;L<N_L;L++) {
-          for(size_t iel=0;iel<Nel;iel++) {
-            // In-element integral
-            prim_tei[Nel*Nel*L + iel*Nel + iel]=radial.twoe_integral(L,iel);
-
-            /*
-              for(size_t jel=0;jel<Nel;jel++) {
-	      // Disjoint integrals. When r(iel)>r(jel), iel gets -1-L, jel gets L.
-	      const arma::mat & iint=(iel>jel) ? disjoint_m1L[L*Nel+iel] : disjoint_L[L*Nel+iel];
-	      const arma::mat & jint=(iel>jel) ? disjoint_L[L*Nel+jel] : disjoint_m1L[L*Nel+jel];
-
-	      // Store integrals
-	      prim_tei[Nel*Nel*L + iel*Nel + jel]=utils::product_tei(iint,jint);
-              }
-              }
-            */
-          }
-        }
-
-        /*
-          The exchange matrix is given by
-          K(jk) = (ij|kl) P(il)
-          i.e. the complex conjugation hits i and l as
-          in the density matrix.
-
-          To get this in the proper order, we permute the integrals
-          K(jk) = (jk;il) P(il)
-          so we don't have to reform the permutations in the exchange routine.
-        */
-        if(exchange) {
-          prim_ktei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-          for(size_t L=0;L<N_L;L++)
-            for(size_t iel=0;iel<Nel;iel++) {
-              // Diagonal integrals
-              size_t Ni(radial.Nprim(iel));
-              prim_ktei[Nel*Nel*L + iel*Nel + iel]=utils::exchange_tei(prim_tei[Nel*Nel*L + iel*Nel + iel],Ni,Ni,Ni,Ni);
-
-              // Off-diagonal integrals (not used since faster to contract
-              // the integrals in factorized form)
-              /*
-                for(size_t jel=0;jel<iel;jel++) {
-                size_t Nj(radial.Nprim(jel));
-                prim_ktei[Nel*Nel*L + iel*Nel + jel]=utils::exchange_tei(prim_tei[Nel*Nel*L + iel*Nel + jel],Ni,Ni,Nj,Nj);
-                }
-                for(size_t jel=iel+1;jel<Nel;jel++) {
-                size_t Nj(radial.Nprim(jel));
-                prim_ktei[Nel*Nel*L + iel*Nel + jel]=utils::exchange_tei(prim_tei[Nel*Nel*L + iel*Nel + jel],Ni,Ni,Nj,Nj);
-                }
-              */
-            }
+        // Delegate to the shared cache builders in CoulombExchangeFE.h.
+        // The bare-Coulomb defaults (yukawa=false, lambda=0) populate
+        // disjoint_L / disjoint_m1L from radial.radial_integral and
+        // prim_tei (in-element only; cross-element is assembled on the
+        // fly from the disjoint factors inside the cached J/K helpers).
+        const int N_L = 2 * arma::max(lval) + 1;
+        atomic::basis::compute_disjoint_radial_integrals(
+            radial, N_L, disjoint_L, disjoint_m1L);
+        atomic::basis::compute_in_element_tei(radial, N_L, prim_tei);
+        // The exchange matrix is K(jk) = (ij|kl) P(il); we precompute the
+        // (jk;il)-permuted form here so the cached K assembly path can
+        // consume the cache without re-permuting.
+        if (exchange) {
+          atomic::basis::compute_in_element_ktei_from_tei(
+              radial, N_L, prim_tei, prim_ktei);
         }
       }
 
       void TwoDBasis::compute_yukawa(double lambda_) {
-        lambda=lambda_;
-        yukawa=true;
-
-        // Number of distinct L values is
-        size_t N_L(2*arma::max(lval)+1);
-        size_t Nel(radial.Nel());
-
-        // Compute disjoint integrals
-        disjoint_iL.resize(Nel*N_L);
-        disjoint_kL.resize(Nel*N_L);
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            disjoint_iL[L*Nel+iel]=radial.bessel_il_integral(L,lambda,iel);
-            disjoint_kL[L*Nel+iel]=radial.bessel_kl_integral(L,lambda,iel);
-          }
-
-        /*
-          The exchange matrix is given by
-          K(jk) = (ij|kl) P(il)
-          i.e. the complex conjugation hits i and l as
-          in the density matrix.
-
-          To get this in the proper order, we permute the integrals
-          K(jk) = (jk;il) P(il)
-          so we don't have to reform the permutations in the exchange routine.
-        */
-        rs_ktei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            // Diagonal integrals
-            size_t Ni(radial.Nprim(iel));
-            rs_ktei[Nel*Nel*L + iel*Nel + iel]=utils::exchange_tei(radial.yukawa_integral(L,lambda,iel),Ni,Ni,Ni,Ni);
-          }
+        lambda = lambda_;
+        yukawa = true;
+        const int N_L = 2 * arma::max(lval) + 1;
+        // Yukawa-mode disjoint factors (bessel i / bessel k) + in-element
+        // Yukawa 2e + the exchange-permuted form needed by the cached K
+        // assembly.
+        atomic::basis::compute_disjoint_radial_integrals(
+            radial, N_L, disjoint_iL, disjoint_kL, /*yukawa=*/true, lambda);
+        std::vector<arma::mat> rs_tei_yk;
+        atomic::basis::compute_in_element_tei(
+            radial, N_L, rs_tei_yk, /*yukawa=*/true, lambda);
+        atomic::basis::compute_in_element_ktei_from_tei(
+            radial, N_L, rs_tei_yk, rs_ktei);
       }
 
       void TwoDBasis::compute_erfc(double mu) {
-        lambda=mu;
-        yukawa=false;
-
-        // Number of distinct L values is
-        size_t N_L(2*arma::max(lval)+1);
-        size_t Nel(radial.Nel());
-
-        // No disjoint integrals
+        lambda = mu;
+        yukawa = false;
+        // Erfc kernel doesn't factorise -- no disjoint integrals; all
+        // (iel, jel) pairs are stored explicitly in rs_ktei.
         disjoint_iL.clear();
         disjoint_kL.clear();
-
-        /*
-          The exchange matrix is given by
-          K(jk) = (ij|kl) P(il)
-          i.e. the complex conjugation hits i and l as
-          in the density matrix.
-
-          To get this in the proper order, we permute the integrals
-          K(jk) = (jk;il) P(il)
-          so we don't have to reform the permutations in the exchange routine.
-        */
-        rs_ktei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            for(size_t kel=0;kel<Nel;kel++) {
-              // Diagonal integrals
-              size_t Ni(radial.Nprim(iel));
-              size_t Nk(radial.Nprim(kel));
-              rs_ktei[Nel*Nel*L + iel*Nel + kel]=utils::exchange_tei(radial.erfc_integral(L,lambda,iel,kel),Ni,Ni,Nk,Nk);
-            }
-          }
+        const int N_L = 2 * arma::max(lval) + 1;
+        atomic::basis::compute_erfc_ktei(radial, N_L, lambda, rs_ktei);
       }
 
       arma::mat TwoDBasis::coulomb(const arma::mat & P0) const {

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -180,118 +180,42 @@ namespace helfem {
       }
 
       void TwoDBasis::compute_tei() {
-        // Number of distinct L values is
-        size_t N_L(2*arma::max(lval)+1);
-        size_t Nel(radial.Nel());
-
-        // Compute disjoint integrals
-        disjoint_L.resize(Nel*N_L);
-        disjoint_m1L.resize(Nel*N_L);
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            disjoint_L[L*Nel+iel]=radial.radial_integral(L,iel);
-            disjoint_m1L[L*Nel+iel]=radial.radial_integral(-L-1,iel);
-          }
-
-        // Form two-electron integrals
-        prim_tei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-        for(size_t L=0;L<N_L;L++) {
-          for(size_t iel=0;iel<Nel;iel++) {
-            // In-element integral
-            prim_tei[Nel*Nel*L + iel*Nel + iel]=radial.twoe_integral(L,iel);
-          }
-        }
-
-        // Two-electron exchange integrals
-        prim_ktei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            // Diagonal integrals
-            size_t Ni(radial.Nprim(iel));
-            prim_ktei[Nel*Nel*L + iel*Nel + iel]=utils::exchange_tei(prim_tei[Nel*Nel*L + iel*Nel + iel],Ni,Ni,Ni,Ni);
-          }
+        // Delegate to the shared cache builders in CoulombExchangeFE.h
+        // -- same path atomic::TwoDBasis uses. Bare Coulomb + in-element
+        // prim_tei + exchange-permuted prim_ktei.
+        const int N_L = 2 * arma::max(lval) + 1;
+        atomic::basis::compute_disjoint_radial_integrals(
+            radial, N_L, disjoint_L, disjoint_m1L);
+        atomic::basis::compute_in_element_tei(radial, N_L, prim_tei);
+        atomic::basis::compute_in_element_ktei_from_tei(
+            radial, N_L, prim_tei, prim_ktei);
       }
 
       void TwoDBasis::compute_yukawa(double lambda_) {
-        lambda=lambda_;
-        yukawa=true;
-
-        // Number of distinct L values is
-        size_t N_L(2*arma::max(lval)+1);
-        size_t Nel(radial.Nel());
-
-        // Compute disjoint integrals
-        disjoint_iL.resize(Nel*N_L);
-        disjoint_kL.resize(Nel*N_L);
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            disjoint_iL[L*Nel+iel]=radial.bessel_il_integral(L,lambda,iel);
-            disjoint_kL[L*Nel+iel]=radial.bessel_kl_integral(L,lambda,iel);
-          }
-
-        /*
-          The exchange matrix is given by
-          K(jk) = (ij|kl) P(il)
-          i.e. the complex conjugation hits i and l as
-          in the density matrix.
-
-          To get this in the proper order, we permute the integrals
-          K(jk) = (jk;il) P(il)
-          so we don't have to reform the permutations in the exchange routine.
-        */
-        rs_ktei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            // Diagonal integrals
-            size_t Ni(radial.Nprim(iel));
-            rs_ktei[Nel*Nel*L + iel*Nel + iel]=utils::exchange_tei(radial.yukawa_integral(L,lambda,iel),Ni,Ni,Ni,Ni);
-          }
+        lambda = lambda_;
+        yukawa = true;
+        const int N_L = 2 * arma::max(lval) + 1;
+        // Yukawa disjoint factors (bessel i / bessel k) + in-element
+        // Yukawa 2e -> exchange-permuted form needed by the cached K
+        // assembly.
+        atomic::basis::compute_disjoint_radial_integrals(
+            radial, N_L, disjoint_iL, disjoint_kL, /*yukawa=*/true, lambda);
+        std::vector<arma::mat> rs_tei_yk;
+        atomic::basis::compute_in_element_tei(
+            radial, N_L, rs_tei_yk, /*yukawa=*/true, lambda);
+        atomic::basis::compute_in_element_ktei_from_tei(
+            radial, N_L, rs_tei_yk, rs_ktei);
       }
 
       void TwoDBasis::compute_erfc(double mu) {
-        lambda=mu;
-        yukawa=false;
-
-        // Number of distinct L values is
-        size_t N_L(2*arma::max(lval)+1);
-        size_t Nel(radial.Nel());
-
-        // No disjoint integrals
+        lambda = mu;
+        yukawa = false;
+        // Erfc kernel doesn't factorise -- no disjoint integrals; all
+        // (iel, jel) pairs are stored explicitly in rs_ktei.
         disjoint_iL.clear();
         disjoint_kL.clear();
-
-        /*
-          The exchange matrix is given by
-          K(jk) = (ij|kl) P(il)
-          i.e. the complex conjugation hits i and l as
-          in the density matrix.
-
-          To get this in the proper order, we permute the integrals
-          K(jk) = (jk;il) P(il)
-          so we don't have to reform the permutations in the exchange routine.
-        */
-        rs_ktei.resize(Nel*Nel*N_L);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2)
-#endif
-        for(size_t L=0;L<N_L;L++)
-          for(size_t iel=0;iel<Nel;iel++) {
-            for(size_t kel=0;kel<Nel;kel++) {
-              // Diagonal integrals
-              size_t Ni(radial.Nprim(iel));
-              size_t Nk(radial.Nprim(kel));
-              rs_ktei[Nel*Nel*L + iel*Nel + kel]=utils::exchange_tei(radial.erfc_integral(L,lambda,iel,kel),Ni,Ni,Nk,Nk);
-            }
-          }
+        const int N_L = 2 * arma::max(lval) + 1;
+        atomic::basis::compute_erfc_ktei(radial, N_L, lambda, rs_ktei);
       }
 
       arma::mat TwoDBasis::coulomb(const arma::mat & P) const {


### PR DESCRIPTION
## Summary

Phase 0 of the Eigen migration arc. The per-element 2e integral cache construction (`compute_tei` / `compute_yukawa` / `compute_erfc`) was duplicated near-verbatim between `atomic::TwoDBasis` and `sadatom::TwoDBasis` — both filled identical `disjoint_L` / `disjoint_m1L` / `prim_tei` / `prim_ktei` structures via the same loop shapes over (L, iel). Consolidate the fill loops into four shared helpers in `CoulombExchangeFE.h`, leaving both call sites as thin wrappers.

## New helpers

Header-only inline, alongside the existing `assemble_*_FE_one_multipole_cached` path:

```cpp
compute_disjoint_radial_integrals(radial, N_L, dj_small, dj_big,
                                  yukawa=false, lambda=0);
compute_in_element_tei(radial, N_L, prim_tei,
                       yukawa=false, lambda=0);
compute_in_element_ktei_from_tei(radial, N_L, prim_tei, prim_ktei);
compute_erfc_ktei(radial, N_L, mu, rs_ktei);
```

Each helper preserves the existing OpenMP parallelisation pattern (`collapse(2)` over L and iel) so the parallel structure of the SCF inner-loop cache build is unchanged.

## Net effect

| File | Before | After | Δ |
|---|---|---|---|
| `atomic/TwoDBasis.cpp` compute_tei/yukawa/erfc | ~115 lines | ~30 lines | -85 |
| `sadatom/basis.cpp`    compute_tei/yukawa/erfc | ~115 lines | ~30 lines | -85 |
| `libhelfem/include/CoulombExchangeFE.h` | — | +123 lines (shared helpers) | +123 |
| **Total** | | | **-58 lines** |

Single source of truth for the cache build; both `atomic` and `sadatom` now go through the same code path.

## Validation

Ne HF at lmax=3 mmax=3 nelem=10 Rmax=15 nnodes=8:
- atomic:  Etot = **−128.5470981080**  (matches basis-limit −128.547098109)
- sadatom: Etot = **−128.547098108**   (matches atomic to 9 digits)

The refactor is pure code reorganisation — no algorithmic or floating-point ordering change (the OpenMP loop structure and operand-of-multiplication order are preserved verbatim inside the shared helpers).

## Status of the Eigen migration arc

- [x] **Phase 0: DRY TwoDBasis cache construction** — this PR
- [ ] Phase 1: Eigen foundation (dep + typedefs + arma↔Eigen converters)
- [ ] Phase 2a: migrate PolynomialBasis family
- [ ] Phase 2b: migrate FEMRadialBasis
- [ ] Phase 2c: migrate TwoDBasis + CoulombExchangeFE helpers
- [ ] Phase 3: migrate src/general + src/atomic + src/sadatom + src/diatomic
- [ ] Phase 4: templatize `Matrix<T>` for arbitrary precision

This PR shrinks the Phase 2c migration target (less duplicated arma-shaped code to convert) and centralises the SCF-inner-loop cache build so subsequent template/Eigen passes touch one place.

## Test plan (verified)

- [x] Full build clean
- [x] Ne HF (atomic) at lmax=3 converges to basis-limit −128.5470981080
- [x] Ne HF (sadatom restricted) matches atomic to 9 digits