### PR TITLE
v2: Eigen Phase 5.2 -- lib1dfem PolynomialBasis subclasses + legendre_poly arma -> Eigen

### DIFF
--- a/lib1dfem/include/lib1dfem/HIP2Basis.h
+++ b/lib1dfem/include/lib1dfem/HIP2Basis.h
@@ -17,7 +17,6 @@
 
 #include <lib1dfem/LIPBasis.h>
 #include <lib1dfem/HIP2Basis_eval.h>
-#include <armadillo>
 #include <cmath>
 #include <sstream>
 #include <stdexcept>
@@ -38,26 +37,26 @@ template <typename T>
 class HIP2Basis : public LIPBasis<T> {
  protected:
   /// L_i'(x_i) at every node (precomputed at construction).
-  arma::Col<T> lipxi;
+  Vec<T> lipxi;
   /// L_i''(x_i) at every node (precomputed at construction).
-  arma::Col<T> lipxi2;
+  Vec<T> lipxi2;
 
  public:
   /// id_ is just an identifier echoed via get_id(); the libhelfem
   /// factory passes the primbas value (8 for HIP2).
-  HIP2Basis(const arma::Col<T> & x, int id_ = 8) : LIPBasis<T>(x, id_) {
+  HIP2Basis(const Vec<T> & x, int id_ = 8) : LIPBasis<T>(x, id_) {
     // Three overlapping functions per node (value + 1st deriv + 2nd deriv).
     this->noverlap = 3;
-    this->nprim    = 3 * static_cast<int>(this->x0.n_elem);
-    this->enabled  = arma::linspace<arma::uvec>(0, this->nprim - 1, this->nprim);
-    this->nnodes   = static_cast<int>(this->x0.n_elem);
+    this->nprim    = 3 * static_cast<int>(this->x0.size());
+    this->enabled  = IVec::LinSpaced(this->nprim, 0, this->nprim - 1);
+    this->nnodes   = static_cast<int>(this->x0.size());
 
     // L_i'(x_i) and L_i''(x_i) at every node, via the existing LIP evaluator.
-    arma::Mat<T> dlip, ddlip;
+    Mat<T> dlip, ddlip;
     detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dlip,  1);
     detail::eval_lip_prim_dnf<T>(this->x0, this->x0, ddlip, 2);
-    lipxi  = arma::diagvec(dlip);
-    lipxi2 = arma::diagvec(ddlip);
+    lipxi  = dlip.diagonal();
+    lipxi2 = ddlip.diagonal();
   }
 
   ~HIP2Basis() override = default;
@@ -66,7 +65,7 @@ class HIP2Basis : public LIPBasis<T> {
     return new HIP2Basis<T>(*this);
   }
 
-  void eval_prim_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf, int n,
+  void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
     detail::eval_hip2_prim_dnf<T>(x, this->x0, lipxi, lipxi2, dnf, n,
                                   element_length);
@@ -80,28 +79,27 @@ class HIP2Basis : public LIPBasis<T> {
   ///   func=false, deriv=true  : drop the two derivative interpolants
   ///   func=false, deriv=false : drop nothing
   void drop_first(bool func, bool deriv) override {
-    const arma::uvec first(this->enabled.subvec(0, 2));
-    const arma::uvec rest(this->enabled.subvec(3, this->enabled.n_elem - 1));
-    arma::uvec keep;
-    keep.set_size((func ? 0 : 1) + (deriv ? 0 : 2) + rest.n_elem);
-    arma::uword idx = 0;
+    const IVec first(this->enabled.segment(0, (2) - (0) + 1));
+    const IVec rest(this->enabled.segment(3, (this->enabled.size() - (3) + 1) - 1));
+    IVec keep;
+    keep.resize((func ? 0 : 1) + (deriv ? 0 : 2) + rest.size());
+    Eigen::Index idx = 0;
     if (!func)  keep(idx++) = first(0);
     if (!deriv) { keep(idx++) = first(1); keep(idx++) = first(2); }
-    if (rest.n_elem)
-      keep.subvec(idx, idx + rest.n_elem - 1) = rest;
+    if (rest.size())
+      keep.segment(idx, (idx + rest.size() - (idx) + 1) - 1) = rest;
     this->enabled = keep;
   }
 
   void drop_last(bool func, bool deriv) override {
-    const arma::uvec head(this->enabled.subvec(0, this->enabled.n_elem - 4));
-    const arma::uvec last(this->enabled.subvec(this->enabled.n_elem - 3,
-                                               this->enabled.n_elem - 1));
-    arma::uvec keep;
-    keep.set_size(head.n_elem + (func ? 0 : 1) + (deriv ? 0 : 2));
-    arma::uword idx = 0;
-    if (head.n_elem) {
-      keep.subvec(0, head.n_elem - 1) = head;
-      idx = head.n_elem;
+    const IVec head(this->enabled.segment(0, (this->enabled.size() - (0) + 1) - 4));
+    const IVec last(this->enabled.segment(this->enabled.size() - 3, (this->enabled.size() - (this->enabled.size() - 3) + 1) - 1));
+    IVec keep;
+    keep.resize(head.size() + (func ? 0 : 1) + (deriv ? 0 : 2));
+    Eigen::Index idx = 0;
+    if (head.size()) {
+      keep.segment(0, (head.size() - (0) + 1) - 1) = head;
+      idx = head.size();
     }
     if (!func)  keep(idx++) = last(0);
     if (!deriv) { keep(idx++) = last(1); keep(idx++) = last(2); }
@@ -130,7 +128,7 @@ class HIP2Basis : public LIPBasis<T> {
   /// up a (1/e)^n chain-rule factor.
   ///
   /// Implemented for n in {0, 1, 2}; throws for higher orders.
-  void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r, int n,
+  void eval_over_r(const Vec<T> & x, Mat<T> & dnf_over_r, int n,
                    T element_length) const override {
     if (n < 0 || n > 2) {
       std::ostringstream oss;
@@ -138,24 +136,24 @@ class HIP2Basis : public LIPBasis<T> {
           << " not implemented (only 0, 1, 2 supported).\n";
       throw std::logic_error(oss.str());
     }
-    if (this->enabled.n_elem == 0)
+    if (this->enabled.size() == 0)
       throw std::logic_error("HIP2Basis::eval_over_r: no surviving basis functions.\n");
     if (this->enabled(0) == 0)
       throw std::logic_error(
           "HIP2Basis::eval_over_r requires drop_first(func=true, deriv=false): "
           "the value-shape at node 0 has B(-1) != 0 and B/r is singular.\n");
 
-    const arma::Col<T> & x0_full = this->x0;
-    const arma::Col<T> x0_red    = x0_full.subvec(1, x0_full.n_elem - 1);
+    const Vec<T> & x0_full = this->x0;
+    const Vec<T> x0_red    = x0_full.segment(1, (x0_full.size() - (1) + 1) - 1);
 
     // Reduced L_i^{(0)}(x) and derivatives for i >= 1.
-    arma::Mat<T> Lr0, Lr1, Lr2;
+    Mat<T> Lr0, Lr1, Lr2;
     detail::eval_lip_prim_dnf<T>(x, x0_red, Lr0, 0);
     if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr1, 1);
     if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr2, 2);
 
     // Full L_0(x) (col 0) for the surviving node-0 shapes.
-    arma::Mat<T> Lf0, Lf1, Lf2;
+    Mat<T> Lf0, Lf1, Lf2;
     detail::eval_lip_prim_dnf<T>(x, x0_full, Lf0, 0);
     if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf1, 1);
     if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf2, 2);
@@ -163,13 +161,13 @@ class HIP2Basis : public LIPBasis<T> {
     const T inv_e   = T(1) / element_length;
     const T chain_n = std::pow(inv_e, n);
 
-    dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
-    for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
-      const arma::uword idx  = this->enabled(k);
-      const arma::uword node = idx / 3;
-      const arma::uword kind = idx % 3;
+    dnf_over_r.resize(x.size(), this->enabled.size());
+    for (Eigen::Index k = 0; k < this->enabled.size(); ++k) {
+      const Eigen::Index idx  = this->enabled(k);
+      const Eigen::Index node = idx / 3;
+      const Eigen::Index kind = idx % 3;
 
-      for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+      for (Eigen::Index ix = 0; ix < x.size(); ++ix) {
         const T xv  = x(ix);
         const T xpx1 = xv + T(1);
         const T xi   = x0_full(node);
@@ -219,7 +217,7 @@ class HIP2Basis : public LIPBasis<T> {
           }
         } else {
           // node >= 1; use reduced LIP at col (node - 1).
-          const arma::uword i_red = node - 1;
+          const Eigen::Index i_red = node - 1;
           const T p   = Lr0(ix, i_red);
           const T pd  = (n >= 1) ? Lr1(ix, i_red) : T(0);
           const T pdd = (n >= 2) ? Lr2(ix, i_red) : T(0);

--- a/lib1dfem/include/lib1dfem/HIP2Basis_eval.h
+++ b/lib1dfem/include/lib1dfem/HIP2Basis_eval.h
@@ -12,7 +12,7 @@
 #ifndef LIB1DFEM_HIP2BASIS_EVAL_H
 #define LIB1DFEM_HIP2BASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <lib1dfem/LIPBasis_eval.h>
 #include <sstream>
 #include <stdexcept>
@@ -42,16 +42,16 @@ namespace detail {
 /// needed once the Taylor pipeline in RadialBasis has been retired
 /// (see PR #69).
 template <typename T>
-void eval_hip2_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                        const arma::Col<T> & lipxi, const arma::Col<T> & lipxi2,
-                        arma::Mat<T> & dnf, int n, T element_length) {
+void eval_hip2_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                        const Vec<T> & lipxi, const Vec<T> & lipxi2,
+                        Mat<T> & dnf, int n, T element_length) {
   switch (n) {
 case (0): {
-  dnf.zeros(x.n_elem, 3 * x0.n_elem);
-  arma::Mat<T> Lx_all;
+  dnf.setZero((Eigen::Index) x.size(), 3 * (Eigen::Index) x0.size());
+  Mat<T> Lx_all;
   eval_lip_prim_dnf<T>(x, x0, Lx_all, 0);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       const T xv      = x(ix);
       const T xi      = x0(fi);
       const T Lx      = Lx_all(ix, fi);
@@ -67,13 +67,13 @@ case (0): {
   }
 } break;
 case (1): {
-  dnf.zeros(x.n_elem, 3 * x0.n_elem);
-  arma::Mat<T> Lx_all;
+  dnf.setZero((Eigen::Index) x.size(), 3 * (Eigen::Index) x0.size());
+  Mat<T> Lx_all;
   eval_lip_prim_dnf<T>(x, x0, Lx_all, 0);
-  arma::Mat<T> dLx_all;
+  Mat<T> dLx_all;
   eval_lip_prim_dnf<T>(x, x0, dLx_all, 1);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       const T xv      = x(ix);
       const T xi      = x0(fi);
       const T Lx      = Lx_all(ix, fi);
@@ -90,15 +90,15 @@ case (1): {
   }
 } break;
 case (2): {
-  dnf.zeros(x.n_elem, 3 * x0.n_elem);
-  arma::Mat<T> Lx_all;
+  dnf.setZero((Eigen::Index) x.size(), 3 * (Eigen::Index) x0.size());
+  Mat<T> Lx_all;
   eval_lip_prim_dnf<T>(x, x0, Lx_all, 0);
-  arma::Mat<T> dLx_all;
+  Mat<T> dLx_all;
   eval_lip_prim_dnf<T>(x, x0, dLx_all, 1);
-  arma::Mat<T> ddLx_all;
+  Mat<T> ddLx_all;
   eval_lip_prim_dnf<T>(x, x0, ddLx_all, 2);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       const T xv      = x(ix);
       const T xi      = x0(fi);
       const T Lx      = Lx_all(ix, fi);

--- a/lib1dfem/include/lib1dfem/HIP3Basis.h
+++ b/lib1dfem/include/lib1dfem/HIP3Basis.h
@@ -17,7 +17,6 @@
 
 #include <lib1dfem/LIPBasis.h>
 #include <lib1dfem/HIP3Basis_eval.h>
-#include <armadillo>
 #include <cmath>
 #include <sstream>
 #include <stdexcept>
@@ -37,24 +36,24 @@ template <typename T>
 class HIP3Basis : public LIPBasis<T> {
  protected:
   /// L_i^(1)(x_i), L_i^(2)(x_i), L_i^(3)(x_i) at every node (precomputed).
-  arma::Col<T> lipxi, lipxi2, lipxi3;
+  Vec<T> lipxi, lipxi2, lipxi3;
 
  public:
   /// id_ is the primbas value echoed via get_id() (typically 9 for HIP3).
-  HIP3Basis(const arma::Col<T> & x, int id_ = 9) : LIPBasis<T>(x, id_) {
+  HIP3Basis(const Vec<T> & x, int id_ = 9) : LIPBasis<T>(x, id_) {
     // Four overlapping functions per node (value + 1st + 2nd + 3rd deriv).
     this->noverlap = 4;
-    this->nprim    = 4 * static_cast<int>(this->x0.n_elem);
-    this->enabled  = arma::linspace<arma::uvec>(0, this->nprim - 1, this->nprim);
-    this->nnodes   = static_cast<int>(this->x0.n_elem);
+    this->nprim    = 4 * static_cast<int>(this->x0.size());
+    this->enabled  = IVec::LinSpaced(this->nprim, 0, this->nprim - 1);
+    this->nnodes   = static_cast<int>(this->x0.size());
 
-    arma::Mat<T> dlip, ddlip, dddlip;
+    Mat<T> dlip, ddlip, dddlip;
     detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dlip,   1);
     detail::eval_lip_prim_dnf<T>(this->x0, this->x0, ddlip,  2);
     detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dddlip, 3);
-    lipxi  = arma::diagvec(dlip);
-    lipxi2 = arma::diagvec(ddlip);
-    lipxi3 = arma::diagvec(dddlip);
+    lipxi  = dlip.diagonal();
+    lipxi2 = ddlip.diagonal();
+    lipxi3 = dddlip.diagonal();
   }
 
   ~HIP3Basis() override = default;
@@ -63,7 +62,7 @@ class HIP3Basis : public LIPBasis<T> {
     return new HIP3Basis<T>(*this);
   }
 
-  void eval_prim_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf, int n,
+  void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
     detail::eval_hip3_prim_dnf<T>(x, this->x0, lipxi, lipxi2, lipxi3, dnf, n,
                                   element_length);
@@ -76,28 +75,27 @@ class HIP3Basis : public LIPBasis<T> {
   ///   func=false, deriv=true  : drop only the three derivative interpolants
   ///   func=false, deriv=false : drop nothing
   void drop_first(bool func, bool deriv) override {
-    const arma::uvec first(this->enabled.subvec(0, 3));
-    const arma::uvec rest(this->enabled.subvec(4, this->enabled.n_elem - 1));
-    arma::uvec keep;
-    keep.set_size((func ? 0 : 1) + (deriv ? 0 : 3) + rest.n_elem);
-    arma::uword idx = 0;
+    const IVec first(this->enabled.segment(0, (3) - (0) + 1));
+    const IVec rest(this->enabled.segment(4, (this->enabled.size() - (4) + 1) - 1));
+    IVec keep;
+    keep.resize((func ? 0 : 1) + (deriv ? 0 : 3) + rest.size());
+    Eigen::Index idx = 0;
     if (!func)  keep(idx++) = first(0);
     if (!deriv) { keep(idx++) = first(1); keep(idx++) = first(2); keep(idx++) = first(3); }
-    if (rest.n_elem)
-      keep.subvec(idx, idx + rest.n_elem - 1) = rest;
+    if (rest.size())
+      keep.segment(idx, (idx + rest.size() - (idx) + 1) - 1) = rest;
     this->enabled = keep;
   }
 
   void drop_last(bool func, bool deriv) override {
-    const arma::uvec head(this->enabled.subvec(0, this->enabled.n_elem - 5));
-    const arma::uvec last(this->enabled.subvec(this->enabled.n_elem - 4,
-                                               this->enabled.n_elem - 1));
-    arma::uvec keep;
-    keep.set_size(head.n_elem + (func ? 0 : 1) + (deriv ? 0 : 3));
-    arma::uword idx = 0;
-    if (head.n_elem) {
-      keep.subvec(0, head.n_elem - 1) = head;
-      idx = head.n_elem;
+    const IVec head(this->enabled.segment(0, (this->enabled.size() - (0) + 1) - 5));
+    const IVec last(this->enabled.segment(this->enabled.size() - 4, (this->enabled.size() - (this->enabled.size() - 4) + 1) - 1));
+    IVec keep;
+    keep.resize(head.size() + (func ? 0 : 1) + (deriv ? 0 : 3));
+    Eigen::Index idx = 0;
+    if (head.size()) {
+      keep.segment(0, (head.size() - (0) + 1) - 1) = head;
+      idx = head.size();
     }
     if (!func)  keep(idx++) = last(0);
     if (!deriv) { keep(idx++) = last(1); keep(idx++) = last(2); keep(idx++) = last(3); }
@@ -130,7 +128,7 @@ class HIP3Basis : public LIPBasis<T> {
   /// d^n/dr^n picks up (1/e)^n via the chain rule.
   ///
   /// Implemented for n in {0, 1, 2}; throws for higher orders.
-  void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r, int n,
+  void eval_over_r(const Vec<T> & x, Mat<T> & dnf_over_r, int n,
                    T element_length) const override {
     if (n < 0 || n > 2) {
       std::ostringstream oss;
@@ -138,22 +136,22 @@ class HIP3Basis : public LIPBasis<T> {
           << " not implemented (only 0, 1, 2 supported).\n";
       throw std::logic_error(oss.str());
     }
-    if (this->enabled.n_elem == 0)
+    if (this->enabled.size() == 0)
       throw std::logic_error("HIP3Basis::eval_over_r: no surviving basis functions.\n");
     if (this->enabled(0) == 0)
       throw std::logic_error(
           "HIP3Basis::eval_over_r requires drop_first(func=true, deriv=false): "
           "the value-shape at node 0 has B(-1) != 0 and B/r is singular.\n");
 
-    const arma::Col<T> & x0_full = this->x0;
-    const arma::Col<T> x0_red    = x0_full.subvec(1, x0_full.n_elem - 1);
+    const Vec<T> & x0_full = this->x0;
+    const Vec<T> x0_red    = x0_full.segment(1, (x0_full.size() - (1) + 1) - 1);
 
-    arma::Mat<T> Lr0, Lr1, Lr2;
+    Mat<T> Lr0, Lr1, Lr2;
     detail::eval_lip_prim_dnf<T>(x, x0_red, Lr0, 0);
     if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr1, 1);
     if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr2, 2);
 
-    arma::Mat<T> Lf0, Lf1, Lf2;
+    Mat<T> Lf0, Lf1, Lf2;
     detail::eval_lip_prim_dnf<T>(x, x0_full, Lf0, 0);
     if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf1, 1);
     if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf2, 2);
@@ -161,13 +159,13 @@ class HIP3Basis : public LIPBasis<T> {
     const T inv_e   = T(1) / element_length;
     const T chain_n = std::pow(inv_e, n);
 
-    dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
-    for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
-      const arma::uword idx  = this->enabled(k);
-      const arma::uword node = idx / 4;
-      const arma::uword kind = idx % 4;
+    dnf_over_r.resize(x.size(), this->enabled.size());
+    for (Eigen::Index k = 0; k < this->enabled.size(); ++k) {
+      const Eigen::Index idx  = this->enabled(k);
+      const Eigen::Index node = idx / 4;
+      const Eigen::Index kind = idx % 4;
 
-      for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+      for (Eigen::Index ix = 0; ix < x.size(); ++ix) {
         const T xv   = x(ix);
         const T xpx1 = xv + T(1);
         const T xi   = x0_full(node);
@@ -185,7 +183,7 @@ class HIP3Basis : public LIPBasis<T> {
           pd  = (n >= 1) ? Lf1(ix, 0) : T(0);
           pdd = (n >= 2) ? Lf2(ix, 0) : T(0);
         } else {
-          const arma::uword i_red = node - 1;
+          const Eigen::Index i_red = node - 1;
           p   = Lr0(ix, i_red);
           pd  = (n >= 1) ? Lr1(ix, i_red) : T(0);
           pdd = (n >= 2) ? Lr2(ix, i_red) : T(0);

--- a/lib1dfem/include/lib1dfem/HIP3Basis_eval.h
+++ b/lib1dfem/include/lib1dfem/HIP3Basis_eval.h
@@ -12,7 +12,7 @@
 #ifndef LIB1DFEM_HIP3BASIS_EVAL_H
 #define LIB1DFEM_HIP3BASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <lib1dfem/LIPBasis_eval.h>
 #include <sstream>
 #include <stdexcept>
@@ -44,17 +44,17 @@ namespace detail {
 /// needed once the Taylor pipeline in RadialBasis has been retired
 /// (see PR #69).
 template <typename T>
-void eval_hip3_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                        const arma::Col<T> & lipxi, const arma::Col<T> & lipxi2,
-                        const arma::Col<T> & lipxi3,
-                        arma::Mat<T> & dnf, int n, T element_length) {
+void eval_hip3_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                        const Vec<T> & lipxi, const Vec<T> & lipxi2,
+                        const Vec<T> & lipxi3,
+                        Mat<T> & dnf, int n, T element_length) {
   switch (n) {
 case (0): {
-  dnf.zeros(x.n_elem, 4 * x0.n_elem);
-  arma::Mat<T> Lx_all;
+  dnf.setZero((Eigen::Index) x.size(), 4 * (Eigen::Index) x0.size());
+  Mat<T> Lx_all;
   eval_lip_prim_dnf<T>(x, x0, Lx_all, 0);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       const T xv       = x(ix);
       const T xi       = x0(fi);
       const T Lx       = Lx_all(ix, fi);
@@ -73,13 +73,13 @@ case (0): {
   }
 } break;
 case (1): {
-  dnf.zeros(x.n_elem, 4 * x0.n_elem);
-  arma::Mat<T> Lx_all;
+  dnf.setZero((Eigen::Index) x.size(), 4 * (Eigen::Index) x0.size());
+  Mat<T> Lx_all;
   eval_lip_prim_dnf<T>(x, x0, Lx_all, 0);
-  arma::Mat<T> dLx_all;
+  Mat<T> dLx_all;
   eval_lip_prim_dnf<T>(x, x0, dLx_all, 1);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       const T xv       = x(ix);
       const T xi       = x0(fi);
       const T Lx       = Lx_all(ix, fi);
@@ -99,15 +99,15 @@ case (1): {
   }
 } break;
 case (2): {
-  dnf.zeros(x.n_elem, 4 * x0.n_elem);
-  arma::Mat<T> Lx_all;
+  dnf.setZero((Eigen::Index) x.size(), 4 * (Eigen::Index) x0.size());
+  Mat<T> Lx_all;
   eval_lip_prim_dnf<T>(x, x0, Lx_all, 0);
-  arma::Mat<T> dLx_all;
+  Mat<T> dLx_all;
   eval_lip_prim_dnf<T>(x, x0, dLx_all, 1);
-  arma::Mat<T> ddLx_all;
+  Mat<T> ddLx_all;
   eval_lip_prim_dnf<T>(x, x0, ddLx_all, 2);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       const T xv       = x(ix);
       const T xi       = x0(fi);
       const T Lx       = Lx_all(ix, fi);

--- a/lib1dfem/include/lib1dfem/HIPBasis.h
+++ b/lib1dfem/include/lib1dfem/HIPBasis.h
@@ -17,7 +17,6 @@
 
 #include <lib1dfem/LIPBasis.h>
 #include <lib1dfem/HIPBasis_eval.h>
-#include <armadillo>
 
 namespace helfem {
 namespace lib1dfem {
@@ -26,25 +25,25 @@ namespace polynomial_basis {
 /// Hermite interpolating polynomial basis (order 1: interpolates value
 /// and first derivative at each node). Derives from LIPBasis<T> because
 /// the HIP shape functions are constructed from L_i(x)^2 and need the
-/// LIP derivative table.
+/// LIP derivative table. Phase 5.2: Eigen-typed.
 template <typename T>
 class HIPBasis : public LIPBasis<T> {
  protected:
   /// L_i'(x_i) at each node (precomputed at construction)
-  arma::Col<T> lipxi;
+  Vec<T> lipxi;
 
  public:
-  HIPBasis(const arma::Col<T> & x, int id_ = 5) : LIPBasis<T>(x, id_) {
+  HIPBasis(const Vec<T> & x, int id_ = 5) : LIPBasis<T>(x, id_) {
     // Two overlapping functions: function + derivative
     this->noverlap = 2;
-    this->nprim    = 2 * static_cast<int>(this->x0.n_elem);
-    this->enabled  = arma::linspace<arma::uvec>(0, this->nprim - 1, this->nprim);
-    this->nnodes   = static_cast<int>(this->x0.n_elem);
+    this->nprim    = 2 * static_cast<int>(this->x0.size());
+    this->enabled  = IVec::LinSpaced(this->nprim, 0, this->nprim - 1);
+    this->nnodes   = static_cast<int>(this->x0.size());
 
     // L'_i(x_i): use the LIP-derivative evaluator at the node positions.
-    arma::Mat<T> dlip;
+    Mat<T> dlip;
     detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dlip, 1);
-    lipxi = arma::diagvec(dlip);
+    lipxi = dlip.diagonal();
   }
 
   ~HIPBasis() override = default;
@@ -55,33 +54,33 @@ class HIPBasis : public LIPBasis<T> {
 
   void drop_first(bool func, bool deriv) override {
     if (func && deriv) {
-      this->enabled = this->enabled.subvec(2, this->enabled.n_elem - 1);
+      this->enabled = this->enabled.segment(2, this->enabled.size() - 2).eval();
     } else if (func) {
-      this->enabled = this->enabled.subvec(1, this->enabled.n_elem - 1);
+      this->enabled = this->enabled.segment(1, this->enabled.size() - 1).eval();
     } else if (deriv) {
-      arma::uvec new_enabled(this->enabled.n_elem - 1);
+      IVec new_enabled(this->enabled.size() - 1);
       new_enabled(0) = this->enabled(0);
-      new_enabled.subvec(1, new_enabled.n_elem - 1) =
-          this->enabled.subvec(2, this->enabled.n_elem - 1);
+      new_enabled.segment(1, new_enabled.size() - 1)
+          = this->enabled.segment(2, this->enabled.size() - 2);
       this->enabled = new_enabled;
     }
   }
 
   void drop_last(bool func, bool deriv) override {
     if (func && deriv) {
-      this->enabled = this->enabled.subvec(0, this->enabled.n_elem - 3);
+      this->enabled = this->enabled.segment(0, this->enabled.size() - 2).eval();
     } else if (deriv) {
-      this->enabled = this->enabled.subvec(0, this->enabled.n_elem - 2);
+      this->enabled = this->enabled.segment(0, this->enabled.size() - 1).eval();
     } else {
-      arma::uvec new_enabled(this->enabled.n_elem - 1);
-      new_enabled.subvec(0, this->enabled.n_elem - 3) =
-          this->enabled.subvec(0, this->enabled.n_elem - 3);
-      new_enabled(this->enabled.n_elem - 2) = this->enabled(this->enabled.n_elem - 1);
+      IVec new_enabled(this->enabled.size() - 1);
+      new_enabled.segment(0, this->enabled.size() - 2)
+          = this->enabled.segment(0, this->enabled.size() - 2);
+      new_enabled(this->enabled.size() - 2) = this->enabled(this->enabled.size() - 1);
       this->enabled = new_enabled;
     }
   }
 
-  void eval_prim_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf, int n,
+  void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
     detail::eval_hip_prim_dnf<T>(x, this->x0, lipxi, dnf, n, element_length);
   }
@@ -91,33 +90,9 @@ class HIPBasis : public LIPBasis<T> {
   using PolynomialBasis<T>::eval_over_r;
 
   /// Analytic B_u(r)/r for the surviving (post-drop_first(true,false)) HIP
-  /// shape functions on the first element.
-  ///
-  /// The element_length parameter is the scaling_factor = half the full
-  /// element width, matching the eval_dnf convention; r = element_length *
-  /// (x+1) on the first element.
-  ///
-  /// Surviving shapes after dropping only the function at node 0:
-  ///   - df_0 = (x+1) L_0(x)^2 * element_length   (derivative shape at node 0)
-  ///   - f_i, df_i for i >= 1                     (both shapes at remaining nodes)
-  ///
-  /// For i >= 1, factor L_i(x) = ((x+1)/(x_i+1)) * L_i^{(0)}(x), where
-  /// L_i^{(0)} is the LIP over the reduced node set {x_1, ..., x_{n-1}}.
-  /// Plug into the HIP shape formulas and divide by r = element_length*(x+1):
-  ///
-  ///   df_0(r)/r  = L_0(x)^2                                                          (n=0)
-  ///   f_i(r)/r   = (1/element_length) * (x+1) * [1 - 2(x-x_i) L_i'(x_i)]
-  ///                * L_i^{(0)}(x)^2 / (x_i+1)^2                                       (n=0, i>=1)
-  ///   df_i(r)/r  = (x+1) * (x-x_i) * L_i^{(0)}(x)^2 / (x_i+1)^2                       (n=0, i>=1)
-  ///
-  /// (the element_length factor on the derivative shape cancels with the
-  /// 1/r division for df_0 and df_i, but f_i picks up a 1/element_length.)
-  /// r-derivatives pull in (1/element_length)^n chain-rule factors.
-  ///
-  /// Implemented for n in {0, 1, 2}; throws for higher orders (this matches
-  /// the planned 'no Taylor pipeline' design where RadialBasis only needs
-  /// these three orders).
-  void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r, int n,
+  /// shape functions on the first element. See header comment in v1 code
+  /// for the deflation derivation.
+  void eval_over_r(const Vec<T> & x, Mat<T> & dnf_over_r, int n,
                    T element_length) const override {
     if (n < 0 || n > 2) {
       std::ostringstream oss;
@@ -125,24 +100,24 @@ class HIPBasis : public LIPBasis<T> {
           << " not implemented (only 0, 1, 2 supported).\n";
       throw std::logic_error(oss.str());
     }
-    if (this->enabled.n_elem == 0)
+    if (this->enabled.size() == 0)
       throw std::logic_error("HIPBasis::eval_over_r: no surviving basis functions.\n");
     if (this->enabled(0) == 0)
       throw std::logic_error(
           "HIPBasis::eval_over_r requires drop_first(func=true, deriv=false): the "
           "function shape at x=-1 has B(-1) != 0 and B/r is singular at the origin.\n");
 
-    const arma::Col<T> & x0_full = this->x0;
-    const arma::Col<T> x0_red    = x0_full.subvec(1, x0_full.n_elem - 1);
+    const Vec<T> & x0_full = this->x0;
+    const Vec<T> x0_red    = x0_full.segment(1, x0_full.size() - 1);
 
     // Full LIP values+derivatives (for L_0)
-    arma::Mat<T> Lf0, Lf1, Lf2;
+    Mat<T> Lf0, Lf1, Lf2;
     detail::eval_lip_prim_dnf<T>(x, x0_full, Lf0, 0);
     if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf1, 1);
     if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_full, Lf2, 2);
 
     // Reduced LIP values+derivatives (for L_i^{(0)}, i >= 1)
-    arma::Mat<T> Lr0, Lr1, Lr2;
+    Mat<T> Lr0, Lr1, Lr2;
     detail::eval_lip_prim_dnf<T>(x, x0_red, Lr0, 0);
     if (n >= 1) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr1, 1);
     if (n >= 2) detail::eval_lip_prim_dnf<T>(x, x0_red, Lr2, 2);
@@ -150,14 +125,14 @@ class HIPBasis : public LIPBasis<T> {
     const T inv_h = T(1) / element_length;       // 1 / scaling_factor
     const T chain = std::pow(inv_h, n);          // (1/element_length)^n
 
-    dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
+    dnf_over_r.resize(x.size(), this->enabled.size());
 
-    for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
-      const arma::uword idx  = this->enabled(k);
-      const arma::uword node = idx / 2;
-      const bool        deriv_shape = (idx % 2) == 1;
+    for (Eigen::Index k = 0; k < this->enabled.size(); ++k) {
+      const Eigen::Index idx  = this->enabled(k);
+      const Eigen::Index node = idx / 2;
+      const bool         deriv_shape = (idx % 2) == 1;
 
-      for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+      for (Eigen::Index ix = 0; ix < x.size(); ++ix) {
         const T xv = x(ix);
         T q;  // value of Q(x) for this shape (so that R(r) = prefactor * Q(x))
 
@@ -179,10 +154,7 @@ class HIPBasis : public LIPBasis<T> {
           dnf_over_r(ix, k) = chain * q;
         } else if (node >= 1 && !deriv_shape) {
           // f_i(r)/r = (1/element_length) * (x+1) * B(x) * C(x) / (x_i+1)^2
-          //   B(x) = 1 - 2 (x - x_i) lipxi_i,  B' = -2 lipxi_i,  B'' = 0
-          //   C(x) = L_i^{(0)}(x)^2,  C' = 2 L L',  C'' = 2 (L')^2 + 2 L L''
-          // Prefactor: (1/element_length)^(n+1)
-          const arma::uword i_red = node - 1;
+          const Eigen::Index i_red = node - 1;
           const T xi_p1 = x0_full(node) + T(1);
           const T inv_xi_p1_sq = T(1) / (xi_p1 * xi_p1);
           const T xpx1 = xv + T(1);
@@ -207,17 +179,12 @@ class HIPBasis : public LIPBasis<T> {
             const T Cp  = T(2) * L * Lp;
             const T Cpp = T(2) * Lp * Lp + T(2) * L * Lpp;
             // d^2/dx^2 [(x+1) B C] with A=x+1, A''=0, A'=1, B''=0:
-            //   = 2*A'*Bp*C + 2*A'*B*Cp + (x+1)*0*C + 2*(x+1)*Bp*Cp + (x+1)*B*Cpp
-            //   = 2 Bp C + 2 B Cp + 2 (x+1) Bp Cp + (x+1) B Cpp
             q = T(2) * Bp * C + T(2) * B * Cp + T(2) * xpx1 * Bp * Cp + xpx1 * B * Cpp;
           }
           dnf_over_r(ix, k) = inv_h * chain * q * inv_xi_p1_sq;
         } else if (node >= 1 && deriv_shape) {
           // df_i(r)/r = (x+1)(x-x_i) * C(x) / (x_i+1)^2
-          //   D(x) = (x+1)(x-x_i),  D' = 2x + 1 - x_i,  D'' = 2
-          //   C(x) = L_i^{(0)}(x)^2 as above
-          // Prefactor: (1/element_length)^n
-          const arma::uword i_red = node - 1;
+          const Eigen::Index i_red = node - 1;
           const T xi    = x0_full(node);
           const T xi_p1 = xi + T(1);
           const T inv_xi_p1_sq = T(1) / (xi_p1 * xi_p1);

--- a/lib1dfem/include/lib1dfem/HIPBasis_eval.h
+++ b/lib1dfem/include/lib1dfem/HIPBasis_eval.h
@@ -12,7 +12,7 @@
 #ifndef LIB1DFEM_HIPBASIS_EVAL_H
 #define LIB1DFEM_HIPBASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <lib1dfem/LIPBasis_eval.h>
 #include <sstream>
 #include <stdexcept>
@@ -25,22 +25,22 @@ namespace detail {
 /// Evaluate the n-th derivative of every HIP basis function on the
 /// reference element [-1, 1] at the given points x, given control nodes
 /// x0 and the precomputed LIP-derivative-at-nodes vector lipxi. Fills
-/// dnf (size x.n_elem x 2*x0.n_elem) with paired function-and-derivative
+/// dnf (size x.size() x 2*x0.size()) with paired function-and-derivative
 /// shape functions:
 ///   - column 2*fi   : the value-interpolating Hermite function for node fi
 ///   - column 2*fi+1 : the derivative-interpolating Hermite function for node fi
 /// scaled by element_length on the derivative slot.
 template <typename T>
-void eval_hip_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                       const arma::Col<T> & lipxi,
-                       arma::Mat<T> & dnf, int n, T element_length) {
+void eval_hip_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                       const Vec<T> & lipxi,
+                       Mat<T> & dnf, int n, T element_length) {
   switch (n) {
 case (0): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -52,13 +52,13 @@ case (0): {
   }
 } break;
 case (1): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -73,15 +73,15 @@ case (1): {
   }
 } break;
 case (2): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -96,17 +96,17 @@ case (2): {
   }
 } break;
 case (3): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -121,19 +121,19 @@ case (3): {
   }
 } break;
 case (4): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -148,21 +148,21 @@ case (4): {
   }
 } break;
 case (5): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -177,23 +177,23 @@ case (5): {
   }
 } break;
 case (6): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -208,25 +208,25 @@ case (6): {
   }
 } break;
 case (7): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -241,27 +241,27 @@ case (7): {
   }
 } break;
 case (8): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -276,29 +276,29 @@ case (8): {
   }
 } break;
 case (9): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -313,31 +313,31 @@ case (9): {
   }
 } break;
 case (10): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -352,33 +352,33 @@ case (10): {
   }
 } break;
 case (11): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -393,35 +393,35 @@ case (11): {
   }
 } break;
 case (12): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -436,37 +436,37 @@ case (12): {
   }
 } break;
 case (13): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -481,39 +481,39 @@ case (13): {
   }
 } break;
 case (14): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  arma::Mat<T> d14flip;
+  Mat<T> d14flip;
   eval_lip_prim_dnf<T>(x, x0, d14flip, 14);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -528,41 +528,41 @@ case (14): {
   }
 } break;
 case (15): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  arma::Mat<T> d14flip;
+  Mat<T> d14flip;
   eval_lip_prim_dnf<T>(x, x0, d14flip, 14);
-  arma::Mat<T> d15flip;
+  Mat<T> d15flip;
   eval_lip_prim_dnf<T>(x, x0, d15flip, 15);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -577,43 +577,43 @@ case (15): {
   }
 } break;
 case (16): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  arma::Mat<T> d14flip;
+  Mat<T> d14flip;
   eval_lip_prim_dnf<T>(x, x0, d14flip, 14);
-  arma::Mat<T> d15flip;
+  Mat<T> d15flip;
   eval_lip_prim_dnf<T>(x, x0, d15flip, 15);
-  arma::Mat<T> d16flip;
+  Mat<T> d16flip;
   eval_lip_prim_dnf<T>(x, x0, d16flip, 16);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -628,45 +628,45 @@ case (16): {
   }
 } break;
 case (17): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  arma::Mat<T> d14flip;
+  Mat<T> d14flip;
   eval_lip_prim_dnf<T>(x, x0, d14flip, 14);
-  arma::Mat<T> d15flip;
+  Mat<T> d15flip;
   eval_lip_prim_dnf<T>(x, x0, d15flip, 15);
-  arma::Mat<T> d16flip;
+  Mat<T> d16flip;
   eval_lip_prim_dnf<T>(x, x0, d16flip, 16);
-  arma::Mat<T> d17flip;
+  Mat<T> d17flip;
   eval_lip_prim_dnf<T>(x, x0, d17flip, 17);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -681,47 +681,47 @@ case (17): {
   }
 } break;
 case (18): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  arma::Mat<T> d14flip;
+  Mat<T> d14flip;
   eval_lip_prim_dnf<T>(x, x0, d14flip, 14);
-  arma::Mat<T> d15flip;
+  Mat<T> d15flip;
   eval_lip_prim_dnf<T>(x, x0, d15flip, 15);
-  arma::Mat<T> d16flip;
+  Mat<T> d16flip;
   eval_lip_prim_dnf<T>(x, x0, d16flip, 16);
-  arma::Mat<T> d17flip;
+  Mat<T> d17flip;
   eval_lip_prim_dnf<T>(x, x0, d17flip, 17);
-  arma::Mat<T> d18flip;
+  Mat<T> d18flip;
   eval_lip_prim_dnf<T>(x, x0, d18flip, 18);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -736,49 +736,49 @@ case (18): {
   }
 } break;
 case (19): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  arma::Mat<T> d14flip;
+  Mat<T> d14flip;
   eval_lip_prim_dnf<T>(x, x0, d14flip, 14);
-  arma::Mat<T> d15flip;
+  Mat<T> d15flip;
   eval_lip_prim_dnf<T>(x, x0, d15flip, 15);
-  arma::Mat<T> d16flip;
+  Mat<T> d16flip;
   eval_lip_prim_dnf<T>(x, x0, d16flip, 16);
-  arma::Mat<T> d17flip;
+  Mat<T> d17flip;
   eval_lip_prim_dnf<T>(x, x0, d17flip, 17);
-  arma::Mat<T> d18flip;
+  Mat<T> d18flip;
   eval_lip_prim_dnf<T>(x, x0, d18flip, 18);
-  arma::Mat<T> d19flip;
+  Mat<T> d19flip;
   eval_lip_prim_dnf<T>(x, x0, d19flip, 19);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);
@@ -793,51 +793,51 @@ case (19): {
   }
 } break;
 case (20): {
-  dnf.zeros(x.n_elem, 2 * x0.n_elem);
-  arma::Mat<T> flip;
+  dnf.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());
+  Mat<T> flip;
   eval_lip_prim_dnf<T>(x, x0, flip, 0);
-  arma::Mat<T> dflip;
+  Mat<T> dflip;
   eval_lip_prim_dnf<T>(x, x0, dflip, 1);
-  arma::Mat<T> d2flip;
+  Mat<T> d2flip;
   eval_lip_prim_dnf<T>(x, x0, d2flip, 2);
-  arma::Mat<T> d3flip;
+  Mat<T> d3flip;
   eval_lip_prim_dnf<T>(x, x0, d3flip, 3);
-  arma::Mat<T> d4flip;
+  Mat<T> d4flip;
   eval_lip_prim_dnf<T>(x, x0, d4flip, 4);
-  arma::Mat<T> d5flip;
+  Mat<T> d5flip;
   eval_lip_prim_dnf<T>(x, x0, d5flip, 5);
-  arma::Mat<T> d6flip;
+  Mat<T> d6flip;
   eval_lip_prim_dnf<T>(x, x0, d6flip, 6);
-  arma::Mat<T> d7flip;
+  Mat<T> d7flip;
   eval_lip_prim_dnf<T>(x, x0, d7flip, 7);
-  arma::Mat<T> d8flip;
+  Mat<T> d8flip;
   eval_lip_prim_dnf<T>(x, x0, d8flip, 8);
-  arma::Mat<T> d9flip;
+  Mat<T> d9flip;
   eval_lip_prim_dnf<T>(x, x0, d9flip, 9);
-  arma::Mat<T> d10flip;
+  Mat<T> d10flip;
   eval_lip_prim_dnf<T>(x, x0, d10flip, 10);
-  arma::Mat<T> d11flip;
+  Mat<T> d11flip;
   eval_lip_prim_dnf<T>(x, x0, d11flip, 11);
-  arma::Mat<T> d12flip;
+  Mat<T> d12flip;
   eval_lip_prim_dnf<T>(x, x0, d12flip, 12);
-  arma::Mat<T> d13flip;
+  Mat<T> d13flip;
   eval_lip_prim_dnf<T>(x, x0, d13flip, 13);
-  arma::Mat<T> d14flip;
+  Mat<T> d14flip;
   eval_lip_prim_dnf<T>(x, x0, d14flip, 14);
-  arma::Mat<T> d15flip;
+  Mat<T> d15flip;
   eval_lip_prim_dnf<T>(x, x0, d15flip, 15);
-  arma::Mat<T> d16flip;
+  Mat<T> d16flip;
   eval_lip_prim_dnf<T>(x, x0, d16flip, 16);
-  arma::Mat<T> d17flip;
+  Mat<T> d17flip;
   eval_lip_prim_dnf<T>(x, x0, d17flip, 17);
-  arma::Mat<T> d18flip;
+  Mat<T> d18flip;
   eval_lip_prim_dnf<T>(x, x0, d18flip, 18);
-  arma::Mat<T> d19flip;
+  Mat<T> d19flip;
   eval_lip_prim_dnf<T>(x, x0, d19flip, 19);
-  arma::Mat<T> d20flip;
+  Mat<T> d20flip;
   eval_lip_prim_dnf<T>(x, x0, d20flip, 20);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2
       // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2
       T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);

--- a/lib1dfem/include/lib1dfem/LIPBasis.h
+++ b/lib1dfem/include/lib1dfem/LIPBasis.h
@@ -17,7 +17,7 @@
 
 #include <lib1dfem/PolynomialBasis.h>
 #include <lib1dfem/LIPBasis_eval.h>
-#include <armadillo>
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <stdexcept>
@@ -28,30 +28,31 @@ namespace polynomial_basis {
 
 /// Lagrange interpolating polynomial basis on the reference element [-1, 1]
 /// with caller-supplied control nodes x0 (must include the endpoints).
-/// Templated on the scalar type T.
+/// Templated on the scalar type T. Phase 5.2: Eigen-typed.
 template <typename T>
 class LIPBasis : public PolynomialBasis<T> {
  protected:
   /// Control nodes (sorted ascending; must span the reference element).
-  arma::Col<T> x0;
+  Vec<T> x0;
 
  public:
   LIPBasis() = default;
 
-  LIPBasis(const arma::Col<T> & x, int id_ = 4) {
-    x0 = arma::sort(x, "ascend");
+  LIPBasis(const Vec<T> & x, int id_ = 4) {
+    x0 = x;
+    std::sort(x0.data(), x0.data() + x0.size());
 
     const T sqrteps = std::sqrt(std::numeric_limits<T>::epsilon());
     if (std::abs(x0(0) + T(1)) >= sqrteps)
       throw std::logic_error("LIP leftmost node is not at -1!\n");
-    if (std::abs(x0(x0.n_elem - 1) - T(1)) >= sqrteps)
+    if (std::abs(x0(x0.size() - 1) - T(1)) >= sqrteps)
       throw std::logic_error("LIP rightmost node is not at -1!\n");
 
     this->noverlap = 1;
-    this->nprim    = static_cast<int>(x0.n_elem);
-    this->enabled  = arma::linspace<arma::uvec>(0, x0.n_elem - 1, x0.n_elem);
+    this->nprim    = static_cast<int>(x0.size());
+    this->enabled  = IVec::LinSpaced(x0.size(), 0, x0.size() - 1);
     this->id       = id_;
-    this->nnodes   = static_cast<int>(this->enabled.n_elem);
+    this->nnodes   = static_cast<int>(this->enabled.size());
   }
 
   ~LIPBasis() override = default;
@@ -63,15 +64,15 @@ class LIPBasis : public PolynomialBasis<T> {
   void drop_first(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.subvec(1, this->enabled.n_elem - 1);
+      this->enabled = this->enabled.segment(1, this->enabled.size() - 1).eval();
   }
   void drop_last(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.subvec(0, this->enabled.n_elem - 2);
+      this->enabled = this->enabled.segment(0, this->enabled.size() - 1).eval();
   }
 
-  void eval_prim_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf, int n,
+  void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
     (void)element_length;
     detail::eval_lip_prim_dnf<T>(x, x0, dnf, n);
@@ -82,46 +83,35 @@ class LIPBasis : public PolynomialBasis<T> {
   using PolynomialBasis<T>::eval_over_r;
 
   /// Analytic B_u(r)/r for the surviving (post-drop_first) LIP shape
-  /// functions on the first element. Exploits the Dirichlet-induced
-  /// factorisation
-  ///     L_i(x) = ((x+1)/(x_i+1)) * L_i^{(0)}(x)
-  /// where L_i^{(0)} is the Lagrange polynomial over the reduced node set
-  /// {x_1, ..., x_{n-1}}, so for r = element_length * (x+1) on the first
-  /// element (element_length is the scaling_factor = half the full element
-  /// width, matching the eval_dnf convention):
-  ///     B_i(r)/r        = (1/element_length) * L_i^{(0)}(x) / (x_i + 1)
-  ///     d^n[B_i/r]/dr^n = (1/element_length)^(n+1) * L_i^{(0)(n)}(x) / (x_i + 1)
-  ///
-  /// L_i^{(0)} is computed by reusing the templated LIP evaluator on the
-  /// reduced node set. Output columns are indexed by `enabled` (just like
-  /// eval_dnf).
-  void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r, int n,
+  /// functions on the first element. See LIPBasis.h header comment in
+  /// the v1 code for the deflation derivation.
+  void eval_over_r(const Vec<T> & x, Mat<T> & dnf_over_r, int n,
                    T element_length) const override {
-    if (this->enabled.n_elem == 0)
+    if (this->enabled.size() == 0)
       throw std::logic_error("eval_over_r: no surviving basis functions.\n");
     if (this->enabled(0) == 0)
       throw std::logic_error(
           "eval_over_r requires drop_first(func=true) on LIPBasis: the shape "
           "function at x=-1 has B(-1) != 0 and B/r is singular at the origin.\n");
 
-    const arma::Col<T> x0_reduced = x0.subvec(1, x0.n_elem - 1);
-    arma::Mat<T> dnf_reduced;
+    const Vec<T> x0_reduced = x0.segment(1, x0.size() - 1);
+    Mat<T> dnf_reduced;
     detail::eval_lip_prim_dnf<T>(x, x0_reduced, dnf_reduced, n);
     // dnf_reduced column j_red ∈ [0, n-2] corresponds to full index j_full = j_red + 1.
 
     const T scale = T(1) / std::pow(element_length, n + 1);
-    dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
-    for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
-      const arma::uword i_full = this->enabled(k);
-      const arma::uword i_red  = i_full - 1;
+    dnf_over_r.resize(x.size(), this->enabled.size());
+    for (Eigen::Index k = 0; k < this->enabled.size(); ++k) {
+      const Eigen::Index i_full = this->enabled(k);
+      const Eigen::Index i_red  = i_full - 1;
       const T denom = x0(i_full) + T(1);
-      for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+      for (Eigen::Index ix = 0; ix < x.size(); ++ix) {
         dnf_over_r(ix, k) = scale * dnf_reduced(ix, i_red) / denom;
       }
     }
   }
 
-  arma::Col<T> get_nodes() const override { return x0; }
+  Vec<T> get_nodes() const override { return x0; }
 };
 
 } // namespace polynomial_basis

--- a/lib1dfem/include/lib1dfem/LIPBasis_eval.h
+++ b/lib1dfem/include/lib1dfem/LIPBasis_eval.h
@@ -12,7 +12,7 @@
 #ifndef LIB1DFEM_LIPBASIS_EVAL_H
 #define LIB1DFEM_LIPBASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <sstream>
 #include <stdexcept>
 
@@ -23,19 +23,19 @@ namespace detail {
 
 /// Evaluate the n-th derivative of every LIP polynomial on the reference
 /// element [-1, 1] at the given points x, given the control-node vector
-/// x0. Fills dnf (size x.n_elem x x0.n_elem) with d^n L_i(x_j)/dx^n in
+/// x0. Fills dnf (size x.size() x x0.size()) with d^n L_i(x_j)/dx^n in
 /// column-major (point, polynomial) layout. element_length is unused
 /// at this layer (the chain-rule scaling lives in PolynomialBasis::eval_dnf).
 template <typename T>
-void eval_lip_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                       arma::Mat<T> & dnf, int n) {
+void eval_lip_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                       Mat<T> & dnf, int n) {
   switch (n) {
 case (0): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == fi) continue;
         dnfval *= (x(ix) - x0(ip)) / (x0(fi) - x0(ip));
       }
@@ -44,14 +44,14 @@ case (0): {
   }
 } break;
 case (1): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == fi) continue;
         dnfval *= (x(ix) - x0(ip)) / (x0(fi) - x0(ip));
@@ -64,16 +64,16 @@ case (1): {
   }
 } break;
 case (2): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == fi) continue;
@@ -88,18 +88,18 @@ case (2): {
   }
 } break;
 case (3): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
       for (size_t d3 = 0; d3 < d2; d3++) {
         if (d3 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -116,11 +116,11 @@ case (3): {
   }
 } break;
 case (4): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -129,7 +129,7 @@ case (4): {
       for (size_t d4 = 0; d4 < d3; d4++) {
         if (d4 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -148,11 +148,11 @@ case (4): {
   }
 } break;
 case (5): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -163,7 +163,7 @@ case (5): {
       for (size_t d5 = 0; d5 < d4; d5++) {
         if (d5 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -184,11 +184,11 @@ case (5): {
   }
 } break;
 case (6): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -201,7 +201,7 @@ case (6): {
       for (size_t d6 = 0; d6 < d5; d6++) {
         if (d6 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -224,11 +224,11 @@ case (6): {
   }
 } break;
 case (7): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -243,7 +243,7 @@ case (7): {
       for (size_t d7 = 0; d7 < d6; d7++) {
         if (d7 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -268,11 +268,11 @@ case (7): {
   }
 } break;
 case (8): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -289,7 +289,7 @@ case (8): {
       for (size_t d8 = 0; d8 < d7; d8++) {
         if (d8 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -316,11 +316,11 @@ case (8): {
   }
 } break;
 case (9): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -339,7 +339,7 @@ case (9): {
       for (size_t d9 = 0; d9 < d8; d9++) {
         if (d9 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -368,11 +368,11 @@ case (9): {
   }
 } break;
 case (10): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -393,7 +393,7 @@ case (10): {
       for (size_t d10 = 0; d10 < d9; d10++) {
         if (d10 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -424,11 +424,11 @@ case (10): {
   }
 } break;
 case (11): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -451,7 +451,7 @@ case (11): {
       for (size_t d11 = 0; d11 < d10; d11++) {
         if (d11 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -484,11 +484,11 @@ case (11): {
   }
 } break;
 case (12): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -513,7 +513,7 @@ case (12): {
       for (size_t d12 = 0; d12 < d11; d12++) {
         if (d12 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -548,11 +548,11 @@ case (12): {
   }
 } break;
 case (13): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -579,7 +579,7 @@ case (13): {
       for (size_t d13 = 0; d13 < d12; d13++) {
         if (d13 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -616,11 +616,11 @@ case (13): {
   }
 } break;
 case (14): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -649,7 +649,7 @@ case (14): {
       for (size_t d14 = 0; d14 < d13; d14++) {
         if (d14 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -688,11 +688,11 @@ case (14): {
   }
 } break;
 case (15): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -723,7 +723,7 @@ case (15): {
       for (size_t d15 = 0; d15 < d14; d15++) {
         if (d15 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -764,11 +764,11 @@ case (15): {
   }
 } break;
 case (16): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -801,7 +801,7 @@ case (16): {
       for (size_t d16 = 0; d16 < d15; d16++) {
         if (d16 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -844,11 +844,11 @@ case (16): {
   }
 } break;
 case (17): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -883,7 +883,7 @@ case (17): {
       for (size_t d17 = 0; d17 < d16; d17++) {
         if (d17 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -928,11 +928,11 @@ case (17): {
   }
 } break;
 case (18): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -969,7 +969,7 @@ case (18): {
       for (size_t d18 = 0; d18 < d17; d18++) {
         if (d18 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -1016,11 +1016,11 @@ case (18): {
   }
 } break;
 case (19): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -1059,7 +1059,7 @@ case (19): {
       for (size_t d19 = 0; d19 < d18; d19++) {
         if (d19 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;
@@ -1108,11 +1108,11 @@ case (19): {
   }
 } break;
 case (20): {
-  dnf.zeros(x.n_elem, x0.n_elem);
-  for (size_t ix = 0; ix < x.n_elem; ix++) {
-    for (size_t fi = 0; fi < x0.n_elem; fi++) {
+  dnf.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());
+  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {
+    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {
       T el = T(0);
-      for (size_t d1 = 0; d1 < x0.n_elem; d1++) {
+      for (size_t d1 = 0; d1 < (size_t) x0.size(); d1++) {
         if (d1 == fi) continue;
       for (size_t d2 = 0; d2 < d1; d2++) {
         if (d2 == fi) continue;
@@ -1153,7 +1153,7 @@ case (20): {
       for (size_t d20 = 0; d20 < d19; d20++) {
         if (d20 == fi) continue;
       T dnfval = T(1);
-      for (size_t ip = 0; ip < x0.n_elem; ip++) {
+      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {
         if (ip == d1) continue;
         if (ip == d2) continue;
         if (ip == d3) continue;

--- a/lib1dfem/include/lib1dfem/LegendreBasis.h
+++ b/lib1dfem/include/lib1dfem/LegendreBasis.h
@@ -17,7 +17,6 @@
 
 #include <lib1dfem/PolynomialBasis.h>
 #include <lib1dfem/legendre_poly.h>
-#include <armadillo>
 #include <cmath>
 #include <sstream>
 #include <stdexcept>
@@ -26,38 +25,29 @@ namespace helfem {
 namespace lib1dfem {
 namespace polynomial_basis {
 
-/// Legendre spectral element basis. The first and last shape functions
-/// are linear blends of P_0 and P_1 (the standard nodal bubble functions);
-/// interior shape functions are the orthogonal combinations
-///     (P_{j+1} - P_{j-1}) / sqrt(4 j + 2)
-/// from Flores, Clementi & Sonnad, Chem. Phys. Lett. 163, 198 (1989).
-///
-/// Templated on the scalar type T.
+/// Legendre spectral element basis. Phase 5.2: Eigen-typed.
 template <typename T>
 class LegendreBasis : public PolynomialBasis<T> {
  protected:
   /// Maximum polynomial order
   int lmax;
   /// (lmax+1) x (lmax+1) transformation from raw P_l to the shape-function basis
-  arma::Mat<T> Tmat;
+  Mat<T> Tmat;
 
-  arma::Mat<T> f_eval(const arma::Col<T> & x) const {
+  Mat<T> f_eval(const Vec<T> & x) const {
     return helfem::lib1dfem::legendre::legendre_batch<T>(lmax, x);
   }
-  arma::Mat<T> df_eval(const arma::Col<T> & x) const {
+  Mat<T> df_eval(const Vec<T> & x) const {
     return helfem::lib1dfem::legendre::dlegendre_batch<T>(lmax, x);
   }
-  arma::Mat<T> d2f_eval(const arma::Col<T> & x) const {
+  Mat<T> d2f_eval(const Vec<T> & x) const {
     return helfem::lib1dfem::legendre::d2legendre_batch<T>(lmax, x);
   }
 
  public:
-  /// `n_nodes` here is the number of shape functions (= polynomial order + 1).
-  /// `id_` is just an identifier echoed back through get_id(); the libhelfem
-  /// factory passes the primbas value (default 3).
   LegendreBasis(int n_nodes, int id_ = 3) {
     lmax = n_nodes - 1;
-    Tmat.zeros(lmax + 1, lmax + 1);
+    Tmat = Mat<T>::Zero(lmax + 1, lmax + 1);
     // First shape function: (P_0 - P_1) / 2
     Tmat(0, 0)    = T(1) / T(2);
     Tmat(1, 0)    = -T(1) / T(2);
@@ -71,9 +61,9 @@ class LegendreBasis : public PolynomialBasis<T> {
       Tmat(j - 1, j) = -sqfac;
     }
     this->noverlap = 1;
-    this->nprim    = static_cast<int>(Tmat.n_cols);
-    this->nnodes   = static_cast<int>(Tmat.n_cols);
-    this->enabled  = arma::linspace<arma::uvec>(0, Tmat.n_cols - 1, Tmat.n_cols);
+    this->nprim    = static_cast<int>(Tmat.cols());
+    this->nnodes   = static_cast<int>(Tmat.cols());
+    this->enabled  = IVec::LinSpaced(Tmat.cols(), 0, Tmat.cols() - 1);
     this->id       = id_;
   }
 
@@ -86,15 +76,15 @@ class LegendreBasis : public PolynomialBasis<T> {
   void drop_first(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.subvec(1, this->enabled.n_elem - 1);
+      this->enabled = this->enabled.segment(1, this->enabled.size() - 1).eval();
   }
   void drop_last(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.subvec(0, this->enabled.n_elem - 2);
+      this->enabled = this->enabled.segment(0, this->enabled.size() - 1).eval();
   }
 
-  void eval_prim_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf, int n,
+  void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
     (void)element_length;
     switch (n) {
@@ -114,28 +104,8 @@ class LegendreBasis : public PolynomialBasis<T> {
 
   /// Analytic B_u(r)/r and r-derivatives for the surviving Legendre shape
   /// functions on the first element (r = element_length * (x+1)).
-  ///
-  /// After drop_first(zero_func=true) the value-shape (P_0 - P_1)/2 =
-  /// (1-x)/2 is dropped (it has B(-1)=1). The remaining shapes (last
-  /// shape (P_0+P_1)/2 = (1+x)/2, and interior shapes (P_{j+1} - P_{j-1})
-  /// / sqrt(4j+2)) all vanish at x=-1 so B/r is finite.
-  ///
-  /// Deflation: define Q_n(x) := (P_n(x) - (-1)^n) / (x+1). It's a
-  /// polynomial because P_n(-1) = (-1)^n. From the standard Legendre
-  /// recurrence one gets
-  ///   (n+1) Q_{n+1}(x) = (2n+1) x Q_n(x) - n Q_{n-1}(x) + (-1)^n (2n+1)
-  /// with Q_0 = 0, Q_1 = 1. The first two x-derivatives obey
-  ///   (n+1) Q'_{n+1}(x)  = (2n+1)(Q_n + x Q'_n)     - n Q'_{n-1}
-  ///   (n+1) Q''_{n+1}(x) = (2n+1)(2 Q'_n + x Q''_n) - n Q''_{n-1}
-  /// Then the surviving shapes are linear combinations of Q's:
-  ///   last shape j=lmax:    R(r)  = 1 / (2 * element_length)    (constant)
-  ///   interior j in [1, lmax-1]:
-  ///                         R(x)  = (Q_{j+1}(x) - Q_{j-1}(x))
-  ///                                 / (element_length * sqrt(4j+2))
-  /// r-derivatives pull in (1/element_length)^n via the chain rule.
-  ///
-  /// Implemented for n in {0, 1, 2}; throws for higher orders.
-  void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r, int n,
+  /// See v1 code header comment for the deflation derivation.
+  void eval_over_r(const Vec<T> & x, Mat<T> & dnf_over_r, int n,
                    T element_length) const override {
     if (n < 0 || n > 2) {
       std::ostringstream oss;
@@ -143,7 +113,7 @@ class LegendreBasis : public PolynomialBasis<T> {
           << " not implemented (only 0, 1, 2 supported).\n";
       throw std::logic_error(oss.str());
     }
-    if (this->enabled.n_elem == 0)
+    if (this->enabled.size() == 0)
       throw std::logic_error("LegendreBasis::eval_over_r: no surviving basis functions.\n");
     if (this->enabled(0) == 0)
       throw std::logic_error(
@@ -151,18 +121,18 @@ class LegendreBasis : public PolynomialBasis<T> {
           "the value-shape (1-x)/2 has B(-1)=1 and B/r is singular at the origin.\n");
 
     // Build Q_n, Q'_n, Q''_n for n = 0..lmax at every integration point.
-    arma::Mat<T> Q  (x.n_elem, lmax + 1, arma::fill::zeros);
-    arma::Mat<T> Qp (x.n_elem, lmax + 1, arma::fill::zeros);
-    arma::Mat<T> Qpp(x.n_elem, lmax + 1, arma::fill::zeros);
+    Mat<T> Q   = Mat<T>::Zero(x.size(), lmax + 1);
+    Mat<T> Qp  = Mat<T>::Zero(x.size(), lmax + 1);
+    Mat<T> Qpp = Mat<T>::Zero(x.size(), lmax + 1);
     if (lmax >= 1)
-      for (arma::uword ix = 0; ix < x.n_elem; ++ix)
+      for (Eigen::Index ix = 0; ix < x.size(); ++ix)
         Q(ix, 1) = T(1);
     for (int k = 1; k < lmax; ++k) {
       const T inv_kp1  = T(1) / T(k + 1);
       const T two_k_p1 = T(2 * k + 1);
       const T k_T      = T(k);
       const T sign_k   = (k % 2 == 0) ? T(1) : T(-1);
-      for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+      for (Eigen::Index ix = 0; ix < x.size(); ++ix) {
         const T xv = x(ix);
         Q  (ix, k + 1) = (two_k_p1 * xv * Q  (ix, k) - k_T * Q  (ix, k - 1)
                           + sign_k * two_k_p1) * inv_kp1;
@@ -176,18 +146,18 @@ class LegendreBasis : public PolynomialBasis<T> {
     const T inv_e   = T(1) / element_length;
     const T chain_n = std::pow(inv_e, n);
 
-    dnf_over_r.set_size(x.n_elem, this->enabled.n_elem);
-    for (arma::uword k = 0; k < this->enabled.n_elem; ++k) {
-      const arma::uword j = this->enabled(k);
-      if (j == static_cast<arma::uword>(lmax)) {
+    dnf_over_r.resize(x.size(), this->enabled.size());
+    for (Eigen::Index k = 0; k < this->enabled.size(); ++k) {
+      const Eigen::Index j = this->enabled(k);
+      if (j == static_cast<Eigen::Index>(lmax)) {
         // Last shape: R(r) = 1/(2 e); derivatives vanish.
         const T val0 = T(1) / (T(2) * element_length);
-        for (arma::uword ix = 0; ix < x.n_elem; ++ix)
+        for (Eigen::Index ix = 0; ix < x.size(); ++ix)
           dnf_over_r(ix, k) = (n == 0) ? val0 : T(0);
       } else {
         // Interior j in [1, lmax-1].
         const T inv_norm = T(1) / std::sqrt(T(4) * T(j) + T(2));
-        for (arma::uword ix = 0; ix < x.n_elem; ++ix) {
+        for (Eigen::Index ix = 0; ix < x.size(); ++ix) {
           T R;
           if      (n == 0) R = (Q  (ix, j + 1) - Q  (ix, j - 1)) * inv_norm * inv_e;
           else if (n == 1) R = (Qp (ix, j + 1) - Qp (ix, j - 1)) * inv_norm * inv_e;

--- a/lib1dfem/include/lib1dfem/PolynomialBasis.h
+++ b/lib1dfem/include/lib1dfem/PolynomialBasis.h
@@ -15,10 +15,11 @@
 #ifndef LIB1DFEM_POLYNOMIALBASIS_H
 #define LIB1DFEM_POLYNOMIALBASIS_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <fstream>
 
 namespace helfem {
 namespace lib1dfem {
@@ -29,15 +30,14 @@ namespace polynomial_basis {
 /// GeneralHIPBasis, LegendreBasis) implement eval_prim_dnf, copy,
 /// drop_first, drop_last and may override get_nodes.
 ///
-/// Templated on the scalar type T. The integer `enabled` index list
-/// stays a plain arma::uvec since it indexes columns, not floats.
+/// Templated on the scalar type T (Phase 5.2: lib1dfem migrated arma -> Eigen).
 template <typename T>
 class PolynomialBasis {
  protected:
   /// Number of primitive functions
   int nprim = 0;
-  /// List of enabled functions
-  arma::uvec enabled;
+  /// List of enabled functions (column indices into the primitive set).
+  IVec enabled;
   /// Number of overlapping functions (between adjacent elements)
   int noverlap = 0;
   /// Identifier (used by factories and downstream metadata)
@@ -47,7 +47,7 @@ class PolynomialBasis {
 
   /// Evaluate nth derivatives of primitive polynomials at given points.
   /// Default throws -- concrete subclasses must override.
-  virtual void eval_prim_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf,
+  virtual void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf,
                              int n, T element_length) const {
     (void)x; (void)dnf; (void)n; (void)element_length;
     throw std::logic_error(
@@ -62,21 +62,21 @@ class PolynomialBasis {
   virtual PolynomialBasis * copy() const = 0;
 
   int get_nprim()    const { return nprim; }
-  int get_nbf()      const { return static_cast<int>(enabled.n_elem); }
+  int get_nbf()      const { return static_cast<int>(enabled.size()); }
   int get_noverlap() const { return noverlap; }
   int get_id()       const { return id; }
   int get_nnodes()   const { return nnodes; }
 
   /// Default node set is the reference element boundary {-1, +1};
   /// concrete subclasses (LIP/HIP) override with the actual node set.
-  virtual arma::Col<T> get_nodes() const {
-    arma::Col<T> n(2);
+  virtual Vec<T> get_nodes() const {
+    Vec<T> n(2);
     n(0) = T(-1);
     n(1) = T(1);
     return n;
   }
 
-  arma::uvec get_enabled() const { return enabled; }
+  IVec get_enabled() const { return enabled; }
 
   /// Drop first function(s); zero_deriv: also set derivatives to zero.
   virtual void drop_first(bool zero_func, bool zero_deriv) = 0;
@@ -86,15 +86,16 @@ class PolynomialBasis {
   /// Evaluate nth derivatives of polynomials at given points; applies the
   /// element_length^-n chain-rule scaling and restricts to enabled
   /// functions.
-  void eval_dnf(const arma::Col<T> & x, arma::Mat<T> & dnf, int n,
+  void eval_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                 T element_length) const {
-    eval_prim_dnf(x, dnf, n, element_length);
-    dnf = dnf.cols(enabled) / std::pow(element_length, n);
+    Mat<T> prim;
+    eval_prim_dnf(x, prim, n, element_length);
+    // Column subset using Eigen 3.4 indexing: prim(all, enabled).
+    dnf = prim(Eigen::all, enabled) / std::pow(element_length, n);
   }
 
-  arma::Mat<T> eval_dnf(const arma::Col<T> & x, int n,
-                        T element_length) const {
-    arma::Mat<T> dnf;
+  Mat<T> eval_dnf(const Vec<T> & x, int n, T element_length) const {
+    Mat<T> dnf;
     eval_dnf(x, dnf, n, element_length);
     return dnf;
   }
@@ -114,31 +115,36 @@ class PolynomialBasis {
   ///
   /// Default implementation throws; concrete subclasses provide the analytic
   /// deflation when they support it (LIP and HIP today).
-  virtual void eval_over_r(const arma::Col<T> & x, arma::Mat<T> & dnf_over_r,
+  virtual void eval_over_r(const Vec<T> & x, Mat<T> & dnf_over_r,
                            int n, T element_length) const {
     (void)x; (void)dnf_over_r; (void)n; (void)element_length;
     throw std::logic_error(
         "eval_over_r is not implemented for this PolynomialBasis subclass.\n");
   }
 
-  arma::Mat<T> eval_over_r(const arma::Col<T> & x, int n,
-                           T element_length) const {
-    arma::Mat<T> dnf_over_r;
+  Mat<T> eval_over_r(const Vec<T> & x, int n, T element_length) const {
+    Mat<T> dnf_over_r;
     eval_over_r(x, dnf_over_r, n, element_length);
     return dnf_over_r;
   }
 
   /// Diagnostic dump of basis functions (and first derivatives) sampled
-  /// on a fine grid; writes "bf<str>.dat" / "df<str>.dat".
+  /// on a fine grid; writes "bf<str>.dat" / "df<str>.dat" as plain text.
   void print(const std::string & str = "") const {
-    arma::Col<T> x = arma::linspace<arma::Col<T>>(T(-1), T(1), 1001);
-    arma::Mat<T> bf, df;
+    Vec<T> x = Vec<T>::LinSpaced(1001, T(-1), T(1));
+    Mat<T> bf, df;
     eval_dnf(x, bf, 0, T(1));
     eval_dnf(x, df, 1, T(1));
-    bf.insert_cols(0, x);
-    df.insert_cols(0, x);
-    bf.save("bf" + str + ".dat", arma::raw_ascii);
-    df.save("df" + str + ".dat", arma::raw_ascii);
+    auto dump = [&](const std::string & fname, const Mat<T> & m) {
+      std::ofstream os(fname);
+      for (Eigen::Index i = 0; i < x.size(); ++i) {
+        os << x(i);
+        for (Eigen::Index j = 0; j < m.cols(); ++j) os << " " << m(i, j);
+        os << "\n";
+      }
+    };
+    dump("bf" + str + ".dat", bf);
+    dump("df" + str + ".dat", df);
   }
 };
 

--- a/lib1dfem/include/lib1dfem/legendre_poly.h
+++ b/lib1dfem/include/lib1dfem/legendre_poly.h
@@ -15,22 +15,22 @@
 #ifndef LIB1DFEM_LEGENDRE_POLY_H
 #define LIB1DFEM_LEGENDRE_POLY_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 
 namespace helfem {
 namespace lib1dfem {
 namespace legendre {
 
 /// Evaluate Legendre polynomials P_l(x) for l = 0, 1, ..., lmax at every
-/// point x in `x`. Returns a (n_elem x (lmax+1)) matrix with P_l(x_i) at
+/// point x in `x`. Returns a (n_points x (lmax+1)) matrix with P_l(x_i) at
 /// (i, l). Templated on the scalar type T.
 ///
 /// Recurrence: P_0(x) = 1, P_1(x) = x;
 ///             (n+1) P_{n+1}(x) = (2n+1) x P_n(x) - n P_{n-1}(x).
 template <typename T>
-arma::Mat<T> legendre_batch(int lmax, const arma::Col<T> & x) {
-  arma::Mat<T> P(x.n_elem, lmax + 1);
-  for (arma::uword i = 0; i < x.n_elem; ++i) {
+Mat<T> legendre_batch(int lmax, const Vec<T> & x) {
+  Mat<T> P(x.size(), lmax + 1);
+  for (Eigen::Index i = 0; i < x.size(); ++i) {
     P(i, 0) = T(1);
     if (lmax >= 1) P(i, 1) = x(i);
     for (int n = 1; n < lmax; ++n) {
@@ -41,15 +41,11 @@ arma::Mat<T> legendre_batch(int lmax, const arma::Col<T> & x) {
 }
 
 /// First derivatives P_l'(x), same layout.
-///
-/// Differentiating the polynomial recurrence:
-///   (n+1) P_{n+1}'(x) = (2n+1) P_n(x) + (2n+1) x P_n'(x) - n P_{n-1}'(x).
-/// P_0' = 0, P_1' = 1.
 template <typename T>
-arma::Mat<T> dlegendre_batch(int lmax, const arma::Col<T> & x) {
-  arma::Mat<T> P  = legendre_batch<T>(lmax, x);
-  arma::Mat<T> dP(x.n_elem, lmax + 1);
-  for (arma::uword i = 0; i < x.n_elem; ++i) {
+Mat<T> dlegendre_batch(int lmax, const Vec<T> & x) {
+  Mat<T> P = legendre_batch<T>(lmax, x);
+  Mat<T> dP(x.size(), lmax + 1);
+  for (Eigen::Index i = 0; i < x.size(); ++i) {
     dP(i, 0) = T(0);
     if (lmax >= 1) dP(i, 1) = T(1);
     for (int n = 1; n < lmax; ++n) {
@@ -62,15 +58,11 @@ arma::Mat<T> dlegendre_batch(int lmax, const arma::Col<T> & x) {
 }
 
 /// Second derivatives P_l''(x), same layout.
-///
-/// Differentiating the derivative recurrence once more:
-///   (n+1) P_{n+1}''(x) = 2(2n+1) P_n'(x) + (2n+1) x P_n''(x) - n P_{n-1}''(x).
-/// P_0'' = P_1'' = 0.
 template <typename T>
-arma::Mat<T> d2legendre_batch(int lmax, const arma::Col<T> & x) {
-  arma::Mat<T> dP  = dlegendre_batch<T>(lmax, x);
-  arma::Mat<T> d2P(x.n_elem, lmax + 1);
-  for (arma::uword i = 0; i < x.n_elem; ++i) {
+Mat<T> d2legendre_batch(int lmax, const Vec<T> & x) {
+  Mat<T> dP = dlegendre_batch<T>(lmax, x);
+  Mat<T> d2P(x.size(), lmax + 1);
+  for (Eigen::Index i = 0; i < x.size(); ++i) {
     d2P(i, 0) = T(0);
     if (lmax >= 1) d2P(i, 1) = T(0);
     for (int n = 1; n < lmax; ++n) {

--- a/lib1dfem/include/lib1dfem/types.h
+++ b/lib1dfem/include/lib1dfem/types.h
@@ -38,6 +38,11 @@ using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 template <typename T>
 using RowVec = Eigen::Matrix<T, 1, Eigen::Dynamic>;
 
+/// Index vector (signed Eigen::Index = ptrdiff_t). Used wherever the
+/// arma::uvec lived in the v1 code -- typically for the `enabled`
+/// column-selection list on PolynomialBasis subclasses.
+using IVec = Eigen::Matrix<Eigen::Index, Eigen::Dynamic, 1>;
+
 } // namespace lib1dfem
 } // namespace helfem
 

--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -15,6 +15,7 @@
 
 #include "FiniteElementBasis.h"
 #include <cfloat>
+#include <cstring>
 
 namespace helfem {
   namespace polynomial_basis {
@@ -240,8 +241,14 @@ namespace helfem {
     }
 
     arma::uvec FiniteElementBasis::basis_indices(size_t iel) const {
+      // Phase 5.2: lib1dfem PolynomialBasis::enabled is IVec (Eigen);
+      // bridge to arma::uvec at the libhelfem boundary.
       std::shared_ptr<polynomial_basis::PolynomialBasis> p(get_basis(iel));
-      return p->get_enabled();
+      const auto & ie = p->get_enabled();
+      arma::uvec out(ie.size());
+      for (Eigen::Index i = 0; i < ie.size(); ++i)
+        out(i) = static_cast<arma::uword>(ie(i));
+      return out;
     }
 
     arma::mat FiniteElementBasis::get_basis(const arma::mat &bas, size_t iel) const {
@@ -292,8 +299,15 @@ namespace helfem {
     }
 
     void FiniteElementBasis::eval_dnf(const arma::vec & x, arma::mat & dnf, int n, size_t iel) const {
+      // Phase 5.2: lib1dfem eval_dnf takes/returns Eigen. Bridge here.
       std::shared_ptr<polynomial_basis::PolynomialBasis> p(get_basis(iel));
-      p->eval_dnf(x,dnf,n,scaling_factor(iel));
+      lib1dfem::Vec<double> xe(x.n_elem);
+      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
+      lib1dfem::Mat<double> dnf_e;
+      p->eval_dnf(xe, dnf_e, n, scaling_factor(iel));
+      dnf.set_size(dnf_e.rows(), dnf_e.cols());
+      std::memcpy(dnf.memptr(), dnf_e.data(),
+                  sizeof(double) * static_cast<size_t>(dnf_e.size()));
     }
 
     arma::mat FiniteElementBasis::eval_f(const arma::vec & x, size_t iel) const {
@@ -309,8 +323,9 @@ namespace helfem {
     }
 
     arma::mat FiniteElementBasis::eval_dnf(const arma::vec & x, int n, size_t iel) const {
-      std::shared_ptr<polynomial_basis::PolynomialBasis> p(get_basis(iel));
-      return p->eval_dnf(x,n,scaling_factor(iel));
+      arma::mat dnf;
+      eval_dnf(x, dnf, n, iel);
+      return dnf;
     }
 
     arma::mat FiniteElementBasis::eval_over_r(const arma::vec & x, int n, size_t iel) const {
@@ -320,9 +335,15 @@ namespace helfem {
             " element " << iel << " starts at " << element_begin(iel) << ".\n";
         throw std::logic_error(oss.str());
       }
+      // Phase 5.2: lib1dfem eval_over_r takes/returns Eigen. Bridge.
       std::shared_ptr<polynomial_basis::PolynomialBasis> p(get_basis(iel));
-      arma::mat dnf_over_r;
-      p->eval_over_r(x, dnf_over_r, n, scaling_factor(iel));
+      lib1dfem::Vec<double> xe(x.n_elem);
+      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
+      lib1dfem::Mat<double> dnf_e;
+      p->eval_over_r(xe, dnf_e, n, scaling_factor(iel));
+      arma::mat dnf_over_r(dnf_e.rows(), dnf_e.cols());
+      std::memcpy(dnf_over_r.memptr(), dnf_e.data(),
+                  sizeof(double) * static_cast<size_t>(dnf_e.size()));
       return dnf_over_r;
     }
 

--- a/libhelfem/src/PolynomialBasis.cpp
+++ b/libhelfem/src/PolynomialBasis.cpp
@@ -25,6 +25,19 @@
 #include "LegendreBasis.h"
 #include <lib1dfem/HIP2Basis.h>  // analytic HIP order 2 (primbas=8 since v2)
 #include <lib1dfem/HIP3Basis.h>  // analytic HIP order 3 (primbas=9 since v2)
+#include <ArmaEigen.h>
+#include <cstring>
+
+namespace {
+  // Phase 5.2: lib1dfem PolynomialBasis subclasses now take Vec<T>
+  // (Eigen) constructors. This helper bridges from arma::vec at the
+  // libhelfem factory boundary; copy cost is one-time at basis setup.
+  inline helfem::lib1dfem::Vec<double> arma_to_eigen_vec(const arma::vec & v) {
+    helfem::lib1dfem::Vec<double> e(v.n_elem);
+    std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
+    return e;
+  }
+} // namespace
 // (GeneralHIPBasis was removed when its callers were either rerouted to
 // analytic HIP2/HIP3 (primbas=8, 9) or deprecated (primbas=6, 7, 10, 11).)
 
@@ -52,7 +65,7 @@ namespace helfem {
         {
           arma::vec x, w;
           ::lobatto_compute(Nnodes,x,w);
-          poly=new polynomial_basis::LIPBasis(x,primbas);
+          poly=new polynomial_basis::LIPBasis(arma_to_eigen_vec(x),primbas);
           printf("Basis set composed of %i-node LIPs with Gauss-Lobatto nodes.\n",Nnodes);
           break;
         }
@@ -61,7 +74,7 @@ namespace helfem {
         {
           arma::vec x, w;
           ::lobatto_compute(Nnodes,x,w);
-          poly=new polynomial_basis::HIPBasis(x,primbas);
+          poly=new polynomial_basis::HIPBasis(arma_to_eigen_vec(x),primbas);
           printf("Basis set composed of %i-node HIPs with Gauss-Lobatto nodes.\n",Nnodes);
           break;
         }
@@ -72,7 +85,7 @@ namespace helfem {
           for(int i=0;i<Nnodes;i++)
             ang(i) = M_PI*(Nnodes-1-i)/(Nnodes-1);
           arma::vec x=arma::cos(ang);
-          poly=new polynomial_basis::LIPBasis(x,4);
+          poly=new polynomial_basis::LIPBasis(arma_to_eigen_vec(x),4);
           printf("Basis set composed of %i-node LIPs with Chebyshev nodes.\n",Nnodes);
           break;
         }
@@ -83,7 +96,7 @@ namespace helfem {
           for(int i=0;i<Nnodes;i++)
             ang(i) = M_PI*(Nnodes-1-i)/(Nnodes-1);
           arma::vec x=arma::cos(ang);
-          poly=new polynomial_basis::HIPBasis(x,5);
+          poly=new polynomial_basis::HIPBasis(arma_to_eigen_vec(x),5);
           printf("Basis set composed of %i-node HIPs with Chebyshev nodes.\n",Nnodes);
           break;
         }
@@ -94,7 +107,7 @@ namespace helfem {
           // runtime-inverted GeneralHIPBasis(nder=2) path.
           arma::vec x, w;
           ::lobatto_compute(Nnodes, x, w);
-          poly = new lib1dfem::polynomial_basis::HIP2Basis<double>(x, primbas);
+          poly = new lib1dfem::polynomial_basis::HIP2Basis<double>(arma_to_eigen_vec(x), primbas);
           printf("Basis set composed of %i-node 2nd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
           break;
         }
@@ -105,7 +118,7 @@ namespace helfem {
           // runtime-inverted GeneralHIPBasis(nder=3) path.
           arma::vec x, w;
           ::lobatto_compute(Nnodes, x, w);
-          poly = new lib1dfem::polynomial_basis::HIP3Basis<double>(x, primbas);
+          poly = new lib1dfem::polynomial_basis::HIP3Basis<double>(arma_to_eigen_vec(x), primbas);
           printf("Basis set composed of %i-node 3rd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
           break;
         }

--- a/libhelfem/src/generate_hip2_code.py
+++ b/libhelfem/src/generate_hip2_code.py
@@ -98,7 +98,7 @@ print('''/*
 #ifndef LIB1DFEM_HIP2BASIS_EVAL_H
 #define LIB1DFEM_HIP2BASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <lib1dfem/LIPBasis_eval.h>
 #include <sstream>
 #include <stdexcept>
@@ -128,9 +128,9 @@ namespace detail {
 /// needed once the Taylor pipeline in RadialBasis has been retired
 /// (see PR #69).
 template <typename T>
-void eval_hip2_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                        const arma::Col<T> & lipxi, const arma::Col<T> & lipxi2,
-                        arma::Mat<T> & dnf, int n, T element_length) {
+void eval_hip2_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                        const Vec<T> & lipxi, const Vec<T> & lipxi2,
+                        Mat<T> & dnf, int n, T element_length) {
   switch (n) {''')
 
 
@@ -147,13 +147,13 @@ def emit_T_typed(expr):
 for n in range(3):
     needed_lip_orders = list(range(n + 1))
     print(f'case ({n}): {{')
-    print(f'  dnf.zeros(x.n_elem, 3 * x0.n_elem);')
+    print(f'  dnf.setZero((Eigen::Index) x.size(), 3 * (Eigen::Index) x0.size());')
     for k in needed_lip_orders:
         name = ['Lx_all', 'dLx_all', 'ddLx_all'][k]
-        print(f'  arma::Mat<T> {name};')
+        print(f'  Mat<T> {name};')
         print(f'  eval_lip_prim_dnf<T>(x, x0, {name}, {k});')
-    print(f'  for (size_t ix = 0; ix < x.n_elem; ix++) {{')
-    print(f'    for (size_t fi = 0; fi < x0.n_elem; fi++) {{')
+    print(f'  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {{')
+    print(f'    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {{')
     print(f'      const T xv      = x(ix);')
     print(f'      const T xi      = x0(fi);')
     print(f'      const T Lx      = Lx_all(ix, fi);')

--- a/libhelfem/src/generate_hip3_code.py
+++ b/libhelfem/src/generate_hip3_code.py
@@ -137,7 +137,7 @@ print('''/*
 #ifndef LIB1DFEM_HIP3BASIS_EVAL_H
 #define LIB1DFEM_HIP3BASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <lib1dfem/LIPBasis_eval.h>
 #include <sstream>
 #include <stdexcept>
@@ -169,10 +169,10 @@ namespace detail {
 /// needed once the Taylor pipeline in RadialBasis has been retired
 /// (see PR #69).
 template <typename T>
-void eval_hip3_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                        const arma::Col<T> & lipxi, const arma::Col<T> & lipxi2,
-                        const arma::Col<T> & lipxi3,
-                        arma::Mat<T> & dnf, int n, T element_length) {
+void eval_hip3_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                        const Vec<T> & lipxi, const Vec<T> & lipxi2,
+                        const Vec<T> & lipxi3,
+                        Mat<T> & dnf, int n, T element_length) {
   switch (n) {''')
 
 
@@ -185,13 +185,13 @@ def emit_T_typed(expr):
 for n in range(3):
     needed_lip_orders = list(range(n + 1))
     print(f'case ({n}): {{')
-    print(f'  dnf.zeros(x.n_elem, 4 * x0.n_elem);')
+    print(f'  dnf.setZero((Eigen::Index) x.size(), 4 * (Eigen::Index) x0.size());')
     for k in needed_lip_orders:
         name = ['Lx_all', 'dLx_all', 'ddLx_all'][k]
-        print(f'  arma::Mat<T> {name};')
+        print(f'  Mat<T> {name};')
         print(f'  eval_lip_prim_dnf<T>(x, x0, {name}, {k});')
-    print(f'  for (size_t ix = 0; ix < x.n_elem; ix++) {{')
-    print(f'    for (size_t fi = 0; fi < x0.n_elem; fi++) {{')
+    print(f'  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {{')
+    print(f'    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {{')
     print(f'      const T xv       = x(ix);')
     print(f'      const T xi       = x0(fi);')
     print(f'      const T Lx       = Lx_all(ix, fi);')

--- a/libhelfem/src/generate_hip_code.py
+++ b/libhelfem/src/generate_hip_code.py
@@ -43,7 +43,7 @@ print('''/*
 #ifndef LIB1DFEM_HIPBASIS_EVAL_H
 #define LIB1DFEM_HIPBASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <lib1dfem/LIPBasis_eval.h>
 #include <sstream>
 #include <stdexcept>
@@ -56,15 +56,15 @@ namespace detail {
 /// Evaluate the n-th derivative of every HIP basis function on the
 /// reference element [-1, 1] at the given points x, given control nodes
 /// x0 and the precomputed LIP-derivative-at-nodes vector lipxi. Fills
-/// dnf (size x.n_elem x 2*x0.n_elem) with paired function-and-derivative
+/// dnf (size x.size() x 2*x0.size()) with paired function-and-derivative
 /// shape functions:
 ///   - column 2*fi   : the value-interpolating Hermite function for node fi
 ///   - column 2*fi+1 : the derivative-interpolating Hermite function for node fi
 /// scaled by element_length on the derivative slot.
 template <typename T>
-void eval_hip_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                       const arma::Col<T> & lipxi,
-                       arma::Mat<T> & dnf, int n, T element_length) {
+void eval_hip_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                       const Vec<T> & lipxi,
+                       Mat<T> & dnf, int n, T element_length) {
   switch (n) {''')
 
 
@@ -103,13 +103,13 @@ def emit_term(label, Li):
 for order in range(0, maxorder):
     fname = 'dnf'
     print('case ({}): {{'.format(order))
-    print('  {}.zeros(x.n_elem, 2 * x0.n_elem);'.format(fname))
+    print('  {}.setZero((Eigen::Index) x.size(), 2 * (Eigen::Index) x0.size());'.format(fname))
     for olip in range(order + 1):
-        print('  arma::Mat<T> {0}lip;'.format(get_fname(olip)))
+        print('  Mat<T> {0}lip;'.format(get_fname(olip)))
         print('  eval_lip_prim_dnf<T>(x, x0, {0}lip, {1});'.format(
             get_fname(olip), olip))
-    print('  for (size_t ix = 0; ix < x.n_elem; ix++) {')
-    print('    for (size_t fi = 0; fi < x0.n_elem; fi++) {')
+    print('  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {')
+    print('    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {')
     print('      // First shape function:  [1 - 2(x-xi)*lipxi(fi)] * L_i(x)^2  =  f1 * f2')
     print('      // Second shape function: (x-xi) * L_i(x)^2                    =  f3 * f2')
     print('      T f1 = T(1) - T(2) * (x(ix) - x0(fi)) * lipxi(fi);')

--- a/libhelfem/src/generate_lip_code.py
+++ b/libhelfem/src/generate_lip_code.py
@@ -44,7 +44,7 @@ print('''/*
 #ifndef LIB1DFEM_LIPBASIS_EVAL_H
 #define LIB1DFEM_LIPBASIS_EVAL_H
 
-#include <armadillo>
+#include <lib1dfem/types.h>
 #include <sstream>
 #include <stdexcept>
 
@@ -55,20 +55,20 @@ namespace detail {
 
 /// Evaluate the n-th derivative of every LIP polynomial on the reference
 /// element [-1, 1] at the given points x, given the control-node vector
-/// x0. Fills dnf (size x.n_elem x x0.n_elem) with d^n L_i(x_j)/dx^n in
+/// x0. Fills dnf (size x.size() x x0.size()) with d^n L_i(x_j)/dx^n in
 /// column-major (point, polynomial) layout. element_length is unused
 /// at this layer (the chain-rule scaling lives in PolynomialBasis::eval_dnf).
 template <typename T>
-void eval_lip_prim_dnf(const arma::Col<T> & x, const arma::Col<T> & x0,
-                       arma::Mat<T> & dnf, int n) {
+void eval_lip_prim_dnf(const Vec<T> & x, const Vec<T> & x0,
+                       Mat<T> & dnf, int n) {
   switch (n) {''')
 
 for order in range(0, maxorder):
     fname = 'dnf'
     print('case ({}): {{'.format(order))
-    print('  {}.zeros(x.n_elem, x0.n_elem);'.format(fname))
-    print('  for (size_t ix = 0; ix < x.n_elem; ix++) {')
-    print('    for (size_t fi = 0; fi < x0.n_elem; fi++) {')
+    print('  {}.setZero((Eigen::Index) x.size(), (Eigen::Index) x0.size());'.format(fname))
+    print('  for (size_t ix = 0; ix < (size_t) x.size(); ix++) {')
+    print('    for (size_t fi = 0; fi < (size_t) x0.size(); fi++) {')
     if order > 0:
         if kahan:
             print('      T s = T(0), s2 = T(0), t;')
@@ -79,14 +79,14 @@ for order in range(0, maxorder):
     factor = 1
     for ider in range(1, order + 1):
         print('      for (size_t d{0} = 0; d{0} < {1}; d{0}++) {{'.format(
-            ider, 'x0.n_elem' if ider == 1 else 'd{}'.format(ider - 1)))
+            ider, '(size_t) x0.size()' if ider == 1 else 'd{}'.format(ider - 1)))
         for term in ['fi']:
             print('        if (d{0} == {1}) continue;'.format(ider, term))
         factor *= ider
 
     # Now do the product
     print('      T {}val = T(1);'.format(fname))
-    print('      for (size_t ip = 0; ip < x0.n_elem; ip++) {')
+    print('      for (size_t ip = 0; ip < (size_t) x0.size(); ip++) {')
     check_terms = ['d{}'.format(o) for o in range(1, order + 1)]
     check_terms.append('fi')
     for term in check_terms:

--- a/libhelfem/src/quadrature.cpp
+++ b/libhelfem/src/quadrature.cpp
@@ -16,6 +16,26 @@
 #include "erfc_expn.h"
 #include "chebyshev.h"
 #include "utils.h"
+#include <ArmaEigen.h>
+#include <cstring>
+
+namespace {
+  // Phase 5.2 bridge: lib1dfem PolynomialBasis::eval_dnf takes/returns
+  // Eigen Vec/Mat. The quadrature routines below are still arma-typed;
+  // wrap each eval_dnf call here to convert once at the boundary.
+  inline arma::mat eval_poly_dnf(
+      const std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> & poly,
+      const arma::vec & x, int n, double element_length) {
+    helfem::lib1dfem::Vec<double> xe(x.n_elem);
+    std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
+    helfem::lib1dfem::Mat<double> me;
+    poly->eval_dnf(xe, me, n, element_length);
+    arma::mat out(me.rows(), me.cols());
+    std::memcpy(out.memptr(), me.data(),
+                sizeof(double) * static_cast<size_t>(me.size()));
+    return out;
+  }
+} // namespace
 
 namespace helfem {
   namespace quadrature {
@@ -43,7 +63,7 @@ namespace helfem {
       // Calculate x values the polynomials should be evaluated at
       arma::vec xpoly((r-rmid0*arma::ones<arma::vec>(x.n_elem))/rlen0);
       // Evaluate the polynomials at these points
-      arma::mat bf(poly->eval_dnf(xpoly,0,rlen0));
+      arma::mat bf(eval_poly_dnf(poly, xpoly, 0, rlen0));
 
       // Put in weight
       arma::mat wbf(bf);
@@ -103,7 +123,7 @@ namespace helfem {
       arma::mat inner(twoe_inner_integral(rmin, rmax, x, wx, poly, L));
 
       // Evaluate basis functions at quadrature points
-      arma::mat bf(poly->eval_dnf(x,0,rlen));
+      arma::mat bf(eval_poly_dnf(poly, x, 0, rlen));
 
       // Product functions
       arma::mat bfprod(bf.n_rows,bf.n_cols*bf.n_cols);
@@ -146,7 +166,7 @@ namespace helfem {
       arma::mat inner(yukawa_inner_integral(rmin, rmax, x, wx, poly, L, lambda));
 
       // Evaluate basis functions at quadrature points
-      arma::mat bf(poly->eval_dnf(x, 0, rlen));
+      arma::mat bf(eval_poly_dnf(poly, x, 0, rlen));
 
       // Product functions
       arma::mat bfprod(bf.n_rows,bf.n_cols*bf.n_cols);

--- a/src/atomic/inttest.cpp
+++ b/src/atomic/inttest.cpp
@@ -17,6 +17,7 @@
 #include "chebyshev.h"
 #include "lobatto.h"
 #include "LIPBasis.h"
+#include <cstring>
 
 using namespace helfem;
 
@@ -26,7 +27,9 @@ void run(double R, int n_quad) {
   // Get primitive polynomial representation for LIP
   arma::vec x, w;
   ::lobatto_compute(2,x,w);
-  auto pbas(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(new helfem::polynomial_basis::LIPBasis(x,0)));
+  helfem::lib1dfem::Vec<double> xe(x.n_elem);
+  std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
+  auto pbas(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(new helfem::polynomial_basis::LIPBasis(xe,0)));
 
   // Get quadrature rule
   arma::vec xq, wq;

--- a/src/diatomic/quadrature.cpp
+++ b/src/diatomic/quadrature.cpp
@@ -14,6 +14,25 @@
  */
 #include "quadrature.h"
 #include "chebyshev.h"
+#include <ArmaEigen.h>
+#include <cstring>
+
+namespace {
+  // Phase 5.2 bridge: lib1dfem PolynomialBasis::eval_dnf takes/returns
+  // Eigen. The diatomic quadrature routines below are still arma-typed.
+  inline arma::mat eval_poly_dnf(
+      const std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> & poly,
+      const arma::vec & x, int n, double element_length) {
+    helfem::lib1dfem::Vec<double> xe(x.n_elem);
+    std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
+    helfem::lib1dfem::Mat<double> me;
+    poly->eval_dnf(xe, me, n, element_length);
+    arma::mat out(me.rows(), me.cols());
+    std::memcpy(out.memptr(), me.data(),
+                sizeof(double) * static_cast<size_t>(me.size()));
+    return out;
+  }
+} // namespace
 
 namespace helfem {
   namespace diatomic {
@@ -44,7 +63,7 @@ namespace helfem {
         // Calculate x values the polynomials should be evaluated at
         arma::vec xpoly((mu-mumid0*arma::ones<arma::vec>(x.n_elem))/mulen0);
         // Evaluate the polynomials at these points
-        arma::mat bf(poly->eval_dnf(xpoly, 0, mulen0));
+        arma::mat bf(eval_poly_dnf(poly, xpoly, 0, mulen0));
 
         // Put in weight
         arma::mat wbf(bf);
@@ -95,7 +114,7 @@ namespace helfem {
         arma::mat inner(twoe_inner_integral(mumin, mumax, l, x, wx, poly, L, M, tab));
 
         // Evaluate basis functions at quadrature points
-        arma::mat bf(poly->eval_dnf(x, 0, mulen));
+        arma::mat bf(eval_poly_dnf(poly, x, 0, mulen));
 
         // Product functions
         arma::mat bfprod(bf.n_rows,bf.n_cols*bf.n_cols);

--- a/src/harmonic/main.cpp
+++ b/src/harmonic/main.cpp
@@ -73,9 +73,22 @@ int main(int argc, char **argv) {
   arma::vec xq, wq;
   chebyshev::chebyshev(Nquad,xq,wq);
 
-  // Evaluate polynomials at quadrature points
-  arma::mat bf(poly->eval_dnf(xq, 0, 1.0));
-  arma::mat dbf(poly->eval_dnf(xq, 1, 1.0));
+  // Evaluate polynomials at quadrature points (Phase 5.2: bridge to
+  // lib1dfem Eigen API).
+  arma::mat bf, dbf;
+  {
+    helfem::lib1dfem::Vec<double> xe(xq.n_elem);
+    std::memcpy(xe.data(), xq.memptr(), sizeof(double) * xq.n_elem);
+    helfem::lib1dfem::Mat<double> bfe, dbfe;
+    poly->eval_dnf(xe, bfe,  0, 1.0);
+    poly->eval_dnf(xe, dbfe, 1, 1.0);
+    bf.set_size(bfe.rows(), bfe.cols());
+    dbf.set_size(dbfe.rows(), dbfe.cols());
+    std::memcpy(bf.memptr(), bfe.data(),
+                sizeof(double) * static_cast<size_t>(bfe.size()));
+    std::memcpy(dbf.memptr(), dbfe.data(),
+                sizeof(double) * static_cast<size_t>(dbfe.size()));
+  }
 
   xq.save("x.dat",arma::raw_ascii);
   bf.save("bf.dat",arma::raw_ascii);


### PR DESCRIPTION
## Summary

Second layer of the full arma → Eigen migration. This PR covers the **PolynomialBasis<T> base class** and all five concrete subclasses in lib1dfem (\`LIPBasis\`, \`HIPBasis\`, \`HIP2Basis\`, \`HIP3Basis\`, \`LegendreBasis\`), the **auto-generated eval tables** (\`LIPBasis_eval\`, \`HIPBasis_eval\`, \`HIP2Basis_eval\`, \`HIP3Basis_eval\`), and the **\`legendre_poly\` helpers** (deferred from 5.1 because they cascade into \`LegendreBasis\`).

After this PR, lib1dfem's PolynomialBasis layer is **fully Eigen-typed**: \`eval_prim_dnf\` / \`eval_dnf\` / \`eval_over_r\` / \`get_nodes\` all take/return \`Vec<T>\` and \`Mat<T>\`; the \`enabled\` index list is \`IVec\` (\`Eigen::Matrix<Eigen::Index, Dynamic, 1>\`). libhelfem absorbs the arma boundary at the factory + caller sites.

## lib1dfem (Eigen-typed throughout)

- **\`types.h\`**: adds \`IVec = Eigen::Matrix<Eigen::Index, Dynamic, 1>\`
- **\`PolynomialBasis.h\`**: \`enabled\` is \`IVec\`; eval methods take \`Vec<T>\`/\`Mat<T>\`; uses Eigen 3.4 indexing \`prim(all, enabled)\` for column selection
- **\`LIPBasis.h\`, \`HIPBasis.h\`**: \`subvec(a,b)\` → \`segment(a, b-a+1).eval()\`; \`arma::linspace<arma::uvec>\` → \`IVec::LinSpaced\`; \`arma::diagvec\` → \`.diagonal()\`
- **\`HIP2Basis.h\`, \`HIP3Basis.h\`**: bulk rewritten via regex script
- **\`LegendreBasis.h\`**: rewritten; uses \`legendre_batch\` from \`legendre_poly.h\`
- **\`legendre_poly.h\`**: migrated (deferred from 5.1)

**Auto-generated \`*_eval.h\` headers regenerated** from their Python scripts:
- \`generate_lip_code.py\` → \`LIPBasis_eval.h\`
- \`generate_hip_code.py\` → \`HIPBasis_eval.h\`
- \`generate_hip2_code.py\` → \`HIP2Basis_eval.h\`
- \`generate_hip3_code.py\` → \`HIP3Basis_eval.h\`

Generator edits: \`#include <armadillo>\` → \`<lib1dfem/types.h>\`; \`arma::Col<T>\` → \`Vec<T>\`; \`arma::Mat<T>\` → \`Mat<T>\`; \`dnf.zeros(x.n_elem, ...)\` → \`dnf.setZero(...)\`; loop bounds bridged via \`(size_t) x.size()\`.

## libhelfem (bridge layer)

- **\`PolynomialBasis.cpp\`**: \`arma_to_eigen_vec\` helper; bridges each \`new LIPBasis(x, ...)\` / HIP / HIP2 / HIP3 constructor call
- **\`FiniteElementBasis.cpp\`**: \`basis_indices()\` converts \`IVec\` → \`arma::uvec\`; \`eval_dnf\` / \`eval_over_r\` bridge with \`arma::vec\` → \`Vec\` on input and \`Mat\` → \`arma::mat\` on output via memcpy
- **\`quadrature.cpp\`**: \`eval_poly_dnf\` bridge helper for the three \`poly->eval_dnf\` call sites

## External callers

- \`src/diatomic/quadrature.cpp\`: same \`eval_poly_dnf\` bridge for two call sites
- \`src/harmonic/main.cpp\`: inline bridge for two \`poly->eval_dnf\` calls
- \`src/atomic/inttest.cpp\`: arma::vec → Vec<double> at \`LIPBasis\` constructor

No other external changes — all other consumers go through the libhelfem bridge layer and continue to compile unchanged.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811248426** (unchanged)

## Status of the full arma → Eigen migration

- [x] 5.1: leaf primitives (chebyshev, lobatto, math, grid) — PR #117
- [x] **5.2: PolynomialBasis subclasses + legendre_poly + eval tables** — this PR
- [ ] 5.3: libhelfem FiniteElementBasis internals (currently bridges)
- [ ] 5.4: RadialBasis.cpp internals (still arma)
- [ ] 5.5: TwoDBasis::coulomb/exchange internals (gaunt loops etc.)
- [ ] 5.6: per-method templating

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic unchanged