### PR TITLE
v2: Eigen Phase 2a -- migrate 2e integral family (twoe, yukawa, erfc + Cholesky factors)

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -204,8 +204,11 @@ namespace helfem {
         inline arma::mat in_element_tei(const FEMRadialBasis & fem, int L,
                                          size_t iel,
                                          bool yukawa, double lambda) {
-          return yukawa ? fem.yukawa_integral(L, lambda, iel)
-                        : fem.twoe_integral(L, iel);
+          // Phase 2a: twoe_integral / yukawa_integral return helfem::Matrix;
+          // bridge here since prim_tei caches are std::vector<arma::mat>.
+          return helfem::to_arma(
+              yukawa ? fem.yukawa_integral(L, lambda, iel)
+                     : fem.twoe_integral(L, iel));
         }
 
       } // namespace detail_fe_2e
@@ -324,9 +327,11 @@ namespace helfem {
             for (size_t jel = 0; jel < Nel; ++jel) {
               const size_t Ni = radial.Nprim(iel);
               const size_t Nj = radial.Nprim(jel);
+              // Phase 2a: erfc_integral returns helfem::Matrix; bridge
+              // here since rs_ktei is std::vector<arma::mat>.
               rs_ktei[Nel * Nel * (size_t) L + iel * Nel + jel] =
                   helfem::utils::exchange_tei(
-                      radial.erfc_integral(L, mu, iel, jel),
+                      helfem::to_arma(radial.erfc_integral(L, mu, iel, jel)),
                       Ni, Ni, Nj, Nj);
             }
           }

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -215,10 +215,11 @@ namespace helfem {
         /// Compute off-center nuclear attraction matrix in element
         arma::mat nuclear_offcenter(size_t iel, double Rhalf, int L) const;
 
-        /// Compute primitive two-electron integral
-        arma::mat twoe_integral(int L, size_t iel) const;
+        /// Compute primitive two-electron integral (Eigen; Phase 2a).
+        helfem::Matrix twoe_integral(int L, size_t iel) const;
         /// Compute primitive Yukawa-screened two-electron integral
-        arma::mat yukawa_integral(int L, double lambda, size_t iel) const;
+        /// (Eigen; Phase 2a).
+        helfem::Matrix yukawa_integral(int L, double lambda, size_t iel) const;
 
         /// Pivoted-Cholesky decomposition of the in-element 4-index
         /// two-electron tensor twoe_integral(L, iel). Returns L of shape
@@ -236,11 +237,13 @@ namespace helfem {
         /// Assumes the in-element tensor is positive semi-definite; this
         /// holds for the bare Coulomb and Yukawa kernels (both PSD as
         /// integral kernels).
-        arma::mat twoe_integral_cholesky(int L, size_t iel,
-                                         double tol = 1e-12) const;
+        /// Eigen-typed (Phase 2a migration).
+        helfem::Matrix twoe_integral_cholesky(int L, size_t iel,
+                                              double tol = 1e-12) const;
         /// Same as above for the Yukawa-screened tensor yukawa_integral.
-        arma::mat yukawa_integral_cholesky(int L, double lambda, size_t iel,
-                                           double tol = 1e-12) const;
+        /// Eigen-typed (Phase 2a).
+        helfem::Matrix yukawa_integral_cholesky(int L, double lambda, size_t iel,
+                                                double tol = 1e-12) const;
 
         // NOTE: the K-permuted in-element tensor (exchange_tei) is
         // essentially full rank as a PSD matrix (~Ni^2) -- its Cholesky
@@ -251,9 +254,10 @@ namespace helfem {
         // for typical FE rank-vs-Ni ratios but the canonical
         // RI/density-fitting form expected by external drivers like
         // PySCF's DF backend).
-        /// Compute primitive complementary error function two-electron integral
-        arma::mat erfc_integral(int L, double lambda, size_t iel,
-                                size_t jel) const;
+        /// Compute primitive complementary error function two-electron
+        /// integral (Eigen; Phase 2a).
+        helfem::Matrix erfc_integral(int L, double lambda, size_t iel,
+                                     size_t jel) const;
         /// Compute a spherically symmetric potential
         arma::mat spherical_potential(size_t iel) const;
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -417,7 +417,7 @@ namespace helfem {
         }
       }
 
-      arma::mat FEMRadialBasis::twoe_integral(int L, size_t iel) const {
+      helfem::Matrix FEMRadialBasis::twoe_integral(int L, size_t iel) const {
         double Rmin(fem.element_begin(iel));
         double Rmax(fem.element_end(iel));
 
@@ -427,7 +427,7 @@ namespace helfem {
         if(tei.has_nan()) {
           printf("twoe_integral(%i,%i) has NaN!\n",L,(int) iel);
         }
-        return tei;
+        return helfem::to_eigen(tei);
       }
 
       // Pivoted Cholesky with truncation. Returns Lout of shape
@@ -474,19 +474,23 @@ namespace helfem {
         return L;
       }
 
-      arma::mat FEMRadialBasis::twoe_integral_cholesky(int L, size_t iel,
-                                                       double tol) const {
-        return pivoted_cholesky_(twoe_integral(L, iel), tol);
+      helfem::Matrix FEMRadialBasis::twoe_integral_cholesky(int L, size_t iel,
+                                                            double tol) const {
+        // Phase 2a: twoe_integral now returns helfem::Matrix; bridge here
+        // -- pivoted_cholesky_ is arma-based.
+        return helfem::to_eigen(
+            pivoted_cholesky_(helfem::to_arma(twoe_integral(L, iel)), tol));
       }
 
-      arma::mat FEMRadialBasis::yukawa_integral_cholesky(int L, double lambda,
-                                                         size_t iel,
-                                                         double tol) const {
-        return pivoted_cholesky_(yukawa_integral(L, lambda, iel), tol);
+      helfem::Matrix FEMRadialBasis::yukawa_integral_cholesky(int L, double lambda,
+                                                              size_t iel,
+                                                              double tol) const {
+        return helfem::to_eigen(
+            pivoted_cholesky_(helfem::to_arma(yukawa_integral(L, lambda, iel)), tol));
       }
 
 
-      arma::mat FEMRadialBasis::yukawa_integral(int L, double lambda, size_t iel) const {
+      helfem::Matrix FEMRadialBasis::yukawa_integral(int L, double lambda, size_t iel) const {
         double Rmin(fem.element_begin(iel));
         double Rmax(fem.element_end(iel));
 
@@ -494,10 +498,10 @@ namespace helfem {
         std::shared_ptr<const polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
         arma::mat tei(quadrature::yukawa_integral(Rmin, Rmax, xq, wq, p, L, lambda));
 
-        return tei;
+        return helfem::to_eigen(tei);
       }
 
-      arma::mat FEMRadialBasis::erfc_integral(int L, double mu, size_t iel, size_t kel) const {
+      helfem::Matrix FEMRadialBasis::erfc_integral(int L, double mu, size_t iel, size_t kel) const {
         // Number of quadrature points
         size_t Nq = xq.n_elem;
         // Number of subintervals
@@ -552,7 +556,7 @@ namespace helfem {
         if (iel == kel)
           tei = 0.5 * (tei + tei.t());
 
-        return tei;
+        return helfem::to_eigen(tei);
       }
 
       arma::mat FEMRadialBasis::spherical_potential(size_t iel) const {


### PR DESCRIPTION
## Summary

Continuation of #109. The two-electron integral family on `FEMRadialBasis` now returns `helfem::Matrix`:

```cpp
helfem::Matrix twoe_integral(int L, size_t iel) const;
helfem::Matrix yukawa_integral(int L, double lambda, size_t iel) const;
helfem::Matrix erfc_integral(int L, double mu, size_t iel, size_t kel) const;
helfem::Matrix twoe_integral_cholesky(int L, size_t iel, double tol) const;
helfem::Matrix yukawa_integral_cholesky(int L, double lambda, size_t iel, double tol) const;
```

These are the **highest-impact remaining Phase-2a methods** — they feed `TwoDBasis::compute_tei` and the radial DF factor build path. Now every in-element 2e cache flows through Eigen-typed accessors at the `FEMRadialBasis` layer; the TwoDBasis caches (still `std::vector<arma::mat>`) bridge with `to_arma` in `CoulombExchangeFE.h`'s detail helpers, which is the natural cascade point for Phase 2c.

## Implementation

- `twoe_integral` / `yukawa_integral`: `quadrature::*` returns `arma::mat`, wrap with `to_eigen` at the return boundary. NaN check stays on the arma form before conversion.
- `erfc_integral`: similar; in-element symmetrisation `0.5*(tei + tei.t())` stays arma, then `to_eigen` at return.
- `twoe_integral_cholesky` / `yukawa_integral_cholesky`: delegate to the arma-based `pivoted_cholesky_` helper, with `to_arma` at the twoe/yukawa call and `to_eigen` at the final return.

## Internal callers bridged

In `libhelfem/include/CoulombExchangeFE.h`:
- `detail_fe_2e::in_element_tei` — bridges with `to_arma` so the `compute_in_element_tei` cache fill (`std::vector<arma::mat> prim_tei`) is unchanged.
- `compute_erfc_ktei` — bridges `erfc_integral` with `to_arma` before `utils::exchange_tei` (which is arma-typed and produces the pairwise `rs_ktei` cache).

## External callers

**None** in chemistry-layer `src/` (verified by grep). `src/diatomic/basis.cpp` has its own 5-arg `radial.twoe_integral` (takes legtab, L, M, ...) which is a different `RadialBasis` method on the diatomic side, not the `FEMRadialBasis::twoe_integral` migrated here.

## Validation

- `eigen_foundation_test`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- `test_radial_df_exhaustive.py`: 3 configs PASS at machine precision (1.11e-16 LIP / 3.16e-13 HIP). The DF path consumes `twoe_integral` via the `prim_tei` cache fill (exercised) and the Cholesky factor via `radial_df_factors` (also exercised).

## What's left in FEMRadialBasis (still arma)

- confinement helpers (polynomial_, exponential_, barrier_, junq_, confinement_potential)
- model_potential (both overloads)
- overlap(rh), radial_integral(rh, ...) — cross-basis
- nuclear_offcenter, spherical_potential
- get_bf, orbitals, orbitals_derivative
- radial_integral(const arma::mat &, int, iel)

All bridge internally with `to_arma` at the (now Eigen-typed) `matrix_element` / `radial_integral` call. A follow-up tracer can finish them in one go.

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [x] Phase 2a: overlap virtual — PR #103
- [x] Phase 2a: + kinetic/kinetic_l/nuclear virtuals — PR #106
- [x] Phase 2a: + matrix_element dispatcher — PR #107
- [x] Phase 2a: + per-element overloads — PR #108
- [x] Phase 2a: + radial_integral / bessel_il/kl — PR #109
- [x] **Phase 2a: + 2e integral family (twoe, yukawa, erfc + Cholesky) — this PR**
  - last small bits: confinement helpers, cross-basis, get_bf, spherical_potential
- [ ] Phase 2c: TwoDBasis + CoulombExchangeFE caches (`disjoint_L`, `prim_tei`, `rs_ktei` etc.)
- [ ] Phase 3: chemistry callers (scope TBD post-libatomscf split — task #6)
- [ ] Phase 4: templatize `Matrix<T>` for arbitrary precision

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] test_radial_df_exhaustive.py passes (3 configs, machine precision)