### PR TITLE
v2: Eigen Phase 2a wrap-up -- confinement helpers

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -198,16 +198,18 @@ namespace helfem {
         helfem::Matrix nuclear() const override;
         /// Compute nuclear attraction matrix in element (Eigen; Phase 2a).
         helfem::Matrix nuclear(size_t iel) const;
+	// Phase 2a wrap-up: confinement helpers Eigen-typed; chain together
+	// via confinement_potential which dispatches by iconf.
 	/// Compute polynomial confinement potential matrix in element
-	arma::mat polynomial_confinement(size_t iel, int N, double shift_pot) const;
+	helfem::Matrix polynomial_confinement(size_t iel, int N, double shift_pot) const;
 	/// Compute exponential confinement potential matrix in element
-	arma::mat exponential_confinement(size_t iel, int N, double r_0, double shift_pot) const;
+	helfem::Matrix exponential_confinement(size_t iel, int N, double r_0, double shift_pot) const;
 	/// Compute barrier confinement potential matrix in element
-	arma::mat barrier_confinement(size_t iel, double V, double r_c) const;
+	helfem::Matrix barrier_confinement(size_t iel, double V, double r_c) const;
 	/// Compute Junquera et al. confinement potential matrix in element
-	arma::mat junq_confinement(size_t iel, int N, double V0, double r_c, double shift_pot) const;
+	helfem::Matrix junq_confinement(size_t iel, int N, double V0, double r_c, double shift_pot) const;
 	/// Driver for computing confinement potential
-	arma::mat confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const;
+	helfem::Matrix confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const;
 
         /// Compute model potential matrix in element (Eigen; Phase 2a).
         helfem::Matrix model_potential(const modelpotential::ModelPotential *nuc,

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -295,17 +295,17 @@ namespace helfem {
       helfem::Matrix FEMRadialBasis::nuclear()      const { return -matrix_element(BasisKind::R0, BasisKind::R0, kRWeight); }
       helfem::Matrix FEMRadialBasis::nuclear(size_t iel) const { return -matrix_element(iel, BasisKind::R0, BasisKind::R0, kRWeight); }
 
-      arma::mat FEMRadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {
-        return helfem::to_arma(matrix_element(iel, BasisKind::R0, BasisKind::R0,
+      helfem::Matrix FEMRadialBasis::polynomial_confinement(size_t iel, int N, double shift_pot) const {
+        return matrix_element(iel, BasisKind::R0, BasisKind::R0,
                               [N, shift_pot](double r) {
                                 return (r < shift_pot)
                                     ? 0.0
                                     : std::pow(r - shift_pot, N + 2);
-                              }));
+                              });
       }
 
-      arma::mat FEMRadialBasis::exponential_confinement(size_t iel, int N, double r_0, double shift_pot) const {
-        return helfem::to_arma(matrix_element(iel, BasisKind::B0, BasisKind::B0,
+      helfem::Matrix FEMRadialBasis::exponential_confinement(size_t iel, int N, double r_0, double shift_pot) const {
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [r_0, N, shift_pot](double r) {
                                 if (r < shift_pot) return 0.0;
                                 const double r_ratio = (r - shift_pot) / r_0;
@@ -320,27 +320,27 @@ namespace helfem {
                                 V += std::exp(r_ratio);
                                 V *= fact;
                                 return V;
-                              }));
+                              });
       }
 
-      arma::mat FEMRadialBasis::barrier_confinement(size_t iel, double V, double shift_pot) const {
-        return helfem::to_arma(matrix_element(iel, BasisKind::B0, BasisKind::B0,
+      helfem::Matrix FEMRadialBasis::barrier_confinement(size_t iel, double V, double shift_pot) const {
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [V, shift_pot](double r) {
                                 return (r < shift_pot) ? 0.0 : V;
-                              }));
+                              });
       }
 
-      arma::mat FEMRadialBasis::junq_confinement(size_t iel, int N, double V0, double r_c, double shift_pot) const {
-        return helfem::to_arma(matrix_element(iel, BasisKind::B0, BasisKind::B0,
+      helfem::Matrix FEMRadialBasis::junq_confinement(size_t iel, int N, double V0, double r_c, double shift_pot) const {
+        return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [N, r_c, V0, shift_pot](double r) {
                                 if (r < shift_pot) return 0.0;
                                 const double denominator  = std::pow(r_c - r, N);
                                 const double exponential  = std::exp(-(r_c - shift_pot) / (r - shift_pot));
                                 return V0 * exponential / denominator;
-                              }));
+                              });
       }
 
-      arma::mat FEMRadialBasis::confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const {
+      helfem::Matrix FEMRadialBasis::confinement_potential(size_t iel, int N, double r_0, int iconf, double V, double shift_pot) const {
 	// Attractive potential does not make sense for shift_pot != 0
 
 	// sign of r0 controls if the potential is attractive or repulsive

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -488,7 +488,7 @@ namespace helfem {
 	  // Where are we in the matrix?
 	  size_t ifirst, ilast;
 	  radial.get_idx(iel,ifirst,ilast);
-	  Orad.submat(ifirst,ifirst,ilast,ilast)+=radial.confinement_potential(iel,N,r_0,iconf,V,shift_pot);
+	  Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.confinement_potential(iel,N,r_0,iconf,V,shift_pot));
 	}
 
         // Fill elements

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -162,7 +162,7 @@ namespace helfem {
 	    size_t ifirst, ilast;
 	    radial.get_idx(iel,ifirst,ilast);
 	    // r_0 is handled by other routine
-	    Vrad.submat(ifirst,ifirst,ilast,ilast)+=radial.confinement_potential(iel, N, r_0, iconf, V, shift_pot);
+	    Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.confinement_potential(iel, N, r_0, iconf, V, shift_pot));
 	  }
 	  return Vrad;
       }


### PR DESCRIPTION
## Summary

The five confinement helpers on \`FEMRadialBasis\` (\`polynomial_\`, \`exponential_\`, \`barrier_\`, \`junq_confinement\` + the \`confinement_potential\` dispatcher) now return \`helfem::Matrix\` instead of \`arma::mat\`. They each compose a single \`matrix_element\` call with a per-r weight lambda, so the \`to_arma\` wrap from #111 was just a boundary formality — removing it makes them one-liner Eigen returns identical in shape to overlap / kinetic / nuclear.

The dispatcher (\`confinement_potential\`, \`iconf == 1/2/3/4\`) does \`scalar * matrix-method\` on its branches; Eigen handles \`scalar * helfem::Matrix\` natively, so the chain stays clean.

## External caller updates (2 sites)

| File | Line | Update |
|---|---|---|
| \`src/atomic/TwoDBasis.cpp\` | 491 | \`submat += to_arma(confinement_potential(...))\` |
| \`src/sadatom/basis.cpp\` | 165 | \`submat += to_arma(confinement_potential(...))\` |

Both bridge with \`helfem::to_arma()\` at the \`submat +=\` boundary since the \`Vrad\` assembly is still arma. **No other callers** for the polynomial_ / exponential_ / barrier_ / junq_ helpers individually — they're only invoked through \`confinement_potential\`.

## Validation

- \`eigen_foundation_test\`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811248426** (unchanged)
- \`test_radial_df_exhaustive.py\`: 3 configs PASS at machine precision

Confinement path not exercised by these cases (\`iconf=0\` default) — the migration is a pure type change; numerics are byte-identical because \`matrix_element\` output is the same Eigen bytes we used to convert to arma and back.

## What's left in FEMRadialBasis (still arma)

- \`get_bf\` / \`get_df\` / \`get_lf\` — heavy cascade through diatomic basis assembly (~12 caller sites) + sadatom plotting/dump
- \`orbitals\` / \`orbitals_derivative\` / \`orbitals_second_derivative\` — low-frequency dump helpers
- \`radial_integral(const arma::mat & bf_c, int n, iel)\` — different overload, few callers

These can be finished in a follow-up sweep when needed; nothing strategic depends on them.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic unchanged
- [x] test_radial_df_exhaustive.py passes