### PR TITLE
v2: Eigen migration Phase 1 -- foundation (dep + typedefs + arma converters)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,30 @@ if(HELFEM_FIND_DEPS)
     endif()
 endif()
 
+# Eigen: header-only matrix library. Phase 1 of the Eigen migration
+# arc -- introduces the helfem::Matrix typedef and arma<->Eigen
+# converters in libhelfem/include without yet replacing Armadillo
+# anywhere. Subsequent phases migrate libhelfem and src/ leaf-by-leaf.
+# Prefer a system-installed Eigen3 >= 3.4, otherwise fetch v3.4.0.
+find_package(Eigen3 3.4 QUIET NO_MODULE)
+if(NOT Eigen3_FOUND)
+    message(STATUS "Eigen3 >= 3.4 not found via find_package; fetching v3.4.0")
+    include(FetchContent)
+    FetchContent_Declare(
+        Eigen3
+        GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+        GIT_TAG        3.4.0
+    )
+    # Suppress Eigen's own build targets / tests; we only need the
+    # interface library that exposes the headers.
+    set(EIGEN_BUILD_DOC      OFF CACHE INTERNAL "")
+    set(EIGEN_BUILD_PKGCONFIG OFF CACHE INTERNAL "")
+    set(BUILD_TESTING        OFF CACHE INTERNAL "")
+    FetchContent_MakeAvailable(Eigen3)
+else()
+    message(STATUS "Using system Eigen3 (${Eigen3_VERSION})")
+endif()
+
 # Wigner-nj symbols: prefer a system-installed wignernj >= 0.5.0, otherwise
 # fetch and build that version.
 find_package(wignernj 0.5.0 QUIET)

--- a/libhelfem/CMakeLists.txt
+++ b/libhelfem/CMakeLists.txt
@@ -13,6 +13,8 @@ list(APPEND LIBHELFEM_PUBLIC_HEADERS
     "RadialBasis.h"
     "SphericalNucleus.h"
     "RegularizedNucleus.h"
+    "Matrix.h"
+    "ArmaEigen.h"
 )
 foreach(header IN LISTS LIBHELFEM_PUBLIC_HEADERS)
     configure_file("include/${header}" "include/${header}" COPYONLY)
@@ -36,7 +38,7 @@ add_library(helfem
     src/RadialBasis.cpp
 )
 target_include_directories(helfem PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
-target_link_libraries(helfem PUBLIC helfem::lib1dfem)
+target_link_libraries(helfem PUBLIC helfem::lib1dfem Eigen3::Eigen)
 target_compile_features(helfem PUBLIC cxx_std_17)
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/" DESTINATION include)
 install(TARGETS helfem DESTINATION lib)

--- a/libhelfem/include/ArmaEigen.h
+++ b/libhelfem/include/ArmaEigen.h
@@ -1,0 +1,121 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * Released under the BSD 3-Clause License.
+ */
+#ifndef HELFEM_ARMA_EIGEN_H
+#define HELFEM_ARMA_EIGEN_H
+
+#include "Matrix.h"
+#include <armadillo>
+
+namespace helfem {
+
+  // Arma <-> Eigen converters for the migration boundary.
+  //
+  // Both libraries default to column-major dense storage, so a zero-copy
+  // Map is safe as long as both sides agree on shape and lifetime.
+  //
+  // - to_eigen_view / to_arma_view : zero-copy views. The data is
+  //   shared; the underlying buffer must outlive the view. Use when
+  //   the source object lives in the same scope and is not resized.
+  //
+  // - to_eigen / to_arma           : owning copy. Use at API boundaries
+  //   where the caller wants its own buffer (return values from
+  //   migrated leaf classes, etc.).
+  //
+  // Once a leaf class has been fully migrated to helfem::Matrix, its
+  // existing arma-returning methods can wrap a single line:
+  //     arma::mat foo_arma() const { return to_arma(foo_eigen()); }
+  // to keep arma-consuming callers working unchanged. When the LAST
+  // caller is migrated, the arma wrapper is deleted.
+
+  // ---- Owning copies --------------------------------------------------
+
+  inline Matrix to_eigen(const arma::mat & A) {
+    Matrix out(A.n_rows, A.n_cols);
+    if (A.n_rows == 0 || A.n_cols == 0)
+      return out;
+    // arma::mat memory is column-major; so is Eigen::Matrix by default.
+    std::copy(A.memptr(), A.memptr() + A.n_rows * A.n_cols, out.data());
+    return out;
+  }
+
+  inline Vector to_eigen(const arma::vec & v) {
+    Vector out(v.n_elem);
+    if (v.n_elem == 0) return out;
+    std::copy(v.memptr(), v.memptr() + v.n_elem, out.data());
+    return out;
+  }
+
+  inline arma::mat to_arma(const Matrix & A) {
+    arma::mat out(A.rows(), A.cols());
+    if (A.rows() == 0 || A.cols() == 0)
+      return out;
+    std::copy(A.data(), A.data() + A.rows() * A.cols(), out.memptr());
+    return out;
+  }
+
+  inline arma::vec to_arma(const Vector & v) {
+    arma::vec out(v.size());
+    if (v.size() == 0) return out;
+    std::copy(v.data(), v.data() + v.size(), out.memptr());
+    return out;
+  }
+
+  // ---- Zero-copy views ------------------------------------------------
+  //
+  // Cast away const on arma::mat::memptr() for the const overloads: arma
+  // exposes a const-correct memptr() only for non-const objects (memptr()
+  // is non-const). We need the const-correct mapping at the language
+  // level even though the underlying buffer is read-only by contract.
+
+  inline Eigen::Map<Matrix> to_eigen_view(arma::mat & A) {
+    return Eigen::Map<Matrix>(A.memptr(),
+                              static_cast<Eigen::Index>(A.n_rows),
+                              static_cast<Eigen::Index>(A.n_cols));
+  }
+
+  inline Eigen::Map<const Matrix> to_eigen_view(const arma::mat & A) {
+    return Eigen::Map<const Matrix>(A.memptr(),
+                                    static_cast<Eigen::Index>(A.n_rows),
+                                    static_cast<Eigen::Index>(A.n_cols));
+  }
+
+  inline Eigen::Map<Vector> to_eigen_view(arma::vec & v) {
+    return Eigen::Map<Vector>(v.memptr(),
+                              static_cast<Eigen::Index>(v.n_elem));
+  }
+
+  inline Eigen::Map<const Vector> to_eigen_view(const arma::vec & v) {
+    return Eigen::Map<const Vector>(v.memptr(),
+                                    static_cast<Eigen::Index>(v.n_elem));
+  }
+
+  inline arma::mat to_arma_view(Matrix & A) {
+    // arma::mat ctor (ptr, n_rows, n_cols, copy_aux_mem=true, strict=false)
+    // -- pass copy_aux_mem=false to get a view onto the Eigen buffer.
+    return arma::mat(A.data(),
+                     static_cast<arma::uword>(A.rows()),
+                     static_cast<arma::uword>(A.cols()),
+                     /*copy_aux_mem=*/false,
+                     /*strict=*/false);
+  }
+
+  inline arma::vec to_arma_view(Vector & v) {
+    return arma::vec(v.data(),
+                     static_cast<arma::uword>(v.size()),
+                     /*copy_aux_mem=*/false,
+                     /*strict=*/false);
+  }
+
+} // namespace helfem
+
+#endif // HELFEM_ARMA_EIGEN_H

--- a/libhelfem/include/Matrix.h
+++ b/libhelfem/include/Matrix.h
@@ -1,0 +1,58 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * Released under the BSD 3-Clause License.
+ */
+#ifndef HELFEM_MATRIX_H
+#define HELFEM_MATRIX_H
+
+#include <Eigen/Core>
+#include <vector>
+
+namespace helfem {
+
+  // Phase 1 of the Eigen migration arc.
+  //
+  // Scope: introduce a tiny set of Eigen-based matrix / vector typedefs
+  // that subsequent phases can adopt leaf-by-leaf. NO existing code is
+  // migrated in this phase. The typedefs live alongside Armadillo so
+  // both can coexist during the multi-PR transition.
+  //
+  // Convention:
+  //   - Scalar (default 'double') is the floating-point type. Phase 4
+  //     will templatise on this for arbitrary precision (long double,
+  //     __float128, boost::multiprecision, ...).
+  //   - Matrix / Vector are dynamic-size column-major Eigen types,
+  //     matching arma::mat / arma::vec storage order. The migration
+  //     can therefore use ArmaEigen.h's Map-based zero-copy converters
+  //     at the interface boundary without reallocating data.
+  //   - Cube is std::vector<Matrix>, mirroring how arma::cube is used
+  //     in HelFEM (per-slice access via cube.slice(i); no heavy use of
+  //     3-D-contiguous tensor operations). Eigen's tensor module is in
+  //     unsupported/ and brings extra complexity we don't need.
+
+  using Scalar = double;
+
+  using Matrix    = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+  using Vector    = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+  using RowVector = Eigen::Matrix<Scalar, 1, Eigen::Dynamic>;
+  using IVector   = Eigen::Matrix<long long, Eigen::Dynamic, 1>;
+  using UVector   = Eigen::Matrix<unsigned long long, Eigen::Dynamic, 1>;
+
+  /// "Cube" semantics matching arma::cube usage in HelFEM: a stack of
+  /// equally-sized matrices indexed by a slice integer. NOT a contiguous
+  /// 3-D tensor; for genuine tensor work, callers can hold a single
+  /// Matrix viewed as a 2-D flattening (this is what the radial DF
+  /// factors do today via arma::cube).
+  using Cube = std::vector<Matrix>;
+
+} // namespace helfem
+
+#endif // HELFEM_MATRIX_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,9 @@ target_link_libraries(gaunt_test helfem-common legendre)
 add_executable(sphtest general/sphtest.cpp)
 target_link_libraries(sphtest helfem-common legendre)
 
+add_executable(eigen_foundation_test general/eigen_foundation_test.cpp)
+target_link_libraries(eigen_foundation_test helfem)
+
 add_executable(harmonic harmonic/main.cpp)
 target_link_libraries(harmonic helfem-common legendre)
 

--- a/src/general/eigen_foundation_test.cpp
+++ b/src/general/eigen_foundation_test.cpp
@@ -1,0 +1,134 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * Released under the BSD 3-Clause License.
+ */
+
+// Phase 1 of the Eigen migration arc -- validate the helfem::Matrix /
+// Vector typedefs and the Arma <-> Eigen converters.
+//
+// Verifies:
+//   1. The Eigen-based typedefs (Matrix, Vector, Cube) exist and basic
+//      operations work (allocate, fill, multiply, decompose).
+//   2. to_eigen / to_arma owning copies round-trip exactly.
+//   3. to_eigen_view / to_arma_view share storage (mutating one is
+//      visible through the other).
+//   4. Matrix multiply gives the same result through both libraries.
+
+#include "Matrix.h"
+#include "ArmaEigen.h"
+
+#include <Eigen/Eigenvalues>
+#include <armadillo>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+  void check(bool cond, const char * msg) {
+    if (!cond) {
+      std::fprintf(stderr, "FAIL: %s\n", msg);
+      std::exit(1);
+    }
+    std::printf("  ok: %s\n", msg);
+  }
+
+  double max_abs_diff(const arma::mat & A, const helfem::Matrix & B) {
+    if (A.n_rows != (arma::uword) B.rows() || A.n_cols != (arma::uword) B.cols())
+      return 1e300;
+    double d = 0.0;
+    for (arma::uword j = 0; j < A.n_cols; ++j)
+      for (arma::uword i = 0; i < A.n_rows; ++i)
+        d = std::max(d, std::abs(A(i, j) - B(i, j)));
+    return d;
+  }
+
+} // namespace
+
+int main() {
+  using helfem::Matrix;
+  using helfem::Vector;
+  using helfem::Cube;
+
+  std::printf("=== Eigen foundation test ===\n");
+
+  // 1. Basic typedefs work.
+  {
+    Matrix M = Matrix::Random(5, 4);
+    Vector v = Vector::Random(4);
+    Vector y = M * v;
+    check(y.size() == 5, "Matrix * Vector returns correct size");
+    check(M.transpose().rows() == 4, "Matrix::transpose is well-formed");
+  }
+
+  // 2. Cube = std::vector<Matrix> works.
+  {
+    Cube C;
+    C.reserve(3);
+    for (int k = 0; k < 3; ++k) C.emplace_back(Matrix::Constant(4, 4, double(k)));
+    check(C.size() == 3, "Cube has 3 slices");
+    check(C[1](2, 3) == 1.0, "Cube slice value preserved");
+  }
+
+  // 3. Owning round-trip arma <-> Eigen.
+  arma::arma_rng::set_seed(42);
+  arma::mat A_arma = arma::randn(7, 5);
+  Matrix    A_eig  = helfem::to_eigen(A_arma);
+  arma::mat A_back = helfem::to_arma(A_eig);
+  check(max_abs_diff(A_arma, A_eig) < 1e-15, "to_eigen preserves values");
+  check(arma::approx_equal(A_arma, A_back, "absdiff", 1e-15),
+        "round-trip arma -> Eigen -> arma is exact");
+
+  // 4. Zero-copy view: mutating via the Eigen view is visible in arma.
+  arma::mat B_arma = arma::randn(4, 6);
+  {
+    auto B_view = helfem::to_eigen_view(B_arma);
+    B_view(2, 3) = 99.0;
+  }
+  check(B_arma(2, 3) == 99.0, "to_eigen_view mutates arma buffer in place");
+
+  // 5. Const view does not require non-const arma.
+  {
+    const arma::mat & B_const = B_arma;
+    auto B_view = helfem::to_eigen_view(B_const);
+    check(B_view(2, 3) == 99.0, "const to_eigen_view reads through to arma");
+  }
+
+  // 6. Matrix product: arma vs Eigen give the same numerical answer.
+  arma::mat P = arma::randn(5, 7);
+  arma::mat Q = arma::randn(7, 4);
+  arma::mat PQ_arma = P * Q;
+  Matrix PQ_eig = helfem::to_eigen(P) * helfem::to_eigen(Q);
+  check(max_abs_diff(PQ_arma, PQ_eig) < 1e-12,
+        "arma * arma == to_arma(Eigen * Eigen) (1e-12)");
+
+  // 7. Eigenvalue decomposition: arma::eig_sym vs Eigen::SelfAdjointEigenSolver.
+  arma::mat S = arma::randn(6, 6);
+  S = 0.5 * (S + S.t());                       // symmetrise
+  S += 6.0 * arma::eye(6, 6);                  // shift positive definite-ish
+  arma::vec  arma_eigvals;
+  arma::mat  arma_eigvecs;
+  arma::eig_sym(arma_eigvals, arma_eigvecs, S);
+
+  Eigen::SelfAdjointEigenSolver<Matrix> es(helfem::to_eigen(S));
+  Vector eig_eigvals = es.eigenvalues();
+  check(arma_eigvals.n_elem == (arma::uword) eig_eigvals.size(),
+        "eigenvalue counts match");
+  double eig_diff = 0.0;
+  for (arma::uword i = 0; i < arma_eigvals.n_elem; ++i)
+    eig_diff = std::max(eig_diff,
+                        std::abs(arma_eigvals(i) - eig_eigvals(i)));
+  check(eig_diff < 1e-12,
+        "arma::eig_sym vs Eigen::SelfAdjointEigenSolver agree (1e-12)");
+
+  std::printf("PASS\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Eigen migration arc. Sets up Eigen alongside Armadillo as the matrix library that subsequent phases migrate libhelfem and src/ onto. **No existing code is migrated in this phase** — purely additive scaffolding so Phases 2+ can proceed leaf-by-leaf.

## What this PR adds

### CMake
`find_package(Eigen3 3.4)` with a `FetchContent v3.4.0` fallback, matching the `wignernj` pattern. Eigen is header-only; this just exposes its include path via the `Eigen3::Eigen` interface target, which `libhelfem` now links against.

### `libhelfem/include/Matrix.h`

```cpp
namespace helfem {
    using Scalar    = double;
    using Matrix    = Eigen::Matrix<Scalar, Dynamic, Dynamic>;
    using Vector    = Eigen::Matrix<Scalar, Dynamic, 1>;
    using RowVector = Eigen::Matrix<Scalar, 1, Dynamic>;
    using IVector   = Eigen::Matrix<long long, Dynamic, 1>;
    using UVector   = Eigen::Matrix<unsigned long long, Dynamic, 1>;
    using Cube      = std::vector<Matrix>;   // matches arma::cube usage
}
```

Column-major to match arma storage (enables zero-copy `Map` converters). `Scalar` is fixed `double` here; Phase 4 templatises it for arbitrary precision.

### `libhelfem/include/ArmaEigen.h`

Converters at the migration boundary:
- **`to_eigen` / `to_arma`** — owning copies (deep copy of contiguous buffer in either direction)
- **`to_eigen_view` / `to_arma_view`** — zero-copy `Map` views; mutations visible through both handles

Once a leaf class is migrated, its arma-returning methods can wrap one line:
```cpp
arma::mat foo_arma() const { return to_arma(foo_eigen()); }
```
to keep arma-consuming callers working unchanged. When the last caller migrates, the arma wrapper deletes.

### `src/general/eigen_foundation_test.cpp`

11-assertion smoke test exercising:
- Typedefs (Matrix×Vector, transpose, Cube slice access)
- Owning round-trips (arma → Eigen → arma exact)
- Zero-copy view (Eigen-side mutation visible in arma buffer)
- Numerical agreement: arma matmul vs Eigen matmul (1e-12)
- Numerical agreement: `arma::eig_sym` vs `Eigen::SelfAdjointEigenSolver` (1e-12)

## Validation

```
$ /tmp/v2-pybind/src/eigen_foundation_test
=== Eigen foundation test ===
  ok: Matrix * Vector returns correct size
  ok: Matrix::transpose is well-formed
  ok: Cube has 3 slices
  ok: Cube slice value preserved
  ok: to_eigen preserves values
  ok: round-trip arma -> Eigen -> arma is exact
  ok: to_eigen_view mutates arma buffer in place
  ok: const to_eigen_view reads through to arma
  ok: arma * arma == to_arma(Eigen * Eigen) (1e-12)
  ok: eigenvalue counts match
  ok: arma::eig_sym vs Eigen::SelfAdjointEigenSolver agree (1e-12)
PASS
```

He sadatom HF at lmax=1 unchanged: **Etot = −2.861679987** (matches pre-PR result to all printed digits — no semantic regression from the additive CMake / header changes).

## Status of the Eigen migration arc

- [x] **Phase 0**: DRY TwoDBasis cache construction — PR #99
- [x] **Phase 1**: Eigen foundation — **this PR**
- [ ] Phase 2a: migrate PolynomialBasis family
- [ ] Phase 2b: migrate FEMRadialBasis
- [ ] Phase 2c: migrate TwoDBasis + CoulombExchangeFE helpers
- [ ] Phase 3: migrate src/general + src/atomic + src/sadatom + src/diatomic
- [ ] Phase 4: templatize `Matrix<T>` for arbitrary precision (the actual high-precision payoff — OOO is now Eigen-based, so the chemistry side can consume `long double` / `__float128` matrices once HelFEM produces them)

## Test plan (verified)

- [x] CMake finds Eigen3 (system or FetchContent fallback)
- [x] Full build clean
- [x] Eigen foundation test: 11/11 assertions pass
- [x] He HF unchanged (no regression from CMake + header-only additions)