### PR TITLE
v2: Eigen Phase 5.11 -- scf::eig_gsym arma -> Eigen

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -539,7 +539,12 @@ int main(int argc, char **argv) {
 	  if(symm)
 	    scf::eig_gsym_sub(Ea,Ca,F,Sinvh,dsym);
 	  else
-	    scf::eig_gsym(Ea,Ca,F,Sinvh);
+	    { // Phase 5.11 bridge: eig_gsym is Eigen.
+	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
+	      scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
+	      Ea = helfem::to_arma(Ea_e);
+	      Ca = helfem::to_arma(Ca_e);
+	    }
 
 	  // Load Fock matrix
 	  loadchk.read("Fb",F);
@@ -553,7 +558,12 @@ int main(int argc, char **argv) {
 	  if(symm)
 	    scf::eig_gsym_sub(Eb,Cb,F,Sinvh,dsym);
 	  else
-	    scf::eig_gsym(Eb,Cb,F,Sinvh);
+	    { // Phase 5.11 bridge: eig_gsym is Eigen.
+	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
+	      scf::eig_gsym(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
+	      Eb = helfem::to_arma(Eb_e);
+	      Cb = helfem::to_arma(Cb_e);
+	    }
 	}
         break;
 
@@ -640,7 +650,12 @@ int main(int argc, char **argv) {
       if(symm)
         scf::eig_gsym_sub(Ea,Ca,Hguess,Sinvh,dsym);
       else
-        scf::eig_gsym(Ea,Ca,Hguess,Sinvh);
+        { // Phase 5.11 bridge: eig_gsym is Eigen.
+          helfem::Vector Ea_e; helfem::Matrix Ca_e;
+          scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(Hguess), helfem::to_eigen(Sinvh));
+          Ea = helfem::to_arma(Ea_e);
+          Ca = helfem::to_arma(Ca_e);
+        }
 
       // Beta guess is the same as the alpha guess
       Cb=Ca;
@@ -934,7 +949,12 @@ int main(int argc, char **argv) {
     if(symm)
       scf::eig_gsym_sub(Ea,Ca,Fa,Sinvh,dsym);
     else
-      scf::eig_gsym(Ea,Ca,Fa,Sinvh);
+      { // Phase 5.11 bridge: eig_gsym is Eigen.
+        helfem::Vector Ea_e; helfem::Matrix Ca_e;
+        scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(Fa), helfem::to_eigen(Sinvh));
+        Ea = helfem::to_arma(Ea_e);
+        Ca = helfem::to_arma(Ca_e);
+      }
     // Enforce occupation according to specified symmetry
     if(i<readocc) {
       scf::enforce_occupations(Ca,Ea,S,occnuma,occsym);
@@ -947,7 +967,12 @@ int main(int argc, char **argv) {
       if(symm)
         scf::eig_gsym_sub(Eb,Cb,Fb,Sinvh,dsym);
       else
-        scf::eig_gsym(Eb,Cb,Fb,Sinvh);
+        { // Phase 5.11 bridge: eig_gsym is Eigen.
+          helfem::Vector Eb_e; helfem::Matrix Cb_e;
+          scf::eig_gsym(Eb_e, Cb_e, helfem::to_eigen(Fb), helfem::to_eigen(Sinvh));
+          Eb = helfem::to_arma(Eb_e);
+          Cb = helfem::to_arma(Cb_e);
+        }
     }
     // Enforce occupation according to specified symmetry
     if(i<readocc) {

--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -161,7 +161,12 @@ int main(int argc, char **argv) {
 
   arma::vec E;
   arma::mat C;
-  scf::eig_gsym(E,C,H0,Sinvh);
+  { // Phase 5.11 bridge: eig_gsym is Eigen.
+    helfem::Vector E_e; helfem::Matrix C_e;
+    scf::eig_gsym(E_e, C_e, helfem::to_eigen(H0), helfem::to_eigen(Sinvh));
+    E = helfem::to_arma(E_e);
+    C = helfem::to_arma(C_e);
+  }
 
   double Ekin=arma::as_scalar(C.col(0).t()*T*C.col(0));
   double Enuc=arma::as_scalar(C.col(0).t()*Vnuc*C.col(0));

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -585,7 +585,12 @@ int main(int argc, char **argv) {
 	  if(symm)
 	    scf::eig_gsym_sub(Ea,Ca,F,Sinvh,dsym);
 	  else
-	    scf::eig_gsym(Ea,Ca,F,Sinvh);
+	    { // Phase 5.11 bridge: eig_gsym is Eigen.
+	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
+	      scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
+	      Ea = helfem::to_arma(Ea_e);
+	      Ca = helfem::to_arma(Ca_e);
+	    }
 
 	  // Load Fock matrix
 	  loadchk.read("Fb",F);
@@ -599,7 +604,12 @@ int main(int argc, char **argv) {
 	  if(symm)
 	    scf::eig_gsym_sub(Eb,Cb,F,Sinvh,dsym);
 	  else
-	    scf::eig_gsym(Eb,Cb,F,Sinvh);
+	    { // Phase 5.11 bridge: eig_gsym is Eigen.
+	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
+	      scf::eig_gsym(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
+	      Eb = helfem::to_arma(Eb_e);
+	      Cb = helfem::to_arma(Cb_e);
+	    }
 	}
         break;
 
@@ -703,7 +713,12 @@ int main(int argc, char **argv) {
       if(symm)
         scf::eig_gsym_sub(Ea,Ca,Hguess,Sinvh,dsym);
       else
-        scf::eig_gsym(Ea,Ca,Hguess,Sinvh);
+        { // Phase 5.11 bridge: eig_gsym is Eigen.
+          helfem::Vector Ea_e; helfem::Matrix Ca_e;
+          scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(Hguess), helfem::to_eigen(Sinvh));
+          Ea = helfem::to_arma(Ea_e);
+          Ca = helfem::to_arma(Ca_e);
+        }
 
       // Beta guess is the same as the alpha guess
       Cb=Ca;
@@ -934,7 +949,12 @@ int main(int argc, char **argv) {
     if(symm)
       scf::eig_gsym_sub(Ea,Ca,Fa,Sinvh,dsym);
     else
-      scf::eig_gsym(Ea,Ca,Fa,Sinvh);
+      { // Phase 5.11 bridge: eig_gsym is Eigen.
+        helfem::Vector Ea_e; helfem::Matrix Ca_e;
+        scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(Fa), helfem::to_eigen(Sinvh));
+        Ea = helfem::to_arma(Ea_e);
+        Ca = helfem::to_arma(Ca_e);
+      }
     // Enforce occupation according to specified symmetry
     if(i<readocc) {
       scf::enforce_occupations(Ca,Ea,S,occnuma,occsym);
@@ -947,7 +967,12 @@ int main(int argc, char **argv) {
       if(symm)
         scf::eig_gsym_sub(Eb,Cb,Fb,Sinvh,dsym);
       else
-        scf::eig_gsym(Eb,Cb,Fb,Sinvh);
+        { // Phase 5.11 bridge: eig_gsym is Eigen.
+          helfem::Vector Eb_e; helfem::Matrix Cb_e;
+          scf::eig_gsym(Eb_e, Cb_e, helfem::to_eigen(Fb), helfem::to_eigen(Sinvh));
+          Eb = helfem::to_arma(Eb_e);
+          Cb = helfem::to_arma(Cb_e);
+        }
     }
     // Enforce occupation according to specified symmetry
     if(i<readocc) {

--- a/src/general/scf_helpers.cpp
+++ b/src/general/scf_helpers.cpp
@@ -14,6 +14,8 @@
  */
 #include "scf_helpers.h"
 #include "timer.h"
+#include <ArmaEigen.h>
+#include <Eigen/Eigenvalues>
 #include <cfloat>
 
 namespace helfem {
@@ -128,15 +130,16 @@ namespace helfem {
       E=E(newidx);
     }
 
-    void eig_gsym(arma::vec & E, arma::mat & C, const arma::mat & F, const arma::mat & Sinvh) {
-      // Form matrix in orthonormal basis
-      arma::mat Forth(Sinvh.t()*F*Sinvh);
-
-      if(!arma::eig_sym(E,C,Forth))
+    // Phase 5.11: Eigen-typed.
+    void eig_gsym(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh) {
+      // Form matrix in orthonormal basis: Forth = Sinvh^T * F * Sinvh.
+      const helfem::Matrix Forth = Sinvh.transpose() * F * Sinvh;
+      Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(Forth);
+      if (es.info() != Eigen::Success)
         throw std::logic_error("Eigendecomposition failed!\n");
-
-      // Return to non-orthonormal basis
-      C=Sinvh*C;
+      E = es.eigenvalues();
+      // Return to non-orthonormal basis: C = Sinvh * V.
+      C = Sinvh * es.eigenvectors();
     }
 
     void eig_gsym_sub(arma::vec & E, arma::mat & C, const arma::mat & F, const arma::mat & Sinvh, const std::vector<arma::uvec> & m_idx, bool verbose) {
@@ -156,10 +159,12 @@ namespace helfem {
         // Column indices of Sinvh that have non-zero elements
         arma::uvec Sind(arma::find(Snrm));
 
-        // Solve subproblem
-        arma::vec Esub;
-        arma::mat Csub;
-        eig_gsym(Esub,Csub,F,Sinvh.cols(Sind));
+        // Solve subproblem (Phase 5.11 bridge: eig_gsym is Eigen).
+        helfem::Vector Esub_e;
+        helfem::Matrix Csub_e;
+        eig_gsym(Esub_e, Csub_e, helfem::to_eigen(F), helfem::to_eigen(arma::mat(Sinvh.cols(Sind))));
+        arma::vec Esub = helfem::to_arma(Esub_e);
+        arma::mat Csub = helfem::to_arma(Csub_e);
 
         // Store solutions
         E.subvec(iidx,iidx+Esub.n_elem-1)=Esub;
@@ -246,10 +251,13 @@ namespace helfem {
       double frz(arma::sum(Fnorm.subvec(Nact-Cocc.n_cols-1,Fnorm.n_elem-1)));
       printf("Active space norm %e, frozen space norm %e\n",act,frz);
 
-      // Form subspace solution
+      // Form subspace solution (Phase 5.11 bridge).
       arma::mat C;
       arma::mat Corth(arma::join_rows(Cocc,Cvirt.cols(0,Nact-Cocc.n_cols-1)));
-      eig_gsym(E,C,F,Corth);
+      helfem::Vector E_e; helfem::Matrix C_e;
+      eig_gsym(E_e, C_e, helfem::to_eigen(F), helfem::to_eigen(Corth));
+      E = helfem::to_arma(E_e);
+      C = helfem::to_arma(C_e);
 
       // Update occupied and virtual orbitals
       Cocc=C.cols(0,Cocc.n_cols-1);
@@ -365,8 +373,12 @@ namespace helfem {
       if(nsub >= Cocc.n_cols+Cvirt.n_cols) {
         arma::mat Corth(arma::join_rows(Cocc,Cvirt));
 
+        // Phase 5.11 bridge.
         arma::mat C;
-        eig_gsym(E,C,F,Corth);
+        helfem::Vector E_e; helfem::Matrix C_e;
+        eig_gsym(E_e, C_e, helfem::to_eigen(F), helfem::to_eigen(Corth));
+        E = helfem::to_arma(E_e);
+        C = helfem::to_arma(C_e);
         if(Cocc.n_cols)
           Cocc=C.cols(0,Cocc.n_cols-1);
         Cvirt=C.cols(Cocc.n_cols,C.n_cols-1);

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -30,8 +30,8 @@ namespace helfem {
     /// Average out the Fock matrix
     arma::mat fock_symmetry_average(const arma::mat & Fin, const std::vector< std::vector<arma::uvec> > & sym_idx);
 
-    /// Solve generalized eigenvalue problem
-    void eig_gsym(arma::vec & E, arma::mat & C, const arma::mat & F, const arma::mat & Sinvh);
+    /// Solve generalized eigenvalue problem (Phase 5.11: Eigen-typed).
+    void eig_gsym(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh);
     /// Solve generalized eigenvalue problem in subspaces
     void eig_gsym_sub(arma::vec & E, arma::mat & C, const arma::mat & F, const arma::mat & Sinvh, const std::vector<arma::uvec> & m_idx, bool verbose=true);
     /// Solve eigenvalue problem in subspaces

--- a/src/sadatom/solver.cpp
+++ b/src/sadatom/solver.cpp
@@ -419,9 +419,11 @@ namespace helfem {
         E.resize(F.n_rows,lmax+1);
         C.resize(F.n_rows,F.n_rows,lmax+1);
         for(int l=0;l<=lmax;l++) {
-          arma::vec El;
-          helfem::scf::eig_gsym(El,C.slice(l),F.slice(l),Sinvh);
-          E.col(l)=El;
+          // Phase 5.11 bridge: eig_gsym is Eigen.
+          helfem::Vector El_e; helfem::Matrix Cl_e;
+          helfem::scf::eig_gsym(El_e, Cl_e, helfem::to_eigen(arma::mat(F.slice(l))), helfem::to_eigen(Sinvh));
+          C.slice(l) = helfem::to_arma(Cl_e);
+          E.col(l) = helfem::to_arma(El_e);
         }
       }
 
@@ -447,9 +449,11 @@ namespace helfem {
             Fl=C.slice(l)*Fmo*C.slice(l).t();
           }
 
-          arma::vec El;
-          helfem::scf::eig_gsym(El,C.slice(l),Fl,Sinvh);
-          E.col(l)=El;
+          // Phase 5.11 bridge.
+          helfem::Vector El_e; helfem::Matrix Cl_e;
+          helfem::scf::eig_gsym(El_e, Cl_e, helfem::to_eigen(Fl), helfem::to_eigen(Sinvh));
+          C.slice(l) = helfem::to_arma(Cl_e);
+          E.col(l) = helfem::to_arma(El_e);
         }
       }
 
@@ -469,13 +473,16 @@ namespace helfem {
             // Shift matrix
             arma::mat shmat(shift*S*Cv*Cv.t()*S);
             // Update orbitals
-            arma::vec El;
-            helfem::scf::eig_gsym(El,C.slice(l),Fl+shmat,Sinvh);
-            E.col(l)=El;
+            // Phase 5.11 bridge.
+            helfem::Vector El_e; helfem::Matrix Cl_e;
+            helfem::scf::eig_gsym(El_e, Cl_e, helfem::to_eigen(arma::mat(Fl+shmat)), helfem::to_eigen(Sinvh));
+            C.slice(l) = helfem::to_arma(Cl_e);
+            E.col(l) = helfem::to_arma(El_e);
           } else {
-            arma::vec El;
-            helfem::scf::eig_gsym(El,C.slice(l),Fl,Sinvh);
-            E.col(l)=El;
+            helfem::Vector El_e; helfem::Matrix Cl_e;
+            helfem::scf::eig_gsym(El_e, Cl_e, helfem::to_eigen(Fl), helfem::to_eigen(Sinvh));
+            C.slice(l) = helfem::to_arma(Cl_e);
+            E.col(l) = helfem::to_arma(El_e);
           }
 
           /*


### PR DESCRIPTION
## Summary

Migrates the generalised symmetric eigenvalue solver \`scf::eig_gsym\` to Eigen. Uses \`Eigen::SelfAdjointEigenSolver\` instead of \`arma::eig_sym\`.

\`\`\`cpp
void scf::eig_gsym(helfem::Vector & E, helfem::Matrix & C,
                   const helfem::Matrix & F, const helfem::Matrix & Sinvh);
\`\`\`

## Caller bridges

**Internal (\`scf_helpers.cpp\`) — 3 sites**: \`eig_gsym_sub\` (subspace dispatch), \`sort_eig\` (subspace solution), \`eig_sub\` (full eigendecomp path). Each constructs Eigen \`Esub_e\`/\`Csub_e\` locals, calls the new Eigen API, copies back to the surrounding arma surface.

**External — 12 sites**:

| File | Calls | Context |
|---|---|---|
| \`src/atomic/main.cpp\` | 5 | HF/UHF SCF + projection paths in restart code |
| \`src/diatomic/main.cpp\` | 5 | same shape |
| \`src/diatomic/1e.cpp\` | 1 | 1-electron diagonalisation |
| \`src/sadatom/solver.cpp\` | 4 | UpdateOrbitals / UpdateOrbitalsDamped / UpdateOrbitalsShifted; arma::cube slice assignments preserved |

Bridge pattern is the same everywhere:

\`\`\`cpp
{ helfem::Vector E_e; helfem::Matrix C_e;
  scf::eig_gsym(E_e, C_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
  E = helfem::to_arma(E_e); C = helfem::to_arma(C_e); }
\`\`\`

Conditional \`eig_gsym_sub\` / \`eig_gsym\` pairs (atomic/diatomic main projection) only have their \`eig_gsym\` branch bridged; the \`eig_gsym_sub\` branch is migrated in 5.12.

## Not in scope

\`scf::eig_gsym_sub\` / \`eig_sym_sub\`: still arma. They take a \`std::vector<arma::uvec>\` for symmetry indices; migrating that parameter cascades into \`TwoDBasis::get_sym_idx\` (whose return type is \`std::vector<arma::uvec>\`). Will be handled together in a follow-up.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811244909** (vs prior −14.5728772811247218; ~2e-13 drift from \`SelfAdjointEigenSolver\` vs \`arma::eig_sym\` summation order)

## Status (Layer L0)

- [x] \`utils::invh\`, \`scf::form_density\`, \`scf::form_Sinvh\` — PR #126
- [x] **\`scf::eig_gsym\`** — this PR
- [ ] \`scf::eig_gsym_sub\` / \`eig_sym_sub\` (eigensolver-sym family) — next
- [ ] \`scf::enforce_occupations\` / \`enforce_fock_symmetry\` / \`fock_symmetry_average\`
- [ ] \`scf::eig_sub_wrk\` / \`sort_eig\` / \`eig_sub\` / \`eig_iter\` (iterative)
- [ ] \`scf::perturbation_matrix\`, \`parse_xc_params\`
- [ ] \`scf::form_NOs\`, \`ROHF_update\`
- [ ] \`src/general/diis.cpp\`
- [ ] \`src/general/lbfgs.cpp\`
- [ ] \`src/general/lcao.cpp\`

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic preserves to 13 sig digits