### PR TITLE
v2: Eigen Phase 2c -- TwoDBasis caches + CoulombExchangeFE helpers

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -74,8 +74,10 @@ namespace helfem {
       /// in mind. Used by the cached overloads below so that consumers
       /// with their own per-(L, iel) integral caches (e.g. TwoDBasis,
       /// driven from an SCF loop) avoid recomputing on every call.
+      // Phase 2c: accessor types now return Eigen Matrix references,
+      // matching the new TwoDBasis cache types (std::vector<helfem::Matrix>).
       using PerElementAccessor =
-          std::function<const arma::mat & (size_t iel)>;
+          std::function<const helfem::Matrix & (size_t iel)>;
 
       // -- Uncached entry points --------------------------------------
 
@@ -129,7 +131,7 @@ namespace helfem {
       /// standard K contraction is applied. No disjoint optimisation
       /// available -- O(Nel^2) per call.
       using PerElementPairAccessor =
-          std::function<const arma::mat & (size_t iel, size_t jel)>;
+          std::function<const helfem::Matrix & (size_t iel, size_t jel)>;
       arma::mat assemble_K_FE_one_multipole_cached_pairwise(
           const FEMRadialBasis & radial,
           const PerElementPairAccessor & ktei_pairwise,
@@ -186,29 +188,23 @@ namespace helfem {
 
       namespace detail_fe_2e {
 
-        inline arma::mat r_small(const FEMRadialBasis & fem, int L, size_t iel,
-                                  bool yukawa, double lambda) {
-          // Phase 2a: bessel_*_integral and radial_integral return
-          // helfem::Matrix; bridge here since the FE caches (disjoint_L
-          // etc.) are still std::vector<arma::mat>.
-          return helfem::to_arma(
-              yukawa ? fem.bessel_il_integral(L, lambda, iel)
-                     : fem.radial_integral(L, iel));
+        // Phase 2c: caches are std::vector<helfem::Matrix>; the bridges
+        // these used to do are no longer needed -- direct return.
+        inline helfem::Matrix r_small(const FEMRadialBasis & fem, int L, size_t iel,
+                                       bool yukawa, double lambda) {
+          return yukawa ? fem.bessel_il_integral(L, lambda, iel)
+                        : fem.radial_integral(L, iel);
         }
-        inline arma::mat r_big(const FEMRadialBasis & fem, int L, size_t iel,
-                                bool yukawa, double lambda) {
-          return helfem::to_arma(
-              yukawa ? fem.bessel_kl_integral(L, lambda, iel)
-                     : fem.radial_integral(-L - 1, iel));
+        inline helfem::Matrix r_big(const FEMRadialBasis & fem, int L, size_t iel,
+                                     bool yukawa, double lambda) {
+          return yukawa ? fem.bessel_kl_integral(L, lambda, iel)
+                        : fem.radial_integral(-L - 1, iel);
         }
-        inline arma::mat in_element_tei(const FEMRadialBasis & fem, int L,
-                                         size_t iel,
-                                         bool yukawa, double lambda) {
-          // Phase 2a: twoe_integral / yukawa_integral return helfem::Matrix;
-          // bridge here since prim_tei caches are std::vector<arma::mat>.
-          return helfem::to_arma(
-              yukawa ? fem.yukawa_integral(L, lambda, iel)
-                     : fem.twoe_integral(L, iel));
+        inline helfem::Matrix in_element_tei(const FEMRadialBasis & fem, int L,
+                                              size_t iel,
+                                              bool yukawa, double lambda) {
+          return yukawa ? fem.yukawa_integral(L, lambda, iel)
+                        : fem.twoe_integral(L, iel);
         }
 
       } // namespace detail_fe_2e
@@ -237,8 +233,8 @@ namespace helfem {
       inline void compute_disjoint_radial_integrals(
           const FEMRadialBasis & radial,
           int N_L,
-          std::vector<arma::mat> & disjoint_small,
-          std::vector<arma::mat> & disjoint_big,
+          std::vector<helfem::Matrix> & disjoint_small,
+          std::vector<helfem::Matrix> & disjoint_big,
           bool yukawa = false,
           double lambda = 0.0) {
         const size_t Nel = radial.Nel();
@@ -264,7 +260,7 @@ namespace helfem {
       inline void compute_in_element_tei(
           const FEMRadialBasis & radial,
           int N_L,
-          std::vector<arma::mat> & prim_tei,
+          std::vector<helfem::Matrix> & prim_tei,
           bool yukawa = false,
           double lambda = 0.0) {
         const size_t Nel = radial.Nel();
@@ -286,8 +282,8 @@ namespace helfem {
       inline void compute_in_element_ktei_from_tei(
           const FEMRadialBasis & radial,
           int N_L,
-          const std::vector<arma::mat> & prim_tei,
-          std::vector<arma::mat> & prim_ktei) {
+          const std::vector<helfem::Matrix> & prim_tei,
+          std::vector<helfem::Matrix> & prim_ktei) {
         const size_t Nel = radial.Nel();
         prim_ktei.resize(Nel * Nel * (size_t) N_L);
 #ifdef _OPENMP
@@ -296,10 +292,13 @@ namespace helfem {
         for (int L = 0; L < N_L; ++L) {
           for (size_t iel = 0; iel < Nel; ++iel) {
             const size_t Ni = radial.Nprim(iel);
+            // utils::exchange_tei is arma-based; bridge here.
+            // Phase 2c: prim_tei / prim_ktei caches are Eigen.
             prim_ktei[Nel * Nel * (size_t) L + iel * Nel + iel] =
-                helfem::utils::exchange_tei(
-                    prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel],
-                    Ni, Ni, Ni, Ni);
+                helfem::to_eigen(helfem::utils::exchange_tei(
+                    helfem::to_arma(
+                        prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel]),
+                    Ni, Ni, Ni, Ni));
           }
         }
       }
@@ -316,7 +315,7 @@ namespace helfem {
           const FEMRadialBasis & radial,
           int N_L,
           double mu,
-          std::vector<arma::mat> & rs_ktei) {
+          std::vector<helfem::Matrix> & rs_ktei) {
         const size_t Nel = radial.Nel();
         rs_ktei.resize(Nel * Nel * (size_t) N_L);
 #ifdef _OPENMP
@@ -327,12 +326,12 @@ namespace helfem {
             for (size_t jel = 0; jel < Nel; ++jel) {
               const size_t Ni = radial.Nprim(iel);
               const size_t Nj = radial.Nprim(jel);
-              // Phase 2a: erfc_integral returns helfem::Matrix; bridge
-              // here since rs_ktei is std::vector<arma::mat>.
+              // utils::exchange_tei is arma-based; convert here.
+              // Phase 2c: rs_ktei is std::vector<helfem::Matrix>.
               rs_ktei[Nel * Nel * (size_t) L + iel * Nel + jel] =
-                  helfem::utils::exchange_tei(
+                  helfem::to_eigen(helfem::utils::exchange_tei(
                       helfem::to_arma(radial.erfc_integral(L, mu, iel, jel)),
-                      Ni, Ni, Nj, Nj);
+                      Ni, Ni, Nj, Nj));
             }
           }
         }
@@ -343,6 +342,10 @@ namespace helfem {
       // NAO use) and cached (look-up-from-SCF-cache, TwoDBasis use)
       // entry points.
 
+      // Phase 2c: assemble helpers migrated to Eigen internals so they
+      // match the new Eigen-typed accessors and caches. P_FE input and
+      // J/K output are still arma (the TwoDBasis SCF assembly is still
+      // arma-typed) -- bridged at the entry/exit boundary.
       inline arma::mat assemble_J_FE_one_multipole_cached(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
@@ -350,34 +353,39 @@ namespace helfem {
           const PerElementAccessor & twoe_in_element,
           const arma::mat & P_FE) {
         const size_t Nel  = radial.Nel();
-        const size_t Nrad = radial.Nbf();
-        arma::mat J_FE(Nrad, Nrad, arma::fill::zeros);
+        const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
+        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        helfem::Matrix J_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
           radial.get_idx(jel, jfirst, jlast);
-          const size_t Nj = jlast - jfirst + 1;
-          arma::mat Psub = P_FE.submat(jfirst, jfirst, jlast, jlast);
-          const double jsmall = arma::trace(r_small(jel) * Psub);
-          const double jbig   = arma::trace(r_big  (jel) * Psub);
+          const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
+          const helfem::Matrix Psub =
+              P_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj);
+          const double jsmall = (r_small(jel) * Psub).trace();
+          const double jbig   = (r_big  (jel) * Psub).trace();
           for (size_t iel = 0; iel < jel; ++iel) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
-            J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                jbig * r_small(iel);
+            const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
+            J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
+                += jbig * r_small(iel);
           }
           for (size_t iel = jel + 1; iel < Nel; ++iel) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
-            J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                jsmall * r_big(iel);
+            const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
+            J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
+                += jsmall * r_big(iel);
           }
-          // In-element 4-index contribution.
-          arma::vec Psub_v = arma::vectorise(Psub);
-          arma::vec Jsub_v = twoe_in_element(jel) * Psub_v;
-          J_FE.submat(jfirst, jfirst, jlast, jlast) +=
-              arma::reshape(Jsub_v, Nj, Nj);
+          // In-element 4-index contribution: J_sub = twoe * vec(Psub),
+          // then reshape back to Nj x Nj.
+          const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Nj * Nj);
+          const Eigen::VectorXd Jsub_v = twoe_in_element(jel) * Psub_v;
+          J_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj)
+              += Eigen::Map<const Eigen::MatrixXd>(Jsub_v.data(), Nj, Nj);
         }
-        return J_FE;
+        return helfem::to_arma(J_E);
       }
 
       inline arma::mat assemble_K_FE_one_multipole_cached(
@@ -387,32 +395,35 @@ namespace helfem {
           const PerElementAccessor & ktei_in_element,
           const arma::mat & P_FE) {
         const size_t Nel  = radial.Nel();
-        const size_t Nrad = radial.Nbf();
-        arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
+        const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
+        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
           radial.get_idx(iel, ifirst, ilast);
-          const size_t Ni = ilast - ifirst + 1;
+          const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
           for (size_t jel = 0; jel < Nel; ++jel) {
             size_t jfirst, jlast;
             radial.get_idx(jel, jfirst, jlast);
-            const size_t Nj = jlast - jfirst + 1;
+            const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
             if (iel == jel) {
-              arma::vec Psub_v = arma::vectorise(
-                  P_FE.submat(ifirst, jfirst, ilast, jlast));
-              arma::vec Ksub_v = ktei_in_element(iel) * Psub_v;
-              K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                  arma::reshape(Ksub_v, Ni, Nj);
+              const helfem::Matrix Psub =
+                  P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
+              const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Ni * Nj);
+              const Eigen::VectorXd Ksub_v = ktei_in_element(iel) * Psub_v;
+              K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
+                  += Eigen::Map<const Eigen::MatrixXd>(Ksub_v.data(), Ni, Nj);
             } else {
-              const arma::mat & iint = (iel > jel) ? r_big(iel) : r_small(iel);
-              const arma::mat & jint = (iel > jel) ? r_small(jel) : r_big(jel);
-              const arma::mat Psub = P_FE.submat(ifirst, jfirst, ilast, jlast);
-              K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                  iint * (Psub * jint.t());
+              const helfem::Matrix & iint = (iel > jel) ? r_big(iel) : r_small(iel);
+              const helfem::Matrix & jint = (iel > jel) ? r_small(jel) : r_big(jel);
+              const helfem::Matrix Psub =
+                  P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
+              K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
+                  += iint * (Psub * jint.transpose());
             }
           }
         }
-        return K_FE;
+        return helfem::to_arma(K_E);
       }
 
       inline arma::mat assemble_K_FE_one_multipole_cached_pairwise(
@@ -420,24 +431,26 @@ namespace helfem {
           const PerElementPairAccessor & ktei_pairwise,
           const arma::mat & P_FE) {
         const size_t Nel  = radial.Nel();
-        const size_t Nrad = radial.Nbf();
-        arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
+        const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
+        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
           radial.get_idx(iel, ifirst, ilast);
-          const size_t Ni = ilast - ifirst + 1;
+          const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
           for (size_t jel = 0; jel < Nel; ++jel) {
             size_t jfirst, jlast;
             radial.get_idx(jel, jfirst, jlast);
-            const size_t Nj = jlast - jfirst + 1;
-            arma::vec Psub_v = arma::vectorise(
-                P_FE.submat(ifirst, jfirst, ilast, jlast));
-            arma::vec Ksub_v = ktei_pairwise(iel, jel) * Psub_v;
-            K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                arma::reshape(Ksub_v, Ni, Nj);
+            const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
+            const helfem::Matrix Psub =
+                P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
+            const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Ni * Nj);
+            const Eigen::VectorXd Ksub_v = ktei_pairwise(iel, jel) * Psub_v;
+            K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
+                += Eigen::Map<const Eigen::MatrixXd>(Ksub_v.data(), Ni, Nj);
           }
         }
-        return K_FE;
+        return helfem::to_arma(K_E);
       }
 
       // --- Cholesky-factored cached helpers -----------------------------
@@ -452,39 +465,43 @@ namespace helfem {
           const PerElementAccessor & twoe_chol_J,
           const arma::mat & P_FE) {
         const size_t Nel  = radial.Nel();
-        const size_t Nrad = radial.Nbf();
-        arma::mat J_FE(Nrad, Nrad, arma::fill::zeros);
+        const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
+        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        helfem::Matrix J_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
           radial.get_idx(jel, jfirst, jlast);
-          const size_t Nj = jlast - jfirst + 1;
-          arma::mat Psub = P_FE.submat(jfirst, jfirst, jlast, jlast);
-          const double jsmall = arma::trace(r_small(jel) * Psub);
-          const double jbig   = arma::trace(r_big  (jel) * Psub);
+          const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
+          const helfem::Matrix Psub =
+              P_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj);
+          const double jsmall = (r_small(jel) * Psub).trace();
+          const double jbig   = (r_big  (jel) * Psub).trace();
           for (size_t iel = 0; iel < jel; ++iel) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
-            J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                jbig * r_small(iel);
+            const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
+            J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
+                += jbig * r_small(iel);
           }
           for (size_t iel = jel + 1; iel < Nel; ++iel) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
-            J_FE.submat(ifirst, ifirst, ilast, ilast) +=
-                jsmall * r_big(iel);
+            const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
+            J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
+                += jsmall * r_big(iel);
           }
           // Factored in-element contribution.
           //   J_{ab} = Sum_p L(ab, p) . <L_p, P>
-          // with the (ab) pair packed column-major (a-fast, b-slow) -- so
-          // vec(P) (Armadillo column-major) matches L's row layout.
-          const arma::mat & L = twoe_chol_J(jel);
-          arma::vec Psub_v = arma::vectorise(Psub);
-          arma::vec scalars = L.t() * Psub_v;           // length r
-          arma::vec Jsub_v  = L * scalars;              // length Nj^2
-          J_FE.submat(jfirst, jfirst, jlast, jlast) +=
-              arma::reshape(Jsub_v, Nj, Nj);
+          // with the (ab) pair packed column-major (a-fast, b-slow) so
+          // vec(P) (Eigen also column-major) matches L's row layout.
+          const helfem::Matrix & L = twoe_chol_J(jel);
+          const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Nj * Nj);
+          const Eigen::VectorXd scalars = L.transpose() * Psub_v;  // length r
+          const Eigen::VectorXd Jsub_v  = L * scalars;             // length Nj^2
+          J_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj)
+              += Eigen::Map<const Eigen::MatrixXd>(Jsub_v.data(), Nj, Nj);
         }
-        return J_FE;
+        return helfem::to_arma(J_E);
       }
 
       inline arma::mat assemble_K_FE_one_multipole_cached_chol(
@@ -494,65 +511,71 @@ namespace helfem {
           const PerElementAccessor & twoe_chol_J,
           const arma::mat & P_FE) {
         const size_t Nel  = radial.Nel();
-        const size_t Nrad = radial.Nbf();
-        arma::mat K_FE(Nrad, Nrad, arma::fill::zeros);
+        const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
+        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
           radial.get_idx(iel, ifirst, ilast);
-          const size_t Ni = ilast - ifirst + 1;
+          const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
           for (size_t jel = 0; jel < Nel; ++jel) {
             size_t jfirst, jlast;
             radial.get_idx(jel, jfirst, jlast);
-            const size_t Nj = jlast - jfirst + 1;
+            const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
             if (iel == jel) {
               // Factored in-element K via the J-ordered Cholesky factor:
               //   K_{a,c} = Sum_p (M_p . P . M_p^T)_{a,c}
-              // with M_p = reshape(L.col(p), Ni, Ni) (Armadillo
-              // column-major so M_p(a, b) = L(a + b*Ni, p), matching the
-              // (ab) row pair in twoe_integral).
-              const arma::mat & L = twoe_chol_J(iel);
-              const arma::mat Psub = P_FE.submat(ifirst, jfirst, ilast, jlast);
-              arma::mat Ksub(Ni, Nj, arma::fill::zeros);
-              for (arma::uword p = 0; p < L.n_cols; ++p) {
-                arma::mat Mp = arma::reshape(L.col(p), Ni, Ni);
-                Ksub += Mp * (Psub * Mp.t());
+              // with M_p = reshape(L.col(p), Ni, Ni) (column-major so
+              // M_p(a, b) = L(a + b*Ni, p), matching the (ab) row pair
+              // in twoe_integral).
+              const helfem::Matrix & L = twoe_chol_J(iel);
+              const helfem::Matrix Psub =
+                  P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
+              helfem::Matrix Ksub = helfem::Matrix::Zero(Ni, Nj);
+              for (Eigen::Index p = 0; p < L.cols(); ++p) {
+                Eigen::Map<const Eigen::MatrixXd> Mp(L.col(p).data(), Ni, Ni);
+                Ksub += Mp * (Psub * Mp.transpose());
               }
-              K_FE.submat(ifirst, jfirst, ilast, jlast) += Ksub;
+              K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
+                  += Ksub;
             } else {
-              const arma::mat & iint = (iel > jel) ? r_big(iel) : r_small(iel);
-              const arma::mat & jint = (iel > jel) ? r_small(jel) : r_big(jel);
-              const arma::mat Psub = P_FE.submat(ifirst, jfirst, ilast, jlast);
-              K_FE.submat(ifirst, jfirst, ilast, jlast) +=
-                  iint * (Psub * jint.t());
+              const helfem::Matrix & iint = (iel > jel) ? r_big(iel) : r_small(iel);
+              const helfem::Matrix & jint = (iel > jel) ? r_small(jel) : r_big(jel);
+              const helfem::Matrix Psub =
+                  P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
+              K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
+                  += iint * (Psub * jint.transpose());
             }
           }
         }
-        return K_FE;
+        return helfem::to_arma(K_E);
       }
 
       // The uncached entry points just wire on-the-fly accessors that
       // call the FE primitives directly.
 
+      // Phase 2c: scratchpads are now std::vector<helfem::Matrix>; the
+      // is_empty check becomes .size() == 0 (Eigen's empty-by-default).
       inline arma::mat assemble_J_FE_one_multipole(
           const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
         // Per-call temporaries to keep the accessor lambdas returning a
         // stable const reference (storing each computed matrix in a
         // capture-list scratchpad).
-        std::vector<arma::mat> scratch_small(radial.Nel());
-        std::vector<arma::mat> scratch_big  (radial.Nel());
-        std::vector<arma::mat> scratch_twoe (radial.Nel());
-        auto rs = [&](size_t iel) -> const arma::mat & {
-          if (scratch_small[iel].is_empty())
+        std::vector<helfem::Matrix> scratch_small(radial.Nel());
+        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
+        std::vector<helfem::Matrix> scratch_twoe (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_small[iel].size() == 0)
             scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, false, 0.0);
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const arma::mat & {
-          if (scratch_big[iel].is_empty())
+        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_big[iel].size() == 0)
             scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, false, 0.0);
           return scratch_big[iel];
         };
-        auto tw = [&](size_t iel) -> const arma::mat & {
-          if (scratch_twoe[iel].is_empty())
+        auto tw = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_twoe[iel].size() == 0)
             scratch_twoe[iel] = detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0);
           return scratch_twoe[iel];
         };
@@ -561,27 +584,28 @@ namespace helfem {
 
       inline arma::mat assemble_K_FE_one_multipole(
           const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
-        std::vector<arma::mat> scratch_small(radial.Nel());
-        std::vector<arma::mat> scratch_big  (radial.Nel());
-        std::vector<arma::mat> scratch_ktei (radial.Nel());
-        auto rs = [&](size_t iel) -> const arma::mat & {
-          if (scratch_small[iel].is_empty())
+        std::vector<helfem::Matrix> scratch_small(radial.Nel());
+        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
+        std::vector<helfem::Matrix> scratch_ktei (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_small[iel].size() == 0)
             scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, false, 0.0);
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const arma::mat & {
-          if (scratch_big[iel].is_empty())
+        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_big[iel].size() == 0)
             scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, false, 0.0);
           return scratch_big[iel];
         };
-        auto kt = [&](size_t iel) -> const arma::mat & {
-          if (scratch_ktei[iel].is_empty()) {
+        auto kt = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_ktei[iel].size() == 0) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
-            scratch_ktei[iel] = utils::exchange_tei(
-                detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0),
-                Ni, Ni, Ni, Ni);
+            // utils::exchange_tei is arma-based; bridge for now.
+            scratch_ktei[iel] = helfem::to_eigen(utils::exchange_tei(
+                helfem::to_arma(detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0)),
+                Ni, Ni, Ni, Ni));
           }
           return scratch_ktei[iel];
         };
@@ -591,21 +615,21 @@ namespace helfem {
       inline arma::mat assemble_J_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
           const arma::mat & P_FE) {
-        std::vector<arma::mat> scratch_small(radial.Nel());
-        std::vector<arma::mat> scratch_big  (radial.Nel());
-        std::vector<arma::mat> scratch_twoe (radial.Nel());
-        auto rs = [&](size_t iel) -> const arma::mat & {
-          if (scratch_small[iel].is_empty())
+        std::vector<helfem::Matrix> scratch_small(radial.Nel());
+        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
+        std::vector<helfem::Matrix> scratch_twoe (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_small[iel].size() == 0)
             scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, true, lambda);
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const arma::mat & {
-          if (scratch_big[iel].is_empty())
+        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_big[iel].size() == 0)
             scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, true, lambda);
           return scratch_big[iel];
         };
-        auto tw = [&](size_t iel) -> const arma::mat & {
-          if (scratch_twoe[iel].is_empty())
+        auto tw = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_twoe[iel].size() == 0)
             scratch_twoe[iel] = detail_fe_2e::in_element_tei(radial, L, iel, true, lambda);
           return scratch_twoe[iel];
         };
@@ -615,27 +639,27 @@ namespace helfem {
       inline arma::mat assemble_K_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
           const arma::mat & P_FE) {
-        std::vector<arma::mat> scratch_small(radial.Nel());
-        std::vector<arma::mat> scratch_big  (radial.Nel());
-        std::vector<arma::mat> scratch_ktei (radial.Nel());
-        auto rs = [&](size_t iel) -> const arma::mat & {
-          if (scratch_small[iel].is_empty())
+        std::vector<helfem::Matrix> scratch_small(radial.Nel());
+        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
+        std::vector<helfem::Matrix> scratch_ktei (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_small[iel].size() == 0)
             scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, true, lambda);
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const arma::mat & {
-          if (scratch_big[iel].is_empty())
+        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_big[iel].size() == 0)
             scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, true, lambda);
           return scratch_big[iel];
         };
-        auto kt = [&](size_t iel) -> const arma::mat & {
-          if (scratch_ktei[iel].is_empty()) {
+        auto kt = [&](size_t iel) -> const helfem::Matrix & {
+          if (scratch_ktei[iel].size() == 0) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
-            scratch_ktei[iel] = utils::exchange_tei(
-                detail_fe_2e::in_element_tei(radial, L, iel, true, lambda),
-                Ni, Ni, Ni, Ni);
+            scratch_ktei[iel] = helfem::to_eigen(utils::exchange_tei(
+                helfem::to_arma(detail_fe_2e::in_element_tei(radial, L, iel, true, lambda)),
+                Ni, Ni, Ni, Ni));
           }
           return scratch_ktei[iel];
         };

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -673,13 +673,14 @@ namespace helfem {
 
         for (int L = 0; L < N_L; ++L) {
           // -- 1. Cached accessor lambdas for the per-L J helper.
-          auto rs = [&, L](size_t iel) -> const arma::mat & {
+          // Phase 2c: caches are now std::vector<helfem::Matrix>.
+          auto rs = [&, L](size_t iel) -> const helfem::Matrix & {
             return disjoint_L[(size_t) L * Nel + iel];
           };
-          auto rb = [&, L](size_t iel) -> const arma::mat & {
+          auto rb = [&, L](size_t iel) -> const helfem::Matrix & {
             return disjoint_m1L[(size_t) L * Nel + iel];
           };
-          auto tw = [&, L](size_t iel) -> const arma::mat & {
+          auto tw = [&, L](size_t iel) -> const helfem::Matrix & {
             return prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel];
           };
 
@@ -824,7 +825,7 @@ namespace helfem {
         // assembly.
         atomic::basis::compute_disjoint_radial_integrals(
             radial, N_L, disjoint_iL, disjoint_kL, /*yukawa=*/true, lambda);
-        std::vector<arma::mat> rs_tei_yk;
+        std::vector<helfem::Matrix> rs_tei_yk;
         atomic::basis::compute_in_element_tei(
             radial, N_L, rs_tei_yk, /*yukawa=*/true, lambda);
         atomic::basis::compute_in_element_ktei_from_tei(
@@ -903,13 +904,13 @@ namespace helfem {
         // the shared helper with our SCF-cached per-(L, iel) integrals.
         for(int L=0;L<(int) Paux.size();L++) {
           const double Lfac=4.0*M_PI/(2*L+1);
-          auto rs = [&,L](size_t iel) -> const arma::mat & {
+          auto rs = [&,L](size_t iel) -> const helfem::Matrix & {
             return disjoint_L[L*Nel+iel];
           };
-          auto rb = [&,L](size_t iel) -> const arma::mat & {
+          auto rb = [&,L](size_t iel) -> const helfem::Matrix & {
             return disjoint_m1L[L*Nel+iel];
           };
-          auto tw = [&,L](size_t iel) -> const arma::mat & {
+          auto tw = [&,L](size_t iel) -> const helfem::Matrix & {
             return prim_tei[Nel*Nel*L + iel*Nel + iel];
           };
           for(int M=-std::min(L,Mmax);M<=std::min(L,Mmax);M++) {
@@ -1040,13 +1041,13 @@ namespace helfem {
               for(size_t L=0; L<N_L; ++L) {
                 if(!couple[L]) continue;
                 const size_t Lc = L;
-                auto rs = [&,Lc](size_t iel) -> const arma::mat & {
+                auto rs = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return disjoint_L[Lc*Nel+iel];
                 };
-                auto rb = [&,Lc](size_t iel) -> const arma::mat & {
+                auto rb = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return disjoint_m1L[Lc*Nel+iel];
                 };
-                auto kt = [&,Lc](size_t iel) -> const arma::mat & {
+                auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return prim_ktei[Nel*Nel*Lc + iel*Nel + iel];
                 };
                 K_block +=
@@ -1155,13 +1156,13 @@ namespace helfem {
                 for(size_t L=0; L<N_L; ++L) {
                   if(!couple[L]) continue;
                   const size_t Lc = L;
-                  auto rs = [&,Lc](size_t iel) -> const arma::mat & {
+                  auto rs = [&,Lc](size_t iel) -> const helfem::Matrix & {
                     return disjoint_iL[Lc*Nel+iel];
                   };
-                  auto rb = [&,Lc](size_t iel) -> const arma::mat & {
+                  auto rb = [&,Lc](size_t iel) -> const helfem::Matrix & {
                     return disjoint_kL[Lc*Nel+iel];
                   };
-                  auto kt = [&,Lc](size_t iel) -> const arma::mat & {
+                  auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
                     return rs_ktei[Nel*Nel*Lc + iel*Nel + iel];
                   };
                   K_block +=
@@ -1178,7 +1179,7 @@ namespace helfem {
                 for(size_t L=0; L<N_L; ++L) {
                   if(!couple[L]) continue;
                   const size_t Lc = L;
-                  auto kt = [&,Lc](size_t iel, size_t jel) -> const arma::mat & {
+                  auto kt = [&,Lc](size_t iel, size_t jel) -> const helfem::Matrix & {
                     return rs_ktei[Nel*Nel*Lc + iel*Nel + jel];
                   };
                   K_block +=
@@ -1236,7 +1237,13 @@ namespace helfem {
       }
 
       std::vector<arma::mat> TwoDBasis::get_prim_tei() const {
-        return prim_tei;
+        // Phase 2c: prim_tei is std::vector<helfem::Matrix> internally;
+        // bridge to arma for the public accessor (low-frequency test/diag
+        // path; consumers can be migrated later).
+        std::vector<arma::mat> out;
+        out.reserve(prim_tei.size());
+        for (const auto & m : prim_tei) out.push_back(helfem::to_arma(m));
+        return out;
       }
 
       arma::cx_mat TwoDBasis::eval_bf(size_t iel, double cth, double phi) const {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -18,6 +18,7 @@
 #include <armadillo>
 #include "../general/model_potential.h"
 #include "../general/sap.h"
+#include <Matrix.h>
 #include <RadialBasis.h>
 
 namespace helfem {
@@ -54,15 +55,16 @@ namespace helfem {
         bool zeroder;
 
         /// Auxiliary integrals
-        std::vector<arma::mat> disjoint_L, disjoint_m1L;
+        // Phase 2c: per-element 2e caches migrated to Eigen.
+        std::vector<helfem::Matrix> disjoint_L, disjoint_m1L;
         /// Auxiliary integrals for Yukawa separation
-        std::vector<arma::mat> disjoint_iL, disjoint_kL;
+        std::vector<helfem::Matrix> disjoint_iL, disjoint_kL;
         /// Primitive two-electron integrals: <Nel^2 * (2L+1)>
-        std::vector<arma::mat> prim_tei;
+        std::vector<helfem::Matrix> prim_tei;
         /// Primitive two-electron integrals: <Nel^2 * (2L+1)> sorted for exchange
-        std::vector<arma::mat> prim_ktei;
+        std::vector<helfem::Matrix> prim_ktei;
         /// Primitive range-separated two-electron integrals: <Nel^2 * (2L+1)> sorted for exchange
-        std::vector<arma::mat> rs_ktei;
+        std::vector<helfem::Matrix> rs_ktei;
 
         /// Add to radial submatrix
         void add_sub(arma::mat & M, size_t iang, size_t jang, const arma::mat & Msub) const;

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -203,7 +203,7 @@ namespace helfem {
         // assembly.
         atomic::basis::compute_disjoint_radial_integrals(
             radial, N_L, disjoint_iL, disjoint_kL, /*yukawa=*/true, lambda);
-        std::vector<arma::mat> rs_tei_yk;
+        std::vector<helfem::Matrix> rs_tei_yk;
         atomic::basis::compute_in_element_tei(
             radial, N_L, rs_tei_yk, /*yukawa=*/true, lambda);
         atomic::basis::compute_in_element_ktei_from_tei(
@@ -231,13 +231,13 @@ namespace helfem {
         const size_t Nel = radial.Nel();
         const int    L   = 0;
         const double Lfac = 4.0 * M_PI / (2 * L + 1);
-        auto rs = [&](size_t iel) -> const arma::mat & {
+        auto rs = [&](size_t iel) -> const helfem::Matrix & {
           return disjoint_L[L * Nel + iel];
         };
-        auto rb = [&](size_t iel) -> const arma::mat & {
+        auto rb = [&](size_t iel) -> const helfem::Matrix & {
           return disjoint_m1L[L * Nel + iel];
         };
-        auto tw = [&](size_t iel) -> const arma::mat & {
+        auto tw = [&](size_t iel) -> const helfem::Matrix & {
           return prim_tei[Nel * Nel * L + iel * Nel + iel];
         };
         return Lfac * atomic::basis::assemble_J_FE_one_multipole_cached(
@@ -333,13 +333,13 @@ namespace helfem {
               // K is accumulated with the standard HF minus sign baked
               // in (matches the pre-refactor convention).
               const int Lint = (int) L;
-              auto rs = [&,Lint](size_t iel) -> const arma::mat & {
+              auto rs = [&,Lint](size_t iel) -> const helfem::Matrix & {
                 return disjoint_L[Lint * Nel + iel];
               };
-              auto rb = [&,Lint](size_t iel) -> const arma::mat & {
+              auto rb = [&,Lint](size_t iel) -> const helfem::Matrix & {
                 return disjoint_m1L[Lint * Nel + iel];
               };
-              auto kt = [&,Lint](size_t iel) -> const arma::mat & {
+              auto kt = [&,Lint](size_t iel) -> const helfem::Matrix & {
                 return prim_ktei[Nel * Nel * Lint + iel * Nel + iel];
               };
               K.slice(lout) -= atomic::basis::assemble_K_FE_one_multipole_cached(
@@ -439,13 +439,13 @@ namespace helfem {
                 // Same FE structure as bare exchange -- just different
                 // kernels in the cache. Delegate to the shared helper.
                 const size_t Lc = L;
-                auto rs = [&,Lc](size_t iel) -> const arma::mat & {
+                auto rs = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return disjoint_iL[Lc*Nel+iel];
                 };
-                auto rb = [&,Lc](size_t iel) -> const arma::mat & {
+                auto rb = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return disjoint_kL[Lc*Nel+iel];
                 };
-                auto kt = [&,Lc](size_t iel) -> const arma::mat & {
+                auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return rs_ktei[Nel*Nel*Lc + iel*Nel + iel];
                 };
                 K.slice(lout) -=
@@ -457,7 +457,7 @@ namespace helfem {
                 // to the pairwise cached helper -- same contraction
                 // pattern, just no disjoint optimisation.
                 const size_t Lc = L;
-                auto kt = [&,Lc](size_t iel, size_t jel) -> const arma::mat & {
+                auto kt = [&,Lc](size_t iel, size_t jel) -> const helfem::Matrix & {
                   return rs_ktei[Nel*Nel*Lc + iel*Nel + jel];
                 };
                 K.slice(lout) -=
@@ -472,7 +472,12 @@ namespace helfem {
       }
 
       std::vector<arma::mat> TwoDBasis::get_prim_tei() const {
-        return prim_tei;
+        // Phase 2c: prim_tei is std::vector<helfem::Matrix> internally;
+        // bridge to arma for the public accessor.
+        std::vector<arma::mat> out;
+        out.reserve(prim_tei.size());
+        for (const auto & m : prim_tei) out.push_back(helfem::to_arma(m));
+        return out;
       }
 
       arma::mat TwoDBasis::eval_bf(size_t iel) const {

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -16,6 +16,7 @@
 #define SADATOM_BASIS_H
 
 #include <armadillo>
+#include <Matrix.h>
 #include "../atomic/basis.h"
 #include <NAORadialBasis.h>
 
@@ -41,16 +42,17 @@ namespace helfem {
         /// Angular basis set: function l values
         arma::ivec lval;
 
+        // Phase 2c: per-element 2e caches migrated to Eigen.
         /// Auxiliary integrals
-        std::vector<arma::mat> disjoint_L, disjoint_m1L;
+        std::vector<helfem::Matrix> disjoint_L, disjoint_m1L;
         /// Auxiliary integrals, Yukawa
-        std::vector<arma::mat> disjoint_iL, disjoint_kL;
+        std::vector<helfem::Matrix> disjoint_iL, disjoint_kL;
         /// Primitive two-electron integrals: <Nel^2 * (2L+1)>
-        std::vector<arma::mat> prim_tei;
+        std::vector<helfem::Matrix> prim_tei;
         /// Primitive two-electron exchange integrals
-        std::vector<arma::mat> prim_ktei;
+        std::vector<helfem::Matrix> prim_ktei;
         /// Primitive two-electron exchange integrals, range separation
-        std::vector<arma::mat> rs_ktei;
+        std::vector<helfem::Matrix> rs_ktei;
 
       public:
         TwoDBasis();


### PR DESCRIPTION
## Summary

Bulk migration of the per-element 2e caches and the J/K assembly helpers that consume them. This unblocks Phase 3 and 4 by ensuring the **J/K hot path internals are Eigen-native end-to-end** — no per-element \`to_arma\` copies on the SCF inner loop.

## Cache type migration

**\`atomic::TwoDBasis\`** (\`src/atomic/TwoDBasis.h\`) and **\`sadatom::TwoDBasis\`** (\`src/sadatom/basis.h\`):

```cpp
std::vector<arma::mat> disjoint_L, disjoint_m1L;
std::vector<arma::mat> disjoint_iL, disjoint_kL;
std::vector<arma::mat> prim_tei, prim_ktei, rs_ktei;
// ->
std::vector<helfem::Matrix> ...   // all five
```

\`TwoDBasis::get_prim_tei()\` keeps its public \`std::vector<arma::mat>\` signature (used by \`src/diatomic/qtest.cpp\`); bridges with \`to_arma\` per element at return.

## CoulombExchangeFE.h — accessors + helpers

**Accessor types:**
```cpp
using PerElementAccessor =
    std::function<const helfem::Matrix & (size_t iel)>;
using PerElementPairAccessor =
    std::function<const helfem::Matrix & (size_t iel, size_t jel)>;
```

**\`detail_fe_2e::{r_small, r_big, in_element_tei}\`**: now return \`helfem::Matrix\` directly (drop the \`to_arma\` bridge from #109).

**\`compute_disjoint_radial_integrals\` / \`compute_in_element_tei\` / \`compute_in_element_ktei_from_tei\` / \`compute_erfc_ktei\`**: fill \`std::vector<helfem::Matrix>\` caches; bridges only where they cross \`utils::exchange_tei\` (still arma-based).

**\`assemble_J/K_FE_one_multipole_cached\` and the \`_chol\` and \`_pairwise\` variants and the on-the-fly entry points**: Eigen-native internals. P_FE input and J/K output stay arma to match TwoDBasis::coulomb's existing arma SCF assembly:

```cpp
const helfem::Matrix P_E = helfem::to_eigen(P_FE);
helfem::Matrix J_E = helfem::Matrix::Zero(Nrad, Nrad);
... Eigen arithmetic inside ...
return helfem::to_arma(J_E);
```

One conversion in / one conversion out per call; **the per-element \`to_arma\` copies on every iel/jel iteration are gone.**

**Arma → Eigen API translation:**

| Arma | Eigen |
|---|---|
| \`arma::trace(A * B)\` | \`(A * B).trace()\` |
| \`arma::vectorise(M)\` | \`Eigen::Map<const VectorXd>(M.data(), M.size())\` |
| \`arma::reshape(v, r, c)\` | \`Eigen::Map<const MatrixXd>(v.data(), r, c)\` |
| \`A.submat(i0, j0, i1, j1)\` | \`A.block(i0, j0, i1-i0+1, j1-j0+1)\` |
| \`A.t()\` | \`A.transpose()\` |
| \`scratch[iel].is_empty()\` | \`scratch[iel].size() == 0\` |

Both libraries are column-major so the \`vectorise\` / \`reshape\` reinterpretations are layout-compatible.

## Caller updates

\`src/atomic/TwoDBasis.cpp\`:
- 12 lambda accessors changed to return \`const helfem::Matrix &\`
- 1 local \`std::vector<arma::mat> rs_tei_yk\` → \`std::vector<helfem::Matrix>\`
- \`radial_df_factors\`'s J-via-cached path now wires Eigen-typed accessors; pivoted Cholesky still arma (D, P, B_L_vecs all stay arma)

\`src/sadatom/basis.cpp\`:
- 9 lambda accessors changed to return \`const helfem::Matrix &\`
- Same local \`rs_tei_yk\` bridge

Bridging at \`TwoDBasis::coulomb\` / \`exchange\` / \`rs_exchange\` call sites is **unchanged** because the J/K helpers still take/return arma at the boundary; the helpers absorb the conversion.

## Validation

- \`eigen_foundation_test\`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- **Be HF via \`src/atomic\` at lmax=2, mmax=0**: Total energy = **−14.5728772811248426** (matches a clean Be HF reference; this exercises J assembly with non-trivial angular L summation)
- \`test_radial_df_exhaustive.py\`: 3 configs PASS at machine precision. The DF path consumes \`prim_tei\` + \`disjoint_L\` + the J helper, all touched here.

## What's left in libhelfem (still arma)

- \`utils::exchange_tei\`: arma-typed; called by \`compute_in_element_ktei_from_tei\` / \`compute_erfc_ktei\`. Bridged locally; next mechanical step before any J/K helper can claim 'no arma anywhere'.
- The TwoDBasis SCF assembly itself (\`coulomb\` / \`exchange\` / \`rs_exchange\` / \`overlap\` / \`hcore\`) — still \`arma::mat\` in/out. **This is the Phase 3 boundary.**
- The 'mid-tier' FEMRadialBasis methods deferred in #111 (get_bf / orbitals / confinement) — not on the J/K cache build path.

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [x] Phase 2a: FEMRadialBasis surface (matrix_element dispatcher; radial_integral / bessel; 2e family; cross-basis; nuclear_offcenter; spherical_potential; …) — PRs #103–#111
- [x] **Phase 2c: TwoDBasis caches + J/K helpers — this PR**
- [ ] Phase 3: TwoDBasis SCF surface (coulomb/exchange/hcore) + \`utils::exchange_tei\` migration
- [ ] Phase 4: templatize \`Matrix<T>\` for arbitrary precision

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic binary unchanged (non-trivial angular L summation exercised)
- [x] test_radial_df_exhaustive.py passes (3 configs, machine precision)