### PR TITLE
v2: Eigen Phase 5.3 -- FiniteElementBasis per-element evaluators arma -> Eigen

### DIFF
--- a/libhelfem/include/FiniteElementBasis.h
+++ b/libhelfem/include/FiniteElementBasis.h
@@ -19,6 +19,7 @@
 #include <armadillo>
 #include <memory>
 #include "PolynomialBasis.h"
+#include "Matrix.h"
 
 namespace helfem {
   namespace polynomial_basis {
@@ -92,15 +93,16 @@ namespace helfem {
       /// Find the element the point is at
       size_t find_element(double x) const;
 
+      // Phase 5.3: per-element evaluators migrated arma -> Eigen.
       /// Evaluate real coordinate values from primitive coordinates
-      arma::vec eval_coord(const arma::vec & xprim, size_t iel) const;
+      helfem::Vector eval_coord(const helfem::Vector & xprim, size_t iel) const;
       /// Evaluate real coordinate values from primitive coordinates
       double eval_coord(double xprim, size_t iel) const;
       /// Evaluate full set of coordinate valuess from primitive coordinates
-      arma::vec eval_coord(const arma::vec & xq) const;
+      helfem::Vector eval_coord(const helfem::Vector & xq) const;
 
       /// Evaluate primitive coordinate values from real coordinates
-      arma::vec eval_prim(const arma::vec & xreal, size_t iel) const;
+      helfem::Vector eval_prim(const helfem::Vector & xreal, size_t iel) const;
 
       /// Evaluate full set of weights for primitive weights
       arma::vec eval_weights(const arma::vec & wq) const;
@@ -121,44 +123,44 @@ namespace helfem {
       size_t get_nelem() const;
 
       /// Evaluate polynomials at given points
-      void eval_f(const arma::vec & x, arma::mat & f, size_t iel) const;
+      void eval_f  (const helfem::Vector & x, helfem::Matrix & f,   size_t iel) const;
       /// Evaluate derivatives of polynomials at given points
-      void eval_df(const arma::vec & x, arma::mat & df, size_t iel) const;
+      void eval_df (const helfem::Vector & x, helfem::Matrix & df,  size_t iel) const;
       /// Evaluate second derivatives of polynomials at given points
-      void eval_d2f(const arma::vec & x, arma::mat & d2f, size_t iel) const;
+      void eval_d2f(const helfem::Vector & x, helfem::Matrix & d2f, size_t iel) const;
       /// Evaluate third derivatives of polynomials at given points
-      void eval_d3f(const arma::vec & x, arma::mat & d3f, size_t iel) const;
+      void eval_d3f(const helfem::Vector & x, helfem::Matrix & d3f, size_t iel) const;
       /// Evaluate fourth derivatives of polynomials at given points
-      void eval_d4f(const arma::vec & x, arma::mat & d4f, size_t iel) const;
+      void eval_d4f(const helfem::Vector & x, helfem::Matrix & d4f, size_t iel) const;
       /// Evaluate fifth derivatives of polynomials at given points
-      void eval_d5f(const arma::vec & x, arma::mat & d5f, size_t iel) const;
+      void eval_d5f(const helfem::Vector & x, helfem::Matrix & d5f, size_t iel) const;
       /// Evaluate nth derivative
-      void eval_dnf(const arma::vec & x, arma::mat & dnf, int n, size_t iel) const;
+      void eval_dnf(const helfem::Vector & x, helfem::Matrix & dnf, int n, size_t iel) const;
 
       /// Evaluate polynomials at given points
-      arma::mat eval_f(const arma::vec & x, size_t iel) const;
+      helfem::Matrix eval_f  (const helfem::Vector & x, size_t iel) const;
       /// Evaluate derivatives of polynomials at given points
-      arma::mat eval_df(const arma::vec & x, size_t iel) const;
+      helfem::Matrix eval_df (const helfem::Vector & x, size_t iel) const;
       /// Evaluate second derivatives of polynomials at given points
-      arma::mat eval_d2f(const arma::vec & x, size_t iel) const;
+      helfem::Matrix eval_d2f(const helfem::Vector & x, size_t iel) const;
       /// Evaluate third derivatives of polynomials at given points
-      arma::mat eval_d3f(const arma::vec & x, size_t iel) const;
+      helfem::Matrix eval_d3f(const helfem::Vector & x, size_t iel) const;
       /// Evaluate fourth derivatives of polynomials at given points
-      arma::mat eval_d4f(const arma::vec & x, size_t iel) const;
+      helfem::Matrix eval_d4f(const helfem::Vector & x, size_t iel) const;
       /// Evaluate fifth derivatives of polynomials at given points
-      arma::mat eval_d5f(const arma::vec & x, size_t iel) const;
+      helfem::Matrix eval_d5f(const helfem::Vector & x, size_t iel) const;
       /// Evaluate nth derivative
-      arma::mat eval_dnf(const arma::vec & x, int n, size_t iel) const;
+      helfem::Matrix eval_dnf(const helfem::Vector & x, int n, size_t iel) const;
 
       /// Evaluate the nth derivative at all quadrature points
-      arma::mat eval_dnf(const arma::vec & xq, int n) const;
+      helfem::Matrix eval_dnf(const helfem::Vector & xq, int n) const;
 
       /// Evaluate the n-th r-derivative of B_u(r)/r for the surviving shape
       /// functions on element iel. Only valid when element iel starts at
       /// r=0 (the Dirichlet-induced (x+1) factor in each B_u is what makes
       /// the deflation work). Delegates to PolynomialBasis::eval_over_r
       /// with the element's scaling_factor as the size argument.
-      arma::mat eval_over_r(const arma::vec & x, int n, size_t iel) const;
+      helfem::Matrix eval_over_r(const helfem::Vector & x, int n, size_t iel) const;
 
       /**
        * Compute matrix elements in the finite element basis <lh|f|rh>

--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -57,13 +57,18 @@ namespace helfem {
       arma::vec dnorm(get_nelem()-1);
       for(size_t iel=0; iel+1<get_nelem(); iel++) {
         // Points that correspond to lh and rh elements
-        arma::vec xrh(1), xlh(1);
-        xlh(0)=1.0;  // right-most point of left element
-        xrh(0)=-1.0; // should equal left-most point of right element
+        // Phase 5.3: eval_coord / eval_dnf now Eigen; build the
+        // 1-element x vectors as Eigen for direct use, materialise
+        // arma copies only for the existing logging code.
+        helfem::Vector xlh_e(1), xrh_e(1);
+        xlh_e(0) = 1.0;
+        xrh_e(0) = -1.0;
 
         /// Check that coordinates match
-        arma::vec rlh(eval_coord(xlh, iel));
-        arma::vec rrh(eval_coord(xrh, iel+1));
+        helfem::Vector rlh_e = eval_coord(xlh_e, iel);
+        helfem::Vector rrh_e = eval_coord(xrh_e, iel + 1);
+        arma::vec rlh(rlh_e.size()); std::memcpy(rlh.memptr(), rlh_e.data(), sizeof(double) * rlh_e.size());
+        arma::vec rrh(rrh_e.size()); std::memcpy(rrh.memptr(), rrh_e.data(), sizeof(double) * rrh_e.size());
         double dr(arma::norm(rlh-rrh,2));
         if(dr > 10*DBL_EPSILON*(1+arma::norm(rlh,2))) {
           rlh.print("rlh");
@@ -78,7 +83,9 @@ namespace helfem {
         arma::mat lh(noverlap, noverlap);
         for(int ider=0;ider<noverlap;ider++) {
           // We want the last noverlap functions evaluated at the r
-          arma::rowvec fval(eval_dnf(xlh, ider, iel));
+          helfem::Matrix fval_e = eval_dnf(xlh_e, ider, iel);
+          arma::rowvec fval(fval_e.cols());
+          std::memcpy(fval.memptr(), fval_e.data(), sizeof(double) * fval_e.size());
           lh.col(ider) = fval.subvec(fval.n_elem-noverlap, fval.n_elem-1).t();
         }
 
@@ -86,7 +93,9 @@ namespace helfem {
         arma::mat rh(noverlap, noverlap);
         for(int ider=0;ider<noverlap;ider++) {
           // We want the first noverlap functions
-          arma::rowvec fval(eval_dnf(xrh, ider, iel+1));
+          helfem::Matrix fval_e = eval_dnf(xrh_e, ider, iel + 1);
+          arma::rowvec fval(fval_e.cols());
+          std::memcpy(fval.memptr(), fval_e.data(), sizeof(double) * fval_e.size());
           rh.col(ider) = fval.subvec(0, noverlap-1).t();
         }
 
@@ -200,20 +209,19 @@ namespace helfem {
       return bval;
     }
 
-    arma::vec FiniteElementBasis::eval_coord(const arma::vec & x, size_t iel) const {
-      // The coordinates are
-      return element_midpoint(iel) * arma::ones<arma::vec>(x.n_elem) + scaling_factor(iel) * x;
+    // Phase 5.3: per-element evaluators migrated arma -> Eigen.
+    helfem::Vector FiniteElementBasis::eval_coord(const helfem::Vector & x, size_t iel) const {
+      return helfem::Vector::Constant(x.size(), element_midpoint(iel)) + scaling_factor(iel) * x;
     }
 
     double FiniteElementBasis::eval_coord(double x, size_t iel) const {
-      // The coordinates are
       return element_midpoint(iel) + scaling_factor(iel) * x;
     }
 
-    arma::vec FiniteElementBasis::eval_coord(const arma::vec & x) const {
-      arma::vec r(get_nelem()*x.n_elem);
-      for(size_t iel=0;iel<get_nelem();iel++)
-        r.subvec(iel*x.n_elem, (iel+1)*x.n_elem-1) = eval_coord(x, iel);
+    helfem::Vector FiniteElementBasis::eval_coord(const helfem::Vector & x) const {
+      helfem::Vector r(get_nelem() * x.size());
+      for (size_t iel = 0; iel < get_nelem(); ++iel)
+        r.segment(iel * x.size(), x.size()) = eval_coord(x, iel);
       return r;
     }
 
@@ -224,12 +232,11 @@ namespace helfem {
       return wr;
     }
 
-    arma::vec FiniteElementBasis::eval_prim(const arma::vec & y, size_t iel) const {
-      if(arma::min(y) < element_begin(iel) || arma::max(y) > element_end(iel)) {
+    helfem::Vector FiniteElementBasis::eval_prim(const helfem::Vector & y, size_t iel) const {
+      if (y.minCoeff() < element_begin(iel) || y.maxCoeff() > element_end(iel)) {
         throw std::logic_error("coordinates don't correspond to this element!\n");
       }
-      // The primitive coordinates are thus
-      return ((y - element_midpoint(iel) * arma::ones<arma::vec>(y.n_elem)) / scaling_factor(iel));
+      return (y - helfem::Vector::Constant(y.size(), element_midpoint(iel))) / scaling_factor(iel);
     }
 
     int FiniteElementBasis::get_poly_id() const {
@@ -286,73 +293,55 @@ namespace helfem {
       return get_basis(iel)->get_nbf();
     }
 
-    void FiniteElementBasis::eval_f(const arma::vec & x, arma::mat & f, size_t iel) const {
-      eval_dnf(x,f,0,iel);
-   }
+    // Phase 5.3: eval_* migrated to Eigen; internal lib1dfem call no longer
+    // bridges (its signature matches).
+    void FiniteElementBasis::eval_f  (const helfem::Vector & x, helfem::Matrix & f,   size_t iel) const { eval_dnf(x, f,   0, iel); }
+    void FiniteElementBasis::eval_df (const helfem::Vector & x, helfem::Matrix & df,  size_t iel) const { eval_dnf(x, df,  1, iel); }
+    void FiniteElementBasis::eval_d2f(const helfem::Vector & x, helfem::Matrix & d2f, size_t iel) const { eval_dnf(x, d2f, 2, iel); }
+    void FiniteElementBasis::eval_d3f(const helfem::Vector & x, helfem::Matrix & d3f, size_t iel) const { eval_dnf(x, d3f, 3, iel); }
+    void FiniteElementBasis::eval_d4f(const helfem::Vector & x, helfem::Matrix & d4f, size_t iel) const { eval_dnf(x, d4f, 4, iel); }
+    void FiniteElementBasis::eval_d5f(const helfem::Vector & x, helfem::Matrix & d5f, size_t iel) const { eval_dnf(x, d5f, 5, iel); }
 
-    void FiniteElementBasis::eval_df(const arma::vec & x, arma::mat & df, size_t iel) const {
-      eval_dnf(x,df,1,iel);
-    }
-
-    void FiniteElementBasis::eval_d2f(const arma::vec & x, arma::mat & d2f, size_t iel) const {
-      eval_dnf(x,d2f,2,iel);
-    }
-
-    void FiniteElementBasis::eval_dnf(const arma::vec & x, arma::mat & dnf, int n, size_t iel) const {
-      // Phase 5.2: lib1dfem eval_dnf takes/returns Eigen. Bridge here.
+    void FiniteElementBasis::eval_dnf(const helfem::Vector & x, helfem::Matrix & dnf, int n, size_t iel) const {
+      // helfem::Vector == lib1dfem::Vec<double>, same for Matrix; no
+      // conversion needed.
       std::shared_ptr<polynomial_basis::PolynomialBasis> p(get_basis(iel));
-      lib1dfem::Vec<double> xe(x.n_elem);
-      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
-      lib1dfem::Mat<double> dnf_e;
-      p->eval_dnf(xe, dnf_e, n, scaling_factor(iel));
-      dnf.set_size(dnf_e.rows(), dnf_e.cols());
-      std::memcpy(dnf.memptr(), dnf_e.data(),
-                  sizeof(double) * static_cast<size_t>(dnf_e.size()));
+      p->eval_dnf(x, dnf, n, scaling_factor(iel));
     }
 
-    arma::mat FiniteElementBasis::eval_f(const arma::vec & x, size_t iel) const {
-      return eval_dnf(x,0,iel);
-    }
+    helfem::Matrix FiniteElementBasis::eval_f  (const helfem::Vector & x, size_t iel) const { return eval_dnf(x, 0, iel); }
+    helfem::Matrix FiniteElementBasis::eval_df (const helfem::Vector & x, size_t iel) const { return eval_dnf(x, 1, iel); }
+    helfem::Matrix FiniteElementBasis::eval_d2f(const helfem::Vector & x, size_t iel) const { return eval_dnf(x, 2, iel); }
+    helfem::Matrix FiniteElementBasis::eval_d3f(const helfem::Vector & x, size_t iel) const { return eval_dnf(x, 3, iel); }
+    helfem::Matrix FiniteElementBasis::eval_d4f(const helfem::Vector & x, size_t iel) const { return eval_dnf(x, 4, iel); }
+    helfem::Matrix FiniteElementBasis::eval_d5f(const helfem::Vector & x, size_t iel) const { return eval_dnf(x, 5, iel); }
 
-    arma::mat FiniteElementBasis::eval_df(const arma::vec & x, size_t iel) const {
-      return eval_dnf(x,1,iel);
-    }
-
-    arma::mat FiniteElementBasis::eval_d2f(const arma::vec & x, size_t iel) const {
-      return eval_dnf(x,2,iel);
-    }
-
-    arma::mat FiniteElementBasis::eval_dnf(const arma::vec & x, int n, size_t iel) const {
-      arma::mat dnf;
+    helfem::Matrix FiniteElementBasis::eval_dnf(const helfem::Vector & x, int n, size_t iel) const {
+      helfem::Matrix dnf;
       eval_dnf(x, dnf, n, iel);
       return dnf;
     }
 
-    arma::mat FiniteElementBasis::eval_over_r(const arma::vec & x, int n, size_t iel) const {
+    helfem::Matrix FiniteElementBasis::eval_over_r(const helfem::Vector & x, int n, size_t iel) const {
       if (std::abs(element_begin(iel)) > 1e-14) {
         std::ostringstream oss;
         oss << "FiniteElementBasis::eval_over_r is only valid when the element starts at r=0;"
             " element " << iel << " starts at " << element_begin(iel) << ".\n";
         throw std::logic_error(oss.str());
       }
-      // Phase 5.2: lib1dfem eval_over_r takes/returns Eigen. Bridge.
       std::shared_ptr<polynomial_basis::PolynomialBasis> p(get_basis(iel));
-      lib1dfem::Vec<double> xe(x.n_elem);
-      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
-      lib1dfem::Mat<double> dnf_e;
-      p->eval_over_r(xe, dnf_e, n, scaling_factor(iel));
-      arma::mat dnf_over_r(dnf_e.rows(), dnf_e.cols());
-      std::memcpy(dnf_over_r.memptr(), dnf_e.data(),
-                  sizeof(double) * static_cast<size_t>(dnf_e.size()));
+      helfem::Matrix dnf_over_r;
+      p->eval_over_r(x, dnf_over_r, n, scaling_factor(iel));
       return dnf_over_r;
     }
 
-    arma::mat FiniteElementBasis::eval_dnf(const arma::vec & x, int n) const {
-      arma::mat f(get_nelem()*x.n_elem,get_nbf());
-      for(size_t iel=0;iel<get_nelem();iel++) {
-        size_t ifirst = first_func_in_element(iel);
-        size_t ilast = last_func_in_element(iel);
-        f.submat(iel*x.n_elem, ifirst, (iel+1)*x.n_elem-1, ilast) = eval_dnf(x, n, iel);
+    helfem::Matrix FiniteElementBasis::eval_dnf(const helfem::Vector & x, int n) const {
+      helfem::Matrix f(get_nelem() * x.size(), get_nbf());
+      f.setZero();
+      for (size_t iel = 0; iel < get_nelem(); ++iel) {
+        const Eigen::Index ifirst = static_cast<Eigen::Index>(first_func_in_element(iel));
+        const Eigen::Index ilast  = static_cast<Eigen::Index>(last_func_in_element(iel));
+        f.block(iel * x.size(), ifirst, x.size(), ilast - ifirst + 1) = eval_dnf(x, n, iel);
       }
       return f;
     }
@@ -405,15 +394,34 @@ namespace helfem {
       return V;
     }
 
+    namespace {
+      // Phase 5.3 bridge: matrix_element's function-pointer overload takes
+      // arma::mat-returning lambdas, but eval_dnf is now Eigen-typed. Wrap
+      // the eval_dnf result through to_arma so the function-pointer
+      // overload's signature stays unchanged.
+      inline std::function<arma::mat(const arma::vec &, size_t)>
+      make_arma_eval_dnf(const FiniteElementBasis * fe, int der) {
+        return [fe, der](const arma::vec & xa, size_t iel) {
+          helfem::Vector xe(xa.n_elem);
+          std::memcpy(xe.data(), xa.memptr(), sizeof(double) * xa.n_elem);
+          helfem::Matrix me = fe->eval_dnf(xe, der, iel);
+          arma::mat out(me.rows(), me.cols());
+          std::memcpy(out.memptr(), me.data(),
+                      sizeof(double) * static_cast<size_t>(me.size()));
+          return out;
+        };
+      }
+    } // namespace
+
     arma::mat FiniteElementBasis::matrix_element(int lhder, int rhder, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      std::function<arma::mat(const arma::vec &,size_t)> eval_lh = [this,lhder](const arma::vec & x, size_t iel) {return this->eval_dnf(x, lhder, iel);};
-      std::function<arma::mat(const arma::vec &,size_t)> eval_rh = [this,rhder](const arma::vec & x, size_t iel) {return this->eval_dnf(x, rhder, iel);};
+      auto eval_lh = make_arma_eval_dnf(this, lhder);
+      auto eval_rh = make_arma_eval_dnf(this, rhder);
       return matrix_element(eval_lh, eval_rh, xq, wq, f);
     }
 
     arma::mat FiniteElementBasis::matrix_element(size_t iel, int lhder, int rhder, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      std::function<arma::mat(const arma::vec &,size_t)> eval_lh = [this,lhder](const arma::vec & x, size_t iel) {return this->eval_dnf(x, lhder, iel);};
-      std::function<arma::mat(const arma::vec &,size_t)> eval_rh = [this,rhder](const arma::vec & x, size_t iel) {return this->eval_dnf(x, rhder, iel);};
+      auto eval_lh = make_arma_eval_dnf(this, lhder);
+      auto eval_rh = make_arma_eval_dnf(this, rhder);
       return matrix_element(iel, eval_lh, eval_rh, xq, wq, f);
     }
 
@@ -422,8 +430,12 @@ namespace helfem {
       // todo: figure out how to transform xq from [-1,1] to [x_left, x_right] and the same transformation for wq
       arma::vec x_shifted((x_right-x_left)/2.0*xq + (x_right+x_left)/2.0*arma::ones<arma::vec>(xq.n_elem));
 
-      // Get coordinate values
-      arma::vec r(eval_coord(x_shifted, iel));
+      // Get coordinate values (Phase 5.3: eval_coord is Eigen).
+      helfem::Vector xs_e(x_shifted.n_elem);
+      std::memcpy(xs_e.data(), x_shifted.memptr(), sizeof(double) * x_shifted.n_elem);
+      helfem::Vector r_e = eval_coord(xs_e, iel);
+      arma::vec r(r_e.size());
+      std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
       // Calculate total weight per point
       arma::vec wp(wq*scaling_factor(iel)*(x_right-x_left)/2.0);
       // Include the function
@@ -448,8 +460,12 @@ namespace helfem {
     }
 
     arma::vec FiniteElementBasis::vector_element(size_t iel, const std::function<arma::mat(arma::vec,size_t)> & eval_bf, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      // Get coordinate values
-      arma::vec r(eval_coord(xq, iel));
+      // Get coordinate values (Phase 5.3 bridge).
+      helfem::Vector xq_e(xq.n_elem);
+      std::memcpy(xq_e.data(), xq.memptr(), sizeof(double) * xq.n_elem);
+      helfem::Vector r_e = eval_coord(xq_e, iel);
+      arma::vec r(r_e.size());
+      std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
       // Calculate total weight per point
       arma::vec wp(wq*scaling_factor(iel));
       // Include the function
@@ -467,12 +483,12 @@ namespace helfem {
     }
 
     arma::vec FiniteElementBasis::vector_element(int der, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      std::function<arma::mat(const arma::vec &,size_t)> eval_f = [this,der](const arma::vec & x, size_t iel) {return this->eval_dnf(x, der, iel);};
+      auto eval_f = make_arma_eval_dnf(this, der);
       return vector_element(eval_f, xq, wq, f);
     }
 
     arma::vec FiniteElementBasis::vector_element(size_t iel, int der, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      std::function<arma::mat(const arma::vec &,size_t)> eval_f = [this,der](const arma::vec & x, size_t iel) {return this->eval_dnf(x, der, iel);};
+      auto eval_f = make_arma_eval_dnf(this, der);
       return vector_element(iel, eval_f, xq, wq, f);
     }
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -95,22 +95,38 @@ namespace helfem {
         return ret;
       }
 
-      // Pre-bound evaluator for each BasisKind: a callable (x, iel) -> arma::mat
-      // suitable for FiniteElementBasis::matrix_element. The evaluator captures
-      // `this` only; it does not allocate per call beyond what fem.eval_*/get_*
-      // already does.
+      namespace {
+        // Phase 5.3 helpers: FiniteElementBasis::eval_f / eval_df / eval_d2f
+        // now take helfem::Vector and return helfem::Matrix. The
+        // matrix_element function-pointer overload still takes arma
+        // lambdas, so the make_evaluator below bridges per-call.
+        inline helfem::Vector arma_to_eigen_vec(const arma::vec & v) {
+          helfem::Vector e(v.n_elem);
+          std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
+          return e;
+        }
+        inline arma::mat eigen_mat_to_arma(const helfem::Matrix & m) {
+          arma::mat out(m.rows(), m.cols());
+          std::memcpy(out.memptr(), m.data(),
+                      sizeof(double) * static_cast<size_t>(m.size()));
+          return out;
+        }
+      } // namespace
+
+      // Pre-bound evaluator for each BasisKind. Bridges arma <-> Eigen
+      // at the per-call boundary; eval_* / get_* are now Eigen-typed.
       static std::function<arma::mat(const arma::vec &, size_t)>
       make_evaluator(const FEMRadialBasis * rb, FEMRadialBasis::BasisKind k) {
         using BK = FEMRadialBasis::BasisKind;
         switch (k) {
           case BK::B0: return [rb](const arma::vec & x, size_t iel) {
-            return rb->get_fem().eval_f(x, iel);
+            return eigen_mat_to_arma(rb->get_fem().eval_f(arma_to_eigen_vec(x), iel));
           };
           case BK::B1: return [rb](const arma::vec & x, size_t iel) {
-            return rb->get_fem().eval_df(x, iel);
+            return eigen_mat_to_arma(rb->get_fem().eval_df(arma_to_eigen_vec(x), iel));
           };
           case BK::B2: return [rb](const arma::vec & x, size_t iel) {
-            return rb->get_fem().eval_d2f(x, iel);
+            return eigen_mat_to_arma(rb->get_fem().eval_d2f(arma_to_eigen_vec(x), iel));
           };
           case BK::R0: return [rb](const arma::vec & x, size_t iel) {
             return rb->get_bf(x, iel);
@@ -170,10 +186,11 @@ namespace helfem {
                                  const arma::vec & x, size_t iel,
                                  FEMRadialBasis::BasisKind k) {
         using BK = FEMRadialBasis::BasisKind;
+        const helfem::Vector xe = arma_to_eigen_vec(x);
         switch (k) {
-          case BK::B0: return fem.eval_f(x, iel);
-          case BK::B1: return fem.eval_df(x, iel);
-          case BK::B2: return fem.eval_d2f(x, iel);
+          case BK::B0: return eigen_mat_to_arma(fem.eval_f  (xe, iel));
+          case BK::B1: return eigen_mat_to_arma(fem.eval_df (xe, iel));
+          case BK::B2: return eigen_mat_to_arma(fem.eval_d2f(xe, iel));
           case BK::R0: case BK::R1: case BK::R2:
             throw std::logic_error(
                 "FEMRadialBasis::matrix_element(cross-basis): R-kinds are not "
@@ -223,9 +240,13 @@ namespace helfem {
             const arma::vec r =
                 intmid * arma::ones<arma::vec>(xproj.n_elem) + intlen * xproj;
 
-            // Back-transform r into each basis's reference coords.
-            const arma::vec xi = fem.eval_prim(r, iel);
-            const arma::vec xj = rh.fem.eval_prim(r, jel);
+            // Back-transform r into each basis's reference coords
+            // (Phase 5.3: eval_prim is Eigen; bridge).
+            const helfem::Vector r_e = arma_to_eigen_vec(r);
+            const helfem::Vector xi_e = fem.eval_prim(r_e, iel);
+            const helfem::Vector xj_e = rh.fem.eval_prim(r_e, jel);
+            arma::vec xi(xi_e.size()); std::memcpy(xi.memptr(), xi_e.data(), sizeof(double) * xi_e.size());
+            arma::vec xj(xj_e.size()); std::memcpy(xj.memptr(), xj_e.data(), sizeof(double) * xj_e.size());
 
             arma::vec wtot = wproj * intlen;
             if (weight)
@@ -511,8 +532,8 @@ namespace helfem {
         // Get lh quadrature points
         arma::vec xi, wi;
         chebyshev::chebyshev(Nq, xi, wi);
-        // and basis function values
-        arma::mat ibf(fem.eval_f(xi, iel));
+        // and basis function values (Phase 5.3 bridge).
+        arma::mat ibf(eigen_mat_to_arma(fem.eval_f(arma_to_eigen_vec(xi), iel)));
         double Rmini(fem.element_begin(iel));
         double Rmaxi(fem.element_end(iel));
 
@@ -532,8 +553,8 @@ namespace helfem {
           // which have the renormalized weights
           wk.subvec(ii * Nq, (ii + 1) * Nq - 1) = wi * ilen;
         }
-        // and basis function values
-        arma::mat kbf(fem.eval_f(xk, kel));
+        // and basis function values (Phase 5.3 bridge).
+        arma::mat kbf(eigen_mat_to_arma(fem.eval_f(arma_to_eigen_vec(xk), kel)));
         double Rmink(fem.element_begin(kel));
         double Rmaxk(fem.element_end(kel));
 
@@ -574,7 +595,9 @@ namespace helfem {
           // Find the element we are in
           size_t iel = fem.find_element(r);
           // Find the value of the primitive coordinate
-          arma::vec x(fem.eval_prim(arma::vec({r}), iel));
+          helfem::Vector r_e(1); r_e(0) = r;
+          helfem::Vector xe = fem.eval_prim(r_e, iel);
+          arma::vec x(xe.size()); std::memcpy(x.memptr(), xe.data(), sizeof(double) * xe.size());
 
           // Evaluate the basis functions in the element
           arma::mat val(get_bf(x, iel));
@@ -587,14 +610,13 @@ namespace helfem {
       }
 
       arma::mat FEMRadialBasis::get_bf(const arma::vec & x, size_t iel) const {
-        // For the element starting at r=0 use the analytic eval_over_r path
-        // (B(r)/r evaluated by deflating the (x+1) factor that the Dirichlet
-        // BC at r=0 guarantees). For other elements r > 0 so direct division
-        // is numerically fine.
+        // Phase 5.3: fem.eval_* / eval_coord are Eigen; bridge.
+        const helfem::Vector xe = arma_to_eigen_vec(x);
         if (iel == 0)
-          return fem.eval_over_r(x, 0, iel);
-        arma::mat val(fem.eval_f(x, iel));
-        arma::vec r(fem.eval_coord(x, iel));
+          return eigen_mat_to_arma(fem.eval_over_r(xe, 0, iel));
+        arma::mat val(eigen_mat_to_arma(fem.eval_f(xe, iel)));
+        const helfem::Vector r_e = fem.eval_coord(xe, iel);
+        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
         for (size_t ifun = 0; ifun < val.n_cols; ifun++)
           for (size_t ir = 0; ir < x.n_elem; ir++)
             val(ir, ifun) /= r(ir);
@@ -606,11 +628,13 @@ namespace helfem {
       }
 
       arma::mat FEMRadialBasis::get_df(const arma::vec & x, size_t iel) const {
+        const helfem::Vector xe = arma_to_eigen_vec(x);
         if (iel == 0)
-          return fem.eval_over_r(x, 1, iel);
-        arma::mat fval(fem.eval_f(x, iel));
-        arma::mat dval(fem.eval_df(x, iel));
-        arma::vec r(fem.eval_coord(x, iel));
+          return eigen_mat_to_arma(fem.eval_over_r(xe, 1, iel));
+        arma::mat fval(eigen_mat_to_arma(fem.eval_f (xe, iel)));
+        arma::mat dval(eigen_mat_to_arma(fem.eval_df(xe, iel)));
+        const helfem::Vector r_e = fem.eval_coord(xe, iel);
+        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
         arma::mat der(fval.n_rows, fval.n_cols);
         for (size_t ifun = 0; ifun < der.n_cols; ifun++)
           for (size_t ir = 0; ir < x.n_elem; ir++) {
@@ -625,12 +649,14 @@ namespace helfem {
       }
 
       arma::mat FEMRadialBasis::get_lf(const arma::vec & x, size_t iel) const {
+        const helfem::Vector xe = arma_to_eigen_vec(x);
         if (iel == 0)
-          return fem.eval_over_r(x, 2, iel);
-        arma::mat fval(fem.eval_f(x, iel));
-        arma::mat dval(fem.eval_df(x, iel));
-        arma::mat lval(fem.eval_d2f(x, iel));
-        arma::vec r(fem.eval_coord(x, iel));
+          return eigen_mat_to_arma(fem.eval_over_r(xe, 2, iel));
+        arma::mat fval(eigen_mat_to_arma(fem.eval_f  (xe, iel)));
+        arma::mat dval(eigen_mat_to_arma(fem.eval_df (xe, iel)));
+        arma::mat lval(eigen_mat_to_arma(fem.eval_d2f(xe, iel)));
+        const helfem::Vector r_e = fem.eval_coord(xe, iel);
+        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
         arma::mat lapl(fval.n_rows, fval.n_cols);
         for (size_t ifun = 0; ifun < lapl.n_cols; ifun++)
           for (size_t ir = 0; ir < x.n_elem; ir++) {
@@ -655,7 +681,9 @@ namespace helfem {
       }
 
       arma::vec FEMRadialBasis::get_r(const arma::vec & x, size_t iel) const {
-        return fem.eval_coord(x, iel);
+        const helfem::Vector r_e = fem.eval_coord(arma_to_eigen_vec(x), iel);
+        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
+        return r;
       }
 
       double FEMRadialBasis::get_r(double x, size_t iel) const {
@@ -672,7 +700,7 @@ namespace helfem {
         x(0) = -1.0;
 
         // Evaluate derivative at nucleus
-        arma::mat der(fem.eval_df(x, 0));
+        arma::mat der(eigen_mat_to_arma(fem.eval_df(arma_to_eigen_vec(x), (size_t) 0)));
 
         // Radial functions in element
         size_t ifirst, ilast;
@@ -695,8 +723,8 @@ namespace helfem {
         x(0) = -1.0;
 
         // Evaluate derivative at nucleus
-        arma::mat der(fem.eval_df(x, 0));
-        arma::mat lapl(fem.eval_d2f(x, 0));
+        arma::mat der(eigen_mat_to_arma(fem.eval_df(arma_to_eigen_vec(x), (size_t) 0)));
+        arma::mat lapl(eigen_mat_to_arma(fem.eval_d2f(arma_to_eigen_vec(x), (size_t) 0)));
 
         // Radial functions in element
         size_t ifirst, ilast;
@@ -716,7 +744,7 @@ namespace helfem {
         x(0) = -1.0;
 
         // Derivative
-        arma::mat der(fem.eval_df(x, 0));
+        arma::mat der(eigen_mat_to_arma(fem.eval_df(arma_to_eigen_vec(x), (size_t) 0)));
         // Radial functions in element
         size_t ifirst, ilast;
         get_idx(0, ifirst, ilast);

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -16,6 +16,29 @@
 #include "quadrature.h"
 #include "PolynomialBasis.h"
 #include "chebyshev.h"
+#include <ArmaEigen.h>
+#include <cstring>
+
+namespace {
+  // Phase 5.3 bridge: FiniteElementBasis::eval_* / eval_coord / eval_prim
+  // now take/return Eigen. Diatomic basis is still arma; bridge here.
+  inline helfem::Vector arma_to_eigen_vec(const arma::vec & v) {
+    helfem::Vector e(v.n_elem);
+    std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
+    return e;
+  }
+  inline arma::vec eigen_vec_to_arma(const helfem::Vector & v) {
+    arma::vec a(v.size());
+    std::memcpy(a.memptr(), v.data(), sizeof(double) * v.size());
+    return a;
+  }
+  inline arma::mat eigen_mat_to_arma(const helfem::Matrix & m) {
+    arma::mat out(m.rows(), m.cols());
+    std::memcpy(out.memptr(), m.data(),
+                sizeof(double) * static_cast<size_t>(m.size()));
+    return out;
+  }
+} // namespace
 #include "../general/spherical_harmonics.h"
 #include "../general/gaunt.h"
 #include "../general/gsz.h"
@@ -160,8 +183,8 @@ namespace helfem {
 	    arma::vec mu(intmid*arma::ones<arma::vec>(xproj.n_elem)+intlen*xproj);
 
             // Calculate x values the polynomials should be evaluated at
-            arma::vec xi(fem.eval_prim(mu, iel));
-	    arma::vec xj(rh.fem.eval_prim(mu, jel));
+            arma::vec xi(eigen_vec_to_arma(fem.eval_prim(arma_to_eigen_vec(mu), iel)));
+	    arma::vec xj(eigen_vec_to_arma(rh.fem.eval_prim(arma_to_eigen_vec(mu), jel)));
 
 	    // Where are we in the matrix?
 	    size_t ifirst, ilast;
@@ -175,8 +198,8 @@ namespace helfem {
 	    if(n!=0)
 	      wtot%=arma::pow(arma::cosh(mu),n);
 	    // Put in weight
-	    arma::mat ibf(fem.eval_f(xi, iel));
-	    arma::mat jbf(rh.fem.eval_f(xj, jel));
+	    arma::mat ibf(eigen_mat_to_arma(fem.eval_f(arma_to_eigen_vec(xi), iel)));
+	    arma::mat jbf(eigen_mat_to_arma(rh.fem.eval_f(arma_to_eigen_vec(xj), jel)));
 
 	    // Perform quadrature
             arma::mat s(arma::trans(ibf)*arma::diagmat(wtot)*jbf);
@@ -267,11 +290,11 @@ namespace helfem {
       }
 
       arma::mat RadialBasis::get_bf(size_t iel, const arma::vec & x) const {
-        return fem.eval_f(x, iel);
+        return eigen_mat_to_arma(fem.eval_f(arma_to_eigen_vec(x), iel));
       }
 
       arma::mat RadialBasis::get_df(size_t iel) const {
-        return fem.eval_df(xq, iel);
+        return eigen_mat_to_arma(fem.eval_df(arma_to_eigen_vec(xq), iel));
       }
 
       arma::vec RadialBasis::get_wrad(size_t iel) const {
@@ -280,7 +303,7 @@ namespace helfem {
       }
 
       arma::vec RadialBasis::get_r(size_t iel) const {
-        return fem.eval_coord(xq, iel);
+        return eigen_vec_to_arma(fem.eval_coord(arma_to_eigen_vec(xq), iel));
       }
 
       void lm_to_l_m(const arma::ivec & lmax, arma::ivec & lval, arma::ivec & mval) {

--- a/src/harmonic/softcoulomb.cpp
+++ b/src/harmonic/softcoulomb.cpp
@@ -18,6 +18,7 @@
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
 #include "chebyshev.h"
+#include <cstring>
 
 using namespace helfem;
 
@@ -145,10 +146,16 @@ int main(int argc, char **argv) {
   Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
   printf("Orbital orthonormality devation is %e\n",arma::norm(Smo,"fro"));
 
-  // Evaluate the basis set: 0th derivative
-  arma::mat bfval(fem.eval_dnf(xq, 0));
+  // Evaluate the basis set: 0th derivative (Phase 5.3 bridge).
+  helfem::Vector xq_e(xq.n_elem);
+  std::memcpy(xq_e.data(), xq.memptr(), sizeof(double) * xq.n_elem);
+  helfem::Matrix bfval_e = fem.eval_dnf(xq_e, 0);
+  arma::mat bfval(bfval_e.rows(), bfval_e.cols());
+  std::memcpy(bfval.memptr(), bfval_e.data(), sizeof(double) * (size_t) bfval_e.size());
   arma::mat phival(bfval*C);
-  arma::mat coords(fem.eval_coord(xq));
+  helfem::Vector coords_e = fem.eval_coord(xq_e);
+  arma::vec coords(coords_e.size());
+  std::memcpy(coords.memptr(), coords_e.data(), sizeof(double) * coords_e.size());
   arma::mat weights(fem.eval_weights(wq));
 
   // Test orbitals are still orthonormal


### PR DESCRIPTION
## Summary

Third layer of the full arma → Eigen migration. Migrates the per-element basis-function evaluators on libhelfem's \`FiniteElementBasis\` (the layer that composes lib1dfem PolynomialBasis):

- \`eval_f\` / \`eval_df\` / \`eval_d2f\` / \`eval_d3f\` / \`eval_d4f\` / \`eval_d5f\`
- \`eval_dnf\` (both overloads: per-element + over-all-elements)
- \`eval_over_r\`
- \`eval_coord\` (per-element vec + all-element vec; scalar overload unchanged)
- \`eval_prim\`

All take/return \`helfem::Vector\` / \`helfem::Matrix\` (= Eigen). After this PR the FE internals no longer bridge to lib1dfem (signatures match directly); the boundary moves up to the FE consumers.

## Explicitly out of scope (still arma; future 5.x PRs)

- \`matrix_element\` (4 overloads incl. fn-pointer variant)
- \`vector_element\` (4 overloads incl. fn-pointer variant)
- \`get_bval\`, \`get_basis(arma::mat&, iel)\`, \`basis_indices\`, \`eval_weights\`
- \`bval\`, \`first_func_in_element\`, \`last_func_in_element\` (member types)

These keep their arma surface so the substantial FE consumers (scf_helpers, checkpoint, atomic main, ...) need no changes here.

## FE.cpp internal bridges

- \`matrix_element(int lhder, int rhder, ...)\` and the \`vector_element\` counterpart now use a small \`make_arma_eval_dnf\` helper to build arma-returning lambdas that wrap the Eigen-returning \`eval_dnf\`.
- The \`matrix_element\` function-pointer overload internally uses \`eval_coord\` (Eigen) — bridged in place with memcpy.
- \`consistency_check\` (in the constructor) calls \`eval_coord\` and \`eval_dnf\` for each element boundary — updated to build Eigen Vectors directly and materialise small arma copies only for the existing log-on-failure code.

## libhelfem caller updates

\`libhelfem/src/RadialBasis.cpp\` (~16 sites):
- \`make_evaluator\`: B0/B1/B2 lambdas now bridge per call via \`arma_to_eigen_vec\` + \`eigen_mat_to_arma\` helpers.
- \`eval_B_at\`: same pattern.
- \`matrix_element(rh, ...)\`: \`eval_prim\` cross-basis result bridged.
- \`get_bf\` / \`get_df\` / \`get_lf\` (per-x-point): all \`fem.eval_*\` / \`eval_coord\` / \`eval_over_r\` calls bridged inline.
- \`eval_orbs\`: \`eval_prim\` bridged.
- \`nuclear_density\` / \`nuclear_density_gradient\` / \`nuclear_orbital\`: \`eval_df\` / \`eval_d2f\` bridged at the \`(size_t)0\` element call sites.
- \`get_r\` (per-x-point): \`eval_coord\` bridged.

## External caller updates

\`src/diatomic/basis.cpp\`:
- Adds anonymous-namespace helpers (\`arma_to_eigen_vec\`, \`eigen_vec_to_arma\`, \`eigen_mat_to_arma\`).
- Bulk-rewrite (Python script) of all \`fem.eval_f\` / \`eval_df\` / \`eval_d2f\` / \`eval_coord\` / \`eval_prim\` call sites (~12).

\`src/harmonic/softcoulomb.cpp\`:
- \`fem.eval_dnf\` and \`fem.eval_coord\` (no-iel-arg overloads) bridged inline.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811248426** (unchanged)

## Status of the lib1dfem + libhelfem arma → Eigen migration

- [x] 5.1: leaf primitives (chebyshev, lobatto, math, grid) — PR #117
- [x] 5.2: PolynomialBasis subclasses + legendre_poly + eval tables — PR #118
- [x] **5.3: FiniteElementBasis per-element evaluators** — this PR
- [ ] 5.4: matrix_element / vector_element + get_bval etc.
- [ ] 5.5: RadialBasis.cpp internal scratch
- [ ] 5.6: TwoDBasis::coulomb / exchange internals
- [ ] 5.7: per-method templating

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic unchanged