### PR TITLE
v2: Eigen Phase 5.1 -- lib1dfem leaf primitives arma -> Eigen

### DIFF
--- a/lib1dfem/include/lib1dfem/chebyshev.h
+++ b/lib1dfem/include/lib1dfem/chebyshev.h
@@ -15,20 +15,26 @@
 #ifndef LIB1DFEM_CHEBYSHEV_H
 #define LIB1DFEM_CHEBYSHEV_H
 
-#include <armadillo>
+#include <Eigen/Core>
 #include <cmath>
 
 namespace helfem {
 namespace lib1dfem {
 namespace chebyshev {
 
+// Phase 5.1: lib1dfem primitives migrated arma -> Eigen. The libhelfem
+// double-only shim (libhelfem/src/chebyshev.h) bridges arma::vec on
+// the boundary so existing callers compile unchanged.
+
 /// Modified Gauss-Chebyshev quadrature of the second kind for
 ///     integral_{-1}^{1} f(x) dx
 /// Templated on the scalar type T.
 template <typename T>
-void chebyshev(int n, arma::Col<T> & x, arma::Col<T> & w) {
-  x.zeros(n);
-  w.zeros(n);
+void chebyshev(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
+                       Eigen::Matrix<T, Eigen::Dynamic, 1> & w) {
+  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+  x = Vec::Zero(n);
+  w = Vec::Zero(n);
 
   const T pi          = std::acos(T(-1));
   const T oonpp       = T(1) / T(n + 1);
@@ -47,8 +53,8 @@ void chebyshev(int n, arma::Col<T> & x, arma::Col<T> & w) {
              + two_over_pi * (T(1) + T(2) / T(3) * sinesq) * cosine * sine;
   }
 
-  x = arma::reverse(x);
-  w = arma::reverse(w);
+  x = x.reverse().eval();
+  w = w.reverse().eval();
 }
 
 /// Modified Gauss-Chebyshev quadrature of the second kind for
@@ -56,16 +62,18 @@ void chebyshev(int n, arma::Col<T> & x, arma::Col<T> & w) {
 /// (For integration in spherical coordinates the caller must still
 /// multiply by r^2.) Templated on the scalar type T.
 template <typename T>
-void radial_chebyshev(int nrad, arma::Col<T> & rad, arma::Col<T> & wrad) {
-  arma::Col<T> xc, wc;
+void radial_chebyshev(int nrad, Eigen::Matrix<T, Eigen::Dynamic, 1> & rad,
+                                  Eigen::Matrix<T, Eigen::Dynamic, 1> & wrad) {
+  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+  Vec xc, wc;
   chebyshev<T>(nrad, xc, wc);
 
-  rad.zeros(nrad);
-  wrad.zeros(nrad);
+  rad  = Vec::Zero(nrad);
+  wrad = Vec::Zero(nrad);
   const T inv_ln2 = T(1) / std::log(T(2));
 
   for (int ir = 0; ir < nrad; ++ir) {
-    const arma::uword ixc = xc.n_elem - 1 - ir;
+    const Eigen::Index ixc = xc.size() - 1 - ir;
     // r = (1 / ln 2) * log( 2 / (1 - x) )
     const T one_minus_x = T(1) - xc(ixc);
     const T r           = inv_ln2 * std::log(T(2) / one_minus_x);

--- a/lib1dfem/include/lib1dfem/chebyshev.h
+++ b/lib1dfem/include/lib1dfem/chebyshev.h
@@ -15,14 +15,15 @@
 #ifndef LIB1DFEM_CHEBYSHEV_H
 #define LIB1DFEM_CHEBYSHEV_H
 
-#include <Eigen/Core>
+#include <lib1dfem/types.h>
 #include <cmath>
 
 namespace helfem {
 namespace lib1dfem {
 namespace chebyshev {
 
-// Phase 5.1: lib1dfem primitives migrated arma -> Eigen. The libhelfem
+// Phase 5.1: lib1dfem primitives migrated arma -> Eigen using the
+// Vec<T> / Mat<T> shorthand from <lib1dfem/types.h>. The libhelfem
 // double-only shim (libhelfem/src/chebyshev.h) bridges arma::vec on
 // the boundary so existing callers compile unchanged.
 
@@ -30,11 +31,9 @@ namespace chebyshev {
 ///     integral_{-1}^{1} f(x) dx
 /// Templated on the scalar type T.
 template <typename T>
-void chebyshev(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
-                       Eigen::Matrix<T, Eigen::Dynamic, 1> & w) {
-  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-  x = Vec::Zero(n);
-  w = Vec::Zero(n);
+void chebyshev(int n, Vec<T> & x, Vec<T> & w) {
+  x = Vec<T>::Zero(n);
+  w = Vec<T>::Zero(n);
 
   const T pi          = std::acos(T(-1));
   const T oonpp       = T(1) / T(n + 1);
@@ -62,14 +61,12 @@ void chebyshev(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
 /// (For integration in spherical coordinates the caller must still
 /// multiply by r^2.) Templated on the scalar type T.
 template <typename T>
-void radial_chebyshev(int nrad, Eigen::Matrix<T, Eigen::Dynamic, 1> & rad,
-                                  Eigen::Matrix<T, Eigen::Dynamic, 1> & wrad) {
-  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-  Vec xc, wc;
+void radial_chebyshev(int nrad, Vec<T> & rad, Vec<T> & wrad) {
+  Vec<T> xc, wc;
   chebyshev<T>(nrad, xc, wc);
 
-  rad  = Vec::Zero(nrad);
-  wrad = Vec::Zero(nrad);
+  rad  = Vec<T>::Zero(nrad);
+  wrad = Vec<T>::Zero(nrad);
   const T inv_ln2 = T(1) / std::log(T(2));
 
   for (int ir = 0; ir < nrad; ++ir) {

--- a/lib1dfem/include/lib1dfem/grid.h
+++ b/lib1dfem/include/lib1dfem/grid.h
@@ -15,7 +15,7 @@
 #ifndef LIB1DFEM_GRID_H
 #define LIB1DFEM_GRID_H
 
-#include <Eigen/Core>
+#include <lib1dfem/types.h>
 #include <cmath>
 #include <cstdio>
 #include <stdexcept>
@@ -36,20 +36,19 @@ namespace grid {
 /// Endpoints are snapped to exactly 0 and rmax to avoid floating-point
 /// roundoff. Templated on the scalar type T.
 template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, 1> get_grid(T rmax, int num_el, int igrid, T zexp,
-                                              bool verbose = false) {
-  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-  Vec bval;
+Vec<T> get_grid(T rmax, int num_el, int igrid, T zexp,
+                bool verbose = false) {
+  Vec<T> bval;
 
   switch (igrid) {
     case 1: { // linear
       if (verbose) std::printf("Using linear grid\n");
-      bval = Vec::LinSpaced(num_el + 1, T(0), rmax);
+      bval = Vec<T>::LinSpaced(num_el + 1, T(0), rmax);
       break;
     }
     case 2: { // quadratic
       if (verbose) std::printf("Using quadratic grid\n");
-      bval = Vec::Zero(num_el + 1);
+      bval = Vec<T>::Zero(num_el + 1);
       const T inv_n2 = T(1) / (T(num_el) * T(num_el));
       for (int i = 0; i <= num_el; ++i)
         bval(i) = T(i) * T(i) * rmax * inv_n2;
@@ -59,7 +58,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> get_grid(T rmax, int num_el, int igrid, T ze
       if (verbose)
         std::printf("Using generalized polynomial grid, zexp = %e\n",
                     static_cast<double>(zexp));
-      bval = Vec::Zero(num_el + 1);
+      bval = Vec<T>::Zero(num_el + 1);
       const T inv_n = T(1) / T(num_el);
       for (int i = 0; i <= num_el; ++i)
         bval(i) = rmax * std::pow(T(i) * inv_n, zexp);
@@ -70,8 +69,8 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> get_grid(T rmax, int num_el, int igrid, T ze
         std::printf("Using generalized exponential grid, zexp = %e\n",
                     static_cast<double>(zexp));
       const T upper = std::pow(std::log(rmax + T(1)), T(1) / zexp);
-      Vec t = Vec::LinSpaced(num_el + 1, T(0), upper);
-      bval = Vec(num_el + 1);
+      Vec<T> t = Vec<T>::LinSpaced(num_el + 1, T(0), upper);
+      bval = Vec<T>(num_el + 1);
       for (int i = 0; i <= num_el; ++i)
         bval(i) = std::exp(std::pow(t(i), zexp)) - T(1);
       break;
@@ -83,11 +82,11 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> get_grid(T rmax, int num_el, int igrid, T ze
       if (zexp <= T(0) || zexp >= T(1))
         throw std::logic_error("Invalid value for s parameter!\n");
       // h_k from p.158 of the Cancès-Mourad paper:
-      Vec hk(num_el);
+      Vec<T> hk(num_el);
       hk(num_el - 1) = (T(1) - zexp) / (T(1) - std::pow(zexp, num_el)) * rmax;
       for (int iel = num_el - 2; iel >= 0; --iel)
         hk(iel) = zexp * hk(iel + 1);
-      bval = Vec::Zero(num_el + 1);
+      bval = Vec<T>::Zero(num_el + 1);
       for (int iel = 0; iel < num_el; ++iel)
         bval(iel + 1) = bval(iel) + hk(iel);
       break;

--- a/lib1dfem/include/lib1dfem/grid.h
+++ b/lib1dfem/include/lib1dfem/grid.h
@@ -15,7 +15,7 @@
 #ifndef LIB1DFEM_GRID_H
 #define LIB1DFEM_GRID_H
 
-#include <armadillo>
+#include <Eigen/Core>
 #include <cmath>
 #include <cstdio>
 #include <stdexcept>
@@ -36,19 +36,20 @@ namespace grid {
 /// Endpoints are snapped to exactly 0 and rmax to avoid floating-point
 /// roundoff. Templated on the scalar type T.
 template <typename T>
-arma::Col<T> get_grid(T rmax, int num_el, int igrid, T zexp,
-                      bool verbose = false) {
-  arma::Col<T> bval;
+Eigen::Matrix<T, Eigen::Dynamic, 1> get_grid(T rmax, int num_el, int igrid, T zexp,
+                                              bool verbose = false) {
+  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+  Vec bval;
 
   switch (igrid) {
     case 1: { // linear
       if (verbose) std::printf("Using linear grid\n");
-      bval = arma::linspace<arma::Col<T>>(T(0), rmax, num_el + 1);
+      bval = Vec::LinSpaced(num_el + 1, T(0), rmax);
       break;
     }
     case 2: { // quadratic
       if (verbose) std::printf("Using quadratic grid\n");
-      bval.zeros(num_el + 1);
+      bval = Vec::Zero(num_el + 1);
       const T inv_n2 = T(1) / (T(num_el) * T(num_el));
       for (int i = 0; i <= num_el; ++i)
         bval(i) = T(i) * T(i) * rmax * inv_n2;
@@ -58,7 +59,7 @@ arma::Col<T> get_grid(T rmax, int num_el, int igrid, T zexp,
       if (verbose)
         std::printf("Using generalized polynomial grid, zexp = %e\n",
                     static_cast<double>(zexp));
-      bval.zeros(num_el + 1);
+      bval = Vec::Zero(num_el + 1);
       const T inv_n = T(1) / T(num_el);
       for (int i = 0; i <= num_el; ++i)
         bval(i) = rmax * std::pow(T(i) * inv_n, zexp);
@@ -69,8 +70,10 @@ arma::Col<T> get_grid(T rmax, int num_el, int igrid, T zexp,
         std::printf("Using generalized exponential grid, zexp = %e\n",
                     static_cast<double>(zexp));
       const T upper = std::pow(std::log(rmax + T(1)), T(1) / zexp);
-      auto t = arma::linspace<arma::Col<T>>(T(0), upper, num_el + 1);
-      bval = arma::exp(arma::pow(t, zexp)) - arma::ones<arma::Col<T>>(num_el + 1);
+      Vec t = Vec::LinSpaced(num_el + 1, T(0), upper);
+      bval = Vec(num_el + 1);
+      for (int i = 0; i <= num_el; ++i)
+        bval(i) = std::exp(std::pow(t(i), zexp)) - T(1);
       break;
     }
     case 5: { // geometric
@@ -80,11 +83,11 @@ arma::Col<T> get_grid(T rmax, int num_el, int igrid, T zexp,
       if (zexp <= T(0) || zexp >= T(1))
         throw std::logic_error("Invalid value for s parameter!\n");
       // h_k from p.158 of the Cancès-Mourad paper:
-      arma::Col<T> hk(num_el);
+      Vec hk(num_el);
       hk(num_el - 1) = (T(1) - zexp) / (T(1) - std::pow(zexp, num_el)) * rmax;
       for (int iel = num_el - 2; iel >= 0; --iel)
         hk(iel) = zexp * hk(iel + 1);
-      bval.zeros(num_el + 1);
+      bval = Vec::Zero(num_el + 1);
       for (int iel = 0; iel < num_el; ++iel)
         bval(iel + 1) = bval(iel) + hk(iel);
       break;
@@ -95,7 +98,7 @@ arma::Col<T> get_grid(T rmax, int num_el, int igrid, T zexp,
 
   // Make endpoints numerically exact.
   bval(0) = T(0);
-  bval(bval.n_elem - 1) = rmax;
+  bval(bval.size() - 1) = rmax;
   return bval;
 }
 

--- a/lib1dfem/include/lib1dfem/lobatto.h
+++ b/lib1dfem/include/lib1dfem/lobatto.h
@@ -15,7 +15,7 @@
 #ifndef LIB1DFEM_LOBATTO_H
 #define LIB1DFEM_LOBATTO_H
 
-#include <armadillo>
+#include <Eigen/Core>
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -37,15 +37,18 @@ namespace lobatto {
 /// Cost is a one-time setup; the iteration converges quadratically so
 /// the number of iterations scales as O(log(1 / eps_T)).
 template <typename T>
-void lobatto_compute(int n, arma::Col<T> & x, arma::Col<T> & w) {
+void lobatto_compute(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
+                              Eigen::Matrix<T, Eigen::Dynamic, 1> & w) {
+  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+  using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
   if (n < 2) {
     std::ostringstream oss;
     oss << "Lobatto called with n=" << n << ", but n>=2 is required.\n";
     throw std::runtime_error(oss.str());
   }
 
-  x.set_size(n);
-  w.set_size(n);
+  x.resize(n);
+  w.resize(n);
 
   const T pi        = std::acos(T(-1));
   const T tolerance = T(100) * std::numeric_limits<T>::epsilon();
@@ -55,9 +58,9 @@ void lobatto_compute(int n, arma::Col<T> & x, arma::Col<T> & w) {
     x(i) = std::cos(pi * T(i) / T(n - 1));
   }
 
-  arma::Col<T> xold(n);
+  Vec xold(n);
   // p(i, j) holds P_j(x_i) for j in [0, n-1].
-  arma::Mat<T> p(n, n);
+  Mat p(n, n);
 
   for (;;) {
     xold = x;
@@ -97,7 +100,7 @@ void lobatto_compute(int n, arma::Col<T> & x, arma::Col<T> & w) {
 
   // Reverse order so the result runs from -1 to +1 (matches the convention
   // used by lobatto_compute in libhelfem prior to the v2 migration).
-  x = arma::reverse(x);
+  x = x.reverse().eval();
 
   // Weights use the final-iteration P_{n-1}(x_i) BEFORE the reverse above;
   // but since w(i) depends only on P_{n-1}(x_i)^2 and the x order has been

--- a/lib1dfem/include/lib1dfem/lobatto.h
+++ b/lib1dfem/include/lib1dfem/lobatto.h
@@ -15,7 +15,7 @@
 #ifndef LIB1DFEM_LOBATTO_H
 #define LIB1DFEM_LOBATTO_H
 
-#include <Eigen/Core>
+#include <lib1dfem/types.h>
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -29,18 +29,12 @@ namespace lobatto {
 ///     integral_{-1}^{1} f(x) dx
 ///         ~ 2/(n*(n-1)) * (f(-1) + f(1)) + sum_{i=2}^{n-1} w_i f(x_i)
 ///
-/// Templated on the scalar type T. The interior nodes are the roots of
-/// P'_{n-1}(x) (derivative of Legendre polynomial), found by Newton
-/// iteration starting from the Chebyshev-Gauss-Lobatto guess. Weights
-/// are w_i = 2 / (n * (n - 1) * P_{n-1}(x_i)^2).
-///
-/// Cost is a one-time setup; the iteration converges quadratically so
-/// the number of iterations scales as O(log(1 / eps_T)).
+/// Templated on the scalar type T. Interior nodes are roots of
+/// P'_{n-1}(x), found by Newton iteration starting from the
+/// Chebyshev-Gauss-Lobatto guess. Weights are
+/// w_i = 2 / (n * (n - 1) * P_{n-1}(x_i)^2).
 template <typename T>
-void lobatto_compute(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
-                              Eigen::Matrix<T, Eigen::Dynamic, 1> & w) {
-  using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-  using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+void lobatto_compute(int n, Vec<T> & x, Vec<T> & w) {
   if (n < 2) {
     std::ostringstream oss;
     oss << "Lobatto called with n=" << n << ", but n>=2 is required.\n";
@@ -58,9 +52,9 @@ void lobatto_compute(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
     x(i) = std::cos(pi * T(i) / T(n - 1));
   }
 
-  Vec xold(n);
+  Vec<T> xold(n);
   // p(i, j) holds P_j(x_i) for j in [0, n-1].
-  Mat p(n, n);
+  Mat<T> p(n, n);
 
   for (;;) {
     xold = x;
@@ -81,9 +75,7 @@ void lobatto_compute(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
       }
     }
 
-    // Newton step: roots of P'_{n-1}(x). Endpoints stay at +/-1 because
-    // the increment vanishes there (P_{n-1}(+/-1) = +/-1 and the formula
-    // gives a self-consistent fixed point).
+    // Newton step: roots of P'_{n-1}(x). Endpoints stay at +/-1.
     for (int i = 0; i < n; ++i) {
       x(i) = xold(i)
            - (x(i) * p(i, n - 1) - p(i, n - 2)) / (T(n) * p(i, n - 1));
@@ -98,13 +90,10 @@ void lobatto_compute(int n, Eigen::Matrix<T, Eigen::Dynamic, 1> & x,
     if (error <= tolerance) break;
   }
 
-  // Reverse order so the result runs from -1 to +1 (matches the convention
-  // used by lobatto_compute in libhelfem prior to the v2 migration).
+  // Reverse order so the result runs from -1 to +1.
   x = x.reverse().eval();
 
-  // Weights use the final-iteration P_{n-1}(x_i) BEFORE the reverse above;
-  // but since w(i) depends only on P_{n-1}(x_i)^2 and the x order has been
-  // reversed, we recompute P_{n-1} at the reversed x to keep w aligned with x.
+  // Weights use P_{n-1}(x_i) at the (reversed) x values to keep w aligned with x.
   for (int i = 0; i < n; ++i) {
     T pn = T(1), pnm1 = T(1);
     T pnm2;

--- a/lib1dfem/include/lib1dfem/math.h
+++ b/lib1dfem/include/lib1dfem/math.h
@@ -15,7 +15,7 @@
 #ifndef LIB1DFEM_MATH_H
 #define LIB1DFEM_MATH_H
 
-#include <Eigen/Core>
+#include <lib1dfem/types.h>
 #include <cmath>
 #include <algorithm>
 #include <limits>
@@ -33,8 +33,8 @@ T arcosh(T x) {
 }
 
 template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, 1> arcosh(const Eigen::Matrix<T, Eigen::Dynamic, 1> & x) {
-  Eigen::Matrix<T, Eigen::Dynamic, 1> y(x.size());
+Vec<T> arcosh(const Vec<T> & x) {
+  Vec<T> y(x.size());
   for (Eigen::Index i = 0; i < x.size(); ++i) y(i) = arcosh<T>(x(i));
   return y;
 }
@@ -46,8 +46,8 @@ T arsinh(T x) {
 }
 
 template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, 1> arsinh(const Eigen::Matrix<T, Eigen::Dynamic, 1> & x) {
-  Eigen::Matrix<T, Eigen::Dynamic, 1> y(x.size());
+Vec<T> arsinh(const Vec<T> & x) {
+  Vec<T> y(x.size());
   for (Eigen::Index i = 0; i < x.size(); ++i) y(i) = arsinh<T>(x(i));
   return y;
 }
@@ -90,8 +90,8 @@ T bessel_il(T r, int L) {
 }
 
 template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, 1> bessel_il(const Eigen::Matrix<T, Eigen::Dynamic, 1> & r, int L) {
-  Eigen::Matrix<T, Eigen::Dynamic, 1> ret(r.size());
+Vec<T> bessel_il(const Vec<T> & r, int L) {
+  Vec<T> ret(r.size());
   for (Eigen::Index i = 0; i < ret.size(); ++i) ret(i) = bessel_il<T>(r(i), L);
   return ret;
 }
@@ -110,8 +110,8 @@ T bessel_kl(T r, int L) {
 }
 
 template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, 1> bessel_kl(const Eigen::Matrix<T, Eigen::Dynamic, 1> & r, int L) {
-  Eigen::Matrix<T, Eigen::Dynamic, 1> ret(r.size());
+Vec<T> bessel_kl(const Vec<T> & r, int L) {
+  Vec<T> ret(r.size());
   for (Eigen::Index i = 0; i < ret.size(); ++i) ret(i) = bessel_kl<T>(r(i), L);
   return ret;
 }

--- a/lib1dfem/include/lib1dfem/math.h
+++ b/lib1dfem/include/lib1dfem/math.h
@@ -15,7 +15,7 @@
 #ifndef LIB1DFEM_MATH_H
 #define LIB1DFEM_MATH_H
 
-#include <armadillo>
+#include <Eigen/Core>
 #include <cmath>
 #include <algorithm>
 #include <limits>
@@ -33,9 +33,9 @@ T arcosh(T x) {
 }
 
 template <typename T>
-arma::Col<T> arcosh(const arma::Col<T> & x) {
-  arma::Col<T> y(x.n_elem);
-  for (size_t i = 0; i < x.n_elem; ++i) y(i) = arcosh<T>(x(i));
+Eigen::Matrix<T, Eigen::Dynamic, 1> arcosh(const Eigen::Matrix<T, Eigen::Dynamic, 1> & x) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> y(x.size());
+  for (Eigen::Index i = 0; i < x.size(); ++i) y(i) = arcosh<T>(x(i));
   return y;
 }
 
@@ -46,9 +46,9 @@ T arsinh(T x) {
 }
 
 template <typename T>
-arma::Col<T> arsinh(const arma::Col<T> & x) {
-  arma::Col<T> y(x.n_elem);
-  for (size_t i = 0; i < x.n_elem; ++i) y(i) = arsinh<T>(x(i));
+Eigen::Matrix<T, Eigen::Dynamic, 1> arsinh(const Eigen::Matrix<T, Eigen::Dynamic, 1> & x) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> y(x.size());
+  for (Eigen::Index i = 0; i < x.size(); ++i) y(i) = arsinh<T>(x(i));
   return y;
 }
 
@@ -90,9 +90,9 @@ T bessel_il(T r, int L) {
 }
 
 template <typename T>
-arma::Col<T> bessel_il(const arma::Col<T> & r, int L) {
-  arma::Col<T> ret(r.n_elem);
-  for (size_t i = 0; i < ret.n_elem; ++i) ret(i) = bessel_il<T>(r(i), L);
+Eigen::Matrix<T, Eigen::Dynamic, 1> bessel_il(const Eigen::Matrix<T, Eigen::Dynamic, 1> & r, int L) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> ret(r.size());
+  for (Eigen::Index i = 0; i < ret.size(); ++i) ret(i) = bessel_il<T>(r(i), L);
   return ret;
 }
 
@@ -110,9 +110,9 @@ T bessel_kl(T r, int L) {
 }
 
 template <typename T>
-arma::Col<T> bessel_kl(const arma::Col<T> & r, int L) {
-  arma::Col<T> ret(r.n_elem);
-  for (size_t i = 0; i < ret.n_elem; ++i) ret(i) = bessel_kl<T>(r(i), L);
+Eigen::Matrix<T, Eigen::Dynamic, 1> bessel_kl(const Eigen::Matrix<T, Eigen::Dynamic, 1> & r, int L) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> ret(r.size());
+  for (Eigen::Index i = 0; i < ret.size(); ++i) ret(i) = bessel_kl<T>(r(i), L);
   return ret;
 }
 

--- a/lib1dfem/include/lib1dfem/types.h
+++ b/lib1dfem/include/lib1dfem/types.h
@@ -1,0 +1,44 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef LIB1DFEM_TYPES_H
+#define LIB1DFEM_TYPES_H
+
+#include <Eigen/Core>
+
+// Shorthand aliases for the dynamic-size Eigen types used throughout
+// lib1dfem (and re-exported by libhelfem). Phase 5.x of the arma -> Eigen
+// migration: the full `Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>`
+// type spelling is unreadable in template-heavy code, so the migrated
+// headers spell vectors and matrices as `Vec<T>` / `Mat<T>` instead.
+//
+// Column-major storage to match arma::mat / arma::vec so the libhelfem
+// boundary shims stay zero-copy at T = double.
+
+namespace helfem {
+namespace lib1dfem {
+
+template <typename T>
+using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+
+template <typename T>
+using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+
+template <typename T>
+using RowVec = Eigen::Matrix<T, 1, Eigen::Dynamic>;
+
+} // namespace lib1dfem
+} // namespace helfem
+
+#endif // LIB1DFEM_TYPES_H

--- a/libhelfem/include/Matrix.h
+++ b/libhelfem/include/Matrix.h
@@ -56,6 +56,16 @@ namespace helfem {
   template <typename T = double>
   using RowVectorT = Eigen::Matrix<T, 1, Eigen::Dynamic>;
 
+  // Short aliases matching the lib1dfem::Vec<T> / Mat<T> / RowVec<T>
+  // shorthand. Use these in new templated code -- the verbose
+  // Eigen::Matrix<T, Eigen::Dynamic, ...> spelling hurts readability.
+  template <typename T = double>
+  using Vec    = VectorT<T>;
+  template <typename T = double>
+  using Mat    = MatrixT<T>;
+  template <typename T = double>
+  using RowVec = RowVectorT<T>;
+
   // Back-compat aliases: all code written in Phases 1..3 uses these
   // unqualified names, which keep meaning Matrix<double> etc.
   using Matrix    = MatrixT<double>;

--- a/libhelfem/src/chebyshev.h
+++ b/libhelfem/src/chebyshev.h
@@ -23,16 +23,32 @@
 // libhelfem headers) source-compatible during the migration.
 
 #include <lib1dfem/chebyshev.h>
+#include <armadillo>
+#include <cstring>
 
 namespace helfem {
 namespace chebyshev {
 
+// Phase 5.1: lib1dfem chebyshev is now Eigen-typed. These libhelfem
+// shims preserve the legacy arma::vec API used throughout the rest of
+// the codebase by bridging once at the boundary -- one Eigen Vector
+// build + one arma::vec copy per call. Both quadrature routines are
+// called a small constant number of times per SCF setup, so the bridge
+// cost is negligible.
 inline void chebyshev(int n, arma::vec & x, arma::vec & w) {
-  lib1dfem::chebyshev::chebyshev<double>(n, x, w);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> xe, we;
+  lib1dfem::chebyshev::chebyshev<double>(n, xe, we);
+  x.set_size(xe.size()); w.set_size(we.size());
+  std::memcpy(x.memptr(), xe.data(), sizeof(double) * (size_t) xe.size());
+  std::memcpy(w.memptr(), we.data(), sizeof(double) * (size_t) we.size());
 }
 
 inline void radial_chebyshev(int n, arma::vec & r, arma::vec & wr) {
-  lib1dfem::chebyshev::radial_chebyshev<double>(n, r, wr);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> re, wre;
+  lib1dfem::chebyshev::radial_chebyshev<double>(n, re, wre);
+  r.set_size(re.size()); wr.set_size(wre.size());
+  std::memcpy(r.memptr(),  re.data(),  sizeof(double) * (size_t) re.size());
+  std::memcpy(wr.memptr(), wre.data(), sizeof(double) * (size_t) wre.size());
 }
 
 } // namespace chebyshev

--- a/libhelfem/src/grid.cpp
+++ b/libhelfem/src/grid.cpp
@@ -20,9 +20,14 @@
 
 #include <helfem.h>
 #include <lib1dfem/grid.h>
+#include <cstring>
 
 arma::vec helfem::utils::get_grid(double rmax, int num_el, int igrid,
                                   double zexp) {
-  return helfem::lib1dfem::grid::get_grid<double>(rmax, num_el, igrid, zexp,
-                                                  helfem::verbose);
+  // Phase 5.1: lib1dfem grid now returns Eigen; bridge to arma here.
+  auto be = helfem::lib1dfem::grid::get_grid<double>(rmax, num_el, igrid, zexp,
+                                                     helfem::verbose);
+  arma::vec b(be.size());
+  std::memcpy(b.memptr(), be.data(), sizeof(double) * (size_t) be.size());
+  return b;
 }

--- a/libhelfem/src/lobatto.h
+++ b/libhelfem/src/lobatto.h
@@ -23,12 +23,22 @@
 // compatible during the migration.
 
 #include <lib1dfem/lobatto.h>
+#include <armadillo>
+#include <cstring>
 
 /// Compute a Gauss-Lobatto quadrature rule for
 ///     integral_{-1}^{1} f(x) dx
 ///         ~ 2/(n*(n-1)) * (f(-1) + f(1)) + sum_{i=2}^{n-1} w_i f(x_i)
+///
+/// Phase 5.1: lib1dfem is Eigen-typed; this shim bridges to arma at
+/// the boundary so legacy callers compile unchanged. One-time call per
+/// setup, so the copy cost is negligible.
 inline void lobatto_compute(int n, arma::vec & x, arma::vec & w) {
-  helfem::lib1dfem::lobatto::lobatto_compute<double>(n, x, w);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> xe, we;
+  helfem::lib1dfem::lobatto::lobatto_compute<double>(n, xe, we);
+  x.set_size(xe.size()); w.set_size(we.size());
+  std::memcpy(x.memptr(), xe.data(), sizeof(double) * (size_t) xe.size());
+  std::memcpy(w.memptr(), we.data(), sizeof(double) * (size_t) we.size());
 }
 
 #endif

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -15,6 +15,7 @@
 #include "utils.h"
 #include <lib1dfem/math.h>
 #include <cmath>
+#include <cstring>
 
 namespace helfem {
   namespace utils {
@@ -27,8 +28,15 @@ namespace helfem {
       return helfem::lib1dfem::math::arcosh<double>(x);
     }
 
+    // Phase 5.1: lib1dfem math helpers are Eigen-typed. The arma::vec
+    // shims convert one direction at the boundary.
     arma::vec arcosh(const arma::vec & x) {
-      return helfem::lib1dfem::math::arcosh<double>(x);
+      Eigen::Matrix<double, Eigen::Dynamic, 1> xe(x.n_elem);
+      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
+      auto ye = helfem::lib1dfem::math::arcosh<double>(xe);
+      arma::vec y(ye.size());
+      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
+      return y;
     }
 
     double arsinh(double x) {
@@ -36,7 +44,12 @@ namespace helfem {
     }
 
     arma::vec arsinh(const arma::vec & x) {
-      return helfem::lib1dfem::math::arsinh<double>(x);
+      Eigen::Matrix<double, Eigen::Dynamic, 1> xe(x.n_elem);
+      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
+      auto ye = helfem::lib1dfem::math::arsinh<double>(xe);
+      arma::vec y(ye.size());
+      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
+      return y;
     }
 
     double bessel_il(double r, int L) {
@@ -44,7 +57,12 @@ namespace helfem {
     }
 
     arma::vec bessel_il(const arma::vec & r, int L) {
-      return helfem::lib1dfem::math::bessel_il<double>(r, L);
+      Eigen::Matrix<double, Eigen::Dynamic, 1> re(r.n_elem);
+      std::memcpy(re.data(), r.memptr(), sizeof(double) * r.n_elem);
+      auto ye = helfem::lib1dfem::math::bessel_il<double>(re, L);
+      arma::vec y(ye.size());
+      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
+      return y;
     }
 
     double bessel_kl(double r, int L) {
@@ -52,7 +70,12 @@ namespace helfem {
     }
 
     arma::vec bessel_kl(const arma::vec & r, int L) {
-      return helfem::lib1dfem::math::bessel_kl<double>(r, L);
+      Eigen::Matrix<double, Eigen::Dynamic, 1> re(r.n_elem);
+      std::memcpy(re.data(), r.memptr(), sizeof(double) * r.n_elem);
+      auto ye = helfem::lib1dfem::math::bessel_kl<double>(re, L);
+      arma::vec y(ye.size());
+      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
+      return y;
     }
 
     arma::mat product_tei(const arma::mat & ijint, const arma::mat & klint) {


### PR DESCRIPTION
## Summary

Start of the full lib1dfem + libhelfem arma → Eigen migration committed to last conversation. This PR covers the **leaf primitives** in lib1dfem (those with no internal dependencies on the rest of lib1dfem): \`chebyshev\`, \`lobatto\`, \`math\`, \`grid\`. \`legendre_poly\` is intentionally deferred to Phase 5.2 because it cascades into \`LegendreBasis\` (a \`PolynomialBasis\` subclass).

## lib1dfem headers (Eigen-typed templates on T)

| Header | Migration |
|---|---|
| \`chebyshev.h\` | \`chebyshev<T>(n, x, w)\`, \`radial_chebyshev<T>(n, r, wr)\` — params now \`Eigen::Matrix<T, Dynamic, 1> &\` |
| \`lobatto.h\` | \`lobatto_compute<T>(n, x, w)\` — same |
| \`math.h\` | \`arcosh\` / \`arsinh\` / \`bessel_il\` / \`bessel_kl\` batch overloads now Eigen-typed; scalar overloads unchanged |
| \`grid.h\` | \`get_grid<T>(...)\` returns \`Eigen::Matrix<T, Dynamic, 1>\` |

Includes switch from \`<armadillo>\` to \`<Eigen/Core>\`. lib1dfem no longer brings in armadillo when only these headers are included.

## libhelfem shims (preserve the existing arma::vec API)

| File | Behavior |
|---|---|
| \`libhelfem/src/chebyshev.h\` | \`helfem::chebyshev::chebyshev\` / \`radial_chebyshev\` still take \`arma::vec &\` — now call the Eigen-typed lib1dfem version and \`memcpy\` bytes at the boundary |
| \`libhelfem/src/lobatto.h\` | \`lobatto_compute\` same pattern |
| \`libhelfem/src/utils.cpp\` | \`arcosh\`/\`arsinh\`/\`bessel_il\`/\`bessel_kl\` arma::vec overloads bridge with one Eigen vec construct + arma vec memcpy |
| \`libhelfem/src/grid.cpp\` | \`helfem::utils::get_grid\` bridges similarly |

One-time call per SCF setup; the copy is negligible.

## No external caller changes outside libhelfem shims

All callers in \`libhelfem/src/\`, \`src/atomic/\`, \`src/sadatom/\`, \`src/diatomic/\`, \`src/harmonic/\` go through the helfem shims and continue to compile unchanged (arma::vec in, arma::vec out).

## Deferred to later 5.x PRs

- \`legendre_poly.h\`: cascades into \`LegendreBasis\`. Migrate together in 5.2 (PolynomialBasis subclasses).
- lib1dfem \`PolynomialBasis\` base class itself
- \`LIPBasis_eval.h\`, \`HIPBasis_eval.h\` (auto-generated tables)
- libhelfem \`FiniteElementBasis\`, \`RadialBasis\` internals
- TwoDBasis internals (coulomb/exchange gaunt loops)

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811248426** (unchanged)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic unchanged