### PR TITLE
v2: Eigen Phase 2a -- cross-basis + model_potential + nuclear_offcenter + spherical_potential

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -209,11 +209,12 @@ namespace helfem {
 	/// Driver for computing confinement potential
 	arma::mat confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const;
 
-        /// Compute model potential matrix in element
-        arma::mat model_potential(const modelpotential::ModelPotential *nuc,
-                                  size_t iel) const;
+        /// Compute model potential matrix in element (Eigen; Phase 2a).
+        helfem::Matrix model_potential(const modelpotential::ModelPotential *nuc,
+                                       size_t iel) const;
         /// Compute off-center nuclear attraction matrix in element
-        arma::mat nuclear_offcenter(size_t iel, double Rhalf, int L) const;
+        /// (Eigen; Phase 2a wrap-up).
+        helfem::Matrix nuclear_offcenter(size_t iel, double Rhalf, int L) const;
 
         /// Compute primitive two-electron integral (Eigen; Phase 2a).
         helfem::Matrix twoe_integral(int L, size_t iel) const;
@@ -258,18 +259,18 @@ namespace helfem {
         /// integral (Eigen; Phase 2a).
         helfem::Matrix erfc_integral(int L, double lambda, size_t iel,
                                      size_t jel) const;
-        /// Compute a spherically symmetric potential
-        arma::mat spherical_potential(size_t iel) const;
+        /// Compute a spherically symmetric potential (Eigen; Phase 2a).
+        helfem::Matrix spherical_potential(size_t iel) const;
 
-        /// Compute cross-basis integral
-        arma::mat radial_integral(const FEMRadialBasis &rh, int n,
-                                  bool lhder = false, bool rhder = false) const;
-        /// Compute cross-basis model potential integral
-        arma::mat model_potential(const FEMRadialBasis &rh,
-                                  const modelpotential::ModelPotential *model,
-                                  bool lhder = false, bool rhder = false) const;
-        /// Compute projection
-        arma::mat overlap(const FEMRadialBasis &rh) const;
+        /// Compute cross-basis integral (Eigen; Phase 2a).
+        helfem::Matrix radial_integral(const FEMRadialBasis &rh, int n,
+                                       bool lhder = false, bool rhder = false) const;
+        /// Compute cross-basis model potential integral (Eigen; Phase 2a).
+        helfem::Matrix model_potential(const FEMRadialBasis &rh,
+                                       const modelpotential::ModelPotential *model,
+                                       bool lhder = false, bool rhder = false) const;
+        /// Compute projection (Eigen; Phase 2a).
+        helfem::Matrix overlap(const FEMRadialBasis &rh) const;
 
         /// Evaluate basis functions at quadrature points
         arma::mat get_bf(size_t iel) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -244,25 +244,22 @@ namespace helfem {
         return helfem::to_eigen(S);
       }
 
-      arma::mat FEMRadialBasis::radial_integral(const FEMRadialBasis &rh, int n,
-                                                bool lhder, bool rhder) const {
+      helfem::Matrix FEMRadialBasis::radial_integral(const FEMRadialBasis &rh, int n,
+                                                     bool lhder, bool rhder) const {
         modelpotential::RadialPotential rad(n);
         return model_potential(rh, &rad, lhder, rhder);
       }
 
-      arma::mat FEMRadialBasis::model_potential(const FEMRadialBasis &rh,
-                                                const modelpotential::ModelPotential *model,
-                                                bool lhder, bool rhder) const {
-        // Phase 2a: matrix_element returns Eigen; bridge here to keep
-        // model_potential's arma API for downstream callers.
-        return helfem::to_arma(
-            matrix_element(rh,
-                           lhder ? BasisKind::B1 : BasisKind::B0,
-                           rhder ? BasisKind::B1 : BasisKind::B0,
-                           [model](double r){ return model->V(r); }));
+      helfem::Matrix FEMRadialBasis::model_potential(const FEMRadialBasis &rh,
+                                                     const modelpotential::ModelPotential *model,
+                                                     bool lhder, bool rhder) const {
+        return matrix_element(rh,
+                              lhder ? BasisKind::B1 : BasisKind::B0,
+                              rhder ? BasisKind::B1 : BasisKind::B0,
+                              [model](double r){ return model->V(r); });
       }
 
-      arma::mat FEMRadialBasis::overlap(const FEMRadialBasis &rh) const {
+      helfem::Matrix FEMRadialBasis::overlap(const FEMRadialBasis &rh) const {
         return radial_integral(rh, 0);
       }
 
@@ -389,31 +386,23 @@ namespace helfem {
       }
 
 
-      arma::mat FEMRadialBasis::model_potential(const modelpotential::ModelPotential *model,
-                                                size_t iel) const {
-        return helfem::to_arma(matrix_element(iel, BasisKind::B0, BasisKind::B0,
-                              [model](double r){ return model->V(r); }));
+      helfem::Matrix FEMRadialBasis::model_potential(const modelpotential::ModelPotential *model,
+                                                     size_t iel) const {
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
+                              [model](double r){ return model->V(r); });
       }
 
-      arma::mat FEMRadialBasis::nuclear_offcenter(size_t iel, double Rhalf, int L) const {
-        // Phase 2a: radial_integral returns helfem::Matrix; materialise
-        // the scalar-times-Matrix expression into a concrete Matrix
-        // before to_arma (disambiguates the Eigen expression-template
-        // overload).
+      helfem::Matrix FEMRadialBasis::nuclear_offcenter(size_t iel, double Rhalf, int L) const {
         if (fem.element_begin(iel) <= Rhalf) {
-          const helfem::Matrix tmp = -sqrt(4.0 * M_PI / (2 * L + 1)) *
-                                      radial_integral(-L - 1, iel) *
-                                      std::pow(Rhalf, L);
-          return helfem::to_arma(tmp);
+          return -sqrt(4.0 * M_PI / (2 * L + 1)) *
+                  radial_integral(-L - 1, iel) *
+                  std::pow(Rhalf, L);
         } else if (fem.element_end(iel) >= Rhalf) {
-          const helfem::Matrix tmp = -sqrt(4.0 * M_PI / (2 * L + 1)) *
-                                      radial_integral(L, iel) *
-                                      std::pow(Rhalf, -L - 1);
-          return helfem::to_arma(tmp);
+          return -sqrt(4.0 * M_PI / (2 * L + 1)) *
+                  radial_integral(L, iel) *
+                  std::pow(Rhalf, -L - 1);
         } else {
           throw std::logic_error("Nucleus placed within element!\n");
-          arma::mat ret;
-          return ret;
         }
       }
 
@@ -559,7 +548,7 @@ namespace helfem {
         return helfem::to_eigen(tei);
       }
 
-      arma::mat FEMRadialBasis::spherical_potential(size_t iel) const {
+      helfem::Matrix FEMRadialBasis::spherical_potential(size_t iel) const {
         double Rmin(fem.element_begin(iel));
         double Rmax(fem.element_end(iel));
 
@@ -567,7 +556,7 @@ namespace helfem {
         std::shared_ptr<polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
         arma::mat pot(quadrature::spherical_potential(Rmin, Rmax, xq, wq, p));
 
-        return pot;
+        return helfem::to_eigen(pot);
       }
 
       arma::mat FEMRadialBasis::get_bf(size_t iel) const {

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -322,7 +322,7 @@ namespace helfem {
         arma::mat S(Ndummy(),rh.Ndummy());
         S.zeros();
         // Form radial overlap
-        arma::mat Srad(radial.overlap(rh.radial));
+        arma::mat Srad(helfem::to_arma(radial.overlap(rh.radial)));
 
         // Fill elements
         for(size_t iang=0;iang<lval.n_elem;iang++)
@@ -408,7 +408,7 @@ namespace helfem {
                 // Where are we in the matrix?
                 size_t ifirst, ilast;
                 radial.get_idx(iel,ifirst,ilast);
-                Vaux[L].submat(ifirst,ifirst,ilast,ilast)+=radial.nuclear_offcenter(iel,Rhalf,L);
+                Vaux[L].submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.nuclear_offcenter(iel,Rhalf,L));
               }
             }
 
@@ -461,7 +461,7 @@ namespace helfem {
 	  // Where are we in the matrix?
 	  size_t ifirst, ilast;
 	  radial.get_idx(iel,ifirst,ilast);
-	  Vrad.submat(ifirst,ifirst,ilast,ilast)+=radial.model_potential(pot,iel);
+	  Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.model_potential(pot,iel));
 	}
 	// Fill elements
 	for(size_t iang=0;iang<lval.n_elem;iang++)

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -176,7 +176,8 @@ namespace helfem {
           // Where are we in the matrix?
           size_t ifirst, ilast;
           radial.get_idx(iel,ifirst,ilast);
-          Vrad.submat(ifirst,ifirst,ilast,ilast)+=radial.model_potential(pot,iel);
+          // Phase 2a: model_potential returns helfem::Matrix; bridge.
+          Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.model_potential(pot,iel));
         }
         return Vrad;
       }
@@ -581,7 +582,7 @@ namespace helfem {
           arma::vec Pv(arma::vectorise(Prad.submat(ifirst,ifirst,ilast,ilast)));
 
           // Calculate the in-element potential
-          arma::mat pot(radial.spherical_potential(iel));
+          arma::mat pot(helfem::to_arma(radial.spherical_potential(iel)));
           V[iel] += pot*Pv;
 
           // Add in the contributions from the other elements


### PR DESCRIPTION
## Summary

Continuation of #110. Migrates the 'mid-tier' `FEMRadialBasis` methods that compose the `matrix_element` / `radial_integral` dispatchers or are called from in-tree chemistry assembly:

```cpp
helfem::Matrix model_potential(const ModelPotential *, size_t iel) const;
helfem::Matrix model_potential(const FEMRadialBasis & rh,
                                const ModelPotential *,
                                bool lhder, bool rhder) const;
helfem::Matrix radial_integral(const FEMRadialBasis & rh, int n,
                                bool lhder, bool rhder) const;
helfem::Matrix overlap(const FEMRadialBasis & rh) const;
helfem::Matrix nuclear_offcenter(size_t iel, double Rhalf, int L) const;
helfem::Matrix spherical_potential(size_t iel) const;
```

After this PR the `matrix_element` / `radial_integral` chain is **entirely Eigen-typed**.

## Caller updates (5 sites)

| File | Line | Method |
|---|---|---|
| `src/atomic/TwoDBasis.cpp` | 325 | `overlap(rh.radial)` |
| `src/atomic/TwoDBasis.cpp` | 411 | `nuclear_offcenter` |
| `src/atomic/TwoDBasis.cpp` | 464 | `model_potential(pot, iel)` |
| `src/sadatom/basis.cpp` | 179 | `model_potential(pot, iel)` |
| `src/sadatom/basis.cpp` | 584 | `spherical_potential` |

All bridge with `helfem::to_arma()`. `radial_integral(rh, ...)` has no external callers in libhelfem consumers — used internally by `overlap(rh)` which is migrated.

## What's left in FEMRadialBasis (still arma)

| Method | Reason |
|---|---|
| `get_bf` / `get_df` / `get_lf` (per-element + per-x-point) | Heavily used by diatomic/basis.cpp basis-function evaluation (~10 call sites) + sadatom plotting; wide cascade, low strategic value vs Phase 2c |
| `orbitals` / `orbitals_derivative` / `orbitals_second_derivative` | Low-frequency dump / plot helpers |
| Confinement helpers (polynomial_, exponential_, barrier_, junq_, confinement_potential) | Single caller in sadatom/basis.cpp confined-atom path |
| `radial_integral(const arma::mat & bf_c, int n, iel)` | Different overload, low-frequency |

These bridge cleanly with `to_arma` where called. Phase 2c (TwoDBasis cache migration) is now the more impactful next step; finishing these later is a mechanical sweep that doesn't block 2c.

## Validation

- `eigen_foundation_test`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- `test_radial_df_exhaustive.py`: 3 configs PASS at machine precision

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [x] Phase 2a: overlap virtual — PR #103
- [x] Phase 2a: + kinetic/kinetic_l/nuclear virtuals — PR #106
- [x] Phase 2a: + matrix_element dispatcher — PR #107
- [x] Phase 2a: + per-element overloads — PR #108
- [x] Phase 2a: + radial_integral / bessel_il/kl — PR #109
- [x] Phase 2a: + 2e integral family — PR #110
- [x] **Phase 2a: + cross-basis / model_potential / nuclear_offcenter / spherical_potential — this PR**
  - last small bits (get_bf, confinement, orbitals) deferred — mechanical sweep when needed
- [ ] **Phase 2c: TwoDBasis + CoulombExchangeFE caches** — now unblocked
- [ ] Phase 3: chemistry callers (scope TBD post-libatomscf split)
- [ ] Phase 4: templatize `Matrix<T>` for arbitrary precision

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] test_radial_df_exhaustive.py passes (3 configs, machine precision)