### PR TITLE
v2: Eigen Phase 2a -- migrate kinetic / kinetic_l / nuclear virtuals

### DIFF
--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -118,19 +118,22 @@ namespace helfem {
           return helfem::to_eigen(S_arma);
         }
 
-        /// T_NAO = C^T T_underlying C.
-        arma::mat kinetic() const override {
-          return C_.t() * underlying_->kinetic() * C_;
+        /// T_NAO = C^T T_underlying C (Phase 2a: underlying returns Eigen).
+        helfem::Matrix kinetic() const override {
+          arma::mat T_arma = C_.t() * helfem::to_arma(underlying_->kinetic()) * C_;
+          return helfem::to_eigen(T_arma);
         }
 
         /// (Centrifugal-per-l(l+1))_NAO = C^T (...)_underlying C.
-        arma::mat kinetic_l() const override {
-          return C_.t() * underlying_->kinetic_l() * C_;
+        helfem::Matrix kinetic_l() const override {
+          arma::mat Tl_arma = C_.t() * helfem::to_arma(underlying_->kinetic_l()) * C_;
+          return helfem::to_eigen(Tl_arma);
         }
 
         /// V_NAO = C^T V_underlying C (Z=1; caller multiplies by +Z).
-        arma::mat nuclear() const override {
-          return C_.t() * underlying_->nuclear() * C_;
+        helfem::Matrix nuclear() const override {
+          arma::mat V_arma = C_.t() * helfem::to_arma(underlying_->nuclear()) * C_;
+          return helfem::to_eigen(V_arma);
         }
 
         /// Evaluate the NAO orbitals (columns of C_orb in the NAO basis)

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -43,15 +43,18 @@ namespace helfem {
         virtual helfem::Matrix overlap() const = 0;
         /// Radial kinetic matrix (1/2) integral u'_i(r) u'_j(r) dr.
         /// EXCLUDES the centrifugal term -- caller adds l*(l+1) * kinetic_l().
-        virtual arma::mat kinetic() const = 0;
+        /// Eigen-typed (Phase 2a migration; follows overlap() in PR #103).
+        virtual helfem::Matrix kinetic() const = 0;
         /// Half the centrifugal-per-l(l+1) matrix:
         /// (1/2) integral u_i(r) u_j(r) / r^2 dr.
         /// Full centrifugal contribution is l*(l+1) * kinetic_l().
-        virtual arma::mat kinetic_l() const = 0;
+        /// Eigen-typed (Phase 2a migration).
+        virtual helfem::Matrix kinetic_l() const = 0;
         /// Nuclear attraction at Z=1 (sign included):
         /// - integral u_i(r) u_j(r) / r dr.
         /// For arbitrary Z, the caller multiplies by +Z.
-        virtual arma::mat nuclear() const = 0;
+        /// Eigen-typed (Phase 2a migration).
+        virtual helfem::Matrix nuclear() const = 0;
 
         /// Evaluate orbitals (columns of C) at a given r.
         virtual arma::vec eval_orbs(const arma::mat & C, double r) const = 0;
@@ -180,17 +183,18 @@ namespace helfem {
         /// Compute overlap matrix in element
         arma::mat overlap(size_t iel) const;
 
-        /// Compute primitive kinetic energy matrix (excluding l part)
-        arma::mat kinetic() const override;
+        /// Compute primitive kinetic energy matrix (excluding l part).
+        /// Eigen-typed; Phase 2a migration.
+        helfem::Matrix kinetic() const override;
         /// Compute primitive kinetic energy matrix in element (excluding l
         /// part)
         arma::mat kinetic(size_t iel) const;
-        /// Compute l part of kinetic energy matrix
-        arma::mat kinetic_l() const override;
+        /// Compute l part of kinetic energy matrix (Eigen; Phase 2a).
+        helfem::Matrix kinetic_l() const override;
         /// Compute l part of kinetic energy matrix in element
         arma::mat kinetic_l(size_t iel) const;
-        /// Compute nuclear attraction matrix
-        arma::mat nuclear() const override;
+        /// Compute nuclear attraction matrix (Eigen; Phase 2a).
+        helfem::Matrix nuclear() const override;
         /// Compute nuclear attraction matrix in element
         arma::mat nuclear(size_t iel) const;
 	/// Compute polynomial confinement potential matrix in element

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -278,13 +278,13 @@ namespace helfem {
       helfem::Matrix FEMRadialBasis::overlap()    const { return helfem::to_eigen(matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight)); }
       arma::mat FEMRadialBasis::overlap(size_t iel) const { return matrix_element(iel, BasisKind::B0, BasisKind::B0, kNoWeight); }
 
-      arma::mat FEMRadialBasis::kinetic()         const { return 0.5 * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight); }
+      helfem::Matrix FEMRadialBasis::kinetic()    const { return helfem::to_eigen(arma::mat(0.5 * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight))); }
       arma::mat FEMRadialBasis::kinetic(size_t iel) const { return 0.5 * matrix_element(iel, BasisKind::B1, BasisKind::B1, kNoWeight); }
 
-      arma::mat FEMRadialBasis::kinetic_l()       const { return 0.5 * matrix_element(BasisKind::R0, BasisKind::R0, kNoWeight); }
+      helfem::Matrix FEMRadialBasis::kinetic_l()  const { return helfem::to_eigen(arma::mat(0.5 * matrix_element(BasisKind::R0, BasisKind::R0, kNoWeight))); }
       arma::mat FEMRadialBasis::kinetic_l(size_t iel) const { return 0.5 * matrix_element(iel, BasisKind::R0, BasisKind::R0, kNoWeight); }
 
-      arma::mat FEMRadialBasis::nuclear()         const { return -matrix_element(BasisKind::R0, BasisKind::R0, kRWeight); }
+      helfem::Matrix FEMRadialBasis::nuclear()    const { return helfem::to_eigen(arma::mat(-matrix_element(BasisKind::R0, BasisKind::R0, kRWeight))); }
       arma::mat FEMRadialBasis::nuclear(size_t iel) const { return -matrix_element(iel, BasisKind::R0, BasisKind::R0, kRWeight); }
 
       arma::mat FEMRadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -105,9 +105,10 @@ int main(int argc, char **argv) {
   arma::mat S(helfem::to_arma(radial.overlap()));
   arma::mat Sinvh=scf::form_Sinvh(S,false);
 
-  arma::mat T(radial.kinetic());
-  arma::mat Tl(radial.kinetic_l());
-  arma::mat V(radial.nuclear());
+  // Phase 2a: radial.kinetic / kinetic_l / nuclear return helfem::Matrix.
+  arma::mat T(helfem::to_arma(radial.kinetic()));
+  arma::mat Tl(helfem::to_arma(radial.kinetic_l()));
+  arma::mat V(helfem::to_arma(radial.nuclear()));
 
   // Compute orbitals
   for(int l=0;l<=lmax;l++) {


### PR DESCRIPTION
## Summary

Continuation of the `overlap()` tracer in PR #103. The remaining three `RadialBasis` pure-virtual methods (`kinetic`, `kinetic_l`, `nuclear`) now return `helfem::Matrix` instead of `arma::mat`. Same recipe.

After this PR: **the four pure-virtual `RadialBasis` interface methods are all Eigen-typed.**

## Changes

**Base class** (`libhelfem/include/RadialBasis.h`):
```cpp
virtual helfem::Matrix kinetic()    const = 0;
virtual helfem::Matrix kinetic_l()  const = 0;
virtual helfem::Matrix nuclear()    const = 0;
```

**FEMRadialBasis override** (`libhelfem/src/RadialBasis.cpp`): one-liner wrapping `matrix_element(...)` with `helfem::to_eigen` plus an `arma::mat()` materialisation of the scaled expression template (`0.5 * matrix_element` or `-matrix_element`) to disambiguate the `to_eigen` overload (arma expression templates don't auto-convert).

**NAORadialBasis override** (`libhelfem/include/NAORadialBasis.h`): `C_.t() * to_arma(underlying_->X()) * C_` materialised to an `arma::mat` before `to_eigen`, same disambiguation pattern.

**Single caller affected:** `src/sadatom/1e.cpp:108-110` — bridge with `to_arma()` (same pattern as overlap in #103). No other site outside the libhelfem classes calls the no-arg variants.

## Excluded (unaffected by this PR)

- `radial.kinetic(iel)` / `kinetic_l(iel)` / `nuclear(iel)` — per-element variants, separate non-virtual methods; still arma.
- `matrix_element` dispatcher — still arma. Next tracer can migrate it; once that's done, the four virtuals share Eigen internals and don't need the trailing `to_eigen` wrap.

## Validation

- `eigen_foundation_test`: 11/11 assertions PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (matches all printed digits of pre-PR value — matrix_element internals unchanged, only return-path conversion differs)
- `test_radial_df_exhaustive.py`: 3 configs PASS at machine precision (1.11e-16 LIP / 3.16e-13 HIP; the DF path consumes `radial.kinetic()` etc. transitively via the cached helpers)

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [x] **Phase 2a: RadialBasis virtuals (overlap) — PR #103**
- [x] **Phase 2a: + kinetic / kinetic_l / nuclear — this PR**
  - next: `matrix_element` dispatcher; per-element overloads; `twoe_integral` / `radial_integral`
- [ ] Phase 2c: TwoDBasis + CoulombExchangeFE helpers
- [ ] Phase 3: chemistry callers (scope TBD post-libatomscf split — task #6)
- [ ] Phase 4: templatize `Matrix<T>` for arbitrary precision

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] test_radial_df_exhaustive.py passes (3 configs, machine precision)