### PR TITLE
v2: Eigen Phase 3 -- TwoDBasis SCF surface migrated to Eigen

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -46,6 +46,7 @@
 #include "../src/atomic/TwoDBasis.h"
 #include "../libhelfem/include/PolynomialBasis.h"
 #include "../libhelfem/include/ModelPotential.h"
+#include "../libhelfem/include/ArmaEigen.h"
 
 namespace py = pybind11;
 
@@ -134,11 +135,16 @@ namespace helfem_py {
       return out;
     }
 
-    py::array_t<double> overlap() const { return arma_to_numpy(basis_.overlap()); }
-    py::array_t<double> kinetic() const { return arma_to_numpy(basis_.kinetic()); }
-    py::array_t<double> nuclear() const { return arma_to_numpy(basis_.nuclear()); }
+    // Phase 3: basis_ SCF surface returns helfem::Matrix; bridge to
+    // arma at the numpy boundary (kept arma_to_numpy for now to
+    // preserve byte-identical Python behavior).
+    py::array_t<double> overlap() const { return arma_to_numpy(helfem::to_arma(basis_.overlap())); }
+    py::array_t<double> kinetic() const { return arma_to_numpy(helfem::to_arma(basis_.kinetic())); }
+    py::array_t<double> nuclear() const { return arma_to_numpy(helfem::to_arma(basis_.nuclear())); }
     py::array_t<double> hcore()   const {
-      return arma_to_numpy(basis_.kinetic() + basis_.nuclear());
+      const arma::mat T = helfem::to_arma(basis_.kinetic());
+      const arma::mat V = helfem::to_arma(basis_.nuclear());
+      return arma_to_numpy(arma::mat(T + V));
     }
 
     /// Build (J, K) from a density matrix. K returned with HF MINUS sign
@@ -149,23 +155,26 @@ namespace helfem_py {
     std::tuple<py::array_t<double>, py::array_t<double>>
     get_jk(py::array_t<double, py::array::c_style | py::array::forcecast> P_in) {
       ensure_tei_();
-      arma::mat P = numpy_to_arma(P_in);
-      arma::mat J = basis_.coulomb(P);
-      arma::mat K = -basis_.exchange(P);   // flip sign for PySCF positivity
+      // Phase 3: basis_.coulomb / exchange take/return helfem::Matrix.
+      const helfem::Matrix P_E = helfem::to_eigen(numpy_to_arma(P_in));
+      const arma::mat J = helfem::to_arma(basis_.coulomb(P_E));
+      const arma::mat K = -helfem::to_arma(basis_.exchange(P_E));  // flip sign for PySCF positivity
       return std::make_tuple(arma_to_numpy(J), arma_to_numpy(K));
     }
 
     py::array_t<double>
     coulomb(py::array_t<double, py::array::c_style | py::array::forcecast> P_in) {
       ensure_tei_();
-      return arma_to_numpy(basis_.coulomb(numpy_to_arma(P_in)));
+      const helfem::Matrix P_E = helfem::to_eigen(numpy_to_arma(P_in));
+      return arma_to_numpy(helfem::to_arma(basis_.coulomb(P_E)));
     }
 
     py::array_t<double>
     exchange(py::array_t<double, py::array::c_style | py::array::forcecast> P_in) {
       ensure_tei_();
+      const helfem::Matrix P_E = helfem::to_eigen(numpy_to_arma(P_in));
       // Match PySCF positive-K convention.
-      return arma_to_numpy(-basis_.exchange(numpy_to_arma(P_in)));
+      return arma_to_numpy(arma::mat(-helfem::to_arma(basis_.exchange(P_E))));
     }
 
     /// Density-fitted (Cholesky-factored) BARE radial Slater integrals.

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -213,8 +213,8 @@ namespace helfem {
       }
 
       arma::mat TwoDBasis::Shalf(bool chol, int sym) const {
-        // Form overlap matrix
-        arma::mat S(overlap());
+        // Phase 3: overlap() returns helfem::Matrix.
+        arma::mat S(helfem::to_arma(overlap()));
 
         // Get the basis function norms
         arma::vec bfnormlz(arma::pow(arma::diagvec(S),-0.5));
@@ -250,8 +250,7 @@ namespace helfem {
       }
 
       arma::mat TwoDBasis::Sinvh(bool chol, int sym) const {
-        // Form overlap matrix
-        arma::mat S(overlap());
+        arma::mat S(helfem::to_arma(overlap()));
 
         // Half-inverse is
         if(sym==0) {
@@ -313,8 +312,9 @@ namespace helfem {
         return remove_boundaries(O);
       }
 
-      arma::mat TwoDBasis::overlap() const {
-        return radial_integral(0);
+      helfem::Matrix TwoDBasis::overlap() const {
+        // Phase 3: SCF surface returns Eigen; internals unchanged.
+        return helfem::to_eigen(radial_integral(0));
       }
 
       arma::mat TwoDBasis::overlap(const TwoDBasis & rh) const {
@@ -333,7 +333,7 @@ namespace helfem {
         return S;
       }
 
-      arma::mat TwoDBasis::kinetic() const {
+      helfem::Matrix TwoDBasis::kinetic() const {
         // Build radial kinetic energy matrix
         size_t Nrad(radial.Nbf());
         arma::mat Trad(Nrad,Nrad);
@@ -364,15 +364,15 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(T);
+        return helfem::to_eigen(remove_boundaries(T));
       }
 
-      arma::mat TwoDBasis::nuclear() const {
+      helfem::Matrix TwoDBasis::nuclear() const {
         if(model != modelpotential::POINT_NUCLEUS) {
           modelpotential::ModelPotential *pot=modelpotential::get_nuclear_model(model,Z,Rrms);
           arma::mat Vnuc(model_potential(pot));
           delete pot;
-          return Vnuc;
+          return helfem::to_eigen(Vnuc);
         } else {
           // Full nuclear attraction matrix
           arma::mat V(Ndummy(),Ndummy());
@@ -444,7 +444,7 @@ namespace helfem {
             }
           }
 
-          return remove_boundaries(V);
+          return helfem::to_eigen(remove_boundaries(V));
         }
       }
 
@@ -843,11 +843,13 @@ namespace helfem {
         atomic::basis::compute_erfc_ktei(radial, N_L, lambda, rs_ktei);
       }
 
-      arma::mat TwoDBasis::coulomb(const arma::mat & P0) const {
+      helfem::Matrix TwoDBasis::coulomb(const helfem::Matrix & P0_in) const {
         if(!prim_tei.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
-        // Extend to boundaries
+        // Phase 3: SCF surface takes Eigen, internals stay arma -- one
+        // conversion at entry, one at exit.
+        const arma::mat P0 = helfem::to_arma(P0_in);
         arma::mat P(expand_boundaries(P0));
 
         // Number of radial elements
@@ -945,14 +947,14 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(J);
+        return helfem::to_eigen(remove_boundaries(J));
       }
 
-      arma::mat TwoDBasis::exchange(const arma::mat & P0) const {
+      helfem::Matrix TwoDBasis::exchange(const helfem::Matrix & P0_in) const {
         if(!prim_ktei.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
-        // Extend to boundaries
+        const arma::mat P0 = helfem::to_arma(P0_in);
         arma::mat P(expand_boundaries(P0));
 
         // Gaunt coefficient table
@@ -1060,14 +1062,14 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(K);
+        return helfem::to_eigen(remove_boundaries(K));
       }
 
-      arma::mat TwoDBasis::rs_exchange(const arma::mat & P0) const {
+      helfem::Matrix TwoDBasis::rs_exchange(const helfem::Matrix & P0_in) const {
         if(!rs_ktei.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
-        // Extend to boundaries
+        const arma::mat P0 = helfem::to_arma(P0_in);
         arma::mat P(expand_boundaries(P0));
 
         // Gaunt coefficient table
@@ -1193,7 +1195,7 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(K);
+        return helfem::to_eigen(remove_boundaries(K));
       }
 
       arma::mat TwoDBasis::remove_boundaries(const arma::mat & Fnob) const {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -147,12 +147,13 @@ namespace helfem {
         arma::mat Sinvh(bool chol, int sym) const;
         /// Form radial integral
         arma::mat radial_integral(int n) const;
+        // Phase 3: SCF surface migrated to Eigen.
         /// Form overlap matrix
-        arma::mat overlap() const;
+        helfem::Matrix overlap() const;
         /// Form kinetic energy matrix
-        arma::mat kinetic() const;
+        helfem::Matrix kinetic() const;
         /// Form nuclear attraction matrix
-        arma::mat nuclear() const;
+        helfem::Matrix nuclear() const;
 	/// Form confinement potential matrix
 	arma::mat confinement(const int N, const double r_0, const int iconf, const double V, const double shift_pot) const;
 	/// Form model potential matrix
@@ -172,11 +173,11 @@ namespace helfem {
         arma::mat form_density(const arma::mat & C, size_t nocc) const;
 
         /// Form Coulomb matrix
-        arma::mat coulomb(const arma::mat & P) const;
+        helfem::Matrix coulomb(const helfem::Matrix & P) const;
         /// Form exchange matrix
-        arma::mat exchange(const arma::mat & P) const;
+        helfem::Matrix exchange(const helfem::Matrix & P) const;
         /// Form range-separated exchange matrix
-        arma::mat rs_exchange(const arma::mat & P) const;
+        helfem::Matrix rs_exchange(const helfem::Matrix & P) const;
 
         /// Density-fitted (Cholesky-factored) BARE radial Slater
         /// integrals R^k(i, j, m, n) for k = 0..2*max(lval).

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -20,6 +20,7 @@
 #include "../general/elements.h"
 #include "../general/timer.h"
 #include "../general/scf_helpers.h"
+#include <ArmaEigen.h>
 #include "basis.h"
 #include "dftgrid.h"
 #include <cfloat>
@@ -367,11 +368,11 @@ int main(int argc, char **argv) {
 
   Timer timer;
 
-  // Form overlap matrix
-  arma::mat S(basis.overlap());
+  // Form overlap matrix (Phase 3: basis.overlap() returns Eigen; bridge here).
+  arma::mat S(helfem::to_arma(basis.overlap()));
   chkpt.write("S",S);
   // Form kinetic energy matrix
-  arma::mat T(basis.kinetic());
+  arma::mat T(helfem::to_arma(basis.kinetic()));
   chkpt.write("T",T);
 
   // Form DFT grid
@@ -456,7 +457,7 @@ int main(int argc, char **argv) {
   Timer tnuc;
   if(Zl!=0 || Zr !=0)
     printf("Computing nuclear attraction integrals\n");
-  arma::mat Vnuc=basis.nuclear();
+  arma::mat Vnuc=helfem::to_arma(basis.nuclear());
   chkpt.write("Vuc",Vnuc);
   if(Zl!=0 || Zr !=0)
     printf("Done in %.6f\n",tnuc.get());
@@ -741,7 +742,8 @@ int main(int argc, char **argv) {
 
     // Form Coulomb matrix
     timer.set();
-    arma::mat J(basis.coulomb(P));
+    // Phase 3: coulomb/exchange/rs_exchange take/return helfem::Matrix.
+    arma::mat J(helfem::to_arma(basis.coulomb(helfem::to_eigen(P))));
     double tJ(timer.get());
     Ecoul=0.5*arma::trace(P*J);
     printf("Coulomb energy %.10e % .6f\n",Ecoul,tJ);
@@ -756,18 +758,18 @@ int main(int argc, char **argv) {
       Ka.zeros(Caocc.n_rows,Caocc.n_rows);
       Kb.zeros(Caocc.n_rows,Caocc.n_rows);
       if(kfrac!=0.0)
-        Ka+=kfrac*basis.exchange(Pa);
+        Ka+=kfrac*helfem::to_arma(basis.exchange(helfem::to_eigen(Pa)));
       if(omega!=0.0)
-        Ka+=kshort*basis.rs_exchange(Pa);
+        Ka+=kshort*helfem::to_arma(basis.rs_exchange(helfem::to_eigen(Pa)));
 
       if(nelb) {
         if(restr && nela==nelb) {
           Kb=Ka;
         } else {
           if(kfrac!=0.0)
-            Kb+=kfrac*basis.exchange(Pb);
+            Kb+=kfrac*helfem::to_arma(basis.exchange(helfem::to_eigen(Pb)));
           if(omega!=0.0)
-            Kb+=kshort*basis.rs_exchange(Pb);
+            Kb+=kshort*helfem::to_arma(basis.rs_exchange(helfem::to_eigen(Pb)));
         }
       }
 

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -66,8 +66,7 @@ namespace helfem {
       }
 
       arma::mat TwoDBasis::Sinvh() const {
-        // Form overlap matrix
-        arma::mat S(overlap());
+        arma::mat S(helfem::to_arma(overlap()));
         return scf::form_Sinvh(S,false);
       }
 
@@ -89,11 +88,12 @@ namespace helfem {
         return Orad;
       }
 
-      arma::mat TwoDBasis::overlap() const {
-        return radial_integral(0);
+      helfem::Matrix TwoDBasis::overlap() const {
+        // Phase 3: SCF surface returns Eigen.
+        return helfem::to_eigen(radial_integral(0));
       }
 
-      arma::mat TwoDBasis::kinetic() const {
+      helfem::Matrix TwoDBasis::kinetic() const {
         // Build radial kinetic energy matrix
         size_t Nrad(radial.Nbf());
         arma::mat Trad(Nrad,Nrad);
@@ -107,10 +107,10 @@ namespace helfem {
           Trad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic(iel));
         }
 
-        return Trad;
+        return helfem::to_eigen(Trad);
       }
 
-      arma::mat TwoDBasis::kinetic_l() const {
+      helfem::Matrix TwoDBasis::kinetic_l() const {
         // Build radial kinetic energy matrix
         size_t Nrad(radial.Nbf());
         arma::mat Trad_l(Nrad,Nrad);
@@ -124,15 +124,15 @@ namespace helfem {
           Trad_l.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic_l(iel));
         }
 
-        return Trad_l;
+        return helfem::to_eigen(Trad_l);
       }
 
-      arma::mat TwoDBasis::nuclear() const {
+      helfem::Matrix TwoDBasis::nuclear() const {
         if(model != modelpotential::POINT_NUCLEUS) {
           modelpotential::ModelPotential * pot = modelpotential::get_nuclear_model(model,Z,Rrms);
           arma::mat Vrad(model_potential(pot));
           delete pot;
-          return Vrad;
+          return helfem::to_eigen(Vrad);
         } else {
           size_t Nrad(radial.Nbf());
           arma::mat Vrad(Nrad,Nrad);
@@ -145,7 +145,7 @@ namespace helfem {
             Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(-1,iel));
           }
 
-          return -Z*Vrad;
+          return helfem::to_eigen(arma::mat(-Z*Vrad));
         }
       }
 
@@ -221,9 +221,12 @@ namespace helfem {
         atomic::basis::compute_erfc_ktei(radial, N_L, lambda, rs_ktei);
       }
 
-      arma::mat TwoDBasis::coulomb(const arma::mat & P) const {
+      helfem::Matrix TwoDBasis::coulomb(const helfem::Matrix & P_in) const {
         if(!prim_tei.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
+        // Phase 3: SCF surface takes Eigen; internal J helper still
+        // takes arma -- one conversion at entry, one at exit.
+        const arma::mat P = helfem::to_arma(P_in);
 
         // sadatom is spherically averaged: only the L=0 multipole
         // contributes. Delegate to the shared FE assembly with our
@@ -240,8 +243,9 @@ namespace helfem {
         auto tw = [&](size_t iel) -> const helfem::Matrix & {
           return prim_tei[Nel * Nel * L + iel * Nel + iel];
         };
-        return Lfac * atomic::basis::assemble_J_FE_one_multipole_cached(
-            radial, rs, rb, tw, P);
+        return helfem::to_eigen(
+            arma::mat(Lfac * atomic::basis::assemble_J_FE_one_multipole_cached(
+                radial, rs, rb, tw, P)));
       }
 
       arma::cube TwoDBasis::exchange(const arma::cube & P) const {

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -77,20 +77,21 @@ namespace helfem {
         arma::mat Sinvh() const;
         /// Form radial integral
         arma::mat radial_integral(int n) const;
+        // Phase 3: SCF surface migrated to Eigen.
         /// Form overlap matrix
-        arma::mat overlap() const;
+        helfem::Matrix overlap() const;
         /// Form basic part kinetic energy matrix
-        arma::mat kinetic() const;
+        helfem::Matrix kinetic() const;
         /// Form l part of kinetic energy matrix
-        arma::mat kinetic_l() const;
+        helfem::Matrix kinetic_l() const;
         /// Form nuclear attraction matrix
-        arma::mat nuclear() const;
+        helfem::Matrix nuclear() const;
 	/// Form confinement potential matrix
 	arma::mat confinement(int N, double r_0, int iconf, double V, double shift_pot) const;
         /// Form model potential matrix
 	arma::mat model_potential(const modelpotential::ModelPotential * model) const;
         /// Form Coulomb matrix
-        arma::mat coulomb(const arma::mat & P) const;
+        helfem::Matrix coulomb(const helfem::Matrix & P) const;
         /// Form exchange matrix
         arma::cube exchange(const arma::cube & P) const;
         /// Form exchange matrix

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -15,6 +15,7 @@
 
 #include "basis.h"
 #include "solver.h"
+#include <ArmaEigen.h>
 #include "../general/dftfuncs.h"
 #include "../general/scf_helpers.h"
 #include "../general/diis.h"
@@ -735,16 +736,16 @@ namespace helfem {
         basis=sadatom::basis::TwoDBasis(Z, (modelpotential::nuclear_model_t) (finitenuc), Rrms, poly, zeroder, Nquad, bval, lmax);
         printf("Basis set has %i radial functions\n",(int) basis.Nbf());
 
-        // Form overlap matrix
-        S=basis.overlap();
+        // Form overlap matrix (Phase 3: basis returns Eigen; bridge).
+        S=helfem::to_arma(basis.overlap());
         // Get half-inverse
         Sinvh=basis.Sinvh();
         // Form kinetic energy matrix
-        T=basis.kinetic();
+        T=helfem::to_arma(basis.kinetic());
         // Form kinetic energy matrix
-        Tl=basis.kinetic_l();
+        Tl=helfem::to_arma(basis.kinetic_l());
         // Form nuclear attraction energy matrix
-        Vnuc=basis.nuclear();
+        Vnuc=helfem::to_arma(basis.nuclear());
 	// Form confinement potential energy matrix
 	Vconf=basis.confinement(conf_N, conf_R, iconf, conf_barrier, shift_pot);
         // Form core Hamiltonian
@@ -884,7 +885,8 @@ namespace helfem {
         }
 
         // Form Coulomb matrix
-        arma::mat J(basis.coulomb(P/angfac));
+        // Phase 3: coulomb takes/returns helfem::Matrix.
+        arma::mat J(helfem::to_arma(basis.coulomb(helfem::to_eigen(arma::mat(P/angfac)))));
         conf.Ecoul=0.5*arma::trace(P*J);
         if(verbose) {
           printf("Coulomb energy %.10e\n",conf.Ecoul);
@@ -972,7 +974,8 @@ namespace helfem {
         conf.Epot=arma::trace(P*Vnuc);
 
         // Form Coulomb matrix
-        arma::mat J(basis.coulomb(P/angfac));
+        // Phase 3: coulomb takes/returns helfem::Matrix.
+        arma::mat J(helfem::to_arma(basis.coulomb(helfem::to_eigen(arma::mat(P/angfac)))));
         conf.Ecoul=0.5*arma::trace(P*J);
         if(verbose) {
           printf("Coulomb energy %.10e\n",conf.Ecoul);


### PR DESCRIPTION
## Summary

The public SCF surface of \`atomic::TwoDBasis\` and \`sadatom::TwoDBasis\` now takes and returns \`helfem::Matrix\`:

```cpp
// atomic::TwoDBasis:
helfem::Matrix overlap(), kinetic(), nuclear();
helfem::Matrix coulomb    (const helfem::Matrix &);
helfem::Matrix exchange   (const helfem::Matrix &);
helfem::Matrix rs_exchange(const helfem::Matrix &);

// sadatom::TwoDBasis:
helfem::Matrix overlap(), kinetic(), kinetic_l(), nuclear();
helfem::Matrix coulomb(const helfem::Matrix &);
// (sadatom exchange / rs_exchange take/return arma::cube -- out of scope.)
```

## Design

Internals stay arma — \`coulomb\` / \`exchange\` in atomic still build per-(L, M) Paux densities, run Gaunt loops, accumulate Jaux in arma. The Eigen surface is achieved by **one to_arma at function entry, one to_eigen at the return boundary**.

This trades a single matrix copy per call (the Nbf×Nbf density / J / K) for a clean public-API type — the minimum scope change that unblocks **Phase 4 (templatize Matrix<T>)** and pybind11/eigen direct exposure later.

Same approach Phase 2c used for the J/K helpers: preserve existing arma-internal arithmetic; only change boundary types.

## Caller updates

**\`src/atomic/main.cpp\`** (+1 include, 8 sites bridged):
- to_arma on overlap/kinetic/nuclear returns
- to_eigen on input + to_arma on output for coulomb/exchange/rs_exchange

**\`src/sadatom/solver.cpp\`** (+1 include, 6 sites bridged):
- S, T, Tl, Vnuc in setup_radial_basis
- J via P/angfac (2 sites)
- sadatom \`exchange\`/\`rs_exchange\` untouched (arma::cube)

**\`python/bindings.cpp\`** (+1 include):
- overlap/kinetic/nuclear/hcore bridge to arma before \`arma_to_numpy\` (byte-identical Python behavior)
- coulomb/exchange/get_jk bridge to_eigen on input, to_arma on output
- A follow-up PR can switch to \`pybind11/eigen.h\` for zero-copy numpy↔Eigen

**\`TwoDBasis.cpp\` internal cross-references** (\`Shalf\`/\`Sinvh\`): bridge with to_arma so arma chol/eig_sym arithmetic stays untouched (~3 sites).

## Not yet migrated (Phase 3 follow-up scope)

- sadatom::TwoDBasis::exchange / rs_exchange (arma::cube I/O)
- TwoDBasis auxiliary methods: Shalf, Sinvh, get_sub, radial_integral, model_potential, confinement, dipole_z, quadrupole_zz, Bz_field, form_density, remove_boundaries, expand_boundaries — still arma::mat in/out
- pybind11/eigen.h direct numpy↔Eigen conversion
- Diatomic TwoDBasis (separate class, different RadialBasis — out of scope for this arc)

## Validation

- \`eigen_foundation_test\`: 11/11 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811248426** (unchanged)
- \`test_smoke.py\` (H 1s + He J/K via PySCF wrapper): PASS
- \`test_radial_df_exhaustive.py\`: 3 configs PASS at machine precision

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic unchanged
- [x] Python smoke test passes
- [x] test_radial_df_exhaustive.py passes