### PR TITLE
v2: Eigen migration Phase 2a tracer -- RadialBasis::overlap() returns helfem::Matrix

### DIFF
--- a/libhelfem/include/GTO.h
+++ b/libhelfem/include/GTO.h
@@ -16,6 +16,7 @@
 #define ATOMIC_BASIS_GTO_H
 
 #include "RadialBasis.h"
+#include "ArmaEigen.h"
 #include "NAORadialBasis.h"
 #include "FiniteElementBasis.h"
 #include "PolynomialBasis.h"
@@ -132,7 +133,8 @@ namespace helfem {
             /*zero_func_left*/true,  /*zero_deriv_left*/false,
             /*zero_func_right*/true, /*zero_deriv_right*/false);
         atomic::basis::FEMRadialBasis radial(fem, 5 * poly->get_nbf());
-        const arma::mat S = radial.overlap();
+        // Phase 2a: radial.overlap() returns helfem::Matrix.
+        const arma::mat S = helfem::to_arma(radial.overlap());
         arma::vec xq, wq;
         helfem::chebyshev::chebyshev(5 * poly->get_nbf(), xq, wq);
         arma::mat C(S.n_rows, basis.size(), arma::fill::zeros);

--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -16,6 +16,7 @@
 #define ATOMIC_BASIS_NAORADIALBASIS_H
 
 #include "RadialBasis.h"
+#include "ArmaEigen.h"
 #include "CoulombExchangeFE.h"
 #include <armadillo>
 #include <memory>
@@ -107,8 +108,14 @@ namespace helfem {
         size_t Nbf() const override { return C_.n_cols; }
 
         /// S_NAO = C^T S_underlying C.
-        arma::mat overlap() const override {
-          return C_.t() * underlying_->overlap() * C_;
+        helfem::Matrix overlap() const override {
+          // Bridge: underlying_->overlap() is Eigen (Phase 2a); C_ is
+          // still arma. Convert at the boundary; subsequent Phase 2
+          // PR migrates C_ to Eigen and drops the round-trip. Force
+          // evaluation of the arma expression template into a concrete
+          // mat before to_eigen to avoid ADL ambiguity.
+          arma::mat S_arma = C_.t() * helfem::to_arma(underlying_->overlap()) * C_;
+          return helfem::to_eigen(S_arma);
         }
 
         /// T_NAO = C^T T_underlying C.

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -17,6 +17,7 @@
 
 #include "ModelPotential.h"
 #include "FiniteElementBasis.h"
+#include "Matrix.h"
 #include <armadillo>
 
 namespace helfem {
@@ -34,8 +35,12 @@ namespace helfem {
         /// Number of basis functions
         virtual size_t Nbf() const = 0;
 
-        /// Overlap matrix S_{ij} = integral u_i(r) u_j(r) dr
-        virtual arma::mat overlap() const = 0;
+        /// Overlap matrix S_{ij} = integral u_i(r) u_j(r) dr.
+        /// Eigen-typed -- first method migrated from arma::mat as part
+        /// of Phase 2a of the v2 Eigen migration arc. The other base
+        /// virtuals (kinetic, kinetic_l, nuclear) follow in subsequent
+        /// PRs.
+        virtual helfem::Matrix overlap() const = 0;
         /// Radial kinetic matrix (1/2) integral u'_i(r) u'_j(r) dr.
         /// EXCLUDES the centrifugal term -- caller adds l*(l+1) * kinetic_l().
         virtual arma::mat kinetic() const = 0;
@@ -170,8 +175,8 @@ namespace helfem {
             const std::function<double(double)> & weight =
                 std::function<double(double)>()) const;
 
-        /// Compute overlap matrix
-        arma::mat overlap() const override;
+        /// Compute overlap matrix (Eigen-typed; Phase 2a migration).
+        helfem::Matrix overlap() const override;
         /// Compute overlap matrix in element
         arma::mat overlap(size_t iel) const;
 

--- a/libhelfem/include/STO.h
+++ b/libhelfem/include/STO.h
@@ -16,6 +16,7 @@
 #define ATOMIC_BASIS_STO_H
 
 #include "RadialBasis.h"
+#include "ArmaEigen.h"
 #include "NAORadialBasis.h"
 #include "FiniteElementBasis.h"
 #include "PolynomialBasis.h"
@@ -159,7 +160,8 @@ namespace helfem {
             /*zero_func_left*/true,  /*zero_deriv_left*/false,
             /*zero_func_right*/true, /*zero_deriv_right*/false);
         atomic::basis::FEMRadialBasis radial(fem, 5 * poly->get_nbf());
-        const arma::mat S = radial.overlap();
+        // Phase 2a: radial.overlap() returns helfem::Matrix.
+        const arma::mat S = helfem::to_arma(radial.overlap());
         // Quadrature points + weights for the projection integrals.
         arma::vec xq, wq;
         helfem::chebyshev::chebyshev(5 * poly->get_nbf(), xq, wq);

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "RadialBasis.h"
+#include "ArmaEigen.h"
 #include "RadialPotential.h"
 #include "chebyshev.h"
 #include "quadrature.h"
@@ -274,7 +275,7 @@ namespace helfem {
       static const std::function<double(double)> kNoWeight;  // default-constructed = identity
       static const std::function<double(double)> kRWeight = [](double r){ return r; };
 
-      arma::mat FEMRadialBasis::overlap()         const { return matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight); }
+      helfem::Matrix FEMRadialBasis::overlap()    const { return helfem::to_eigen(matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight)); }
       arma::mat FEMRadialBasis::overlap(size_t iel) const { return matrix_element(iel, BasisKind::B0, BasisKind::B0, kNoWeight); }
 
       arma::mat FEMRadialBasis::kinetic()         const { return 0.5 * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight); }

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -99,8 +99,10 @@ int main(int argc, char **argv) {
   polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
   atomic::basis::FEMRadialBasis radial(fem, Nquad);
 
-  // Compute matrices
-  arma::mat S(radial.overlap());
+  // Compute matrices. Phase 2a: radial.overlap() returns
+  // helfem::Matrix (Eigen); rest of sadatom 1e is still arma -- bridge
+  // at the boundary via to_arma until the chemistry layer migrates.
+  arma::mat S(helfem::to_arma(radial.overlap()));
   arma::mat Sinvh=scf::form_Sinvh(S,false);
 
   arma::mat T(radial.kinetic());


### PR DESCRIPTION
## Summary

First actual API migration in the v2 Eigen migration arc — a focused **tracer-bullet** PR that flips `RadialBasis::overlap()` from `arma::mat` to `helfem::Matrix` and updates all three callers. Demonstrates the migration pattern end-to-end (base class virtual + two concrete overrides + caller bridging via `to_arma`) without committing to the full cascade in one shot.

## Why a tracer first

A full migration of `FEMRadialBasis` (50+ arma occurrences in the header alone, 800+ across the chemistry callers in `src/atomic/`, `src/sadatom/`, `src/diatomic/`) is a multi-thousand-line PR. Doing one method first proves the pattern compiles, links, and runs at **bit-for-bit identical numerics**, then subsequent PRs roll out the same recipe to the remaining methods.

## Changes

**Base class:** `RadialBasis::overlap()` virtual now returns `helfem::Matrix` instead of `arma::mat`.

**Concrete overrides:**
- `FEMRadialBasis::overlap()` wraps `matrix_element(...)` with `helfem::to_eigen` at the return boundary. `matrix_element` itself stays arma-typed; future PRs migrate the dispatcher.
- `NAORadialBasis::overlap()` header-inline override evaluates `C_^T * underlying->overlap() * C_` into a concrete `arma::mat` (to disambiguate `to_eigen` vs arma expression templates), then converts. NAO's `C_` matrix stays `arma::mat` — subsequent PR migrates it to drop the round-trip.

**Caller bridging (3 sites that call `radial.overlap()` directly):**

| File | Change |
|---|---|
| `src/sadatom/1e.cpp` | `S = to_arma(radial.overlap())` |
| `libhelfem/include/STO.h` | same |
| `libhelfem/include/GTO.h` | same |

All three feed `S` into arma operations downstream (`form_Sinvh`, `arma::solve`), so `to_arma` at the call site is the minimum change.

## Excluded (unaffected by this PR)

- `radial.overlap(iel)` (per-element variant, separate method, still arma)
- `radial.overlap(rh.radial)` / `radial.overlap(rh.radial, n)` (cross-basis variants used by atomic/diatomic TwoDBasis, still arma)
- `basis.overlap()` where `basis` is a TwoDBasis (a different class entirely; not touched)

## Validation

- Full build clean
- Eigen foundation test (11 assertions): PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (matches pre-PR value to all printed digits — numerics preserved through the arma↔Eigen round-trip at the caller boundary)
- Exhaustive radial DF round-trip across three FE configurations (LIP/HIP, nelem=2/4, nnodes=6/8): all PASS at machine precision (intra max err 1e-16, inter max err 1e-17 — the radial DF path consumes `radial.overlap()` transitively via cached helpers and gives identical results before/after)

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [/] **Phase 2a: migrate FEMRadialBasis (tracer)** — this PR
  - next: migrate (`kinetic`, `kinetic_l`, `nuclear`) virtuals
  - then: migrate `matrix_element` dispatcher (lets all four virtuals share Eigen internals)
  - then: migrate per-element / cross-basis overloads
- [ ] Phase 2b: migrate TwoDBasis caches
- [ ] Phase 2c: migrate CoulombExchangeFE helpers
- [ ] Phase 3: migrate src/general + chemistry callers
- [ ] Phase 4: templatise `Matrix<T>` for arbitrary precision

## Test plan (verified)

- [x] Full build clean
- [x] Eigen foundation test PASS
- [x] He sadatom HF Etot unchanged to all printed digits
- [x] Exhaustive radial DF round-trip (3 configs): PASS at machine precision