### PR TITLE
v2: fix install_full_eri complex-AO bug + mark complex-unsafe

### DIFF
--- a/python/helfem/pyscf_driver.py
+++ b/python/helfem/pyscf_driver.py
@@ -160,41 +160,39 @@ def build_active_eri(basis, mo_active):
     repeated J calls into a HelFEM basis. Returns the UNPACKED tensor of
     shape (N, N, N, N) where N = mo_active.shape[1].
 
-    Cost: N*(N+1)/2 J builds (one per unique active orbital pair) plus
+    Cost: N**2 J builds (one per ordered active orbital pair) plus
     N**4 traces. For a typical active space N ~ 5-20 on top of an
     Nbf ~ 300-3000 atomic FE basis, the J builds dominate at
     ~ms each. Negligible compared to the CI / orbital-opt loop.
 
-    Math: with the symmetrised pair density
-        P_ij_sym = (c_i c_j^T + c_j c_i^T) / 2   for i != j
-                 = c_i c_i^T                       for i == j
-    we have J(P_ij_sym)_{ab} = (ab | ij)   (since the AO Coulomb kernel
-    is symmetric under (alpha, beta) swap, the asymmetric c_i c_j^T
-    and c_j c_i^T pieces average to the symmetric product), and so
-        (mn | ij) = c_m^T . J(P_ij_sym) . c_n.
+    Math: with the ASYMMETRIC pair-density indicator P = c_i c_j^T,
+        J(P)_{ab} = sum_{c,d} P_{cd} (ab|cd) = (ab | ij)
+    and the active-space entry
+        (mn | ij) = c_m^T . J(P) . c_n.
+
+    Why asymmetric P (not the half-sum of c_i c_j^T and c_j c_i^T): for
+    complex Y_lm AOs (HelFEM's atomic basis), (mn|ij) and (mn|ji) have
+    DIFFERENT m-conservation patterns -- one can be nonzero while the
+    other is zero. Averaging mixes them and contaminates the tensor
+    with spurious m-non-conserving entries (this was a real bug: He
+    lmax=1 CCSD gave a 5 mEh-wrong correlation energy through this
+    contamination; see install_full_eri's deprecation note below).
+    For REAL AO bases (Y_l0 only, or real spherical harmonics) the
+    two halves coincide and either form gives the same answer.
     """
     N = mo_active.shape[1]
     eri = np.zeros((N, N, N, N))
     for i in range(N):
-        for j in range(i, N):
+        for j in range(N):
             ci = mo_active[:, i]
             cj = mo_active[:, j]
-            if i == j:
-                P = np.outer(ci, ci)
-            else:
-                P = 0.5 * (np.outer(ci, cj) + np.outer(cj, ci))
+            # Asymmetric pair-density indicator: J(c_i c_j^T) extracts
+            # exactly (.|ij), with no (.|ji) contamination.
+            P = np.outer(ci, cj)
             Jij = basis.coulomb(P)
             # (mn | ij) = c_m^T . J . c_n.
             # JC = J . mo_active  -> (Nbf, N)   then mo_active.T @ JC -> (N, N).
-            mtJn = mo_active.T @ (Jij @ mo_active)        # shape (N, N)
-            eri[:, :, i, j] = mtJn
-            if i != j:
-                eri[:, :, j, i] = mtJn
-    # Enforce the (mn) <-> (ij) pair-swap symmetry that's required by
-    # PySCF's 8-fold-packed (s8) format. The block we computed
-    # satisfies (mn | ij) symmetry in m<->n and i<->j, but symmetrising
-    # over pair-swap protects against small numerical asymmetries.
-    eri = 0.5 * (eri + eri.transpose(2, 3, 0, 1))
+            eri[:, :, i, j] = mo_active.T @ (Jij @ mo_active)
     return eri
 
 
@@ -502,17 +500,70 @@ def install_full_eri(mf, basis):
     against the HelFEM basis through normal code paths -- no per-method
     overrides needed.
 
-    Cost: Nbf*(Nbf+1)/2 J builds + O(Nbf^4) storage. For a compact NAO
-    basis (Nbf ~ 10-30) this is trivial (Nbf^4 ~ 10k-800k entries).
-    For larger Nbf the storage blows up -- use DF/Cholesky or stick to
-    the per-multipole install_eri_builder path instead. Typical NAO
-    workflows are small enough that this is the path of least
-    resistance for CASSCF.
+    !!! DEPRECATED for complex-Y_lm AOs (mmax > 0). !!!
+
+    HelFEM's atomic basis labels each AO by a definite (l, m)
+    quantum-mechanical magnetic-quantum-number, i.e. the AOs are
+    complex spherical harmonics Y_l,m(Omega) * u(r). For lmax = 0 only
+    the (l=0, m=0) shell exists and Y_00 is real-valued, so the
+    AO ERI tensor has full 8-fold permutational symmetry and the
+    s8-packed mf._eri + PySCF post-HF stack works correctly.
+
+    For any shell with m != 0 (lmax > 0 / mmax > 0):
+      - The AO ERI is REAL (m-conservation) but only 2-fold symmetric
+        ((mn|ij) = (ij|mn)); the other PySCF-assumed symmetries
+        ((mn|ij) = (nm|ij), (mn|ij) = (mn|ji)) FAIL because complex
+        AOs conjugate the bra differently.
+      - PySCF's CCSD / CASSCF / MP2 internals derive equations from
+        the 8-fold-symmetric ERI; running them on a 2-fold-symmetric
+        tensor gives WRONG correlation energies. (Empirically, He
+        lmax=1 mmax=1 install_full_eri -> CCSD gave a 5.6 mEh wrong
+        correlation; the correct route via radial_df_factors gave the
+        right answer.)
+      - Even with build_active_eri's symmetrisation bug fixed (this PR:
+        asymmetric P, m-conservation respected), s8 packing throws
+        away non-symmetric entries, and s1 packing into PySCF's CCSD
+        still doesn't reach the right answer because PySCF assumes
+        full 8-fold symmetry internally.
+
+    The supported general path is:
+        basis.radial_df_factors(tol) -> Bk
+    consumed by libatomscf's cderi_from_radial_df + PySCF DF post-HF,
+    which builds the AO ERI in the REAL spherical-harmonic basis where
+    full 8-fold symmetry holds. See radial_df_factors() docstring on
+    the C++ AtomicBasis side; the angular Gaunt assembly and PySCF DF
+    wiring live in libatomscf, not here.
+
+    This function now raises NotImplementedError when basis has any
+    shell with m != 0. For real-Y_lm AOs (m == 0 only) it still works
+    and is useful as a small-case cross-check.
     """
+    mvals = list(basis.mvals())
+    complex_shells = [(i, basis.lvals()[i], m) for i, m in enumerate(mvals) if m != 0]
+    if complex_shells:
+        raise NotImplementedError(
+            "install_full_eri is complex-AO-unsafe: HelFEM uses complex Y_lm,\n"
+            "and PySCF's 8-fold-symmetric post-HF machinery doesn't produce\n"
+            f"correct correlation energies on a 2-fold-symmetric ERI.\n"
+            f"  basis has {len(complex_shells)} shell(s) with m != 0:\n"
+            f"    {complex_shells[:3]}{' ...' if len(complex_shells) > 3 else ''}\n"
+            "\n"
+            "Use the radial_df_factors() + libatomscf cderi path for post-HF\n"
+            "calculations at lmax > 0 (or mmax > 0):\n"
+            "\n"
+            "    B = basis.radial_df_factors(tol=1e-12)\n"
+            "    cderi = libatomscf.cderi_from_radial_df(B, basis.lvals(),\n"
+            "                                            basis.mvals(),\n"
+            "                                            basis.Nrad())\n"
+            "    # feed cderi to PySCF DF-CCSD / DF-CASSCF / etc.\n"
+            "\n"
+            "install_full_eri remains correct (and useful as a cross-check)\n"
+            "for the lmax == 0, mmax == 0 case (s-shell-only, real AOs)."
+        )
     Nbf = basis.Nbf()
     # build_active_eri with identity coefficients returns the AO ERI.
     eri_unpacked = build_active_eri(basis, np.eye(Nbf))
-    # Store in 8-fold-packed form (the format PySCF uses internally).
+    # Store in 8-fold-packed form (valid for real AOs, lmax=0 only).
     mf._eri = ao2mo.restore('s8', eri_unpacked, Nbf)
     return mf
 

--- a/python/test_install_full_eri.py
+++ b/python/test_install_full_eri.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Regression test for install_full_eri / build_active_eri.
+
+Three checks:
+ (1) Bug-fix verification: build_active_eri (asymmetric P) produces an
+     AO ERI tensor that satisfies m-conservation for complex Y_lm AOs.
+     The old code symmetrised c_i c_j^T + c_j c_i^T which mixed
+     (mn|ij) with (mn|ji) -- different m-conservation patterns --
+     contaminating the tensor with m-non-conserving entries.
+
+ (2) Real-AO case (lmax = 0): install_full_eri still works and gives a
+     self-consistent CCSD result for the He s-shell-only basis.
+
+ (3) Complex-AO case (lmax > 0): install_full_eri raises a clear
+     NotImplementedError pointing to the radial_df_factors path.
+
+The 5.6 mEh wrong-correlation bug at He lmax=1 mmax=1 (reported by
+the external consumer) is what motivated the symmetrisation fix +
+the explicit complex-AO guard. The supported general path for
+post-HF with HelFEM's complex AOs is radial_df_factors + libatomscf's
+cderi (which builds the AO ERI in the real spherical-harmonic basis
+where full 8-fold symmetry holds and PySCF post-HF works).
+"""
+import sys
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+
+import helfem
+from helfem.pyscf_driver import (
+    helfem_scf, build_active_eri, install_full_eri,
+)
+
+
+def check(cond, msg):
+    if not cond:
+        print(f"  FAIL: {msg}")
+        sys.exit(1)
+    print(f"  ok: {msg}")
+
+
+def test_m_conservation_complex_AOs():
+    """Build the He lmax=1 mmax=1 AO ERI via build_active_eri (after
+    the asymmetric-P fix) and confirm m-conservation holds for every
+    nonzero entry."""
+    print("\n=== Test 1: m-conservation for complex Y_lm AOs ===")
+    P = dict(Z=2, lmax=1, mmax=1, nnodes=6, nelem=2, Rmax=40)
+    b = helfem.AtomicBasis(**P)
+    Nbf, Nrad = b.Nbf(), b.Nrad()
+    mvals = list(b.mvals())
+    print(f"  Nbf={Nbf}, shells={list(zip(b.lvals(), mvals))}")
+
+    eri = build_active_eri(b, np.eye(Nbf))
+
+    # m_l of AO index p = iang*Nrad + irad
+    m_a = np.array([mvals[p // Nrad] for p in range(Nbf)])
+    # m-conservation: m_a - m_b + m_c - m_d == 0 for any nonzero entry
+    nonzero = np.abs(eri) > 1e-10
+    ML = m_a[:, None, None, None] - m_a[None, :, None, None] + \
+         m_a[None, None, :, None] - m_a[None, None, None, :]
+    violations = nonzero & (ML != 0)
+    print(f"  nonzero entries: {nonzero.sum()}")
+    print(f"  m-conservation violations: {violations.sum()}")
+    check(violations.sum() == 0,
+          "all nonzero (mn|ij) satisfy m-conservation m_m - m_n + m_i - m_j = 0")
+
+
+def test_install_full_eri_lmax0():
+    """For lmax = 0 (real-AO basis), install_full_eri works correctly
+    and produces a self-consistent CCSD result."""
+    print("\n=== Test 2: install_full_eri at lmax = 0 (real-AO case) ===")
+    P = dict(Z=2, lmax=0, mmax=0, nnodes=6, nelem=2, Rmax=40)
+    b = helfem.AtomicBasis(**P)
+    print(f"  Nbf={b.Nbf()}, shells={list(zip(b.lvals(), b.mvals()))}")
+    mf, _ = helfem_scf(**P)
+    mf.mol.incore_anyway = True
+    mf.kernel()
+    install_full_eri(mf, b)
+    check(mf._eri is not None, "install_full_eri sets mf._eri")
+
+    from pyscf import cc
+    ccs = cc.CCSD(mf); ccs.verbose = 0; ccs.kernel()
+    print(f"  E_HF = {mf.e_tot:.8f}, E_corr(CCSD) = {ccs.e_corr:.6f}")
+    # For He lmax=0 with this compact basis: ~-0.0227 (basis-dependent;
+    # basis-limit partial-wave value is ~-0.0126).
+    check(-0.035 < ccs.e_corr < -0.005,
+          "CCSD correlation in expected range for compact s-only He basis")
+
+
+def test_install_full_eri_complex_raises():
+    """For lmax > 0 (complex-Y_lm AOs), install_full_eri raises a clear
+    NotImplementedError pointing at radial_df_factors."""
+    print("\n=== Test 3: install_full_eri raises for complex AOs ===")
+    P = dict(Z=2, lmax=1, mmax=1, nnodes=6, nelem=2, Rmax=40)
+    b = helfem.AtomicBasis(**P)
+    mf, _ = helfem_scf(**P); mf.kernel()
+
+    raised = False
+    msg = ""
+    try:
+        install_full_eri(mf, b)
+    except NotImplementedError as e:
+        raised = True
+        msg = str(e)
+    check(raised, "install_full_eri raises NotImplementedError for lmax=1 mmax=1")
+    check("radial_df_factors" in msg,
+          "error message points at radial_df_factors as the supported route")
+    check("complex" in msg.lower() or "m != 0" in msg,
+          "error message explains the complex-AO root cause")
+
+
+def main():
+    test_m_conservation_complex_AOs()
+    test_install_full_eri_lmax0()
+    test_install_full_eri_complex_raises()
+    print("\nALL TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

External consumer report: `install_full_eri` at He lmax=1 mmax=1 gave CCSD E_corr = **−0.0341**, the correct value is **−0.0397** (the known He through-l=1 partial-wave correlation, also produced by the radial-DF reference via `radial_df_factors` + libatomscf cderi + PySCF DF-CCSD). HF matched between both routes to 9e-16 — HF / integrals are right; only `install_full_eri`'s m≠0 path was wrong.

## Root cause (two compounding bugs)

**(a) `build_active_eri` symmetrised the pair-density indicator:**
```
P_ij_sym = 0.5 (c_i c_j^T + c_j c_i^T)
```
For complex Y_lm AOs the integrals (mn|ij) and (mn|ji) have **different m-conservation patterns** — one can be nonzero while the other is zero, because complex AOs swap-with-conjugation `(ab|cd) = (ba|cd)*`. Averaging them mixed the two, contaminating `eri[m, n, i, j]` with spurious m-non-conserving entries.

Diagnostic on He lmax=1 mmax=1: **43218 of 134456** nonzero entries had `m_m − m_n + m_i − m_j ≠ 0`.

**(b) PySCF's 8-fold-symmetric post-HF assumes `(mn|ij) = (nm|ij) = (mn|ji) = (ij|mn)`.** For complex Y_lm AOs only the pair-swap `(mn|ij) = (ij|mn)` holds; the bra-ket swaps fail (need conjugation). PySCF's CCSD/CASSCF/MP2 internals derive equations from the full 8-fold-symmetric form; running them on a 2-fold-symmetric tensor gives wrong correlation energies, even with the symmetrisation bug fixed (s1 packing into PySCF CCSD still gave −0.0408 vs correct −0.0397).

## Fix

**(a)** `build_active_eri` now uses **asymmetric** `P = c_i c_j^T`. `J(P)` extracts exactly `(.|ij)` with no `(.|ji)` contamination. m-conservation now respected bit-for-bit (0 violations on the same He test). Cost: N² J builds instead of N(N+1)/2 — but each is fast; negligible overall.

**(b)** `install_full_eri` now **raises `NotImplementedError`** for any basis with m ≠ 0 shells. Error message points at the supported general path:

```python
B = basis.radial_df_factors(tol=1e-12)
cderi = libatomscf.cderi_from_radial_df(B, basis.lvals(), basis.mvals(), basis.Nrad())
# feed cderi to PySCF DF-CCSD / DF-CASSCF / etc.
```

which builds the AO ERI in the **real spherical-harmonic basis** where 8-fold symmetry holds and PySCF post-HF works correctly.

For lmax == 0 (real-AO basis: Y_00 only), `install_full_eri` remains correct and useful as a small-case cross-check.

## Why deprecate instead of fully fix

A 'real fix' requires transforming both the AO ERI and the MO coefficients from complex Y_lm to real Y_lm basis (unitary 2x2 block per `(l, |m|, n_rad)`), which would grow significant functionality on `install_full_eri`.

External-consumer guidance:
> "keep radial_df_factors as the supported two-electron interface, fix install_full_eri only enough to serve as a small-case cross-check (or mark it complex-unsafe), and don't grow new functionality on it."

This PR follows that recommendation.

## Regression test (`test_install_full_eri.py`)

| Case | Check |
|---|---|
| He lmax=1 mmax=1 AO ERI from `build_active_eri` | 0 m-conservation violations (was 43218) |
| He lmax=0 install_full_eri → CCSD | still works, E_corr ≈ −0.0227 (self-consistent for compact basis) |
| He lmax=1 mmax=1 install_full_eri | raises `NotImplementedError`; message points at `radial_df_factors` and explains complex-AO root cause |

## Cascade

`helfem_casci` / `helfem_casscf` auto-call `install_full_eri`, so they too raise for mmax > 0. Existing mmax = 0 demos (`test_pyscf_he_method_ladder.py`, `test_pyscf_he_cas.py`, etc.) continue to work unchanged. The mmax > 0 demos (`test_pyscf_be_mchf`, the mmax=1 case in `test_pyscf_he_states`) were producing **wrong** answers and now correctly raise — they need to switch to the `radial_df_factors` + libatomscf route, which is the user-recommended production path anyway.

## Test plan (verified)

- [x] Bug reproduced before fix: install_full_eri → He lmax=1 mmax=1 CCSD = −0.0341
- [x] After fix: build_active_eri produces 0 m-conservation violations
- [x] After fix: install_full_eri at lmax=0 still works
- [x] After fix: install_full_eri at lmax=1 mmax=1 raises with clear message
- [x] Unchanged mmax=0 demos still pass (verified test_pyscf_he_method_ladder.py: He CCSD = FCI to 1e-7)