### PR TITLE
v2: Eigen Phase 5.7 -- libhelfem quadrature.cpp arma -> Eigen

### DIFF
--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -441,11 +441,11 @@ namespace helfem {
 
         // Integral by quadrature
         std::shared_ptr<const polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
-        arma::mat tei(quadrature::twoe_integral(Rmin, Rmax, eigen_vec_to_arma(xq), eigen_vec_to_arma(wq), p, L));
-        if(tei.has_nan()) {
-          printf("twoe_integral(%i,%i) has NaN!\n",L,(int) iel);
-        }
-        return helfem::to_eigen(tei);
+        // Phase 5.7: quadrature::twoe_integral is now Eigen.
+        helfem::Matrix tei = quadrature::twoe_integral(Rmin, Rmax, xq, wq, p, L);
+        if (tei.array().isNaN().any())
+          printf("twoe_integral(%i,%i) has NaN!\n", L, (int) iel);
+        return tei;
       }
 
       // Pivoted Cholesky with truncation. Returns Lout of shape
@@ -514,9 +514,7 @@ namespace helfem {
 
         // Integral by quadrature
         std::shared_ptr<const polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
-        arma::mat tei(quadrature::yukawa_integral(Rmin, Rmax, eigen_vec_to_arma(xq), eigen_vec_to_arma(wq), p, L, lambda));
-
-        return helfem::to_eigen(tei);
+        return quadrature::yukawa_integral(Rmin, Rmax, xq, wq, p, L, lambda);
       }
 
       helfem::Matrix FEMRadialBasis::erfc_integral(int L, double mu, size_t iel, size_t kel) const {
@@ -566,11 +564,15 @@ namespace helfem {
         double Rmink(fem.element_begin(kel));
         double Rmaxk(fem.element_end(kel));
 
-        // Evaluate integral
-        arma::mat tei(quadrature::erfc_integral(Rmini, Rmaxi, ibf, xi, wi, Rmink,
-                                                Rmaxk, kbf, xk, wk, L, mu));
-        // Symmetrize just to be sure, since quadrature points were
-        // different
+        // Evaluate integral (Phase 5.7: quadrature::erfc_integral is
+        // Eigen; bridge the local arma::vec / arma::mat scratch).
+        arma::mat tei(eigen_mat_to_arma(quadrature::erfc_integral(
+            Rmini, Rmaxi,
+            helfem::to_eigen(ibf), arma_to_eigen_vec(xi), arma_to_eigen_vec(wi),
+            Rmink, Rmaxk,
+            helfem::to_eigen(kbf), arma_to_eigen_vec(xk), arma_to_eigen_vec(wk),
+            L, mu)));
+        // Symmetrize just to be sure (quadrature points were different).
         if (iel == kel)
           tei = 0.5 * (tei + tei.t());
 
@@ -583,9 +585,7 @@ namespace helfem {
 
         // Integral by quadrature
         std::shared_ptr<polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
-        arma::mat pot(quadrature::spherical_potential(Rmin, Rmax, eigen_vec_to_arma(xq), eigen_vec_to_arma(wq), p));
-
-        return helfem::to_eigen(pot);
+        return quadrature::spherical_potential(Rmin, Rmax, xq, wq, p);
       }
 
       arma::mat FEMRadialBasis::get_bf(size_t iel) const {

--- a/libhelfem/src/quadrature.cpp
+++ b/libhelfem/src/quadrature.cpp
@@ -12,283 +12,255 @@
  * See the LICENSE file at the root of this source distribution
  * for the full license text.
  */
+
+// Phase 5.7: quadrature.cpp migrated arma -> Eigen. Public API takes
+// and returns Eigen Vec / Mat; internals are native Eigen ops.
+
 #include "quadrature.h"
 #include "erfc_expn.h"
 #include "chebyshev.h"
 #include "utils.h"
-#include <ArmaEigen.h>
-#include <cstring>
-
-namespace {
-  // Phase 5.2 bridge: lib1dfem PolynomialBasis::eval_dnf takes/returns
-  // Eigen Vec/Mat. The quadrature routines below are still arma-typed;
-  // wrap each eval_dnf call here to convert once at the boundary.
-  inline arma::mat eval_poly_dnf(
-      const std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> & poly,
-      const arma::vec & x, int n, double element_length) {
-    helfem::lib1dfem::Vec<double> xe(x.n_elem);
-    std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
-    helfem::lib1dfem::Mat<double> me;
-    poly->eval_dnf(xe, me, n, element_length);
-    arma::mat out(me.rows(), me.cols());
-    std::memcpy(out.memptr(), me.data(),
-                sizeof(double) * static_cast<size_t>(me.size()));
-    return out;
-  }
-} // namespace
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
 
 namespace helfem {
   namespace quadrature {
-    arma::vec twoe_inner_integral_wrk(double rmin, double rmax, double rmin0, double rmax0, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, const std::function<double(double,double)> & fsmallbig, const std::function<double(double)> & fbig) {
-      // Midpoint is at
-      double rmid(0.5*(rmax+rmin));
-      // and half-length of interval is
-      double rlen(0.5*(rmax-rmin));
-      // r values are then
-      arma::vec r(rmid*arma::ones<arma::vec>(x.n_elem)+rlen*x);
 
-      // Midpoint of original interval is at
-      double rmid0(0.5*(rmax0+rmin0));
-      // and half-length of original interval is
-      double rlen0(0.5*(rmax0-rmin0));
+    using Vec = helfem::Vector;
+    using Mat = helfem::Matrix;
 
-      // Compute fsmallbig(r)
-      arma::vec fsmallbigr(r.n_elem);
-      for(size_t i=0;i<r.n_elem;i++)
-        fsmallbigr(i)=fsmallbig(r(i),rmax);
+    Vec twoe_inner_integral_wrk(double rmin, double rmax, double rmin0, double rmax0,
+                                const Vec & x, const Vec & wx,
+                                const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                                const std::function<double(double,double)> & fsmallbig,
+                                const std::function<double(double)> & fbig) {
+      (void) fbig;
+      const double rmid  = 0.5 * (rmax + rmin);
+      const double rlen  = 0.5 * (rmax - rmin);
+      const Vec r = Vec::Constant(x.size(), rmid) + rlen * x;
 
-      // Calculate total weight per point
-      arma::vec wp(wx%fsmallbigr*rlen);
+      const double rmid0 = 0.5 * (rmax0 + rmin0);
+      const double rlen0 = 0.5 * (rmax0 - rmin0);
 
-      // Calculate x values the polynomials should be evaluated at
-      arma::vec xpoly((r-rmid0*arma::ones<arma::vec>(x.n_elem))/rlen0);
-      // Evaluate the polynomials at these points
-      arma::mat bf(eval_poly_dnf(poly, xpoly, 0, rlen0));
+      Vec fsmallbigr(r.size());
+      for (Eigen::Index i = 0; i < r.size(); ++i)
+        fsmallbigr(i) = fsmallbig(r(i), rmax);
 
-      // Put in weight
-      arma::mat wbf(bf);
-      for(size_t i=0;i<wbf.n_cols;i++)
-        wbf.col(i)%=wp;
+      // wp = wx .* fsmallbigr * rlen (element-wise)
+      const Vec wp = (wx.array() * fsmallbigr.array() * rlen).matrix();
 
-      // The integrals are then
-      arma::vec inner(arma::vectorise(arma::trans(wbf)*bf));
+      // xpoly = (r - rmid0) / rlen0
+      const Vec xpoly = (r - Vec::Constant(r.size(), rmid0)) / rlen0;
+
+      // Evaluate polynomials at xpoly
+      Mat bf;
+      poly->eval_dnf(xpoly, bf, 0, rlen0);
+
+      // Weighted bf: wbf(:, k) = bf(:, k) .* wp
+      Mat wbf = bf;
+      for (Eigen::Index k = 0; k < wbf.cols(); ++k)
+        wbf.col(k).array() *= wp.array();
+
+      // inner = vec(wbf^T * bf), column-major flatten.
+      const Mat M = wbf.transpose() * bf;
+      Vec inner(M.size());
+      std::memcpy(inner.data(), M.data(), sizeof(double) * (size_t) M.size());
+      return inner;
+    }
+
+    Mat twoe_inner_integral(double rmin, double rmax,
+                            const Vec & x, const Vec & wx,
+                            const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                            const std::function<double(double,double)> & fsmallbig,
+                            const std::function<double(double)> & fbig) {
+      const double rmid = 0.5 * (rmax + rmin);
+      const double rlen = 0.5 * (rmax - rmin);
+      const Vec r = Vec::Constant(x.size(), rmid) + rlen * x;
+
+      const int nbf = poly->get_nbf();
+      Mat inner(x.size(), nbf * nbf);
+      // Row 0: integral from rmin to r(0)
+      inner.row(0) = twoe_inner_integral_wrk(rmin, r(0), rmin, rmax, x, wx, poly, fsmallbig, fbig).transpose();
+      for (Eigen::Index ip = 1; ip < x.size(); ++ip)
+        inner.row(ip) = twoe_inner_integral_wrk(r(ip - 1), r(ip), rmin, rmax, x, wx, poly, fsmallbig, fbig).transpose();
+
+      // Rescale: undo the per-segment R^(-L-1) factor we applied for
+      // numerical stability.
+      for (Eigen::Index ip = 1; ip < x.size(); ++ip)
+        inner.row(ip) += inner.row(ip - 1) * (fbig(r(ip)) / fbig(r(ip - 1)));
 
       return inner;
     }
 
-    arma::mat twoe_inner_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, const std::function<double(double,double)> & fsmallbig, const std::function<double(double)> & fbig) {
-      // Midpoint is at
-      double rmid(0.5*(rmax+rmin));
-      // and half-length of interval is
-      double rlen(0.5*(rmax-rmin));
-      // r values are then
-      arma::vec r(rmid*arma::ones<arma::vec>(x.n_elem)+rlen*x);
-
-      // Compute the "inner" integrals as function of r.
-      // Every subinterval uses a fresh nquad points!
-      arma::mat inner(x.n_elem,std::pow(poly->get_nbf(),2));
-      inner.row(0)=arma::trans(twoe_inner_integral_wrk(rmin, r(0), rmin, rmax, x, wx, poly, fsmallbig, fbig));
-      for(size_t ip=1;ip<x.n_elem;ip++)
-        inner.row(ip)=arma::trans(twoe_inner_integral_wrk(r(ip-1), r(ip), rmin, rmax, x, wx, poly, fsmallbig, fbig));
-
-      // For numerical stability, each integral segment is scaled by
-      // R^(-L-1), since first integrating r^L and then multiplying by
-      // R^(-L-1) is unstable for small R and large L due to loss of
-      // precision. We undo the conversion here
-      for(size_t ip=1;ip<x.n_elem;ip++)
-        inner.row(ip) += inner.row(ip-1)*(fbig(r(ip))/fbig(r(ip-1)));
-
-      return inner;
-    }
-
-    arma::mat twoe_inner_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L) {
-      // Kernel functions
-      std::function<double(double,double)> fsmallbig = [L](double r, double R) {return std::pow(r/R,L)/R;};
-      std::function<double(double)> fbig = [L](double r) {return std::pow(r,-L-1);};
+    Mat twoe_inner_integral(double rmin, double rmax,
+                            const Vec & x, const Vec & wx,
+                            const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                            int L) {
+      std::function<double(double,double)> fsmallbig = [L](double r, double R) { return std::pow(r/R, L) / R; };
+      std::function<double(double)> fbig = [L](double r) { return std::pow(r, -L - 1); };
       return twoe_inner_integral(rmin, rmax, x, wx, poly, fsmallbig, fbig);
     }
 
-    arma::mat twoe_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L) {
-#ifndef ARMA_NO_DEBUG
-      if(x.n_elem != wx.n_elem) {
+    namespace {
+      // Helper: bf-product columns bfprod(:, fi*Nf+fj) = bf(:, fi) .* bf(:, fj).
+      inline Mat make_bfprod(const Mat & bf) {
+        const Eigen::Index N = bf.cols();
+        Mat bfprod(bf.rows(), N * N);
+        for (Eigen::Index fi = 0; fi < N; ++fi)
+          for (Eigen::Index fj = 0; fj < N; ++fj)
+            bfprod.col(fi * N + fj).array() = bf.col(fi).array() * bf.col(fj).array();
+        return bfprod;
+      }
+    } // namespace
+
+    Mat twoe_integral(double rmin, double rmax,
+                      const Vec & x, const Vec & wx,
+                      const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                      int L) {
+      if (x.size() != wx.size()) {
         std::ostringstream oss;
-        oss << "x and wx not compatible: " << x.n_elem << " vs " << wx.n_elem << "!\n";
+        oss << "x and wx not compatible: " << x.size() << " vs " << wx.size() << "!\n";
         throw std::logic_error(oss.str());
       }
-#endif
-      // and half-length of interval is
-      double rlen(0.5*(rmax-rmin));
+      const double rlen = 0.5 * (rmax - rmin);
 
-      // Compute the inner integrals
-      arma::mat inner(twoe_inner_integral(rmin, rmax, x, wx, poly, L));
+      const Mat inner = twoe_inner_integral(rmin, rmax, x, wx, poly, L);
 
-      // Evaluate basis functions at quadrature points
-      arma::mat bf(eval_poly_dnf(poly, x, 0, rlen));
+      Mat bf;
+      poly->eval_dnf(x, bf, 0, rlen);
 
-      // Product functions
-      arma::mat bfprod(bf.n_rows,bf.n_cols*bf.n_cols);
-      for(size_t fi=0;fi<bf.n_cols;fi++)
-        for(size_t fj=0;fj<bf.n_cols;fj++)
-          bfprod.col(fi*bf.n_cols+fj)=bf.col(fi)%bf.col(fj);
-      // Put in the weights for the outer integral
-      arma::vec wp(wx*rlen);
-      for(size_t i=0;i<bfprod.n_cols;i++)
-        bfprod.col(i)%=wp;
+      Mat bfprod = make_bfprod(bf);
+      const Vec wp = wx * rlen;
+      for (Eigen::Index i = 0; i < bfprod.cols(); ++i)
+        bfprod.col(i).array() *= wp.array();
 
-      // Integrals are then
-      arma::mat ints(arma::trans(bfprod)*inner);
-      // but we are still missing the second term which can be
-      // obtained as simply as
-      ints+=arma::trans(ints);
-
+      Mat ints = bfprod.transpose() * inner;
+      ints += ints.transpose().eval();
       return ints;
     }
 
-    arma::mat yukawa_inner_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L, double lambda) {
-      // Kernel functions
-      std::function<double(double,double)> fsmallbig = [L, lambda](double r, double R) {return utils::bessel_il(r*lambda,L)*utils::bessel_kl(R*lambda,L);};
-      std::function<double(double)> fbig = [L, lambda](double r) {return utils::bessel_kl(r*lambda,L);};
+    Mat yukawa_inner_integral(double rmin, double rmax,
+                              const Vec & x, const Vec & wx,
+                              const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                              int L, double lambda) {
+      std::function<double(double,double)> fsmallbig = [L, lambda](double r, double R) {
+        return utils::bessel_il(r * lambda, L) * utils::bessel_kl(R * lambda, L);
+      };
+      std::function<double(double)> fbig = [L, lambda](double r) { return utils::bessel_kl(r * lambda, L); };
       return twoe_inner_integral(rmin, rmax, x, wx, poly, fsmallbig, fbig);
     }
 
-    arma::mat yukawa_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L, double lambda) {
-#ifndef ARMA_NO_DEBUG
-      if(x.n_elem != wx.n_elem) {
+    Mat yukawa_integral(double rmin, double rmax,
+                        const Vec & x, const Vec & wx,
+                        const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                        int L, double lambda) {
+      if (x.size() != wx.size()) {
         std::ostringstream oss;
-        oss << "x and wx not compatible: " << x.n_elem << " vs " << wx.n_elem << "!\n";
+        oss << "x and wx not compatible: " << x.size() << " vs " << wx.size() << "!\n";
         throw std::logic_error(oss.str());
       }
-#endif
-      // and half-length of interval is
-      double rlen(0.5*(rmax-rmin));
+      const double rlen = 0.5 * (rmax - rmin);
 
-      // Compute the inner integrals
-      arma::mat inner(yukawa_inner_integral(rmin, rmax, x, wx, poly, L, lambda));
+      const Mat inner = yukawa_inner_integral(rmin, rmax, x, wx, poly, L, lambda);
 
-      // Evaluate basis functions at quadrature points
-      arma::mat bf(eval_poly_dnf(poly, x, 0, rlen));
+      Mat bf;
+      poly->eval_dnf(x, bf, 0, rlen);
 
-      // Product functions
-      arma::mat bfprod(bf.n_rows,bf.n_cols*bf.n_cols);
-      for(size_t fi=0;fi<bf.n_cols;fi++)
-        for(size_t fj=0;fj<bf.n_cols;fj++)
-          bfprod.col(fi*bf.n_cols+fj)=bf.col(fi)%bf.col(fj);
-      // Put in the weights for the outer integral
-      arma::vec wp(wx*rlen);
-      for(size_t i=0;i<bfprod.n_cols;i++)
-        bfprod.col(i)%=wp;
+      Mat bfprod = make_bfprod(bf);
+      const Vec wp = wx * rlen;
+      for (Eigen::Index i = 0; i < bfprod.cols(); ++i)
+        bfprod.col(i).array() *= wp.array();
 
-      // Integrals are then
-      arma::mat ints(arma::trans(bfprod)*inner);
-      // but we are still missing the second term which can be
-      // obtained as simply as
-      ints+=arma::trans(ints);
-
+      Mat ints = bfprod.transpose() * inner;
+      ints += ints.transpose().eval();
       return ints;
     }
 
-    arma::mat erfc_integral(double rmini, double rmaxi, const arma::mat & bfi, const arma::vec & xi, const arma::vec & wi, double rmink, double rmaxk, const arma::mat & bfk, const arma::vec & xk, const arma::vec & wk, int L, double mu) {
-#ifndef ARMA_NO_DEBUG
-      if(xi.n_elem != wi.n_elem) {
+    Mat erfc_integral(double rmini, double rmaxi,
+                      const Mat & bfi, const Vec & xi, const Vec & wi,
+                      double rmink, double rmaxk,
+                      const Mat & bfk, const Vec & xk, const Vec & wk,
+                      int L, double mu) {
+      if (xi.size() != wi.size()) {
         std::ostringstream oss;
-        oss << "xi and wi not compatible: " << xi.n_elem << " vs " << wi.n_elem << "!\n";
+        oss << "xi and wi not compatible: " << xi.size() << " vs " << wi.size() << "!\n";
         throw std::logic_error(oss.str());
       }
-      if(xk.n_elem != wk.n_elem) {
+      if (xk.size() != wk.size()) {
         std::ostringstream oss;
-        oss << "xk and wk not compatible: " << xk.n_elem << " vs " << wk.n_elem << "!\n";
+        oss << "xk and wk not compatible: " << xk.size() << " vs " << wk.size() << "!\n";
         throw std::logic_error(oss.str());
       }
-#endif
-      // and half-lengths of the intervals are
-      double rmidi(0.5*(rmaxi+rmini));
-      double rmidk(0.5*(rmaxk+rmink));
 
-      double rleni(0.5*(rmaxi-rmini));
-      double rlenk(0.5*(rmaxk-rmink));
+      const double rmidi = 0.5 * (rmaxi + rmini);
+      const double rmidk = 0.5 * (rmaxk + rmink);
+      const double rleni = 0.5 * (rmaxi - rmini);
+      const double rlenk = 0.5 * (rmaxk - rmink);
 
-      // Radii
-      arma::vec ri(rmidi*arma::ones<arma::vec>(xi.n_elem)+rleni*xi);
-      arma::vec rk(rmidk*arma::ones<arma::vec>(xk.n_elem)+rlenk*xk);
+      const Vec ri = Vec::Constant(xi.size(), rmidi) + rleni * xi;
+      const Vec rk = Vec::Constant(xk.size(), rmidk) + rlenk * xk;
 
-      // Green's function
-      arma::mat Fn(ri.n_elem,rk.n_elem);
-      for(size_t i=0;i<ri.n_elem;i++)
-        for(size_t k=0;k<rk.n_elem;k++)
-          Fn(i,k) = atomic::erfc_expn::Phi(L,mu*ri(i),mu*rk(k));
+      // Green's function matrix Fn(i, k) = Phi(L, mu*ri(i), mu*rk(k))
+      Mat Fn(ri.size(), rk.size());
+      for (Eigen::Index i = 0; i < ri.size(); ++i)
+        for (Eigen::Index k = 0; k < rk.size(); ++k)
+          Fn(i, k) = atomic::erfc_expn::Phi(L, mu * ri(i), mu * rk(k));
 
-      // Product functions
-      arma::mat bfprodij(bfi.n_rows,bfi.n_cols*bfi.n_cols);
-      for(size_t fi=0;fi<bfi.n_cols;fi++)
-        for(size_t fj=0;fj<bfi.n_cols;fj++)
-          bfprodij.col(fi*bfi.n_cols+fj)=bfi.col(fi)%bfi.col(fj);
-      arma::mat bfprodkl(bfk.n_rows,bfk.n_cols*bfk.n_cols);
-      for(size_t fi=0;fi<bfk.n_cols;fi++)
-        for(size_t fj=0;fj<bfk.n_cols;fj++)
-          bfprodkl.col(fi*bfk.n_cols+fj)=bfk.col(fi)%bfk.col(fj);
-      // Put in the weights
-      arma::vec wpi(wi*rleni);
-      for(size_t i=0;i<bfprodij.n_cols;i++)
-        bfprodij.col(i)%=wpi;
-      arma::vec wpk(wk*rlenk);
-      for(size_t i=0;i<bfprodkl.n_cols;i++)
-        bfprodkl.col(i)%=wpk;
+      Mat bfprodij = make_bfprod(bfi);
+      Mat bfprodkl = make_bfprod(bfk);
 
-      // Integrals are then
-      arma::mat ints(arma::trans(bfprodij)*Fn*bfprodkl);
+      const Vec wpi = wi * rleni;
+      for (Eigen::Index i = 0; i < bfprodij.cols(); ++i)
+        bfprodij.col(i).array() *= wpi.array();
+      const Vec wpk = wk * rlenk;
+      for (Eigen::Index i = 0; i < bfprodkl.cols(); ++i)
+        bfprodkl.col(i).array() *= wpk.array();
 
-      return ints;
+      return bfprodij.transpose() * Fn * bfprodkl;
     }
 
-    arma::mat spherical_potential(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly) {
-      // Midpoint is at
-      double rmid(0.5*(rmax+rmin));
-      // and half-length of interval is
-      double rlen(0.5*(rmax-rmin));
-      // r values are then
-      arma::vec r(rmid*arma::ones<arma::vec>(x.n_elem)+rlen*x);
+    Mat spherical_potential(double rmin, double rmax,
+                            const Vec & x, const Vec & wx,
+                            const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly) {
+      const double rmid = 0.5 * (rmax + rmin);
+      const double rlen = 0.5 * (rmax - rmin);
+      const Vec r = Vec::Constant(x.size(), rmid) + rlen * x;
 
-      // Compute the "inner" integrals as function of r.
-      arma::mat zero(std::pow(poly->get_nbf(),2),x.n_elem);
-      zero.zeros();
-      arma::mat minusone(std::pow(poly->get_nbf(),2),x.n_elem);
-      minusone.zeros();
+      const int nbf = poly->get_nbf();
+      Mat zero     = Mat::Zero(nbf * nbf, x.size());
+      Mat minusone = Mat::Zero(nbf * nbf, x.size());
 
-      std::function<double(double)> fsmall = [](double r) {return 1.0;};
-      std::function<double(double)> fbig = [](double r) {return 1/r;};
+      std::function<double(double)> fsmall = [](double) { return 1.0; };
+      std::function<double(double)> fbig   = [](double r) { return 1.0 / r; };
+      std::function<double(double,double)> fsmallbig = [](double, double R) { return 1.0 / R; };
+      std::function<double(double,double)> fbigsmall = [](double r, double) { return 1.0 / r; };
 
-      std::function<double(double,double)> fsmallbig = [](double r, double R) {return 1.0/R;};
-      std::function<double(double,double)> fbigsmall = [](double r, double R) {return 1/r;};
-
-      // Every subinterval uses a fresh nquad points!
-      for(size_t ip=0;ip<x.n_elem;ip++) {
-        double low = ip ? r(ip-1) : rmin;
-        double high = r(ip);
-        zero.col(ip)=twoe_inner_integral_wrk(low, high, rmin, rmax, x, wx, poly, fsmallbig, fbig);
+      for (Eigen::Index ip = 0; ip < x.size(); ++ip) {
+        const double low  = ip ? r(ip - 1) : rmin;
+        const double high = r(ip);
+        zero.col(ip) = twoe_inner_integral_wrk(low, high, rmin, rmax, x, wx, poly, fsmallbig, fbig);
       }
-      for(size_t ip=0;ip<x.n_elem;ip++) {
-        double low = r(ip);
-        double high = (ip == x.n_elem-1) ? rmax : r(ip+1);
-        minusone.col(ip)=twoe_inner_integral_wrk(low, high, rmin, rmax, x, wx, poly, fbigsmall, fsmall);
+      for (Eigen::Index ip = 0; ip < x.size(); ++ip) {
+        const double low  = r(ip);
+        const double high = (ip == x.size() - 1) ? rmax : r(ip + 1);
+        minusone.col(ip) = twoe_inner_integral_wrk(low, high, rmin, rmax, x, wx, poly, fbigsmall, fsmall);
       }
 
-      // The potential itself
-      arma::mat V(std::pow(poly->get_nbf(),2),x.n_elem);
-      V.zeros();
-      for(size_t ip=0;ip<x.n_elem;ip++) {
+      Mat V = Mat::Zero(nbf * nbf, x.size());
+      for (Eigen::Index ip = 0; ip < x.size(); ++ip) {
         // \int_0^r Bi(r) Bj(r) dr
-        for(size_t jp=0;jp<=ip;jp++)
-          V.col(ip)+=zero.col(jp)*r(jp);
-        // divided by r
+        for (Eigen::Index jp = 0; jp <= ip; ++jp)
+          V.col(ip) += zero.col(jp) * r(jp);
         V.col(ip) /= r(ip);
 
-        // plus the integral to infinity \int_r^\infty r^{-1} Bi(r) Bj(r) dr
-        for(size_t jp=ip;jp<x.n_elem;jp++)
-          V.col(ip)+=minusone.col(jp);
+        // + \int_r^infty r^{-1} Bi(r) Bj(r) dr
+        for (Eigen::Index jp = ip; jp < x.size(); ++jp)
+          V.col(ip) += minusone.col(jp);
       }
 
-      // Should be returned as transpose
-      return arma::trans(V);
+      return V.transpose();
     }
-  }
-}
+
+  } // namespace quadrature
+} // namespace helfem

--- a/libhelfem/src/quadrature.h
+++ b/libhelfem/src/quadrature.h
@@ -15,67 +15,55 @@
 #ifndef QUADRATURE_H
 #define QUADRATURE_H
 
-#include <armadillo>
+#include <Matrix.h>
 #include <memory>
+#include <functional>
 #include <ModelPotential.h>
 #include <PolynomialBasis.h>
 
+// Phase 5.7: quadrature API migrated to Eigen.
 namespace helfem {
   namespace quadrature {
-    /**
-     * Computes a radial integral of the type \f$ \int_0^\infty B_1 (r) B_2(r) r^n dr \f$.
-     *
-     * Input
-     *   rmin: start of element boundary
-     *   rmax: end of element boundary
-     *      x: integration nodes
-     *     wx: integration weights
-     *     bf: basis functions evaluated at integration nodes.
-     */
-    arma::mat radial_integral(double rmin, double rmax, int n, const arma::vec & x, const arma::vec & wx, const arma::mat & bf);
+    /// Inner in-element two-electron integral
+    ///   phi(r) = (1 / r^(L+1)) * integral_0^r dr' r'^L B_k(r') B_l(r')
+    helfem::Matrix twoe_inner_integral(double rmin, double rmax,
+                                        const helfem::Vector & x, const helfem::Vector & wx,
+                                        const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                                        int L);
 
-    /**
-     * Computes a derivative matrix element of the type
-     * r^2 dB_1(r)/dr dB_2/dr dr
-     */
-    arma::mat derivative_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const arma::mat & dbf);
+    /// Primitive in-element two-electron integral. Cross-element pieces
+    /// reduce to products of radial integrals (handled by caller).
+    helfem::Matrix twoe_integral(double rmin, double rmax,
+                                  const helfem::Vector & x, const helfem::Vector & wx,
+                                  const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                                  int L);
 
-    /**
-     * Computes the inner in-element two-electron integral:
-     * \f$ \phi(r) = \frac 1 r^{L+1} \int_0^r dr' r'^{L} B_k(r') B_l(r') \f$
-     */
-    arma::mat twoe_inner_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L);
+    /// Inner in-element two-electron Yukawa integral.
+    helfem::Matrix yukawa_inner_integral(double rmin, double rmax,
+                                          const helfem::Vector & x, const helfem::Vector & wx,
+                                          const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                                          int L, double lambda);
 
-    /**
-     * Computes a primitive two-electron in-element integral.
-     * Cross-element integrals reduce to products of radial integrals.
-     * Note that the routine needs the polynomial representation.
-     */
-    arma::mat twoe_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L);
+    /// Primitive in-element two-electron Yukawa integral.
+    helfem::Matrix yukawa_integral(double rmin, double rmax,
+                                    const helfem::Vector & x, const helfem::Vector & wx,
+                                    const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                                    int L, double lambda);
 
-    /**
-     * Computes the inner in-element two-electron Yukawa integral:
-     * \f$ \phi(r) = \frac 1 r^{L+1} \int_0^r dr' r'^{L} B_k(r') B_l(r') \f$
-     */
-    arma::mat yukawa_inner_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L, double lambda);
+    /// Primitive two-electron complementary error function integral.
+    /// These do not factorise across elements.
+    helfem::Matrix erfc_integral(double rmini, double rmaxi,
+                                  const helfem::Matrix & bfi,
+                                  const helfem::Vector & xi, const helfem::Vector & wi,
+                                  double rmink, double rmaxk,
+                                  const helfem::Matrix & bfk,
+                                  const helfem::Vector & xk, const helfem::Vector & wk,
+                                  int L, double mu);
 
-    /**
-     * Computes a primitive two-electron in-element Yukawa integral.
-     * Cross-element integrals reduce to products of radial integrals.
-     * Note that the routine needs the polynomial representation.
-     */
-    arma::mat yukawa_integral(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L, double lambda);
-
-    /**
-     * Computes a primitive two-electron complementary error function
-     * integral. Note that these integrals do not factorize.
-     */
-    arma::mat erfc_integral(double rmini, double rmaxi, const arma::mat & bfi, const arma::vec & xi, const arma::vec & wi, double rmink, double rmaxk, const arma::mat & bfk, const arma::vec & xk, const arma::vec & wk, int L, double mu);
-
-    /**
-     * Computes the spherically symmetric potential V(r).
-     */
-    arma::mat spherical_potential(double rmin, double rmax, const arma::vec & x, const arma::vec & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly);
+    /// Spherically symmetric potential V(r).
+    helfem::Matrix spherical_potential(double rmin, double rmax,
+                                        const helfem::Vector & x, const helfem::Vector & wx,
+                                        const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly);
   }
 }
 

--- a/src/atomic/inttest.cpp
+++ b/src/atomic/inttest.cpp
@@ -17,6 +17,7 @@
 #include "chebyshev.h"
 #include "lobatto.h"
 #include "LIPBasis.h"
+#include <ArmaEigen.h>
 #include <cstring>
 
 using namespace helfem;
@@ -35,8 +36,9 @@ void run(double R, int n_quad) {
   arma::vec xq, wq;
   chebyshev::chebyshev(n_quad,xq,wq);
 
-  // Get inner integral by quadrature
-  arma::mat teiinner(quadrature::twoe_inner_integral(0,R,xq,wq,pbas,0));
+  // Get inner integral by quadrature (Phase 5.7: quadrature is Eigen).
+  arma::mat teiinner(helfem::to_arma(
+      quadrature::twoe_inner_integral(0, R, helfem::to_eigen(xq), helfem::to_eigen(wq), pbas, 0)));
 
   // Test against analytical integrals. r values are
   arma::vec r(0.5*R*arma::ones<arma::vec>(xq.n_elem)+0.5*R*xq);
@@ -55,7 +57,8 @@ void run(double R, int n_quad) {
   teiishould-=teiinner;
   printf("Error in inner integral is %e\n",arma::norm(teiishould,"fro"));
 
-  arma::mat teiq(quadrature::twoe_integral(0,R,xq,wq,pbas,0));
+  arma::mat teiq(helfem::to_arma(
+      quadrature::twoe_integral(0, R, helfem::to_eigen(xq), helfem::to_eigen(wq), pbas, 0)));
 
   arma::mat tei(4,4);
   // Maple gives the following integrals for L=0, in units of R


### PR DESCRIPTION
## Summary

Migrates \`libhelfem/src/quadrature.{h,cpp}\` (\`twoe_inner_integral\`, \`twoe_integral\`, \`yukawa_inner_integral\`, \`yukawa_integral\`, \`erfc_integral\`, \`spherical_potential\`) to take and return Eigen Vec / Mat. The \`RadialBasis.cpp\` 2e integral methods now pass \`xq\`/\`wq\` directly without the \`eigen_vec_to_arma\` bridges that 5.6 had to keep.

## Changes

**\`libhelfem/src/quadrature.h\`**: all signatures now use \`helfem::Vector\` / \`helfem::Matrix\`. Drop \`<armadillo>\`; add \`<Matrix.h>\`, \`<functional>\`.

**\`libhelfem/src/quadrature.cpp\`**: complete rewrite of internals arma → Eigen:

| arma idiom | Eigen replacement |
|---|---|
| \`arma::vec / arma::mat\` | \`helfem::Vector\` / \`helfem::Matrix\` |
| \`arma::ones<arma::vec>(n)*a + b*v\` | \`Vec::Constant(n, a) + b*v\` |
| \`arma::vec(x % y * c)\` | \`(x.array() * y.array() * c).matrix()\` |
| \`M.col(i) %= v\` | \`M.col(i).array() *= v.array()\` |
| \`arma::vectorise(M)\` | Eigen::Map / memcpy to Vec |
| \`arma::trans(M)\` | \`M.transpose()\` |
| \`.row(i) = arma::trans(v)\` | \`.row(i) = v.transpose()\` |
| \`bf.col(fi) % bf.col(fj)\` | \`.array() * .array()\` |
| \`M.zeros\` / \`.ones\` | \`Mat::Zero\` / \`Vec::Constant\` |

Drops the \`eval_poly_dnf\` bridge helper (5.2 added it; \`poly->eval_dnf\` is Eigen so the bridge isn't needed anymore).

**\`libhelfem/src/RadialBasis.cpp\`**:
- \`twoe_integral\` / \`yukawa_integral\` / \`spherical_potential\`: drop the 4 \`eigen_vec_to_arma(xq/wq)\` bridges; pass \`xq\`/\`wq\` directly; result is Eigen so no \`helfem::to_eigen\` wrap. NaN check switches arma \`.has_nan()\` → Eigen \`.array().isNaN().any()\`.
- \`erfc_integral\`: bridges the local arma scratch (ibf, kbf, xi, wi, xk, wk) to Eigen at the quadrature call site, then arma at return. (Migrating that local scratch is a future tracer; surrounding chebyshev setup is still arma.)

**\`src/atomic/inttest.cpp\`**: bridges 2 quadrature calls with \`helfem::to_eigen\` / \`to_arma\`. Adds \`ArmaEigen.h\` include.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811249101** (vs prior −14.5728772811251392; ~2e-13 drift from Eigen vs arma quadrature internals — well below SCF convergence threshold)

## Status of the lib1dfem + libhelfem arma → Eigen migration

- [x] 5.1: leaf primitives — PR #117
- [x] 5.2: PolynomialBasis subclasses + legendre_poly + eval tables — PR #118
- [x] 5.3: FiniteElementBasis per-element evaluators — PR #119
- [x] 5.4: FiniteElementBasis matrix_element / vector_element / get_bval — PR #120
- [x] 5.5: FiniteElementBasis members — PR #121
- [x] 5.6: FEMRadialBasis xq/wq members — PR #122
- [x] **5.7: libhelfem quadrature.cpp** — this PR
- [ ] 5.8: RadialBasis.cpp remaining arma scratch + erfc_integral local chebyshev + utils::exchange_tei arma callers in diatomic
- [ ] 5.9: TwoDBasis::coulomb / exchange internals
- [ ] 5.10: per-method templating

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic preserves to 13 sig digits