### PR TITLE
v2: Eigen Phase 5.10 -- utils::invh + scf::form_density + scf::form_Sinvh

### DIFF
--- a/libhelfem/include/helfem.source.h
+++ b/libhelfem/include/helfem.source.h
@@ -16,6 +16,7 @@
 #define __HELFEM__
 
 #include <armadillo>
+#include <Matrix.h>
 #include <string>
 
 #define __HELFEM_VERSION__ "${LIBHELFEM_VERSION}"
@@ -53,8 +54,9 @@ namespace helfem {
 
     /**
      * Calculates the half-inverse of a matrix.
+     * Phase 5.10: Eigen-typed.
      */
-    arma::mat invh(arma::mat S, bool chol);
+    helfem::Matrix invh(helfem::Matrix S, bool chol);
   } // namespace utils
 } // namespace helfem
 

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -14,6 +14,9 @@
  */
 #include "utils.h"
 #include <lib1dfem/math.h>
+#include <Eigen/Cholesky>
+#include <Eigen/Eigenvalues>
+#include <Eigen/LU>
 #include <cmath>
 #include <cstring>
 
@@ -192,28 +195,37 @@ namespace helfem {
       return strcasecmp(str1.c_str(),str2.c_str());
     }
 
-    arma::mat invh(arma::mat S, bool chol) {
-      // Get the basis function norms
-      arma::vec bfnormlz(arma::pow(arma::diagvec(S),-0.5));
-      // Go to normalized basis
-      S=arma::diagmat(bfnormlz)*S*arma::diagmat(bfnormlz);
+    // Phase 5.10: invh migrated to Eigen.
+    helfem::Matrix invh(helfem::Matrix S, bool chol) {
+      // Basis function norms: 1 / sqrt(diag(S))
+      const helfem::Vector bfnormlz = S.diagonal().array().pow(-0.5).matrix();
 
-      // Half-inverse is
-      arma::mat Sinvh;
-      if(chol) {
-        Sinvh = arma::inv(arma::chol(S));
+      // Go to normalized basis: S -> diag(bfnormlz) S diag(bfnormlz)
+      S = bfnormlz.asDiagonal() * S * bfnormlz.asDiagonal();
+
+      helfem::Matrix Sinvh;
+      if (chol) {
+        // Sinvh = inv(chol(S))  -- upper-triangular L from LLT, inverted.
+        Eigen::LLT<helfem::Matrix> llt(S);
+        if (llt.info() != Eigen::Success)
+          throw std::logic_error("Cholesky decomposition of overlap matrix failed\n");
+        // arma::chol(S) returns the upper triangular U with U^T U = S;
+        // Eigen LLT stores L (lower) with L L^T = S. To mirror arma we
+        // take L^T then invert.
+        const helfem::Matrix U = llt.matrixL().transpose();
+        Sinvh = U.inverse();
       } else {
-        arma::vec Sval;
-        arma::mat Svec;
-        if(!arma::eig_sym(Sval,Svec,S)) {
+        Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(S);
+        if (es.info() != Eigen::Success)
           throw std::logic_error("Diagonalization of overlap matrix failed\n");
-        }
-        printf("Smallest eigenvalue of overlap matrix is % e, condition number %e\n",Sval(0),Sval(Sval.n_elem-1)/Sval(0));
-
-        Sinvh=Svec*arma::diagmat(arma::pow(Sval,-0.5))*arma::trans(Svec);
+        const helfem::Vector Sval = es.eigenvalues();
+        const helfem::Matrix Svec = es.eigenvectors();
+        printf("Smallest eigenvalue of overlap matrix is % e, condition number %e\n",
+               Sval(0), Sval(Sval.size() - 1) / Sval(0));
+        Sinvh = Svec * Sval.array().pow(-0.5).matrix().asDiagonal() * Svec.transpose();
       }
 
-      Sinvh=arma::diagmat(bfnormlz)*Sinvh;
+      Sinvh = bfnormlz.asDiagonal() * Sinvh;
       return Sinvh;
     }
   }

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -254,7 +254,7 @@ namespace helfem {
 
         // Half-inverse is
         if(sym==0) {
-          return scf::form_Sinvh(S,chol);
+          return helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S), chol));
         } else {
           // Get basis function indices
           std::vector<arma::uvec> midx(get_sym_idx(sym));
@@ -267,7 +267,7 @@ namespace helfem {
 
             // Column indices
             arma::uvec cidx(arma::linspace<arma::uvec>(ioff,ioff+midx[i].n_elem-1,midx[i].n_elem));
-            Sinvh(midx[i],cidx)=scf::form_Sinvh(S(midx[i],midx[i]),chol);
+            Sinvh(midx[i],cidx)=helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(arma::mat(S(midx[i],midx[i]))),chol));
             // Increment offset
             ioff += midx[i].n_elem;
           }

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -719,8 +719,8 @@ int main(int argc, char **argv) {
     printf("\n**** Iteration %i ****\n\n",i);
 
     // Form density matrix
-    Pa=scf::form_density(Caocc,nela);
-    Pb=scf::form_density(Cbocc,nelb);
+    Pa=helfem::to_arma(scf::form_density(helfem::to_eigen(Caocc),nela));
+    Pb=helfem::to_arma(scf::form_density(helfem::to_eigen(Cbocc),nelb));
     if(Pb.n_rows == 0)
       Pb.zeros(Pa.n_rows,Pa.n_cols);
     P=Pa+Pb;

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -652,7 +652,7 @@ namespace helfem {
 
         // Half-inverse is
         if(sym==0) {
-          return scf::form_Sinvh(S,chol);
+          return helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S), chol));
         } else {
           // Get basis function indices
           std::vector<arma::uvec> midx(get_sym_idx(sym));
@@ -665,7 +665,7 @@ namespace helfem {
 
             // Column indices
             arma::uvec cidx(arma::linspace<arma::uvec>(ioff,ioff+midx[i].n_elem-1,midx[i].n_elem));
-            Sinvh(midx[i],cidx)=scf::form_Sinvh(S(midx[i],midx[i]),chol);
+            Sinvh(midx[i],cidx)=helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(arma::mat(S(midx[i],midx[i]))),chol));
             // Increment offset
             ioff += midx[i].n_elem;
           }

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -778,8 +778,8 @@ int main(int argc, char **argv) {
     printf("\n**** Iteration %i ****\n\n",i);
 
     // Form density matrix
-    Pa=scf::form_density(Caocc,nela);
-    Pb=scf::form_density(Cbocc,nelb);
+    Pa=helfem::to_arma(scf::form_density(helfem::to_eigen(Caocc),nela));
+    Pb=helfem::to_arma(scf::form_density(helfem::to_eigen(Cbocc),nelb));
     if(Pb.n_rows == 0)
       Pb.zeros(Pa.n_rows,Pa.n_cols);
     P=Pa+Pb;

--- a/src/general/scf_helpers.cpp
+++ b/src/general/scf_helpers.cpp
@@ -18,13 +18,14 @@
 
 namespace helfem {
   namespace scf {
-    arma::mat form_density(const arma::mat & C, size_t nocc) {
-      if(C.n_cols<nocc)
+    // Phase 5.10: Eigen-typed.
+    helfem::Matrix form_density(const helfem::Matrix & C, size_t nocc) {
+      if (static_cast<size_t>(C.cols()) < nocc)
         throw std::logic_error("Not enough orbitals!\n");
-      else if(nocc>0)
-        return C.cols(0,nocc-1)*arma::trans(C.cols(0,nocc-1));
-      else // nocc=0
-        return arma::zeros<arma::mat>(C.n_rows,C.n_rows);
+      if (nocc == 0)
+        return helfem::Matrix::Zero(C.rows(), C.rows());
+      const auto Cocc = C.leftCols(static_cast<Eigen::Index>(nocc));
+      return Cocc * Cocc.transpose();
     }
 
     void enforce_occupations(arma::mat & C, arma::vec & E, const arma::mat & S, const arma::ivec & nocc, const std::vector<arma::uvec> & m_idx) {

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -16,11 +16,12 @@
 #define SCF_HELPERS_H
 #include <armadillo>
 #include <helfem.h>
+#include <Matrix.h>
 
 namespace helfem {
   namespace scf {
-    /// Form density matrix
-    arma::mat form_density(const arma::mat & C, size_t nocc);
+    /// Form density matrix (Phase 5.10: Eigen-typed).
+    helfem::Matrix form_density(const helfem::Matrix & C, size_t nocc);
     /// Enforce occupation of wanted symmetries
     void enforce_occupations(arma::mat & C, arma::vec & E, const arma::mat & S, const arma::ivec & nocc, const std::vector<arma::uvec> & m_idx);
 
@@ -51,8 +52,8 @@ namespace helfem {
 
     /// Form natural orbitals
     void form_NOs(const arma::mat & P, const arma::mat & Sh, const arma::mat & Sinvh, arma::mat & AO_to_NO, arma::mat & NO_to_AO, arma::vec & occs);
-    /// Form half-inverse overlap
-    inline arma::mat form_Sinvh(arma::mat S, bool chol=false) {
+    /// Form half-inverse overlap (Phase 5.10: Eigen-typed).
+    inline helfem::Matrix form_Sinvh(helfem::Matrix S, bool chol=false) {
       return utils::invh(S, chol);
     }
 

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
   // helfem::Matrix (Eigen); rest of sadatom 1e is still arma -- bridge
   // at the boundary via to_arma until the chemistry layer migrates.
   arma::mat S(helfem::to_arma(radial.overlap()));
-  arma::mat Sinvh=scf::form_Sinvh(S,false);
+  arma::mat Sinvh=helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S),false));
 
   // Phase 2a: radial.kinetic / kinetic_l / nuclear return helfem::Matrix.
   arma::mat T(helfem::to_arma(radial.kinetic()));

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -67,7 +67,7 @@ namespace helfem {
 
       arma::mat TwoDBasis::Sinvh() const {
         arma::mat S(helfem::to_arma(overlap()));
-        return scf::form_Sinvh(S,false);
+        return helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S), false));
       }
 
       arma::mat TwoDBasis::radial_integral(int Rexp) const {


### PR DESCRIPTION
## Summary

First L0 (SCF utilities) PR of the full arma → Eigen removal arc. Migrates three foundational utility functions:

- **\`utils::invh(M, chol)\`**: symmetric orthogonalisation kernel producing S^(-1/2). Now Eigen-typed: uses \`LLT\` for the Cholesky path and \`SelfAdjointEigenSolver\` for the eigendecomp path, with per-basis-function normalisation that the arma version applied via \`diagmat\`.
- **\`scf::form_density(C, nocc)\`**: D = C_occ * C_occ^T
- **\`scf::form_Sinvh(S, chol)\`**: inline wrapper over invh

## Caller bridges (10 sites)

| File | Caller |
|---|---|
| \`src/atomic/TwoDBasis.cpp\` | \`Sinvh(bool, int sym)\` wrapper |
| \`src/diatomic/basis.cpp\` | \`Sinvh(bool, int sym)\` wrapper |
| \`src/sadatom/basis.cpp\` | \`Sinvh()\` wrapper |
| \`src/sadatom/1e.cpp\` | \`Sinvh\` from radial overlap |
| \`src/atomic/main.cpp\` | \`Pa = form_density(Caocc, nela)\` ×2 |
| \`src/diatomic/main.cpp\` | \`Pa = form_density(Caocc, nela)\` ×2 |

Each bridges with \`helfem::to_eigen\` on input and \`helfem::to_arma\` on output; surrounding chemistry-side code stays arma.

## Design note on Cholesky orientation

- \`arma::chol(S)\` returns upper-triangular \`U\` with \`U^T U = S\`
- \`Eigen::LLT\` stores lower \`L\` with \`L L^T = S\`

To mirror arma's \`inv(chol(S))\` we take \`L^T\` (= U) and invert it.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811247218** (vs prior −14.5728772811249101; ~2e-13 drift from \`SelfAdjointEigenSolver\` vs \`arma::eig_sym\` summation order in the orthogonalisation — well below SCF convergence threshold)

## Status of the full arma → Eigen removal arc

**Target**: drop libhelfem's armadillo dependency entirely.

### Layer L0 (SCF utilities): in progress

- [x] \`utils::invh\`, \`scf::form_density\`, \`scf::form_Sinvh\` — this PR
- [ ] \`scf::eig_gsym\` / \`eig_gsym_sub\` / \`eig_sym_sub\` (eigensolver family)
- [ ] \`scf::enforce_occupations\` / \`enforce_fock_symmetry\` / \`fock_symmetry_average\`
- [ ] \`scf::eig_sub_wrk\` / \`sort_eig\` / \`eig_sub\` / \`eig_iter\` (iterative)
- [ ] \`scf::perturbation_matrix\`, \`parse_xc_params\`
- [ ] \`scf::form_NOs\`, \`ROHF_update\`
- [ ] \`src/general/diis.cpp\` (DIIS extrapolation)
- [ ] \`src/general/lbfgs.cpp\` (L-BFGS minimiser)
- [ ] \`src/general/lcao.cpp\`

### Subsequent layers

- L1: DFT grid integration (atomic/sadatom/diatomic dftgrid)
- L2: TwoDBasis internals (atomic + sadatom)
- L3: Diatomic basis internals
- L4: SCF drivers (main.cpp x3, sadatom/solver.cpp)
- L5: I/O (checkpoint.cpp HDF5 binding)
- L6: libhelfem leaves (get_bf/df/lf etc.)
- L7: cleanup — remove armadillo dependency from CMakeLists

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic preserves to 13 sig digits