### PR TITLE
v2: Eigen Phase 5.12 -- scf::eig_gsym_sub + eig_sym_sub arma -> Eigen

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -233,7 +233,12 @@ namespace helfem {
           if(sym) {
             // Symmetries
             std::vector<arma::uvec> midx(get_sym_idx(sym));
-            scf::eig_sym_sub(Sval,Svec,S,midx);
+            { // Phase 5.12 bridge: eig_sym_sub is Eigen.
+              helfem::Vector Sval_e; helfem::Matrix Svec_e;
+              scf::eig_sym_sub(Sval_e, Svec_e, helfem::to_eigen(S), midx);
+              Sval = helfem::to_arma(Sval_e);
+              Svec = helfem::to_arma(Svec_e);
+            }
           } else {
             if(!arma::eig_sym(Sval,Svec,S)) {
               S.save("S.dat",arma::raw_ascii);

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -537,7 +537,12 @@ int main(int argc, char **argv) {
 	  F=SSinvh*F*arma::trans(SSinvh);
 	  // Diagonalize
 	  if(symm)
-	    scf::eig_gsym_sub(Ea,Ca,F,Sinvh,dsym);
+	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
+	      scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
+	      Ea = helfem::to_arma(Ea_e);
+	      Ca = helfem::to_arma(Ca_e);
+	    }
 	  else
 	    { // Phase 5.11 bridge: eig_gsym is Eigen.
 	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
@@ -556,7 +561,12 @@ int main(int argc, char **argv) {
 	  F=SSinvh*F*arma::trans(SSinvh);
 	  // Diagonalize
 	  if(symm)
-	    scf::eig_gsym_sub(Eb,Cb,F,Sinvh,dsym);
+	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
+	      scf::eig_gsym_sub(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
+	      Eb = helfem::to_arma(Eb_e);
+	      Cb = helfem::to_arma(Cb_e);
+	    }
 	  else
 	    { // Phase 5.11 bridge: eig_gsym is Eigen.
 	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
@@ -648,7 +658,12 @@ int main(int argc, char **argv) {
 
       // Diagonalize the hamiltonian
       if(symm)
-        scf::eig_gsym_sub(Ea,Ca,Hguess,Sinvh,dsym);
+        { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+          helfem::Vector Ea_e; helfem::Matrix Ca_e;
+          scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(Hguess), helfem::to_eigen(Sinvh), dsym);
+          Ea = helfem::to_arma(Ea_e);
+          Ca = helfem::to_arma(Ca_e);
+        }
       else
         { // Phase 5.11 bridge: eig_gsym is Eigen.
           helfem::Vector Ea_e; helfem::Matrix Ca_e;
@@ -947,7 +962,12 @@ int main(int argc, char **argv) {
     timer.set();
     arma::mat Ca, Cb;
     if(symm)
-      scf::eig_gsym_sub(Ea,Ca,Fa,Sinvh,dsym);
+      { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+        helfem::Vector Ea_e; helfem::Matrix Ca_e;
+        scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(Fa), helfem::to_eigen(Sinvh), dsym);
+        Ea = helfem::to_arma(Ea_e);
+        Ca = helfem::to_arma(Ca_e);
+      }
     else
       { // Phase 5.11 bridge: eig_gsym is Eigen.
         helfem::Vector Ea_e; helfem::Matrix Ca_e;
@@ -965,7 +985,12 @@ int main(int argc, char **argv) {
       Cb=Ca;
     } else {
       if(symm)
-        scf::eig_gsym_sub(Eb,Cb,Fb,Sinvh,dsym);
+        { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+          helfem::Vector Eb_e; helfem::Matrix Cb_e;
+          scf::eig_gsym_sub(Eb_e, Cb_e, helfem::to_eigen(Fb), helfem::to_eigen(Sinvh), dsym);
+          Eb = helfem::to_arma(Eb_e);
+          Cb = helfem::to_arma(Cb_e);
+        }
       else
         { // Phase 5.11 bridge: eig_gsym is Eigen.
           helfem::Vector Eb_e; helfem::Matrix Cb_e;

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -630,7 +630,12 @@ namespace helfem {
           if(sym) {
             // Symmetries
             std::vector<arma::uvec> midx(get_sym_idx(sym));
-            scf::eig_sym_sub(Sval,Svec,S,midx);
+            { // Phase 5.12 bridge: eig_sym_sub is Eigen.
+              helfem::Vector Sval_e; helfem::Matrix Svec_e;
+              scf::eig_sym_sub(Sval_e, Svec_e, helfem::to_eigen(S), midx);
+              Sval = helfem::to_arma(Sval_e);
+              Svec = helfem::to_arma(Svec_e);
+            }
           } else {
             if(!arma::eig_sym(Sval,Svec,S)) {
               S.save("S.dat",arma::raw_ascii);

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -99,7 +99,12 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   // Use core guess
   arma::vec Ev;
   arma::mat C;
-  scf::eig_gsym_sub(Ev,C,H0,Sinvh,dsym);
+  { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+    helfem::Vector Ev_e; helfem::Matrix C_e;
+    scf::eig_gsym_sub(Ev_e, C_e, helfem::to_eigen(H0), helfem::to_eigen(Sinvh), dsym);
+    Ev = helfem::to_arma(Ev_e);
+    C = helfem::to_arma(C_e);
+  }
   //scf::eig_gsym(Ev,C,H0,Sinvh);
 
   // Sanity check

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -583,7 +583,12 @@ int main(int argc, char **argv) {
 	  F=SSinvh*F*arma::trans(SSinvh);
 	  // Diagonalize
 	  if(symm)
-	    scf::eig_gsym_sub(Ea,Ca,F,Sinvh,dsym);
+	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
+	      scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
+	      Ea = helfem::to_arma(Ea_e);
+	      Ca = helfem::to_arma(Ca_e);
+	    }
 	  else
 	    { // Phase 5.11 bridge: eig_gsym is Eigen.
 	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
@@ -602,7 +607,12 @@ int main(int argc, char **argv) {
 	  F=SSinvh*F*arma::trans(SSinvh);
 	  // Diagonalize
 	  if(symm)
-	    scf::eig_gsym_sub(Eb,Cb,F,Sinvh,dsym);
+	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
+	      scf::eig_gsym_sub(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
+	      Eb = helfem::to_arma(Eb_e);
+	      Cb = helfem::to_arma(Cb_e);
+	    }
 	  else
 	    { // Phase 5.11 bridge: eig_gsym is Eigen.
 	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
@@ -711,7 +721,12 @@ int main(int argc, char **argv) {
 
       // Diagonalize
       if(symm)
-        scf::eig_gsym_sub(Ea,Ca,Hguess,Sinvh,dsym);
+        { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+          helfem::Vector Ea_e; helfem::Matrix Ca_e;
+          scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(Hguess), helfem::to_eigen(Sinvh), dsym);
+          Ea = helfem::to_arma(Ea_e);
+          Ca = helfem::to_arma(Ca_e);
+        }
       else
         { // Phase 5.11 bridge: eig_gsym is Eigen.
           helfem::Vector Ea_e; helfem::Matrix Ca_e;
@@ -947,7 +962,12 @@ int main(int argc, char **argv) {
     timer.set();
     arma::mat Ca, Cb;
     if(symm)
-      scf::eig_gsym_sub(Ea,Ca,Fa,Sinvh,dsym);
+      { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+        helfem::Vector Ea_e; helfem::Matrix Ca_e;
+        scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(Fa), helfem::to_eigen(Sinvh), dsym);
+        Ea = helfem::to_arma(Ea_e);
+        Ca = helfem::to_arma(Ca_e);
+      }
     else
       { // Phase 5.11 bridge: eig_gsym is Eigen.
         helfem::Vector Ea_e; helfem::Matrix Ca_e;
@@ -965,7 +985,12 @@ int main(int argc, char **argv) {
       Cb=Ca;
     } else {
       if(symm)
-        scf::eig_gsym_sub(Eb,Cb,Fb,Sinvh,dsym);
+        { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
+          helfem::Vector Eb_e; helfem::Matrix Cb_e;
+          scf::eig_gsym_sub(Eb_e, Cb_e, helfem::to_eigen(Fb), helfem::to_eigen(Sinvh), dsym);
+          Eb = helfem::to_arma(Eb_e);
+          Cb = helfem::to_arma(Cb_e);
+        }
       else
         { // Phase 5.11 bridge: eig_gsym is Eigen.
           helfem::Vector Eb_e; helfem::Matrix Cb_e;

--- a/src/general/scf_helpers.cpp
+++ b/src/general/scf_helpers.cpp
@@ -142,82 +142,108 @@ namespace helfem {
       C = Sinvh * es.eigenvectors();
     }
 
-    void eig_gsym_sub(arma::vec & E, arma::mat & C, const arma::mat & F, const arma::mat & Sinvh, const std::vector<arma::uvec> & m_idx, bool verbose) {
-      E.zeros(F.n_rows);
-      C.zeros(F.n_rows,F.n_rows);
-
-      size_t iidx=0;
-      // Loop over symmetries
-      for(size_t isym=0;isym<m_idx.size();isym++) {
-        // Find basis vectors that belong to this symmetry
-        arma::mat Scmp(Sinvh.rows(m_idx[isym]));
-
-        arma::vec Snrm(Scmp.n_cols);
-        for(size_t i=0;i<Snrm.n_elem;i++)
-          Snrm(i)=arma::norm(Scmp.col(i),"fro");
-
-        // Column indices of Sinvh that have non-zero elements
-        arma::uvec Sind(arma::find(Snrm));
-
-        // Solve subproblem (Phase 5.11 bridge: eig_gsym is Eigen).
-        helfem::Vector Esub_e;
-        helfem::Matrix Csub_e;
-        eig_gsym(Esub_e, Csub_e, helfem::to_eigen(F), helfem::to_eigen(arma::mat(Sinvh.cols(Sind))));
-        arma::vec Esub = helfem::to_arma(Esub_e);
-        arma::mat Csub = helfem::to_arma(Csub_e);
-
-        // Store solutions
-        E.subvec(iidx,iidx+Esub.n_elem-1)=Esub;
-        C.cols(iidx,iidx+Esub.n_elem-1)=Csub;
-
-#if 0
-        printf("Symmetry %i\n",isym);
-        Esub.t().print();
-#endif
-
-        // Increment offset
-        iidx+=Esub.n_elem;
+    namespace {
+      // Convert one arma::uvec (chemistry-side index list) to a vector
+      // of Eigen::Index, suitable for Eigen 3.4 (rows/cols) indexing.
+      inline std::vector<Eigen::Index> uvec_to_indices(const arma::uvec & u) {
+        std::vector<Eigen::Index> v(u.n_elem);
+        for (size_t i = 0; i < u.n_elem; ++i) v[i] = static_cast<Eigen::Index>(u(i));
+        return v;
       }
-      if(iidx!=F.n_rows) {
-        std::ostringstream oss;
-        oss << "Symmetry mismatch: expected " << F.n_rows << " vectors but got " << iidx << "!\n";
-        throw std::logic_error(oss.str());
+      // Pivot-sort indices ascending by E values (stable not required).
+      inline std::vector<Eigen::Index> sort_index_ascending(const helfem::Vector & E) {
+        std::vector<Eigen::Index> idx(E.size());
+        for (Eigen::Index i = 0; i < E.size(); ++i) idx[i] = i;
+        std::sort(idx.begin(), idx.end(),
+                  [&E](Eigen::Index a, Eigen::Index b) { return E(a) < E(b); });
+        return idx;
       }
-
-      // Sort energies
-      arma::uvec Eord=arma::sort_index(E,"ascend");
-      E=E(Eord);
-      C=C.cols(Eord);
     }
 
-    void eig_sym_sub(arma::vec & E, arma::mat & C, const arma::mat & F, const std::vector<arma::uvec> & m_idx) {
-      E.zeros(F.n_rows);
-      C.zeros(F.n_rows,F.n_rows);
+    // Phase 5.12: Eigen matrices; m_idx kept arma::uvec until TwoDBasis
+    // ::get_sym_idx migrates.
+    void eig_gsym_sub(helfem::Vector & E, helfem::Matrix & C,
+                      const helfem::Matrix & F, const helfem::Matrix & Sinvh,
+                      const std::vector<arma::uvec> & m_idx, bool verbose) {
+      (void) verbose;
+      E = helfem::Vector::Zero(F.rows());
+      C = helfem::Matrix::Zero(F.rows(), F.rows());
 
-      size_t iidx=0;
-      // Loop over symmetries
-      for(size_t i=0;i<m_idx.size();i++) {
-        // Solve subproblem
-        arma::vec Esub;
-        arma::mat Csub;
-        arma::eig_sym(Esub,Csub,F(m_idx[i],m_idx[i]));
+      Eigen::Index iidx = 0;
+      for (size_t isym = 0; isym < m_idx.size(); ++isym) {
+        const auto rows = uvec_to_indices(m_idx[isym]);
+        // Scmp = Sinvh(rows, :).
+        const helfem::Matrix Scmp = Sinvh(rows, Eigen::all);
+        // Snrm(j) = ||Scmp.col(j)||.
+        helfem::Vector Snrm(Scmp.cols());
+        for (Eigen::Index j = 0; j < Scmp.cols(); ++j)
+          Snrm(j) = Scmp.col(j).norm();
+        // Sind = indices of columns with nonzero norm.
+        std::vector<Eigen::Index> Sind;
+        Sind.reserve(Snrm.size());
+        for (Eigen::Index j = 0; j < Snrm.size(); ++j)
+          if (Snrm(j) != 0.0) Sind.push_back(j);
 
-        // Store solutions
-        arma::uvec cidx(arma::linspace<arma::uvec>(iidx,iidx+Esub.n_elem-1,Esub.n_elem));
-        E(cidx)=Esub;
-        C(m_idx[i],cidx)=Csub;
-        iidx+=Esub.n_elem;
+        helfem::Vector Esub;
+        helfem::Matrix Csub;
+        const helfem::Matrix SinvhSub = Sinvh(Eigen::all, Sind);
+        eig_gsym(Esub, Csub, F, SinvhSub);
+
+        E.segment(iidx, Esub.size()) = Esub;
+        C.middleCols(iidx, Csub.cols()) = Csub;
+        iidx += Esub.size();
       }
-      if(iidx!=F.n_rows) {
+      if (iidx != F.rows()) {
         std::ostringstream oss;
-        oss << "Symmetry mismatch: expected " << F.n_rows << " vectors but got " << iidx << "!\n";
+        oss << "Symmetry mismatch: expected " << F.rows() << " vectors but got " << iidx << "!\n";
         throw std::logic_error(oss.str());
       }
 
-      // Sort energies
-      arma::uvec Eord=arma::sort_index(E,"ascend");
-      E=E(Eord);
-      C=C.cols(Eord);
+      // Sort energies ascending.
+      const auto Eord = sort_index_ascending(E);
+      const helfem::Vector Eold = E;
+      const helfem::Matrix Cold = C;
+      for (Eigen::Index i = 0; i < E.size(); ++i) {
+        E(i) = Eold(Eord[i]);
+        C.col(i) = Cold.col(Eord[i]);
+      }
+    }
+
+    void eig_sym_sub(helfem::Vector & E, helfem::Matrix & C,
+                     const helfem::Matrix & F, const std::vector<arma::uvec> & m_idx) {
+      E = helfem::Vector::Zero(F.rows());
+      C = helfem::Matrix::Zero(F.rows(), F.rows());
+
+      Eigen::Index iidx = 0;
+      for (size_t i = 0; i < m_idx.size(); ++i) {
+        const auto idx = uvec_to_indices(m_idx[i]);
+        // Subblock F(idx, idx).
+        const helfem::Matrix Fsub = F(idx, idx);
+        Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(Fsub);
+        if (es.info() != Eigen::Success)
+          throw std::logic_error("Subspace eigendecomposition failed!\n");
+        const helfem::Vector Esub = es.eigenvalues();
+        const helfem::Matrix Csub = es.eigenvectors();
+        // Place results: E[iidx:iidx+n] = Esub; C(idx, iidx:iidx+n) = Csub.
+        E.segment(iidx, Esub.size()) = Esub;
+        for (Eigen::Index k = 0; k < Csub.cols(); ++k)
+          for (size_t r = 0; r < idx.size(); ++r)
+            C(idx[r], iidx + k) = Csub(static_cast<Eigen::Index>(r), k);
+        iidx += Esub.size();
+      }
+      if (iidx != F.rows()) {
+        std::ostringstream oss;
+        oss << "Symmetry mismatch: expected " << F.rows() << " vectors but got " << iidx << "!\n";
+        throw std::logic_error(oss.str());
+      }
+
+      const auto Eord = sort_index_ascending(E);
+      const helfem::Vector Eold = E;
+      const helfem::Matrix Cold = C;
+      for (Eigen::Index i = 0; i < E.size(); ++i) {
+        E(i) = Eold(Eord[i]);
+        C.col(i) = Cold.col(Eord[i]);
+      }
     }
 
     void eig_sub_wrk(arma::vec & E, arma::mat & Cocc, arma::mat & Cvirt, const arma::mat & F, size_t Nact) {

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -32,10 +32,10 @@ namespace helfem {
 
     /// Solve generalized eigenvalue problem (Phase 5.11: Eigen-typed).
     void eig_gsym(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh);
-    /// Solve generalized eigenvalue problem in subspaces
-    void eig_gsym_sub(arma::vec & E, arma::mat & C, const arma::mat & F, const arma::mat & Sinvh, const std::vector<arma::uvec> & m_idx, bool verbose=true);
-    /// Solve eigenvalue problem in subspaces
-    void eig_sym_sub(arma::vec & E, arma::mat & C, const arma::mat & F, const std::vector<arma::uvec> & m_idx);
+    /// Solve generalized eigenvalue problem in subspaces (Phase 5.12: Eigen matrices; m_idx kept arma::uvec).
+    void eig_gsym_sub(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh, const std::vector<arma::uvec> & m_idx, bool verbose=true);
+    /// Solve eigenvalue problem in subspaces (Phase 5.12: Eigen matrices; m_idx kept arma::uvec).
+    void eig_sym_sub(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const std::vector<arma::uvec> & m_idx);
 
     /// Solve eigenvalue problem in subspace
     void eig_sub_wrk(arma::vec & E, arma::mat & Cocc, arma::mat & Cvirt, const arma::mat & F, size_t Nact);


### PR DESCRIPTION
## Summary

Migrates the per-symmetry-block eigenvalue solvers. Matrix arguments (\`E\`, \`C\`, \`F\`, \`Sinvh\`) are now Eigen; the \`m_idx\` parameter (\`std::vector<arma::uvec>\`) is kept (migrating it cascades into \`TwoDBasis::get_sym_idx\`; deferred to a focused later PR).

\`\`\`cpp
void scf::eig_gsym_sub(helfem::Vector & E, helfem::Matrix & C,
                       const helfem::Matrix & F,
                       const helfem::Matrix & Sinvh,
                       const std::vector<arma::uvec> & m_idx,
                       bool verbose=true);

void scf::eig_sym_sub(helfem::Vector & E, helfem::Matrix & C,
                      const helfem::Matrix & F,
                      const std::vector<arma::uvec> & m_idx);
\`\`\`

## Implementation

Anonymous namespace helpers:
- **\`uvec_to_indices\`**: \`arma::uvec\` → \`std::vector<Eigen::Index>\` for Eigen 3.4 indexed access \`M(rows, cols)\`
- **\`sort_index_ascending\`**: ascending sort of \`Eigen::Index\` by vector value (replaces \`arma::sort_index(\"ascend\")\`)

| arma idiom | Eigen replacement |
|---|---|
| \`Sinvh.rows(m_idx[isym])\` | \`Sinvh(rows, Eigen::all)\` |
| \`arma::norm(.col(j), \"fro\")\` | \`.col(j).norm()\` |
| \`arma::find(Snrm)\` | manual loop building index vec |
| \`Sinvh.cols(Sind)\` | \`Sinvh(Eigen::all, Sind)\` |
| \`E.subvec(i, j) = Esub\` | \`E.segment(i, n) = Esub\` |
| \`C.cols(i, j) = Csub\` | \`C.middleCols(i, n) = Csub\` |
| \`arma::sort_index(E)\` + reorder | \`sort_index_ascending\` + explicit column copy |

\`eig_sym_sub\`: native Eigen via \`SelfAdjointEigenSolver\` on \`F(idx, idx)\` subblock; places \`Csub\` into \`C(idx, iidx:iidx+n)\` via explicit nested loop (Eigen 3.4 has no clean (rows, cols) block-assignment from an arbitrary subview).

## Caller bridges (13 sites)

Same bridge pattern as 5.11:

\`\`\`cpp
{ helfem::Vector E_e; helfem::Matrix C_e;
  scf::eig_*_sub(E_e, C_e, helfem::to_eigen(F), ...);
  E = helfem::to_arma(E_e); C = helfem::to_arma(C_e); }
\`\`\`

| File | Sites | Notes |
|---|---|---|
| \`src/atomic/main.cpp\` | 5 | 5.11 left the \`eig_gsym_sub\` branches arma; now bridged |
| \`src/diatomic/main.cpp\` | 5 | |
| \`src/diatomic/corebasis.cpp\` | 1 | |
| \`src/atomic/TwoDBasis.cpp\` | 1 | \`eig_sym_sub\` |
| \`src/diatomic/basis.cpp\` | 1 | \`eig_sym_sub\` |

After this PR, the \`if(symm) eig_gsym_sub else eig_gsym\` pairs in the SCF drivers are uniformly bridged via the same pattern.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811244909** (bit-identical to 5.11 baseline — Be HF doesn't hit the symmetry path)

## Status (Layer L0)

- [x] \`utils::invh\`, \`scf::form_density\`, \`scf::form_Sinvh\` — PR #126
- [x] \`scf::eig_gsym\` — PR #127
- [x] **\`scf::eig_gsym_sub\`, \`eig_sym_sub\`** — this PR
- [ ] \`scf::enforce_occupations\` / \`enforce_fock_symmetry\` / \`fock_symmetry_average\`
- [ ] \`scf::eig_sub_wrk\` / \`sort_eig\` / \`eig_sub\` / \`eig_iter\` (iterative)
- [ ] \`scf::perturbation_matrix\`, \`parse_xc_params\`
- [ ] \`scf::form_NOs\`, \`ROHF_update\`
- [ ] \`src/general/diis.cpp\`
- [ ] \`src/general/lbfgs.cpp\`
- [ ] \`src/general/lcao.cpp\`

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR