### PR TITLE
v2: Eigen Phase 5.4 -- FiniteElementBasis matrix_element/vector_element + get_bval/eval_weights

### DIFF
--- a/libhelfem/include/FiniteElementBasis.h
+++ b/libhelfem/include/FiniteElementBasis.h
@@ -80,7 +80,7 @@ namespace helfem {
       arma::mat get_basis(const arma::mat &bas, size_t iel) const;
 
       /// Get the element boundaries
-      arma::vec get_bval() const;
+      helfem::Vector get_bval() const;
       /// Element begins at
       double element_begin(size_t iel) const;
       /// Element ends at
@@ -105,7 +105,7 @@ namespace helfem {
       helfem::Vector eval_prim(const helfem::Vector & xreal, size_t iel) const;
 
       /// Evaluate full set of weights for primitive weights
-      arma::vec eval_weights(const arma::vec & wq) const;
+      helfem::Vector eval_weights(const helfem::Vector & wq) const;
 
       /// Element size scaling factor
       double scaling_factor(size_t iel) const;
@@ -171,9 +171,12 @@ namespace helfem {
        * wq:    quadrature weights
        * f(r):  additional weight function, use nullptr for unit weight
        */
-      arma::mat matrix_element(int lhder, int rhder, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      // Phase 5.4: matrix_element / vector_element overloads migrated to
+      // Eigen. The fn-pointer overload's lambda signature is now
+      // helfem::Matrix(helfem::Vector, size_t).
+      helfem::Matrix matrix_element(int lhder, int rhder, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const;
       /// Same as above, but only in a single element
-      arma::mat matrix_element(size_t iel, int lhder, int rhder, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      helfem::Matrix matrix_element(size_t iel, int lhder, int rhder, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const;
 
       /**
        * Compute vector elements in the finite element basis <lh|f|rh>
@@ -183,9 +186,9 @@ namespace helfem {
        * wq:    quadrature weights
        * f(r):  additional weight function, use nullptr for unit weight
        */
-      arma::vec vector_element(int der, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      helfem::Vector vector_element(int der, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const;
       /// Same as above, but only in a single element
-      arma::vec vector_element(size_t iel, int der, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      helfem::Vector vector_element(size_t iel, int der, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const;
 
       /**
        * Compute matrix elements in the finite element basis <lh|f|rh>
@@ -196,9 +199,9 @@ namespace helfem {
        * wq:    quadrature weights
        * f(r):  additional weight function, use nullptr for unit weight
        */
-      arma::mat matrix_element(const std::function<arma::mat(arma::vec,size_t)> & eval_lh, const std::function<arma::mat(arma::vec,size_t)> & eval_rh, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      helfem::Matrix matrix_element(const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_lh, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_rh, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const;
       /// The driver function
-      arma::mat matrix_element(size_t iel, const std::function<arma::mat(arma::vec,size_t)> & eval_lh, const std::function<arma::mat(arma::vec,size_t)> & eval_rh, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f, double x_left = -1.0, double x_right = 1.0) const;
+      helfem::Matrix matrix_element(size_t iel, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_lh, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_rh, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f, double x_left = -1.0, double x_right = 1.0) const;
 
 
       /**
@@ -209,9 +212,9 @@ namespace helfem {
        * wq:    quadrature weights
        * f(r):  additional weight function, use nullptr for unit weight
        */
-      arma::vec vector_element(const std::function<arma::mat(arma::vec,size_t)> & eval_bf, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      helfem::Vector vector_element(const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_bf, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const;
       /// The driver function
-      arma::vec vector_element(size_t iel, const std::function<arma::mat(arma::vec,size_t)> & eval_bf, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const;
+      helfem::Vector vector_element(size_t iel, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_bf, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const;
 
       /// Print out the basis functions
       void print(const std::string & str="") const;

--- a/libhelfem/include/GTO.h
+++ b/libhelfem/include/GTO.h
@@ -141,8 +141,10 @@ namespace helfem {
         for (size_t k = 0; k < basis.size(); ++k) {
           const GTOContracted & gto = basis[k];
           auto f = [&gto](double r) { return detail_gto::eval_u(gto, r); };
-          arma::vec b = fem.vector_element(/*der=*/0, xq, wq, f);
-          C.col(k) = arma::solve(S, b);
+          // Phase 5.4: fem.vector_element is Eigen-typed.
+          const helfem::Vector be = fem.vector_element(/*der=*/0,
+              helfem::to_eigen(xq), helfem::to_eigen(wq), f);
+          C.col(k) = arma::solve(S, helfem::to_arma(be));
         }
         return NAORadialBasis::from_owned_radial(std::move(radial), std::move(C));
       }

--- a/libhelfem/include/STO.h
+++ b/libhelfem/include/STO.h
@@ -170,8 +170,10 @@ namespace helfem {
         for (size_t k = 0; k < basis.size(); ++k) {
           const STOContracted & sto = basis[k];
           auto f = [&sto](double r) { return detail_sto::eval_u(sto, r); };
-          arma::vec b = fem.vector_element(/*der=*/0, xq, wq, f);
-          C.col(k) = arma::solve(S, b);
+          // Phase 5.4: fem.vector_element is Eigen-typed.
+          const helfem::Vector be = fem.vector_element(/*der=*/0,
+              helfem::to_eigen(xq), helfem::to_eigen(wq), f);
+          C.col(k) = arma::solve(S, helfem::to_arma(be));
         }
         return NAORadialBasis::from_owned_radial(std::move(radial), std::move(C));
       }

--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -205,8 +205,12 @@ namespace helfem {
       }
     }
 
-    arma::vec FiniteElementBasis::get_bval() const {
-      return bval;
+    helfem::Vector FiniteElementBasis::get_bval() const {
+      // Phase 5.4: bval is still an arma::vec member; bridge at the
+      // accessor boundary. A future PR will migrate the member.
+      helfem::Vector out(bval.n_elem);
+      std::memcpy(out.data(), bval.memptr(), sizeof(double) * bval.n_elem);
+      return out;
     }
 
     // Phase 5.3: per-element evaluators migrated arma -> Eigen.
@@ -225,10 +229,10 @@ namespace helfem {
       return r;
     }
 
-    arma::vec FiniteElementBasis::eval_weights(const arma::vec & w) const {
-      arma::vec wr(get_nelem()*w.n_elem);
-      for(size_t iel=0;iel<get_nelem();iel++)
-        wr.subvec(iel*w.n_elem, (iel+1)*w.n_elem-1) = w*scaling_factor(iel);
+    helfem::Vector FiniteElementBasis::eval_weights(const helfem::Vector & w) const {
+      helfem::Vector wr(get_nelem() * w.size());
+      for (size_t iel = 0; iel < get_nelem(); ++iel)
+        wr.segment(iel * w.size(), w.size()) = w * scaling_factor(iel);
       return wr;
     }
 
@@ -346,149 +350,112 @@ namespace helfem {
       return f;
     }
 
-    arma::mat FiniteElementBasis::matrix_element(const std::function<arma::mat(arma::vec,size_t)> & eval_lh, const std::function<arma::mat(arma::vec,size_t)> & eval_rh, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
+    // Phase 5.4: matrix_element / vector_element migrated to Eigen.
+    // Function-pointer overload's lambdas now have signature
+    // helfem::Matrix(helfem::Vector, size_t), matching eval_dnf.
+    helfem::Matrix FiniteElementBasis::matrix_element(const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_lh, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_rh, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const {
       // Compute matrix elements in parallel
-      std::vector<arma::mat> matel(get_nelem());
+      std::vector<helfem::Matrix> matel(get_nelem());
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for(size_t iel=0; iel<get_nelem(); iel++) {
+      for (size_t iel = 0; iel < get_nelem(); ++iel) {
         matel[iel] = matrix_element(iel, eval_lh, eval_rh, xq, wq, f);
       }
 
-      // Fill in the global matrix
-      arma::mat M(get_nbf(),get_nbf(),arma::fill::zeros);
-      for(size_t iel=0; iel<get_nelem(); iel++) {
-        // Indices in matrix
+      const Eigen::Index N = static_cast<Eigen::Index>(get_nbf());
+      helfem::Matrix M = helfem::Matrix::Zero(N, N);
+      for (size_t iel = 0; iel < get_nelem(); ++iel) {
         size_t ifirst, ilast;
         get_idx(iel, ifirst, ilast);
-
-        // Accumulate
-        M.submat(ifirst, ifirst, ilast, ilast) += matel[iel];
+        M.block((Eigen::Index) ifirst, (Eigen::Index) ifirst,
+                ilast - ifirst + 1, ilast - ifirst + 1) += matel[iel];
       }
-
       return M;
     }
 
-    arma::vec FiniteElementBasis::vector_element(const std::function<arma::mat(arma::vec,size_t)> & eval, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      // Compute matrix elements in parallel
-      std::vector<arma::vec> vecel(get_nelem());
+    helfem::Vector FiniteElementBasis::vector_element(const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const {
+      std::vector<helfem::Vector> vecel(get_nelem());
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for(size_t iel=0; iel<get_nelem(); iel++) {
+      for (size_t iel = 0; iel < get_nelem(); ++iel) {
         vecel[iel] = vector_element(iel, eval, xq, wq, f);
       }
 
-      // Fill in the global vector
-      arma::vec V(get_nbf(),arma::fill::zeros);
-      for(size_t iel=0; iel<get_nelem(); iel++) {
-        // Indices in matrix
+      helfem::Vector V = helfem::Vector::Zero(get_nbf());
+      for (size_t iel = 0; iel < get_nelem(); ++iel) {
         size_t ifirst, ilast;
         get_idx(iel, ifirst, ilast);
-
-        // Accumulate
-        V.subvec(ifirst, ilast) += vecel[iel];
+        V.segment((Eigen::Index) ifirst, ilast - ifirst + 1) += vecel[iel];
       }
-
       return V;
     }
 
-    namespace {
-      // Phase 5.3 bridge: matrix_element's function-pointer overload takes
-      // arma::mat-returning lambdas, but eval_dnf is now Eigen-typed. Wrap
-      // the eval_dnf result through to_arma so the function-pointer
-      // overload's signature stays unchanged.
-      inline std::function<arma::mat(const arma::vec &, size_t)>
-      make_arma_eval_dnf(const FiniteElementBasis * fe, int der) {
-        return [fe, der](const arma::vec & xa, size_t iel) {
-          helfem::Vector xe(xa.n_elem);
-          std::memcpy(xe.data(), xa.memptr(), sizeof(double) * xa.n_elem);
-          helfem::Matrix me = fe->eval_dnf(xe, der, iel);
-          arma::mat out(me.rows(), me.cols());
-          std::memcpy(out.memptr(), me.data(),
-                      sizeof(double) * static_cast<size_t>(me.size()));
-          return out;
-        };
-      }
-    } // namespace
-
-    arma::mat FiniteElementBasis::matrix_element(int lhder, int rhder, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      auto eval_lh = make_arma_eval_dnf(this, lhder);
-      auto eval_rh = make_arma_eval_dnf(this, rhder);
+    helfem::Matrix FiniteElementBasis::matrix_element(int lhder, int rhder, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const {
+      auto eval_lh = [this, lhder](helfem::Vector x, size_t iel) { return this->eval_dnf(x, lhder, iel); };
+      auto eval_rh = [this, rhder](helfem::Vector x, size_t iel) { return this->eval_dnf(x, rhder, iel); };
       return matrix_element(eval_lh, eval_rh, xq, wq, f);
     }
 
-    arma::mat FiniteElementBasis::matrix_element(size_t iel, int lhder, int rhder, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      auto eval_lh = make_arma_eval_dnf(this, lhder);
-      auto eval_rh = make_arma_eval_dnf(this, rhder);
+    helfem::Matrix FiniteElementBasis::matrix_element(size_t iel, int lhder, int rhder, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const {
+      auto eval_lh = [this, lhder](helfem::Vector x, size_t iel_) { return this->eval_dnf(x, lhder, iel_); };
+      auto eval_rh = [this, rhder](helfem::Vector x, size_t iel_) { return this->eval_dnf(x, rhder, iel_); };
       return matrix_element(iel, eval_lh, eval_rh, xq, wq, f);
     }
 
-    arma::mat FiniteElementBasis::matrix_element(size_t iel, const std::function<arma::mat(arma::vec,size_t)> & eval_lh, const std::function<arma::mat(arma::vec,size_t)> & eval_rh, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f, double x_left, double x_right) const {
+    helfem::Matrix FiniteElementBasis::matrix_element(size_t iel, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_lh, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_rh, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f, double x_left, double x_right) const {
+      // Transform xq from [-1,1] to [x_left, x_right] and the same for wq.
+      const double a = (x_right - x_left) / 2.0;
+      const double b = (x_right + x_left) / 2.0;
+      const helfem::Vector x_shifted = a * xq + helfem::Vector::Constant(xq.size(), b);
 
-      // todo: figure out how to transform xq from [-1,1] to [x_left, x_right] and the same transformation for wq
-      arma::vec x_shifted((x_right-x_left)/2.0*xq + (x_right+x_left)/2.0*arma::ones<arma::vec>(xq.n_elem));
-
-      // Get coordinate values (Phase 5.3: eval_coord is Eigen).
-      helfem::Vector xs_e(x_shifted.n_elem);
-      std::memcpy(xs_e.data(), x_shifted.memptr(), sizeof(double) * x_shifted.n_elem);
-      helfem::Vector r_e = eval_coord(xs_e, iel);
-      arma::vec r(r_e.size());
-      std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
-      // Calculate total weight per point
-      arma::vec wp(wq*scaling_factor(iel)*(x_right-x_left)/2.0);
-      // Include the function
-      if(f) {
-          for(size_t i=0; i<wp.n_elem; i++)
-            wp(i)*=f(r(i));
+      // Get coordinate values
+      const helfem::Vector r = eval_coord(x_shifted, iel);
+      // Total weight per point
+      helfem::Vector wp = wq * scaling_factor(iel) * a;
+      if (f) {
+        for (Eigen::Index i = 0; i < wp.size(); ++i)
+          wp(i) *= f(r(i));
       }
 
       // Evaluate basis functions
-      if(!eval_lh)
+      if (!eval_lh)
         throw std::logic_error("Need function for evaluating left-hand basis functions!\n");
-      arma::mat lhbf = eval_lh(x_shifted, iel);
-      if(!eval_rh)
+      helfem::Matrix lhbf = eval_lh(x_shifted, iel);
+      if (!eval_rh)
         throw std::logic_error("Need function for evaluating right-hand basis functions!\n");
-      arma::mat rhbf = eval_rh(x_shifted, iel);
+      const helfem::Matrix rhbf = eval_rh(x_shifted, iel);
 
-      // Include weight in the lh operand
-      for(size_t i=0;i<lhbf.n_cols;i++)
-        lhbf.col(i)%=wp;
+      // Include weight in lh operand (column-wise multiply by wp).
+      for (Eigen::Index j = 0; j < lhbf.cols(); ++j)
+        lhbf.col(j).array() *= wp.array();
 
-      return arma::trans(lhbf)*rhbf;
+      return lhbf.transpose() * rhbf;
     }
 
-    arma::vec FiniteElementBasis::vector_element(size_t iel, const std::function<arma::mat(arma::vec,size_t)> & eval_bf, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      // Get coordinate values (Phase 5.3 bridge).
-      helfem::Vector xq_e(xq.n_elem);
-      std::memcpy(xq_e.data(), xq.memptr(), sizeof(double) * xq.n_elem);
-      helfem::Vector r_e = eval_coord(xq_e, iel);
-      arma::vec r(r_e.size());
-      std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
-      // Calculate total weight per point
-      arma::vec wp(wq*scaling_factor(iel));
-      // Include the function
-      if(f) {
-          for(size_t i=0; i<wp.n_elem; i++)
-            wp(i)*=f(r(i));
+    helfem::Vector FiniteElementBasis::vector_element(size_t iel, const std::function<helfem::Matrix(helfem::Vector,size_t)> & eval_bf, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const {
+      const helfem::Vector r = eval_coord(xq, iel);
+      helfem::Vector wp = wq * scaling_factor(iel);
+      if (f) {
+        for (Eigen::Index i = 0; i < wp.size(); ++i)
+          wp(i) *= f(r(i));
       }
 
-      // Evaluate basis functions
-      if(!eval_bf)
+      if (!eval_bf)
         throw std::logic_error("Need function for evaluating basis functions!\n");
-      arma::mat bf = eval_bf(xq, iel);
+      const helfem::Matrix bf = eval_bf(xq, iel);
 
-      return bf.t()*wp;
+      return bf.transpose() * wp;
     }
 
-    arma::vec FiniteElementBasis::vector_element(int der, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      auto eval_f = make_arma_eval_dnf(this, der);
+    helfem::Vector FiniteElementBasis::vector_element(int der, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const {
+      auto eval_f = [this, der](helfem::Vector x, size_t iel) { return this->eval_dnf(x, der, iel); };
       return vector_element(eval_f, xq, wq, f);
     }
 
-    arma::vec FiniteElementBasis::vector_element(size_t iel, int der, const arma::vec & xq, const arma::vec & wq, const std::function<double(double)> & f) const {
-      auto eval_f = make_arma_eval_dnf(this, der);
+    helfem::Vector FiniteElementBasis::vector_element(size_t iel, int der, const helfem::Vector & xq, const helfem::Vector & wq, const std::function<double(double)> & f) const {
+      auto eval_f = [this, der](helfem::Vector x, size_t iel_) { return this->eval_dnf(x, der, iel_); };
       return vector_element(iel, eval_f, xq, wq, f);
     }
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -27,6 +27,29 @@
 namespace helfem {
   namespace atomic {
     namespace basis {
+      namespace {
+        // Phase 5.3/5.4 helpers: FiniteElementBasis methods are now
+        // Eigen-typed. RadialBasis keeps its arma::vec/arma::mat surface
+        // for downstream chemistry code; bridge inline at every fem.*
+        // call site via these one-line memcpy converters.
+        inline helfem::Vector arma_to_eigen_vec(const arma::vec & v) {
+          helfem::Vector e(v.n_elem);
+          std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
+          return e;
+        }
+        inline arma::mat eigen_mat_to_arma(const helfem::Matrix & m) {
+          arma::mat out(m.rows(), m.cols());
+          std::memcpy(out.memptr(), m.data(),
+                      sizeof(double) * static_cast<size_t>(m.size()));
+          return out;
+        }
+        inline arma::vec eigen_vec_to_arma(const helfem::Vector & v) {
+          arma::vec out(v.size());
+          std::memcpy(out.memptr(), v.data(), sizeof(double) * v.size());
+          return out;
+        }
+      } // namespace
+
       FEMRadialBasis::FEMRadialBasis() {}
 
       FEMRadialBasis::FEMRadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad) : fem(fem_) {
@@ -71,7 +94,9 @@ namespace helfem {
       }
 
       arma::vec FEMRadialBasis::get_bval() const {
-        return fem.get_bval();
+        // Phase 5.4: fem.get_bval() is Eigen; bridge here -- RadialBasis
+        // keeps its arma::vec surface for downstream chemistry-layer code.
+        return eigen_vec_to_arma(fem.get_bval());
       }
 
       int FEMRadialBasis::get_poly_id() const {
@@ -95,47 +120,29 @@ namespace helfem {
         return ret;
       }
 
-      namespace {
-        // Phase 5.3 helpers: FiniteElementBasis::eval_f / eval_df / eval_d2f
-        // now take helfem::Vector and return helfem::Matrix. The
-        // matrix_element function-pointer overload still takes arma
-        // lambdas, so the make_evaluator below bridges per-call.
-        inline helfem::Vector arma_to_eigen_vec(const arma::vec & v) {
-          helfem::Vector e(v.n_elem);
-          std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
-          return e;
-        }
-        inline arma::mat eigen_mat_to_arma(const helfem::Matrix & m) {
-          arma::mat out(m.rows(), m.cols());
-          std::memcpy(out.memptr(), m.data(),
-                      sizeof(double) * static_cast<size_t>(m.size()));
-          return out;
-        }
-      } // namespace
-
-      // Pre-bound evaluator for each BasisKind. Bridges arma <-> Eigen
-      // at the per-call boundary; eval_* / get_* are now Eigen-typed.
-      static std::function<arma::mat(const arma::vec &, size_t)>
+      // Phase 5.4: matrix_element fn-pointer is now Eigen-typed.
+      // get_bf/df/lf are still arma; bridge there per call.
+      static std::function<helfem::Matrix(helfem::Vector, size_t)>
       make_evaluator(const FEMRadialBasis * rb, FEMRadialBasis::BasisKind k) {
         using BK = FEMRadialBasis::BasisKind;
         switch (k) {
-          case BK::B0: return [rb](const arma::vec & x, size_t iel) {
-            return eigen_mat_to_arma(rb->get_fem().eval_f(arma_to_eigen_vec(x), iel));
+          case BK::B0: return [rb](helfem::Vector x, size_t iel) {
+            return rb->get_fem().eval_f(x, iel);
           };
-          case BK::B1: return [rb](const arma::vec & x, size_t iel) {
-            return eigen_mat_to_arma(rb->get_fem().eval_df(arma_to_eigen_vec(x), iel));
+          case BK::B1: return [rb](helfem::Vector x, size_t iel) {
+            return rb->get_fem().eval_df(x, iel);
           };
-          case BK::B2: return [rb](const arma::vec & x, size_t iel) {
-            return eigen_mat_to_arma(rb->get_fem().eval_d2f(arma_to_eigen_vec(x), iel));
+          case BK::B2: return [rb](helfem::Vector x, size_t iel) {
+            return rb->get_fem().eval_d2f(x, iel);
           };
-          case BK::R0: return [rb](const arma::vec & x, size_t iel) {
-            return rb->get_bf(x, iel);
+          case BK::R0: return [rb](helfem::Vector x, size_t iel) {
+            return helfem::to_eigen(rb->get_bf(eigen_vec_to_arma(x), iel));
           };
-          case BK::R1: return [rb](const arma::vec & x, size_t iel) {
-            return rb->get_df(x, iel);
+          case BK::R1: return [rb](helfem::Vector x, size_t iel) {
+            return helfem::to_eigen(rb->get_df(eigen_vec_to_arma(x), iel));
           };
-          case BK::R2: return [rb](const arma::vec & x, size_t iel) {
-            return rb->get_lf(x, iel);
+          case BK::R2: return [rb](helfem::Vector x, size_t iel) {
+            return helfem::to_eigen(rb->get_lf(eigen_vec_to_arma(x), iel));
           };
         }
         throw std::logic_error("FEMRadialBasis::matrix_element: unknown BasisKind\n");
@@ -144,10 +151,13 @@ namespace helfem {
       helfem::Matrix FEMRadialBasis::matrix_element(
           size_t iel, BasisKind bra, BasisKind ket,
           const std::function<double(double)> & weight) const {
+        // Phase 5.4: fem.matrix_element is Eigen; xq, wq members
+        // are still arma -- bridge.
         auto lhs = make_evaluator(this, bra);
         auto rhs = make_evaluator(this, ket);
-        return helfem::to_eigen(
-            fem.matrix_element(iel, lhs, rhs, xq, wq, weight));
+        return fem.matrix_element(iel, lhs, rhs,
+                                  arma_to_eigen_vec(xq),
+                                  arma_to_eigen_vec(wq), weight);
       }
 
       helfem::Matrix FEMRadialBasis::matrix_element(
@@ -155,8 +165,9 @@ namespace helfem {
           const std::function<double(double)> & weight) const {
         auto lhs = make_evaluator(this, bra);
         auto rhs = make_evaluator(this, ket);
-        return helfem::to_eigen(
-            fem.matrix_element(lhs, rhs, xq, wq, weight));
+        return fem.matrix_element(lhs, rhs,
+                                  arma_to_eigen_vec(xq),
+                                  arma_to_eigen_vec(wq), weight);
       }
 
       helfem::Matrix FEMRadialBasis::matrix_element(
@@ -165,8 +176,9 @@ namespace helfem {
           double x_left, double x_right) const {
         auto lhs = make_evaluator(this, bra);
         auto rhs = make_evaluator(this, ket);
-        return helfem::to_eigen(
-            fem.matrix_element(iel, lhs, rhs, xq, wq, weight, x_left, x_right));
+        return fem.matrix_element(iel, lhs, rhs,
+                                  arma_to_eigen_vec(xq),
+                                  arma_to_eigen_vec(wq), weight, x_left, x_right);
       }
 
       helfem::Matrix FEMRadialBasis::bessel_il_integral(int L, double lambda, size_t iel) const {

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -78,7 +78,7 @@ namespace helfem {
       }
 
       arma::vec RadialBasis::get_bval() const {
-        return fem.get_bval();
+        return eigen_vec_to_arma(fem.get_bval());
       }
 
       int RadialBasis::get_poly_id() const {
@@ -120,7 +120,7 @@ namespace helfem {
         } else if(m==0 && n!=0) {
           chsh = [n](double mu) { return std::pow(std::cosh(mu), n); };
         }
-        return fem.matrix_element(false, false, xq, wq, chsh);
+        return eigen_mat_to_arma(fem.matrix_element(false, false, arma_to_eigen_vec(xq), arma_to_eigen_vec(wq), chsh));
       }
 
       arma::mat RadialBasis::overlap(const RadialBasis & rh, int n) const {
@@ -219,7 +219,7 @@ namespace helfem {
         } else {
           Plm = [legtab, L, M](double mu) { return std::sinh(mu)*legtab.get_Plm(L,M,cosh(mu)); };
         }
-        return fem.matrix_element(iel, false, false, xq, wq, Plm);
+        return eigen_mat_to_arma(fem.matrix_element(iel, false, false, arma_to_eigen_vec(xq), arma_to_eigen_vec(wq), Plm));
       }
 
       arma::mat RadialBasis::Qlm_integral(int k, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const {
@@ -229,12 +229,12 @@ namespace helfem {
         } else {
           Qlm = [legtab, L, M](double mu) { return std::sinh(mu)*legtab.get_Qlm(L,M,cosh(mu)); };
         }
-        return fem.matrix_element(iel, false, false, xq, wq, Qlm);
+        return eigen_mat_to_arma(fem.matrix_element(iel, false, false, arma_to_eigen_vec(xq), arma_to_eigen_vec(wq), Qlm));
       }
 
       arma::mat RadialBasis::kinetic() const {
         std::function<double(double)> sinhmu = [](double mu) {return std::sinh(mu);};
-        return fem.matrix_element(true, true, xq, wq, sinhmu);
+        return eigen_mat_to_arma(fem.matrix_element(true, true, arma_to_eigen_vec(xq), arma_to_eigen_vec(wq), sinhmu));
       }
 
       arma::mat RadialBasis::twoe_integral(int alpha, int beta, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const {

--- a/src/harmonic/main.cpp
+++ b/src/harmonic/main.cpp
@@ -16,11 +16,25 @@
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
 #include "chebyshev.h"
+#include <cstring>
 
 using namespace helfem;
 
+namespace {
+  inline helfem::Vector to_e(const arma::vec & v) {
+    helfem::Vector e(v.n_elem);
+    std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
+    return e;
+  }
+  inline arma::mat to_a(const helfem::Matrix & m) {
+    arma::mat out(m.rows(), m.cols());
+    std::memcpy(out.memptr(), m.data(), sizeof(double) * (size_t) m.size());
+    return out;
+  }
+} // namespace
+
 arma::mat overlap(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return fem.matrix_element(false, false, x, wx, nullptr);
+  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), nullptr));
 }
 
 double square_potential(double r) {
@@ -28,11 +42,11 @@ double square_potential(double r) {
 }
 
 arma::mat potential(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return fem.matrix_element(false, false, x, wx, square_potential);
+  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), square_potential));
 }
 
 arma::mat kinetic(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return fem.matrix_element(true, true, x, wx, nullptr);
+  return to_a(fem.matrix_element(true, true, to_e(x), to_e(wx), nullptr));
 }
 
 int main(int argc, char **argv) {

--- a/src/harmonic/softcoulomb.cpp
+++ b/src/harmonic/softcoulomb.cpp
@@ -22,8 +22,22 @@
 
 using namespace helfem;
 
+namespace {
+  // Phase 5.4 bridge.
+  inline helfem::Vector to_e(const arma::vec & v) {
+    helfem::Vector e(v.n_elem);
+    std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
+    return e;
+  }
+  inline arma::mat to_a(const helfem::Matrix & m) {
+    arma::mat out(m.rows(), m.cols());
+    std::memcpy(out.memptr(), m.data(), sizeof(double) * (size_t) m.size());
+    return out;
+  }
+} // namespace
+
 arma::mat overlap(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return fem.matrix_element(false, false, x, wx, nullptr);
+  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), nullptr));
 }
 
 arma::mat potential(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx, double z, double x0, double alpha, bool abs) {
@@ -37,11 +51,11 @@ arma::mat potential(const helfem::polynomial_basis::FiniteElementBasis & fem, co
       return -z/sqrt((x-x0)*(x-x0)+alpha*alpha);
     };
   }
-  return fem.matrix_element(false, false, x, wx, soft_coulomb);
+  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), soft_coulomb));
 }
 
 arma::mat kinetic(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return 0.5*fem.matrix_element(true, true, x, wx, nullptr);
+  return 0.5*to_a(fem.matrix_element(true, true, to_e(x), to_e(wx), nullptr));
 }
 
 int main(int argc, char **argv) {
@@ -156,7 +170,9 @@ int main(int argc, char **argv) {
   helfem::Vector coords_e = fem.eval_coord(xq_e);
   arma::vec coords(coords_e.size());
   std::memcpy(coords.memptr(), coords_e.data(), sizeof(double) * coords_e.size());
-  arma::mat weights(fem.eval_weights(wq));
+  helfem::Vector weights_e(fem.eval_weights(to_e(wq)));
+  arma::vec weights(weights_e.size());
+  std::memcpy(weights.memptr(), weights_e.data(), sizeof(double) * weights_e.size());
 
   // Test orbitals are still orthonormal
   arma::mat Sgrid(phival.t()*arma::diagmat(weights)*phival);


### PR DESCRIPTION
## Summary

Fourth layer of the full arma → Eigen migration. Migrates the remaining arma-typed FE surface that Phase 5.3 deferred:

- \`matrix_element\` (4 overloads): value-arg + function-pointer (lambda signature). All take/return Eigen.
- \`vector_element\` (4 overloads): same.
- \`get_bval()\`: returns \`helfem::Vector\`.
- \`eval_weights()\`: takes/returns \`helfem::Vector\`.

After this PR the FiniteElementBasis public API surface that's accessible from chemistry code is **entirely Eigen-typed**; only the FE class members (\`bval\` / \`first_func_in_element\` / \`last_func_in_element\` / \`basis_indices\` return type / \`get_basis\` arma overload) still arma — a follow-up PR can finish them.

## Key design choice — fn-pointer lambda signature

The function-pointer \`matrix_element\` / \`vector_element\` overloads used arma lambdas:
```cpp
std::function<arma::mat(arma::vec, size_t)> eval_lh;
```
now become:
```cpp
std::function<helfem::Matrix(helfem::Vector, size_t)> eval_lh;
```
matching the migrated \`eval_dnf\`. The 5.3 \`make_arma_eval_dnf\` shim is removed — lambdas are now native Eigen.

## FE.cpp internals native Eigen

\`matrix_element\` / \`vector_element\` internals rewritten in Eigen arithmetic (\`block\` / \`segment\` / \`.array()\` column-wise multiply / \`.transpose()\` / \`Vec::Constant\`). The \`(1/h, x_shifted, wp, r, lhbf, rhbf)\` chain works directly on \`Vec<double>\` / \`Mat<double>\`; no per-element bridging.

\`get_bval()\` bridges from the still-arma \`bval\` member with memcpy.

## libhelfem callers

\`libhelfem/src/RadialBasis.cpp\`:
- Moves \`arma_to_eigen_vec\` / \`eigen_mat_to_arma\` / \`eigen_vec_to_arma\` helpers up to file-scope anonymous namespace.
- \`make_evaluator\`: BasisKind::B0/B1/B2 lambdas return \`helfem::Matrix\` directly; R0/R1/R2 bridge \`get_bf/df/lf\` (still arma) per call.
- \`matrix_element\` (3 overloads) calls \`fem.matrix_element\` with bridged \`xq\` / \`wq\` since members stay arma::vec.
- \`get_bval()\`: bridges \`fem.get_bval()\` to arma::vec.

## External callers

\`src/diatomic/basis.cpp\`:
- \`get_bval()\` bridges with \`eigen_vec_to_arma\`.
- 4 \`fem.matrix_element\` call sites bridged via regex substitution.

\`src/harmonic/main.cpp\`, \`src/harmonic/softcoulomb.cpp\`:
- Each adds local \`to_e\` / \`to_a\` helpers and bridges 3 \`fem.matrix_element\` calls each. softcoulomb also bridges \`fem.eval_weights\`.

\`libhelfem/include/STO.h\`, \`libhelfem/include/GTO.h\`:
- Single \`fem.vector_element\` call each, bridged with \`helfem::to_eigen\` / \`to_arma\`.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **Total = −14.5728772811251392** (vs prior −14.5728772811248426 — ~3e-13 drift from Eigen vs arma summation order in matmul / element-wise scaling; expected and well below SCF convergence threshold of 1e-7)
- \`test_radial_df_exhaustive.py\`: 3 configs PASS at machine precision

## Status of the lib1dfem + libhelfem arma → Eigen migration

- [x] 5.1: leaf primitives — PR #117
- [x] 5.2: PolynomialBasis subclasses + legendre_poly + eval tables — PR #118
- [x] 5.3: FiniteElementBasis per-element evaluators — PR #119
- [x] **5.4: FiniteElementBasis matrix_element / vector_element / get_bval** — this PR
- [ ] 5.5: RadialBasis.cpp internal scratch (xq/wq members → Eigen) + FE bval member + basis_indices
- [ ] 5.6: TwoDBasis::coulomb/exchange internals
- [ ] 5.7: per-method templating

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic preserves to 12 sig digits
- [x] test_radial_df_exhaustive.py passes