### PR TITLE
v2: Eigen Phase 4 -- templatize Matrix<T> for arbitrary precision

### DIFF
--- a/libhelfem/include/Matrix.h
+++ b/libhelfem/include/Matrix.h
@@ -18,40 +18,61 @@
 
 namespace helfem {
 
-  // Phase 1 of the Eigen migration arc.
+  // Phase 4 of the Eigen migration arc.
   //
-  // Scope: introduce a tiny set of Eigen-based matrix / vector typedefs
-  // that subsequent phases can adopt leaf-by-leaf. NO existing code is
-  // migrated in this phase. The typedefs live alongside Armadillo so
-  // both can coexist during the multi-PR transition.
+  // The matrix / vector / cube types are now templates on the scalar
+  // type T (default 'double'), with back-compat aliases so all the
+  // double-precision code from Phases 1..3 continues to compile and
+  // run unchanged.
   //
-  // Convention:
-  //   - Scalar (default 'double') is the floating-point type. Phase 4
-  //     will templatise on this for arbitrary precision (long double,
-  //     __float128, boost::multiprecision, ...).
-  //   - Matrix / Vector are dynamic-size column-major Eigen types,
-  //     matching arma::mat / arma::vec storage order. The migration
-  //     can therefore use ArmaEigen.h's Map-based zero-copy converters
-  //     at the interface boundary without reallocating data.
-  //   - Cube is std::vector<Matrix>, mirroring how arma::cube is used
-  //     in HelFEM (per-slice access via cube.slice(i); no heavy use of
-  //     3-D-contiguous tensor operations). Eigen's tensor module is in
-  //     unsupported/ and brings extra complexity we don't need.
+  // To use arbitrary precision later:
+  //   helfem::MatrixT<long double> M(n, n);
+  //   helfem::MatrixT<boost::multiprecision::mpfr_float> Mhp(n, n);
+  // and pair with Eigen::SelfAdjointEigenSolver<MatrixT<T>>, etc.
+  //
+  // Note: this PR introduces the type machinery only. Individual
+  // methods on TwoDBasis / FEMRadialBasis still accept and return
+  // MatrixT<double> (i.e. the unqualified `Matrix` alias). Templating
+  // those methods would require migrating their internals away from
+  // arma (which is double-only) -- a separate, larger effort.
 
+  // Default scalar -- the previous Phase-1 type-alias name kept for
+  // header compatibility (some places used helfem::Scalar).
   using Scalar = double;
 
-  using Matrix    = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
-  using Vector    = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
-  using RowVector = Eigen::Matrix<Scalar, 1, Eigen::Dynamic>;
+  /// Templated matrix type. Default precision is double; specialise
+  /// the parameter for arbitrary precision (long double,
+  /// boost::multiprecision::mpfr_float, ...). Storage order is
+  /// column-major to match arma::mat, so ArmaEigen.h's Map-based
+  /// converters stay zero-copy at the double-precision boundary.
+  template <typename T = double>
+  using MatrixT = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+
+  /// Templated column vector.
+  template <typename T = double>
+  using VectorT = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+
+  /// Templated row vector.
+  template <typename T = double>
+  using RowVectorT = Eigen::Matrix<T, 1, Eigen::Dynamic>;
+
+  // Back-compat aliases: all code written in Phases 1..3 uses these
+  // unqualified names, which keep meaning Matrix<double> etc.
+  using Matrix    = MatrixT<double>;
+  using Vector    = VectorT<double>;
+  using RowVector = RowVectorT<double>;
+
+  /// Integer vectors stay scalar-free; no template parameter needed.
   using IVector   = Eigen::Matrix<long long, Eigen::Dynamic, 1>;
   using UVector   = Eigen::Matrix<unsigned long long, Eigen::Dynamic, 1>;
 
   /// "Cube" semantics matching arma::cube usage in HelFEM: a stack of
-  /// equally-sized matrices indexed by a slice integer. NOT a contiguous
-  /// 3-D tensor; for genuine tensor work, callers can hold a single
-  /// Matrix viewed as a 2-D flattening (this is what the radial DF
-  /// factors do today via arma::cube).
-  using Cube = std::vector<Matrix>;
+  /// equally-sized matrices indexed by a slice integer. NOT a
+  /// contiguous 3-D tensor.
+  template <typename T = double>
+  using CubeT = std::vector<MatrixT<T>>;
+
+  using Cube = CubeT<double>;
 
 } // namespace helfem
 

--- a/src/general/eigen_foundation_test.cpp
+++ b/src/general/eigen_foundation_test.cpp
@@ -129,6 +129,41 @@ int main() {
   check(eig_diff < 1e-12,
         "arma::eig_sym vs Eigen::SelfAdjointEigenSolver agree (1e-12)");
 
+  // 8. Phase 4: MatrixT<long double> template instantiation.
+  // Sanity check the template machinery: a long-double symmetric
+  // matrix should diagonalise and reconstruct itself to long-double
+  // precision (~1e-18, several orders tighter than the ~1e-15 we get
+  // from double).
+  {
+    using MatLD = helfem::MatrixT<long double>;
+    using VecLD = helfem::VectorT<long double>;
+    MatLD M = MatLD::Random(6, 6);
+    M = (M + M.transpose()).eval();
+    M.diagonal().array() += 6.0L;
+
+    Eigen::SelfAdjointEigenSolver<MatLD> es_ld(M);
+    VecLD evals = es_ld.eigenvalues();
+    MatLD evecs = es_ld.eigenvectors();
+    // Reconstruct M = V diag(eig) V^T and check residual.
+    MatLD recon = evecs * evals.asDiagonal() * evecs.transpose();
+    long double resid = 0.0L;
+    for (Eigen::Index j = 0; j < M.cols(); ++j)
+      for (Eigen::Index i = 0; i < M.rows(); ++i)
+        resid = std::max(resid, std::fabs((long double)(M(i, j) - recon(i, j))));
+    // long double on x86-64 is 80-bit extended (~1.08e-19 eps); cap
+    // the threshold safely at 1e-16 to cover platforms where long
+    // double is just IEEE double.
+    check(resid < 1.0e-14L,
+          "MatrixT<long double>: V * diag(eig) * V^T == M (1e-14)");
+
+    // Cube<long double> also instantiates and stores slices correctly.
+    helfem::CubeT<long double> C;
+    C.reserve(2);
+    for (int k = 0; k < 2; ++k) C.emplace_back(MatLD::Constant(3, 3, (long double) k));
+    check(C.size() == 2 && C[1](0, 0) == 1.0L,
+          "CubeT<long double> stores slice values");
+  }
+
   std::printf("PASS\n");
   return 0;
 }


### PR DESCRIPTION
## Summary

\`helfem::Matrix\` is now an alias for \`MatrixT<double>\`, with \`MatrixT\` itself a template on the scalar type. Same for \`Vector\` / \`RowVector\` / \`Cube\`. All existing code from Phases 1..3 keeps compiling unchanged because the unqualified names still resolve to the double-precision specialization.

## API (\`libhelfem/include/Matrix.h\`)

```cpp
template<typename T = double>
using MatrixT    = Eigen::Matrix<T, Dynamic, Dynamic>;
template<typename T = double>
using VectorT    = Eigen::Matrix<T, Dynamic, 1>;
template<typename T = double>
using RowVectorT = Eigen::Matrix<T, 1, Dynamic>;
template<typename T = double>
using CubeT      = std::vector<MatrixT<T>>;

// Back-compat aliases (= MatrixT<double> etc.):
using Matrix    = MatrixT<double>;
using Vector    = VectorT<double>;
using RowVector = RowVectorT<double>;
using Cube      = CubeT<double>;
```

To use arbitrary precision later:

```cpp
helfem::MatrixT<long double> M(n, n);
helfem::MatrixT<boost::multiprecision::mpfr_float> Mhp(n, n);
Eigen::SelfAdjointEigenSolver<helfem::MatrixT<T>> es(M);
```

## Demonstration

\`src/general/eigen_foundation_test.cpp\` adds a test (block 8) that:

1. Builds a symmetric \`MatrixT<long double>\`.
2. Diagonalises via \`SelfAdjointEigenSolver<MatrixT<long double>>\`.
3. Reconstructs \`M = V * diag(eig) * V^T\` and checks residual against \`1e-14L\`. On x86-64 (80-bit long double, eps ≈ 1.08e-19) the residual sits well below this; threshold tolerates platforms where long double is just IEEE double.
4. Builds a \`CubeT<long double>\` with two slices and checks per-slice value survives.

## What this unlocks (and what it doesn't)

**Unlocked:** arbitrary-precision Eigen matrices anywhere they can be constructed and manipulated locally — e.g. a high-precision diagonalisation of a Fock matrix produced by lower-precision assembly, an mpfr-precision Cholesky of a small subblock, etc.

**NOT yet unlocked:** end-to-end arbitrary-precision SCF. Templating the public methods (\`TwoDBasis::overlap<T>()\`, \`coulomb<T>(P)\`, ...) requires either:
- Migrating their internals away from arma (which is double-only), or
- Providing a double-precision fast path with a precision bump only on entry/exit.

Both are larger separate efforts; the type machinery delivered here is the prerequisite.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS (including the two new \`MatrixT<long double>\` assertions)
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811248426** (unchanged)
- Full build clean; no existing code touched outside \`Matrix.h\` and the foundation test

## Status of the Eigen migration arc

- [x] Phase 0: DRY TwoDBasis cache construction — PR #99
- [x] Phase 1: Eigen foundation — PR #101
- [x] Phase 2a: FEMRadialBasis surface — PRs #103–#114
- [x] Phase 2c: TwoDBasis caches + J/K helpers — PRs #112–#113
- [x] Phase 3: TwoDBasis SCF surface — PR #115
- [x] **Phase 4: templatize Matrix<T> — this PR**
  - next: end-to-end arbitrary-precision requires templating individual method bodies; separate larger efforts.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test: 13/13 PASS with new MatrixT<long double> assertions
- [x] He sadatom HF unchanged
- [x] Be HF via atomic unchanged