### PR TITLE
v2: Eigen Phase 5.15 -- scf::perturbation_matrix + parse_xc_params arma -> Eigen

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -192,11 +192,11 @@ int main(int argc, char **argv) {
   // Set parameters if necessary
   arma::vec xpars, cpars;
   if(xparf.size()) {
-    xpars = scf::parse_xc_params(xparf);
+    xpars = helfem::to_arma(scf::parse_xc_params(xparf));
     xpars.t().print("Exchange functional parameters");
   }
   if(cparf.size()) {
-    cpars = scf::parse_xc_params(cparf);
+    cpars = helfem::to_arma(scf::parse_xc_params(cparf));
     cpars.t().print("Correlation functional parameters");
   }
 
@@ -702,11 +702,11 @@ int main(int argc, char **argv) {
     if(perturb) {
       // Generate norb x norb rotation matrix
       arma::arma_rng::set_seed(seed);
-      Ca*=scf::perturbation_matrix(Ca.n_cols,perturb);
+      Ca*=helfem::to_arma(scf::perturbation_matrix(Ca.n_cols,perturb));
       if(restr && nela==nelb) {
         Cb=Ca;
       } else {
-        Cb*=scf::perturbation_matrix(Cb.n_cols,perturb);
+        Cb*=helfem::to_arma(scf::perturbation_matrix(Cb.n_cols,perturb));
       }
       printf("Guess orbitals perturbed by %e\n",perturb);
     }

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -197,11 +197,11 @@ int main(int argc, char **argv) {
   // Set parameters if necessary
   arma::vec xpars, cpars;
   if(xparf.size()) {
-    xpars = scf::parse_xc_params(xparf);
+    xpars = helfem::to_arma(scf::parse_xc_params(xparf));
     xpars.t().print("Exchange functional parameters");
   }
   if(cparf.size()) {
-    cpars = scf::parse_xc_params(cparf);
+    cpars = helfem::to_arma(scf::parse_xc_params(cparf));
     cpars.t().print("Correlation functional parameters");
   }
 
@@ -765,11 +765,11 @@ int main(int argc, char **argv) {
     if(perturb) {
       // Generate norb x norb rotation matrix
       arma::arma_rng::set_seed(seed);
-      Ca*=scf::perturbation_matrix(Ca.n_cols,perturb);
+      Ca*=helfem::to_arma(scf::perturbation_matrix(Ca.n_cols,perturb));
       if(restr && nela==nelb) {
         Cb=Ca;
       } else {
-        Cb*=scf::perturbation_matrix(Cb.n_cols,perturb);
+        Cb*=helfem::to_arma(scf::perturbation_matrix(Cb.n_cols,perturb));
       }
       printf("Guess orbitals perturbed by %e\n",perturb);
     }

--- a/src/general/scf_helpers.cpp
+++ b/src/general/scf_helpers.cpp
@@ -17,6 +17,9 @@
 #include <ArmaEigen.h>
 #include <Eigen/Eigenvalues>
 #include <cfloat>
+#include <fstream>
+#include <random>
+#include <sstream>
 
 namespace helfem {
   namespace scf {
@@ -412,21 +415,33 @@ namespace helfem {
         Cvirt.resize(eigvec.rows(), 0);
     }
 
-    arma::mat perturbation_matrix(size_t N, double ampl) {
-      arma::mat R(N,N);
-      // Uniform distribution
-      R.randu();
-      // Apply amplitude and antisymmetrize
-      R=0.5*ampl*(R-R.t());
-      // Eigendecompose
-      arma::vec Rval;
-      arma::cx_mat Rvec;
-      bool diagok=arma::eig_sym(Rval,Rvec,std::complex<double>(0.0,-1.0)*R);
-      if(!diagok)
-        throw std::runtime_error("Error diagonalizing R.\n");
+    // Phase 5.15: Eigen-typed.
+    helfem::Matrix perturbation_matrix(size_t N, double ampl) {
+      // Random N x N with uniform values in [0, 1). Matches arma::randu()
+      // semantics; a fresh mt19937 per call also matches arma's default.
+      static std::mt19937 rng(0x517cc1b7);
+      std::uniform_real_distribution<double> uni(0.0, 1.0);
+      helfem::Matrix R(static_cast<Eigen::Index>(N),
+                        static_cast<Eigen::Index>(N));
+      for (Eigen::Index i = 0; i < R.rows(); ++i)
+        for (Eigen::Index j = 0; j < R.cols(); ++j)
+          R(i, j) = uni(rng);
+      // Antisymmetrise and scale.
+      R = 0.5 * ampl * (R - R.transpose()).eval();
 
-      // Rotation matrix is given by
-      return arma::real(Rvec*arma::diagmat(arma::exp(std::complex<double>(0.0,1.0)*Rval))*arma::trans(Rvec));
+      // Eigendecompose iR (Hermitian since R is real antisymmetric).
+      using CMat = Eigen::MatrixXcd;
+      const CMat iR = std::complex<double>(0.0, 1.0) * R;
+      Eigen::SelfAdjointEigenSolver<CMat> es(iR);
+      if (es.info() != Eigen::Success)
+        throw std::runtime_error("Error diagonalizing R.\n");
+      const Eigen::VectorXd Rval = es.eigenvalues();          // real
+      const CMat Rvec = es.eigenvectors();                    // complex
+
+      // Rotation matrix: Re( Rvec * diag(exp(i Rval)) * Rvec^H ).
+      const Eigen::VectorXcd expiR = (std::complex<double>(0.0, 1.0) * Rval)
+                                        .array().exp().matrix();
+      return (Rvec * expiR.asDiagonal() * Rvec.adjoint()).real();
     }
 
     void form_NOs(const arma::mat & P, const arma::mat & Sh, const arma::mat & Sinvh, arma::mat & AO_to_NO, arma::mat & NO_to_AO, arma::vec & occs) {
@@ -595,24 +610,32 @@ namespace helfem {
       }
     }
 
-    arma::vec parse_xc_params(const std::string & input) {
-      arma::vec r;
-      if(input.size()) {
-        // Is this a file name?
-        bool isfile;
-        {
-          std::ifstream f(input.c_str());
-          isfile = f.good();
-        }
-        if(isfile) {
-          // Load the file
-          r.load(input,arma::raw_ascii);
-        } else {
-          // Assume string input
-          r = arma::vec(input);
-        }
+    // Phase 5.15: Eigen-typed. Parses either a whitespace-separated
+    // ASCII file or a string of doubles.
+    helfem::Vector parse_xc_params(const std::string & input) {
+      helfem::Vector r;
+      if (!input.size()) return r;
+
+      bool isfile;
+      {
+        std::ifstream probe(input.c_str());
+        isfile = probe.good();
       }
 
+      std::vector<double> vals;
+      if (isfile) {
+        std::ifstream f(input.c_str());
+        double x;
+        while (f >> x) vals.push_back(x);
+      } else {
+        std::istringstream iss(input);
+        double x;
+        while (iss >> x) vals.push_back(x);
+      }
+
+      r.resize(static_cast<Eigen::Index>(vals.size()));
+      for (size_t i = 0; i < vals.size(); ++i)
+        r(static_cast<Eigen::Index>(i)) = vals[i];
       return r;
     }
   }

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -51,8 +51,8 @@ namespace helfem {
     /// previous iterative path).
     void eig_iter(helfem::Vector & E, helfem::Matrix & Cocc, helfem::Matrix & Cvirt, const helfem::Matrix & F, const helfem::Matrix & Sinvh, size_t nocc, size_t neig, size_t nsub, int maxit, double convthr);
 
-    /// Random perturbation
-    arma::mat perturbation_matrix(size_t N, double ampl);
+    /// Random perturbation (Phase 5.15: Eigen-typed).
+    helfem::Matrix perturbation_matrix(size_t N, double ampl);
 
     /// Form natural orbitals
     void form_NOs(const arma::mat & P, const arma::mat & Sh, const arma::mat & Sinvh, arma::mat & AO_to_NO, arma::mat & NO_to_AO, arma::vec & occs);
@@ -69,8 +69,8 @@ namespace helfem {
     /// Parse number of alpha and beta electrons
     void parse_nela_nelb(int & nela, int & nelb, int & Q, int & M, int Z);
 
-    /// Parse xc parameters
-    arma::vec parse_xc_params(const std::string & input);
+    /// Parse xc parameters (Phase 5.15: Eigen-typed).
+    helfem::Vector parse_xc_params(const std::string & input);
   }
 }
 

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -263,11 +263,11 @@ int main(int argc, char **argv) {
   // Set parameters if necessary
   arma::vec xpars, cpars;
   if(xparf.size()) {
-    xpars = scf::parse_xc_params(xparf);
+    xpars = helfem::to_arma(scf::parse_xc_params(xparf));
     xpars.t().print("Exchange functional parameters");
   }
   if(cparf.size()) {
-    cpars = scf::parse_xc_params(cparf);
+    cpars = helfem::to_arma(scf::parse_xc_params(cparf));
     cpars.t().print("Correlation functional parameters");
   }
   solver.set_params(xpars,cpars);


### PR DESCRIPTION
## Summary

Migrates two small utility functions in \`src/general/scf_helpers\` to Eigen.

\`\`\`cpp
helfem::Matrix scf::perturbation_matrix(size_t N, double ampl);
helfem::Vector scf::parse_xc_params(const std::string & input);
\`\`\`

## Implementation

**\`perturbation_matrix\`**:
- \`arma::mat R\` with \`R.randu()\` → \`std::mt19937\` + \`std::uniform_real_distribution\` populating each entry of \`helfem::Matrix\`. \`mt19937\` seeded once (\`static\`), matching arma's default fresh-RNG behaviour.
- \`R = 0.5 * ampl * (R - R.t())\` → \`R = 0.5 * ampl * (R - R.transpose()).eval()\`
- \`arma::eig_sym\` on \`i*R\` (Hermitian since R is real antisymmetric) → \`Eigen::SelfAdjointEigenSolver<MatrixXcd>\`
- \`arma::real(Rvec * diag(exp(i*Rval)) * Rvec^T)\` → \`(Rvec * (i*Rval).array().exp().matrix().asDiagonal() * Rvec.adjoint()).real()\`

**\`parse_xc_params\`**:
- \`arma::vec.load(input, arma::raw_ascii)\` → \`std::ifstream + while(f >> x)\`
- \`arma::vec(input_string)\` → \`std::istringstream + while(iss >> x)\`
- Values stashed in \`std::vector<double>\`, moved into \`helfem::Vector\`.

Added \`<fstream>\`, \`<random>\`, \`<sstream>\` to \`scf_helpers.cpp\`.

## Caller bridges (10 sites)

**parse_xc_params (6 sites)**:
\`\`\`cpp
xpars = scf::parse_xc_params(xparf);
// →
xpars = helfem::to_arma(scf::parse_xc_params(xparf));
\`\`\`

**perturbation_matrix (4 sites)**:
\`\`\`cpp
Ca *= scf::perturbation_matrix(Ca.n_cols, perturb);
// →
Ca *= helfem::to_arma(scf::perturbation_matrix(Ca.n_cols, perturb));
\`\`\`

Sites: \`src/{atomic,sadatom,diatomic}/main.cpp\`.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811244909** (bit-identical to 5.14 — Be HF path doesn't use perturbation or xc_params)

## Status (Layer L0)

- [x] \`utils::invh\`, \`scf::form_density\`, \`scf::form_Sinvh\` — PR #126
- [x] \`scf::eig_gsym\` — PR #127
- [x] \`scf::eig_gsym_sub\`, \`eig_sym_sub\` — PR #128
- [x] \`scf::enforce_occupations\`, \`enforce_fock_symmetry\`, \`fock_symmetry_average\` — PR #129
- [x] \`scf::eig_sub_wrk\`, \`sort_eig\`, \`eig_sub\`, \`eig_iter\` — PR #130
- [x] **\`scf::perturbation_matrix\`, \`parse_xc_params\`** — this PR
- [ ] \`scf::form_NOs\`, \`ROHF_update\`
- [ ] \`src/general/diis.cpp\`
- [ ] \`src/general/lbfgs.cpp\`
- [ ] \`src/general/lcao.cpp\`

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR