### PR TITLE
v2: Eigen Phase 2a -- migrate per-element overlap/kinetic/kinetic_l/nuclear

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -181,23 +181,23 @@ namespace helfem {
 
         /// Compute overlap matrix (Eigen-typed; Phase 2a migration).
         helfem::Matrix overlap() const override;
-        /// Compute overlap matrix in element
-        arma::mat overlap(size_t iel) const;
+        /// Compute overlap matrix in element (Eigen-typed; Phase 2a).
+        helfem::Matrix overlap(size_t iel) const;
 
         /// Compute primitive kinetic energy matrix (excluding l part).
         /// Eigen-typed; Phase 2a migration.
         helfem::Matrix kinetic() const override;
         /// Compute primitive kinetic energy matrix in element (excluding l
-        /// part)
-        arma::mat kinetic(size_t iel) const;
+        /// part). Eigen-typed (Phase 2a).
+        helfem::Matrix kinetic(size_t iel) const;
         /// Compute l part of kinetic energy matrix (Eigen; Phase 2a).
         helfem::Matrix kinetic_l() const override;
-        /// Compute l part of kinetic energy matrix in element
-        arma::mat kinetic_l(size_t iel) const;
+        /// Compute l part of kinetic energy matrix in element (Eigen; Phase 2a).
+        helfem::Matrix kinetic_l(size_t iel) const;
         /// Compute nuclear attraction matrix (Eigen; Phase 2a).
         helfem::Matrix nuclear() const override;
-        /// Compute nuclear attraction matrix in element
-        arma::mat nuclear(size_t iel) const;
+        /// Compute nuclear attraction matrix in element (Eigen; Phase 2a).
+        helfem::Matrix nuclear(size_t iel) const;
 	/// Compute polynomial confinement potential matrix in element
 	arma::mat polynomial_confinement(size_t iel, int N, double shift_pot) const;
 	/// Compute exponential confinement potential matrix in element

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -292,17 +292,17 @@ namespace helfem {
       // arithmetic works on the return value with no manual wrapping).
       // Per-element variants stay arma-typed; bridge with to_arma at the
       // matrix_element call site.
-      helfem::Matrix FEMRadialBasis::overlap()    const { return matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight); }
-      arma::mat FEMRadialBasis::overlap(size_t iel) const { return helfem::to_arma(matrix_element(iel, BasisKind::B0, BasisKind::B0, kNoWeight)); }
+      helfem::Matrix FEMRadialBasis::overlap()      const { return matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight); }
+      helfem::Matrix FEMRadialBasis::overlap(size_t iel) const { return matrix_element(iel, BasisKind::B0, BasisKind::B0, kNoWeight); }
 
-      helfem::Matrix FEMRadialBasis::kinetic()    const { return 0.5 * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight); }
-      arma::mat FEMRadialBasis::kinetic(size_t iel) const { return 0.5 * helfem::to_arma(matrix_element(iel, BasisKind::B1, BasisKind::B1, kNoWeight)); }
+      helfem::Matrix FEMRadialBasis::kinetic()      const { return 0.5 * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight); }
+      helfem::Matrix FEMRadialBasis::kinetic(size_t iel) const { return 0.5 * matrix_element(iel, BasisKind::B1, BasisKind::B1, kNoWeight); }
 
-      helfem::Matrix FEMRadialBasis::kinetic_l()  const { return 0.5 * matrix_element(BasisKind::R0, BasisKind::R0, kNoWeight); }
-      arma::mat FEMRadialBasis::kinetic_l(size_t iel) const { return 0.5 * helfem::to_arma(matrix_element(iel, BasisKind::R0, BasisKind::R0, kNoWeight)); }
+      helfem::Matrix FEMRadialBasis::kinetic_l()    const { return 0.5 * matrix_element(BasisKind::R0, BasisKind::R0, kNoWeight); }
+      helfem::Matrix FEMRadialBasis::kinetic_l(size_t iel) const { return 0.5 * matrix_element(iel, BasisKind::R0, BasisKind::R0, kNoWeight); }
 
-      helfem::Matrix FEMRadialBasis::nuclear()    const { return -matrix_element(BasisKind::R0, BasisKind::R0, kRWeight); }
-      arma::mat FEMRadialBasis::nuclear(size_t iel) const { return -helfem::to_arma(matrix_element(iel, BasisKind::R0, BasisKind::R0, kRWeight)); }
+      helfem::Matrix FEMRadialBasis::nuclear()      const { return -matrix_element(BasisKind::R0, BasisKind::R0, kRWeight); }
+      helfem::Matrix FEMRadialBasis::nuclear(size_t iel) const { return -matrix_element(iel, BasisKind::R0, BasisKind::R0, kRWeight); }
 
       arma::mat FEMRadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {
         return helfem::to_arma(matrix_element(iel, BasisKind::R0, BasisKind::R0,

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "TwoDBasis.h"
+#include <ArmaEigen.h>
 #include <CoulombExchangeFE.h>
 #include "basis.h"
 #include "quadrature.h"
@@ -344,8 +345,10 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-          Trad.submat(ifirst,ifirst,ilast,ilast)+=radial.kinetic(iel);
-          Trad_l.submat(ifirst,ifirst,ilast,ilast)+=radial.kinetic_l(iel);
+          // Phase 2a: radial.kinetic(iel) / kinetic_l(iel) now return
+          // helfem::Matrix; bridge here -- TwoDBasis caches are still arma.
+          Trad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic(iel));
+          Trad_l.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic_l(iel));
         }
 
         // Full kinetic energy matrix

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "basis.h"
+#include <ArmaEigen.h>
 #include <CoulombExchangeFE.h>
 #include "chebyshev.h"
 #include "../general/spherical_harmonics.h"
@@ -102,7 +103,7 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-          Trad.submat(ifirst,ifirst,ilast,ilast)+=radial.kinetic(iel);
+          Trad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic(iel));
         }
 
         return Trad;
@@ -119,7 +120,7 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-          Trad_l.submat(ifirst,ifirst,ilast,ilast)+=radial.kinetic_l(iel);
+          Trad_l.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic_l(iel));
         }
 
         return Trad_l;
@@ -912,8 +913,8 @@ namespace helfem {
 	  radial.get_idx(iel,ifirst,ilast);
 	  // Density matrix
 	  arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
-	  // Overlap matrix
-	  arma::mat S(radial.overlap(iel));
+	  // Overlap matrix (Phase 2a: overlap(iel) returns helfem::Matrix).
+	  arma::mat S(helfem::to_arma(radial.overlap(iel)));
 	  densities[iel]=arma::trace(Psub*S);
 	}
 


### PR DESCRIPTION
## Summary

Continuation of PR #107. The four per-element variants now return `helfem::Matrix`, matching the base virtuals. Since the `matrix_element` dispatcher is Eigen-typed (PR #107), each is a one-line direct call — the previous `to_arma` wrapping inside the impls is no longer needed.

## Changes

**Header** (`libhelfem/include/RadialBasis.h`):
```cpp
helfem::Matrix overlap(size_t iel)   const;
helfem::Matrix kinetic(size_t iel)   const;
helfem::Matrix kinetic_l(size_t iel) const;
helfem::Matrix nuclear(size_t iel)   const;
```

**Implementations** (`libhelfem/src/RadialBasis.cpp`):
```cpp
helfem::Matrix overlap(size_t iel)   const { return matrix_element(iel, B0, B0, kNoWeight); }
helfem::Matrix kinetic(size_t iel)   const { return 0.5 * matrix_element(iel, B1, B1, kNoWeight); }
helfem::Matrix kinetic_l(size_t iel) const { return 0.5 * matrix_element(iel, R0, R0, kNoWeight); }
helfem::Matrix nuclear(size_t iel)   const { return -matrix_element(iel, R0, R0, kRWeight); }
```

**Caller updates** (5 sites in chemistry-layer in-tree code):

| File | Line | Method |
|---|---|---|
| `src/atomic/TwoDBasis.cpp` | 347 | `kinetic(iel)` |
| `src/atomic/TwoDBasis.cpp` | 348 | `kinetic_l(iel)` |
| `src/sadatom/basis.cpp` | 106 | `kinetic(iel)` |
| `src/sadatom/basis.cpp` | 123 | `kinetic_l(iel)` |
| `src/sadatom/basis.cpp` | 917 | `overlap(iel)` |

All bridge with `helfem::to_arma()` at the `submat +=` assignment; the `TwoDBasis` caches stay arma until Phase 2c.

## Excluded (next tracers)

`bessel_il_integral`, `bessel_kl_integral`, `radial_integral(int, iel, ...)`, the 2e integral family (`twoe_integral`, `twoe_integral_cholesky`, `yukawa_integral`, `erfc_integral`), confinement helpers, `model_potential`, cross-basis (`overlap(rh)`, `radial_integral(rh, ...)`). All still arma with internal `to_arma` bridge at the `matrix_element` call. Mechanical follow-ups; the per-element variants done here are the most-used in the SCF inner loop.

## Validation

- `eigen_foundation_test`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- `test_radial_df_exhaustive.py`: 3 configs PASS at machine precision (1.11e-16 LIP / 3.16e-13 HIP)

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [x] Phase 2a: overlap virtual — PR #103
- [x] Phase 2a: + kinetic/kinetic_l/nuclear virtuals — PR #106
- [x] Phase 2a: + matrix_element dispatcher — PR #107
- [x] **Phase 2a: + per-element overloads — this PR**
  - next: bessel / radial_integral / 2e — mechanical cascade through TwoDBasis caches; bridge into Phase 2c
- [ ] Phase 2c: TwoDBasis + CoulombExchangeFE helpers
- [ ] Phase 3: chemistry callers (scope TBD post-libatomscf split — task #6)
- [ ] Phase 4: templatize `Matrix<T>` for arbitrary precision

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] test_radial_df_exhaustive.py passes (3 configs, machine precision)