### PR TITLE
v2: Eigen Phase 2c cleanup -- utils::exchange_tei Eigen overload

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -28,6 +28,11 @@ namespace helfem {
   namespace utils {
     arma::mat exchange_tei(const arma::mat & tei, size_t Ni, size_t Nj,
                             size_t Nk, size_t Nl);
+    /// Eigen overload (Phase 2c wrap-up): same (ij|kl) -> (jk|il) permutation
+    /// for helfem::Matrix-typed in-element TEIs, avoids the
+    /// to_eigen(to_arma(...)) round-trip the helpers used to do.
+    helfem::Matrix exchange_tei(const helfem::Matrix & tei, size_t Ni, size_t Nj,
+                                 size_t Nk, size_t Nl);
   }
   namespace atomic {
     namespace basis {
@@ -292,13 +297,13 @@ namespace helfem {
         for (int L = 0; L < N_L; ++L) {
           for (size_t iel = 0; iel < Nel; ++iel) {
             const size_t Ni = radial.Nprim(iel);
-            // utils::exchange_tei is arma-based; bridge here.
-            // Phase 2c: prim_tei / prim_ktei caches are Eigen.
+            // Phase 2c wrap-up: utils::exchange_tei now has an Eigen
+            // overload, so prim_tei (Eigen) -> prim_ktei (Eigen) is
+            // direct -- no arma round-trip.
             prim_ktei[Nel * Nel * (size_t) L + iel * Nel + iel] =
-                helfem::to_eigen(helfem::utils::exchange_tei(
-                    helfem::to_arma(
-                        prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel]),
-                    Ni, Ni, Ni, Ni));
+                helfem::utils::exchange_tei(
+                    prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel],
+                    Ni, Ni, Ni, Ni);
           }
         }
       }
@@ -326,12 +331,12 @@ namespace helfem {
             for (size_t jel = 0; jel < Nel; ++jel) {
               const size_t Ni = radial.Nprim(iel);
               const size_t Nj = radial.Nprim(jel);
-              // utils::exchange_tei is arma-based; convert here.
-              // Phase 2c: rs_ktei is std::vector<helfem::Matrix>.
+              // Phase 2c wrap-up: utils::exchange_tei Eigen overload
+              // -- direct erfc_integral (Eigen) -> rs_ktei (Eigen).
               rs_ktei[Nel * Nel * (size_t) L + iel * Nel + jel] =
-                  helfem::to_eigen(helfem::utils::exchange_tei(
-                      helfem::to_arma(radial.erfc_integral(L, mu, iel, jel)),
-                      Ni, Ni, Nj, Nj));
+                  helfem::utils::exchange_tei(
+                      radial.erfc_integral(L, mu, iel, jel),
+                      Ni, Ni, Nj, Nj);
             }
           }
         }
@@ -602,10 +607,9 @@ namespace helfem {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
-            // utils::exchange_tei is arma-based; bridge for now.
-            scratch_ktei[iel] = helfem::to_eigen(utils::exchange_tei(
-                helfem::to_arma(detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0)),
-                Ni, Ni, Ni, Ni));
+            scratch_ktei[iel] = utils::exchange_tei(
+                detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0),
+                Ni, Ni, Ni, Ni);
           }
           return scratch_ktei[iel];
         };
@@ -657,9 +661,9 @@ namespace helfem {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
-            scratch_ktei[iel] = helfem::to_eigen(utils::exchange_tei(
-                helfem::to_arma(detail_fe_2e::in_element_tei(radial, L, iel, true, lambda)),
-                Ni, Ni, Ni, Ni));
+            scratch_ktei[iel] = utils::exchange_tei(
+                detail_fe_2e::in_element_tei(radial, L, iel, true, lambda),
+                Ni, Ni, Ni, Ni);
           }
           return scratch_ktei[iel];
         };

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -139,6 +139,32 @@ namespace helfem {
       return ktei;
     }
 
+    helfem::Matrix exchange_tei(const helfem::Matrix & tei,
+                                 size_t Ni, size_t Nj, size_t Nk, size_t Nl) {
+      // Eigen overload of the same scalar-by-scalar (ij|kl) -> (jk|il)
+      // permutation. Both arma and Eigen are column-major so the
+      // packed-pair index layout (a-fast, b-slow) is identical.
+      if (static_cast<size_t>(tei.rows()) != Ni*Nj) {
+        std::ostringstream oss;
+        oss << "Invalid input tei: was supposed to get " << Ni*Nj
+            << " rows but got " << tei.rows() << "!\n";
+        throw std::logic_error(oss.str());
+      }
+      if (static_cast<size_t>(tei.cols()) != Nk*Nl) {
+        std::ostringstream oss;
+        oss << "Invalid input tei: was supposed to get " << Nk*Nl
+            << " cols but got " << tei.cols() << "!\n";
+        throw std::logic_error(oss.str());
+      }
+      helfem::Matrix ktei = helfem::Matrix::Zero(Nj*Nk, Ni*Nl);
+      for (size_t ii = 0; ii < Ni; ++ii)
+        for (size_t jj = 0; jj < Nj; ++jj)
+          for (size_t kk = 0; kk < Nk; ++kk)
+            for (size_t ll = 0; ll < Nl; ++ll)
+              ktei(kk*Nj+jj, ll*Ni+ii) = tei(jj*Ni+ii, ll*Nk+kk);
+      return ktei;
+    }
+
     int stricmp(const std::string & str1, const std::string & str2) {
       return strcasecmp(str1.c_str(),str2.c_str());
     }

--- a/libhelfem/src/utils.h
+++ b/libhelfem/src/utils.h
@@ -16,6 +16,7 @@
 #define UTILS_H
 
 #include <armadillo>
+#include "../include/Matrix.h"
 
 namespace helfem {
   namespace utils {
@@ -45,6 +46,11 @@ namespace helfem {
 
     /// Permute indices (ij|kl) -> (jk|il)
     arma::mat exchange_tei(const arma::mat & tei, size_t Ni, size_t Nj, size_t Nk, size_t Nl);
+    /// Eigen overload of the same permutation (Phase 2c cleanup -- lets
+    /// the libhelfem 2e helpers skip the to_eigen(to_arma(...)) round-
+    /// trip that bridged the old arma-only function).
+    helfem::Matrix exchange_tei(const helfem::Matrix & tei,
+                                 size_t Ni, size_t Nj, size_t Nk, size_t Nl);
 
     /// Case independent string comparison
     int stricmp(const std::string & str1, const std::string & str2);


### PR DESCRIPTION
## Summary

Continuation of #112. Adds an Eigen overload of \`utils::exchange_tei\` alongside the existing arma overload, and removes the four internal \`to_eigen(to_arma(...))\` round-trips inside the libhelfem 2e helpers that #112 had to keep as a bridge.

## Changes

**\`libhelfem/src/utils.h\`**:
```cpp
arma::mat exchange_tei(const arma::mat &, ...);
+ helfem::Matrix exchange_tei(const helfem::Matrix &, ...);
```

**\`libhelfem/src/utils.cpp\`**: adds the Eigen overload. Same scalar-by-scalar \`(ij|kl) -> (jk|il)\` permutation; both libraries are column-major so the packed-pair layout is identical.

**\`libhelfem/include/CoulombExchangeFE.h\`**: the forward-declaration of \`utils::exchange_tei\` in this header gets the Eigen overload too, so callers in this header resolve to the new version. The four bridge sites simplify:

- \`compute_in_element_ktei_from_tei\` (drops to_arma + to_eigen)
- \`compute_erfc_ktei\` (same)
- \`assemble_K_FE_one_multipole\` (scratch_ktei lambda)
- \`assemble_K_FE_one_multipole_yukawa\` (same)

## No external caller changes

The 17 external \`utils::exchange_tei\` call sites (all in \`src/diatomic/basis.cpp\` where prim_tei is still \`std::vector<arma::mat>\`) continue to bind to the arma overload by overload resolution. Migrating the diatomic prim_tei to Eigen would be a separate future PR.

## Validation

- \`eigen_foundation_test\`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811248426** (unchanged)
- \`test_radial_df_exhaustive.py\`: 3 configs PASS at machine precision. Exercises the \`compute_in_element_ktei_from_tei\` path indirectly via \`prim_ktei\` consumed by exchange assembly.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic unchanged
- [x] test_radial_df_exhaustive.py passes