### PR TITLE
v2: Eigen Phase 2a -- migrate radial_integral + bessel_il/kl_integral

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -16,6 +16,7 @@
 #define ATOMIC_BASIS_COULOMB_EXCHANGE_FE_H
 
 #include "RadialBasis.h"
+#include "ArmaEigen.h"
 #include <armadillo>
 #include <functional>
 
@@ -187,13 +188,18 @@ namespace helfem {
 
         inline arma::mat r_small(const FEMRadialBasis & fem, int L, size_t iel,
                                   bool yukawa, double lambda) {
-          return yukawa ? fem.bessel_il_integral(L, lambda, iel)
-                        : fem.radial_integral(L, iel);
+          // Phase 2a: bessel_*_integral and radial_integral return
+          // helfem::Matrix; bridge here since the FE caches (disjoint_L
+          // etc.) are still std::vector<arma::mat>.
+          return helfem::to_arma(
+              yukawa ? fem.bessel_il_integral(L, lambda, iel)
+                     : fem.radial_integral(L, iel));
         }
         inline arma::mat r_big(const FEMRadialBasis & fem, int L, size_t iel,
                                 bool yukawa, double lambda) {
-          return yukawa ? fem.bessel_kl_integral(L, lambda, iel)
-                        : fem.radial_integral(-L - 1, iel);
+          return helfem::to_arma(
+              yukawa ? fem.bessel_kl_integral(L, lambda, iel)
+                     : fem.radial_integral(-L - 1, iel));
         }
         inline arma::mat in_element_tei(const FEMRadialBasis & fem, int L,
                                          size_t iel,

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -119,13 +119,13 @@ namespace helfem {
         arma::mat radial_integral(const arma::mat &bf_c, int n,
                                   size_t iel) const;
         /// Compute radial matrix elements <r^n> in element (overlap is n=0,
-        /// nuclear is n=-1)
-        arma::mat radial_integral(int n, size_t iel, double x_left = -1.0, double x_right = 1.0) const;
+        /// nuclear is n=-1). Eigen-typed (Phase 2a migration).
+        helfem::Matrix radial_integral(int n, size_t iel, double x_left = -1.0, double x_right = 1.0) const;
 
-        /// Compute Bessel i_L integral
-        arma::mat bessel_il_integral(int L, double lambda, size_t iel) const;
-        /// Compute Bessel k_L integral
-        arma::mat bessel_kl_integral(int L, double lambda, size_t iel) const;
+        /// Compute Bessel i_L integral (Eigen; Phase 2a).
+        helfem::Matrix bessel_il_integral(int L, double lambda, size_t iel) const;
+        /// Compute Bessel k_L integral (Eigen; Phase 2a).
+        helfem::Matrix bessel_kl_integral(int L, double lambda, size_t iel) const;
 
         /// Identifies which representation of the radial basis to use when
         /// evaluating bra/ket factors in a matrix element. Bn is the raw FE

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -82,19 +82,15 @@ namespace helfem {
         return fem.get_poly_nnodes();
       }
 
-      arma::mat FEMRadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
+      helfem::Matrix FEMRadialBasis::radial_integral(int Rexp, size_t iel, double x_left, double x_right) const {
         // <R | r^Rexp | R> with the FE-natural dr measure means weight r^(Rexp+2):
         //   integral B(r)^2 r^(Rexp+2) / r^2  dr  =  integral R(r)^2 r^(Rexp+2)  dr
         // = QM <r^Rexp> = integral R^2 r^Rexp r^2 dr.
         const std::function<double(double)> rpowL =
             [Rexp](double r){ return std::pow(r, Rexp + 2); };
-        // Phase 2a: matrix_element now returns helfem::Matrix; bridge to
-        // arma here -- radial_integral itself is still arma-typed (per-
-        // element variant; migrated in a later tracer).
-        arma::mat ret = helfem::to_arma(
-            matrix_element(iel, BasisKind::R0, BasisKind::R0,
-                           rpowL, x_left, x_right));
-        if (ret.has_nan())
+        helfem::Matrix ret = matrix_element(iel, BasisKind::R0, BasisKind::R0,
+                                            rpowL, x_left, x_right);
+        if (ret.array().isNaN().any())
           printf("radial_integral(%i,%i) has NaN!\n", Rexp, (int)iel);
         return ret;
       }
@@ -157,16 +153,14 @@ namespace helfem {
             fem.matrix_element(iel, lhs, rhs, xq, wq, weight, x_left, x_right));
       }
 
-      arma::mat FEMRadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {
-        // Phase 2a: matrix_element now returns helfem::Matrix; bridge here.
-        return helfem::to_arma(matrix_element(iel, BasisKind::B0, BasisKind::B0,
-                              [L, lambda](double r){ return utils::bessel_il(r * lambda, L); }));
+      helfem::Matrix FEMRadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [L, lambda](double r){ return utils::bessel_il(r * lambda, L); });
       }
 
-      arma::mat FEMRadialBasis::bessel_kl_integral(int L, double lambda, size_t iel) const {
-        // Phase 2a: matrix_element now returns helfem::Matrix; bridge here.
-        return helfem::to_arma(matrix_element(iel, BasisKind::B0, BasisKind::B0,
-                              [L, lambda](double r){ return utils::bessel_kl(r * lambda, L); }));
+      helfem::Matrix FEMRadialBasis::bessel_kl_integral(int L, double lambda, size_t iel) const {
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [L, lambda](double r){ return utils::bessel_kl(r * lambda, L); });
       }
 
       // Per-element B-evaluator for cross-basis quadrature. Only B-kinds
@@ -402,13 +396,21 @@ namespace helfem {
       }
 
       arma::mat FEMRadialBasis::nuclear_offcenter(size_t iel, double Rhalf, int L) const {
-        if (fem.element_begin(iel) <= Rhalf)
-          return -sqrt(4.0 * M_PI / (2 * L + 1)) * radial_integral(-L - 1, iel) *
-            std::pow(Rhalf, L);
-        else if (fem.element_end(iel) >= Rhalf)
-          return -sqrt(4.0 * M_PI / (2 * L + 1)) * radial_integral(L, iel) *
-            std::pow(Rhalf, -L - 1);
-        else {
+        // Phase 2a: radial_integral returns helfem::Matrix; materialise
+        // the scalar-times-Matrix expression into a concrete Matrix
+        // before to_arma (disambiguates the Eigen expression-template
+        // overload).
+        if (fem.element_begin(iel) <= Rhalf) {
+          const helfem::Matrix tmp = -sqrt(4.0 * M_PI / (2 * L + 1)) *
+                                      radial_integral(-L - 1, iel) *
+                                      std::pow(Rhalf, L);
+          return helfem::to_arma(tmp);
+        } else if (fem.element_end(iel) >= Rhalf) {
+          const helfem::Matrix tmp = -sqrt(4.0 * M_PI / (2 * L + 1)) *
+                                      radial_integral(L, iel) *
+                                      std::pow(Rhalf, -L - 1);
+          return helfem::to_arma(tmp);
+        } else {
           throw std::logic_error("Nucleus placed within element!\n");
           arma::mat ret;
           return ret;

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -299,7 +299,8 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-	  Orad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(Rexp,iel);
+	  // Phase 2a: radial_integral returns helfem::Matrix; bridge here.
+	  Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(Rexp,iel));
         }
 
         // Full overlap matrix
@@ -386,7 +387,7 @@ namespace helfem {
               // Where are we in the matrix?
               size_t ifirst, ilast;
               radial.get_idx(iel,ifirst,ilast);
-              Vrad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(-1,iel);
+              Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(-1,iel));
             }
             // Fill elements
             for(size_t iang=0;iang<lval.n_elem;iang++)
@@ -512,7 +513,7 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-          Orad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(1,iel);
+          Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(1,iel));
         }
 
         int gmax(std::max(arma::max(lval),arma::max(mval)));
@@ -552,7 +553,7 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-          Orad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(2,iel);
+          Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(2,iel));
         }
 
         int gmax(std::max(arma::max(lval),arma::max(mval)));
@@ -596,8 +597,8 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-          O0rad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(0,iel);
-          O2rad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(2,iel);
+          O0rad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(0,iel));
+          O2rad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(2,iel));
         }
 
         // Full coupling

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -82,7 +82,8 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-	  Orad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(Rexp,iel);
+	  // Phase 2a: radial_integral returns helfem::Matrix; bridge here.
+	  Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(Rexp,iel));
         }
 
         return Orad;
@@ -141,7 +142,7 @@ namespace helfem {
             // Where are we in the matrix?
             size_t ifirst, ilast;
             radial.get_idx(iel,ifirst,ilast);
-            Vrad.submat(ifirst,ifirst,ilast,ilast)+=radial.radial_integral(-1,iel);
+            Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(-1,iel));
           }
 
           return -Z*Vrad;
@@ -556,8 +557,8 @@ namespace helfem {
           radial.get_idx(iel,ifirst,ilast);
           // Density matrix
           arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
-          arma::mat zm(radial.radial_integral(0,iel));
-          arma::mat mo(radial.radial_integral(-1,iel));
+          arma::mat zm(helfem::to_arma(radial.radial_integral(0,iel)));
+          arma::mat mo(helfem::to_arma(radial.radial_integral(-1,iel)));
           zero(iel)=arma::trace(Psub*zm);
           minusone(iel)=arma::trace(Psub*mo);
         }
@@ -941,7 +942,7 @@ namespace helfem {
 	double m=a+(b-a)/2.0;
 	while(b-a>=conv_thr) {
 	  m=a+(b-a)/2.0;
-	  result=arma::trace(Psub*radial.radial_integral(0,ielement,m,1.0));
+	  result=arma::trace(Psub*helfem::to_arma(radial.radial_integral(0,ielement,m,1.0)));
 	  if(result<s_left)
 	    b=m;
 	  else if(result>s_left)


### PR DESCRIPTION
## Summary

Continuation of #108. The three per-element radial-integral helpers (`radial_integral(int n, iel, ...)`, `bessel_il_integral`, `bessel_kl_integral`) now return `helfem::Matrix`. Since the `matrix_element` dispatcher is Eigen-typed (#107), each is a one-line direct call — the previously-needed `to_arma` bridge inside the impls drops out.

## Changes

**Header (`libhelfem/include/RadialBasis.h`):**
```cpp
helfem::Matrix radial_integral(int n, size_t iel,
                                double x_left = -1.0,
                                double x_right = 1.0) const;
helfem::Matrix bessel_il_integral(int L, double lambda, size_t iel) const;
helfem::Matrix bessel_kl_integral(int L, double lambda, size_t iel) const;
```

**Implementations:** direct returns from `matrix_element`, no `to_arma` wrap. The `radial_integral` NaN check switches from arma's `.has_nan()` to Eigen's `.array().isNaN().any()`.

**Internal helpers (`libhelfem/include/CoulombExchangeFE.h` `detail_fe_2e::r_small` / `r_big`):** bridge with `to_arma` since the TwoDBasis caches (`disjoint_L` etc. = `std::vector<arma::mat>`) are unchanged. Added `#include "ArmaEigen.h"` for `to_arma`.

**`nuclear_offcenter`** (still arma-typed): materialises the scalar × Eigen-Matrix expression into a concrete `helfem::Matrix` before `to_arma` to disambiguate the Eigen expression-template overload.

## External caller updates (11 sites, all chemistry-layer in-tree code)

| File | Lines | Method |
|---|---|---|
| `src/atomic/TwoDBasis.cpp` | 302, 389, 515, 555, 599, 600 | `radial_integral` |
| `src/sadatom/basis.cpp` | 85, 144, 559, 560, 944 | `radial_integral` |

All bridge with `helfem::to_arma()` at the `submat +=` / `arma::mat()` construction / `arma::trace()` site. Local arma assembly and the TwoDBasis caches stay arma until Phase 2c.

## Excluded (next tracers)

- confinement helpers (polynomial_, exponential_, barrier_, junq_, confinement_potential)
- 2e integral family (twoe_integral, twoe_integral_cholesky, yukawa_integral, yukawa_integral_cholesky, erfc_integral)
- model_potential (both overloads), overlap(rh), radial_integral(rh, ...)
- radial_integral(const arma::mat & bf_c, int n, iel) — different overload
- nuclear_offcenter, spherical_potential, get_bf

All still arma; internal `to_arma` bridge at the `matrix_element` call.

## Validation

- `eigen_foundation_test`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- `test_radial_df_exhaustive.py`: 3 configs PASS at machine precision (1.11e-16 LIP / 3.16e-13 HIP). The radial DF path consumes `radial_integral` through `CoulombExchangeFE.h`'s `compute_disjoint_radial_integrals`, exercised by this test.

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [x] Phase 2a: overlap virtual — PR #103
- [x] Phase 2a: + kinetic/kinetic_l/nuclear virtuals — PR #106
- [x] Phase 2a: + matrix_element dispatcher — PR #107
- [x] Phase 2a: + per-element overloads — PR #108
- [x] **Phase 2a: + radial_integral / bessel_il / bessel_kl — this PR**
  - next: confinement helpers; 2e integral family; remaining cross-basis / model_potential
- [ ] Phase 2c: TwoDBasis + CoulombExchangeFE helpers
- [ ] Phase 3: chemistry callers (scope TBD post-libatomscf split — task #6)
- [ ] Phase 4: templatize `Matrix<T>` for arbitrary precision

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] test_radial_df_exhaustive.py passes (3 configs, machine precision)