### PR TITLE
v2: Eigen Phase 5.17 -- src/general/lbfgs + diis internals arma -> Eigen

### DIFF
--- a/src/general/diis.cpp
+++ b/src/general/diis.cpp
@@ -13,10 +13,21 @@
  * for the full license text.
  */
 
-
+// Phase 5.17: internal state and math migrated arma -> Eigen. The
+// public API (constructors, update, solve_F, solve_P) still takes
+// arma::mat / arma::mat& for SCF-driver compat; bridging happens at
+// the class boundary.
 
 #include <algorithm>
 #include <cfloat>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <ArmaEigen.h>
+#include <Eigen/SVD>
+#include <Eigen/QR>
 #include "diis.h"
 #include "lbfgs.h"
 
@@ -28,628 +39,434 @@
 bool operator<(const diis_pol_entry_t & lhs, const diis_pol_entry_t & rhs) {
   return lhs.E < rhs.E;
 }
-
 bool operator<(const diis_unpol_entry_t & lhs, const diis_unpol_entry_t & rhs) {
   return lhs.E < rhs.E;
 }
 
+namespace {
+  // Vectorise a matrix in column-major order into an Eigen Vector.
+  inline helfem::Vector vectorise(const helfem::Matrix & M) {
+    helfem::Vector v(M.size());
+    std::memcpy(v.data(), M.data(), sizeof(double) * static_cast<size_t>(M.size()));
+    return v;
+  }
+}
+
 DIIS::DIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) {
-  S=S_;
-  Sinvh=Sinvh_;
-  usediis=usediis_;
-  useadiis=useadiis_;
-  verbose=verbose_;
-  imax=imax_;
-
-  // Start mixing in DIIS weight when error is
-  diiseps=diiseps_;
-  // and switch to full DIIS when error is
-  diisthr=diisthr_;
-
-  // No cooloff
-  cooloff=0;
+  S = helfem::to_eigen(S_);
+  Sinvh = helfem::to_eigen(Sinvh_);
+  usediis  = usediis_;
+  useadiis = useadiis_;
+  verbose  = verbose_;
+  imax     = imax_;
+  diiseps  = diiseps_;
+  diisthr  = diisthr_;
+  cooloff  = 0;
 }
 
-rDIIS::rDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : DIIS(S_,Sinvh_,usediis_,diiseps_,diisthr_,useadiis_,verbose_,imax_) {
-}
+rDIIS::rDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : DIIS(S_, Sinvh_, usediis_, diiseps_, diisthr_, useadiis_, verbose_, imax_) {}
 
-uDIIS::uDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool combine_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : DIIS(S_,Sinvh_,usediis_,diiseps_,diisthr_,useadiis_,verbose_,imax_), combine(combine_) {
-}
+uDIIS::uDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool combine_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : DIIS(S_, Sinvh_, usediis_, diiseps_, diisthr_, useadiis_, verbose_, imax_), combine(combine_) {}
 
-DIIS::~DIIS() {
-}
+DIIS::~DIIS() {}
+rDIIS::~rDIIS() {}
+uDIIS::~uDIIS() {}
 
-rDIIS::~rDIIS() {
-}
-
-uDIIS::~uDIIS() {
-}
-
-void rDIIS::clear() {
-  stack.clear();
-}
-
-void uDIIS::clear() {
-  stack.clear();
-}
-
-void rDIIS::erase_last() {
-  stack.erase(stack.begin());
-}
-
-void uDIIS::erase_last() {
-  stack.erase(stack.begin());
-}
+void rDIIS::clear() { stack.clear(); }
+void uDIIS::clear() { stack.clear(); }
+void rDIIS::erase_last() { stack.erase(stack.begin()); }
+void uDIIS::erase_last() { stack.erase(stack.begin()); }
 
 void rDIIS::update(const arma::mat & F, const arma::mat & P, double E, double & error) {
-  // New entry
   diis_unpol_entry_t hlp;
-  hlp.F=F;
-  hlp.P=P;
-  hlp.E=E;
+  hlp.F = helfem::to_eigen(F);
+  hlp.P = helfem::to_eigen(P);
+  hlp.E = E;
 
-  // Compute error matrix
-  arma::mat errmat(F*P*S);
-  // FPS - SPF
-  errmat-=arma::trans(errmat);
-  // and transform it to the orthonormal basis (1982 paper, page 557)
-  errmat=arma::trans(Sinvh)*errmat*Sinvh;
-  // and store it
-  hlp.err=arma::vectorise(errmat);
+  // errmat = F P S; FPS - SPF; then to orthonormal basis.
+  helfem::Matrix errmat = hlp.F * hlp.P * S;
+  errmat -= errmat.transpose().eval();
+  errmat = Sinvh.transpose() * errmat * Sinvh;
+  hlp.err = vectorise(errmat);
 
-  // DIIS error is
-  error=arma::max(arma::max(arma::abs(errmat)));
+  error = errmat.cwiseAbs().maxCoeff();
 
-  // Is stack full?
-  if(stack.size()==imax) {
-    erase_last();
-  }
-  // Add to stack
+  if (stack.size() == imax) erase_last();
   stack.push_back(hlp);
 
-  // Update ADIIS helpers
   PiF_update();
 }
 
 void rDIIS::PiF_update() {
-  const arma::mat & Fn=stack[stack.size()-1].F;
-  const arma::mat & Pn=stack[stack.size()-1].P;
+  const helfem::Matrix & Fn = stack.back().F;
+  const helfem::Matrix & Pn = stack.back().P;
 
-  // Update matrices
-  PiF.zeros(stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    PiF(i)=arma::trace((stack[i].P-Pn)*Fn);
+  PiF = helfem::Vector::Zero(stack.size());
+  for (size_t i = 0; i < stack.size(); ++i)
+    PiF(i) = ((stack[i].P - Pn) * Fn).trace();
 
-  PiFj.zeros(stack.size(),stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    for(size_t j=0;j<stack.size();j++)
-      PiFj(i,j)=arma::trace((stack[i].P-Pn)*(stack[j].F-Fn));
+  PiFj = helfem::Matrix::Zero(stack.size(), stack.size());
+  for (size_t i = 0; i < stack.size(); ++i)
+    for (size_t j = 0; j < stack.size(); ++j)
+      PiFj(i, j) = ((stack[i].P - Pn) * (stack[j].F - Fn)).trace();
 }
 
 void uDIIS::update(const arma::mat & Fa, const arma::mat & Fb, const arma::mat & Pa, const arma::mat & Pb, double E, double & error) {
-  // New entry
   diis_pol_entry_t hlp;
-  hlp.Fa=Fa;
-  hlp.Fb=Fb;
-  hlp.Pa=Pa;
-  hlp.Pb=Pb;
-  hlp.E=E;
+  hlp.Fa = helfem::to_eigen(Fa);
+  hlp.Fb = helfem::to_eigen(Fb);
+  hlp.Pa = helfem::to_eigen(Pa);
+  hlp.Pb = helfem::to_eigen(Pb);
+  hlp.E  = E;
 
-  // Compute error matrices
-  arma::mat errmata(Fa*Pa*S);
-  arma::mat errmatb(Fb*Pb*S);
-  // FPS - SPF
-  errmata-=arma::trans(errmata);
-  errmatb-=arma::trans(errmatb);
-  // and transform them to the orthonormal basis (1982 paper, page 557)
-  errmata=arma::trans(Sinvh)*errmata*Sinvh;
-  errmatb=arma::trans(Sinvh)*errmatb*Sinvh;
-  // and store it
-  if(combine) {
-    hlp.err=arma::vectorise(errmata+errmatb);
+  helfem::Matrix errmata = hlp.Fa * hlp.Pa * S;
+  helfem::Matrix errmatb = hlp.Fb * hlp.Pb * S;
+  errmata -= errmata.transpose().eval();
+  errmatb -= errmatb.transpose().eval();
+  errmata = Sinvh.transpose() * errmata * Sinvh;
+  errmatb = Sinvh.transpose() * errmatb * Sinvh;
+
+  if (combine) {
+    hlp.err = vectorise(helfem::Matrix(errmata + errmatb));
   } else {
-    hlp.err.zeros(errmata.n_elem+errmatb.n_elem);
-    hlp.err.subvec(0,errmata.n_elem-1)=arma::vectorise(errmata);
-    hlp.err.subvec(errmata.n_elem,hlp.err.n_elem-1)=arma::vectorise(errmatb);
+    const helfem::Vector va = vectorise(errmata);
+    const helfem::Vector vb = vectorise(errmatb);
+    hlp.err.resize(va.size() + vb.size());
+    hlp.err.head(va.size()) = va;
+    hlp.err.tail(vb.size()) = vb;
   }
 
-  // DIIS error is
-  error=arma::max(arma::abs(hlp.err));
+  error = hlp.err.cwiseAbs().maxCoeff();
 
-  // Is stack full?
-  if(stack.size()==imax) {
-    erase_last();
-  }
-  // Add to stack
+  if (stack.size() == imax) erase_last();
   stack.push_back(hlp);
 
-  // Update ADIIS helpers
   PiF_update();
 }
 
 void uDIIS::PiF_update() {
-  const arma::mat & Fan=stack[stack.size()-1].Fa;
-  const arma::mat & Fbn=stack[stack.size()-1].Fb;
-  const arma::mat & Pan=stack[stack.size()-1].Pa;
-  const arma::mat & Pbn=stack[stack.size()-1].Pb;
+  const helfem::Matrix & Fan = stack.back().Fa;
+  const helfem::Matrix & Fbn = stack.back().Fb;
+  const helfem::Matrix & Pan = stack.back().Pa;
+  const helfem::Matrix & Pbn = stack.back().Pb;
 
-  // Update matrices
-  PiF.zeros(stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    PiF(i)=arma::trace((stack[i].Pa-Pan)*Fan) + arma::trace((stack[i].Pb-Pbn)*Fbn);
+  PiF = helfem::Vector::Zero(stack.size());
+  for (size_t i = 0; i < stack.size(); ++i)
+    PiF(i) = ((stack[i].Pa - Pan) * Fan).trace()
+            + ((stack[i].Pb - Pbn) * Fbn).trace();
 
-  PiFj.zeros(stack.size(),stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    for(size_t j=0;j<stack.size();j++)
-      PiFj(i,j)=arma::trace((stack[i].Pa-Pan)*(stack[j].Fa-Fan))+arma::trace((stack[i].Pb-Pbn)*(stack[j].Fb-Fbn));
+  PiFj = helfem::Matrix::Zero(stack.size(), stack.size());
+  for (size_t i = 0; i < stack.size(); ++i)
+    for (size_t j = 0; j < stack.size(); ++j)
+      PiFj(i, j) = ((stack[i].Pa - Pan) * (stack[j].Fa - Fan)).trace()
+                 + ((stack[i].Pb - Pbn) * (stack[j].Fb - Fbn)).trace();
 }
 
-arma::vec rDIIS::get_energies() const {
-  arma::vec E(stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    E(i)=stack[i].E;
+helfem::Vector rDIIS::get_energies() const {
+  helfem::Vector E(stack.size());
+  for (size_t i = 0; i < stack.size(); ++i) E(i) = stack[i].E;
   return E;
 }
 
-arma::mat rDIIS::get_diis_error() const {
-  arma::mat err(stack[0].err.n_elem,stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    err.col(i)=stack[i].err;
+helfem::Matrix rDIIS::get_diis_error() const {
+  helfem::Matrix err(stack[0].err.size(), stack.size());
+  for (size_t i = 0; i < stack.size(); ++i) err.col(i) = stack[i].err;
   return err;
 }
 
-arma::vec uDIIS::get_energies() const {
-  arma::vec E(stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    E(i)=stack[i].E;
+helfem::Vector uDIIS::get_energies() const {
+  helfem::Vector E(stack.size());
+  for (size_t i = 0; i < stack.size(); ++i) E(i) = stack[i].E;
   return E;
 }
-arma::mat uDIIS::get_diis_error() const {
-  arma::mat err(stack[0].err.n_elem,stack.size());
-  for(size_t i=0;i<stack.size();i++)
-    err.col(i)=stack[i].err;
+helfem::Matrix uDIIS::get_diis_error() const {
+  helfem::Matrix err(stack[0].err.size(), stack.size());
+  for (size_t i = 0; i < stack.size(); ++i) err.col(i) = stack[i].err;
   return err;
 }
 
-arma::vec DIIS::get_w() {
-  // DIIS error
-  arma::mat de=get_diis_error();
-  double err=arma::max(arma::abs(de.col(de.n_cols-1)));
+helfem::Vector DIIS::get_w() {
+  const helfem::Matrix de = get_diis_error();
+  const double err = de.col(de.cols() - 1).cwiseAbs().maxCoeff();
 
-  // Weight
-  arma::vec w;
+  helfem::Vector w;
 
-  if(useadiis && !usediis) {
-    w=get_w_adiis();
-    if(verbose) {
+  if (useadiis && !usediis) {
+    w = get_w_adiis();
+    if (verbose) {
       printf("ADIIS weights\n");
-      w.t().print();
+      std::cout << w.transpose() << "\n";
     }
-  } else if(!useadiis && usediis) {
-    // Use DIIS only if error is smaller than threshold
-    if(err>diisthr)
+  } else if (!useadiis && usediis) {
+    if (err > diisthr)
       throw std::runtime_error("DIIS error too large for only DIIS to converge wave function.\n");
-
-    w=get_w_diis();
-
-    if(verbose) {
+    w = get_w_diis();
+    if (verbose) {
       printf("DIIS weights\n");
-      w.t().print();
+      std::cout << w.transpose() << "\n";
     }
-  } else if(useadiis && usediis) {
-    // Sliding scale: DIIS weight goes from 0 at err=diiseps to 1 at err=diisthr.
-    // The two thresholds should be distinct; if they collapse to the same value
-    // we fall back to a hard switch instead of dividing by zero.
+  } else if (useadiis && usediis) {
     double diisw;
-    if(diiseps == diisthr) {
+    if (diiseps == diisthr) {
       diisw = (err <= diisthr) ? 1.0 : 0.0;
     } else {
-      diisw = std::clamp(1.0 - (err-diisthr)/(diiseps-diisthr), 0.0, 1.0);
+      diisw = std::clamp(1.0 - (err - diisthr) / (diiseps - diisthr), 0.0, 1.0);
     }
-    // ADIIS weght
-    double adiisw=1.0-diisw;
+    double adiisw = 1.0 - diisw;
 
-    // Determine cooloff
-    if(cooloff>0) {
-      diisw=0.0;
+    if (cooloff > 0) {
+      diisw = 0.0;
       cooloff--;
     } else {
-      // Check if energy has increased
-      arma::vec E=get_energies();
-      if(E.n_elem>1 &&  E(E.n_elem-1)-E(E.n_elem-2) > COOLTHR) {
-	cooloff=2;
-	diisw=0.0;
+      const helfem::Vector E = get_energies();
+      if (E.size() > 1 && E(E.size() - 1) - E(E.size() - 2) > COOLTHR) {
+        cooloff = 2;
+        diisw = 0.0;
       }
     }
 
-    w.zeros(de.n_cols);
+    w = helfem::Vector::Zero(de.cols());
 
-    // DIIS and ADIIS weights
-    arma::vec wd, wa;
-    if(diisw!=0.0) {
-      wd=get_w_diis();
-      w+=diisw*wd;
+    helfem::Vector wd, wa;
+    if (diisw != 0.0) {
+      wd = get_w_diis();
+      w += diisw * wd;
     }
-    if(adiisw!=0.0) {
-      wa=get_w_adiis();
-      w+=adiisw*wa;
-    }
-
-    if(verbose) {
-      if(adiisw!=0.0) {
-        printf("ADIIS weights\n");
-        wa.t().print();
-      }
-      if(diisw!=0.0) {
-        printf("CDIIS weights\n");
-        wd.t().print();
-      }
-      if(adiisw!=0.0 && diisw!=0.0) {
-        printf(" DIIS weights\n");
-        w.t().print();
-      }
+    if (adiisw != 0.0) {
+      wa = get_w_adiis();
+      w += adiisw * wa;
     }
 
-  } else
+    if (verbose) {
+      if (adiisw != 0.0) { printf("ADIIS weights\n"); std::cout << wa.transpose() << "\n"; }
+      if (diisw  != 0.0) { printf("CDIIS weights\n"); std::cout << wd.transpose() << "\n"; }
+      if (adiisw != 0.0 && diisw != 0.0) { printf(" DIIS weights\n"); std::cout << w.transpose() << "\n"; }
+    }
+  } else {
     throw std::runtime_error("Nor DIIS or ADIIS has been turned on.\n");
-
+  }
   return w;
 }
 
-arma::vec DIIS::get_w_diis() const {
-  arma::mat errs=get_diis_error();
-  return get_w_diis_wrk(errs);
+helfem::Vector DIIS::get_w_diis() const {
+  return get_w_diis_wrk(get_diis_error());
 }
 
-arma::vec DIIS::get_w_diis_wrk(const arma::mat & errs) const {
-  // Size of LA problem
-  int N=(int) errs.n_cols;
+helfem::Vector DIIS::get_w_diis_wrk(const helfem::Matrix & errs) const {
+  const Eigen::Index N = errs.cols();
 
-  // Array holding the errors
-  arma::mat B(N,N);
-  B.zeros();
-  // Compute errors
-  for(int i=0;i<N;i++)
-    for(int j=0;j<N;j++) {
-      B(i,j)=arma::dot(errs.col(i),errs.col(j));
-    }
+  helfem::Matrix B = helfem::Matrix::Zero(N, N);
+  for (Eigen::Index i = 0; i < N; ++i)
+    for (Eigen::Index j = 0; j < N; ++j)
+      B(i, j) = errs.col(i).dot(errs.col(j));
 
-  /*
-    The C1-DIIS method is equivalent to solving the group of linear
-    equations
-            B w = lambda 1       (1)
+  // Solve B w = 1 via SVD; then renormalise so sum(w) = 1.
+  helfem::Vector rh = helfem::Vector::Ones(N);
+  Eigen::JacobiSVD<helfem::Matrix> svd(B, Eigen::ComputeThinU | Eigen::ComputeThinV);
+  const helfem::Vector sval = svd.singularValues();
+  const helfem::Matrix U = svd.matrixU();
+  const helfem::Matrix V = svd.matrixV();
 
-    where B is the error matrix, w are the DIIS weights, lambda is the
-    Lagrange multiplier that guarantees that the weights sum to unity,
-    and 1 stands for a unit vector (1 1 ... 1)^T.
+  helfem::Vector sol = helfem::Vector::Zero(N);
+  for (Eigen::Index i = 0; i < N; ++i)
+    if (sval(i) != 0.0)
+      sol += (U.col(i).dot(rh) / sval(i)) * V.col(i);
 
-    By rescaling the weights as w -> w/lambda, equation (1) is
-    reverted to the form
-            B w = 1              (2)
-
-    which can easily be solved using SVD techniques.
-
-    Finally, the weights are renormalized to satisfy
-            \sum_i w_i = 1
-    which takes care of the Lagrange multipliers.
-  */
-
-  // Right-hand side of equation is
-  arma::vec rh(N);
-  rh.ones();
-
-  // Singular value decomposition
-  arma::mat U, V;
-  arma::vec sval;
-  if(!arma::svd(U,sval,V,B,"std")) {
-    throw std::logic_error("SVD failed in DIIS.\n");
-  }
-  //sval.print("Singular values");
-
-  // Form solution vector
-  arma::vec sol(N);
-  sol.zeros();
-  for(int i=0;i<N;i++) {
-#if 0
-    // Perform Tikhonov regularization for the singular
-    // eigenvalues. This doesn't appear to work as well as just
-    // cutting out the spectrum.
-    double s(sval(i));
-    double t=1e-4;
-    double invs=s/(s*s + t*t);
-    sol += arma::dot(U.col(i),rh)*invs * V.col(i);
-#else
-    // Just cut out the problematic part. Weirdly, it appears that any
-    // kind of screening of the singular eigenvalues results in poorer
-    // convergence behavior(!)
-    if(sval(i) != 0.0)
-      sol += arma::dot(U.col(i),rh)/sval(i) * V.col(i);
-#endif
-  }
-
-  // Sanity check
-  if(arma::sum(sol)==0.0)
-    sol.ones();
-
-  // Normalize solution
-  //printf("Sum of weights is %e\n",arma::sum(sol));
-  sol/=arma::sum(sol);
-
+  if (sol.sum() == 0.0)
+    sol = helfem::Vector::Ones(N);
+  sol /= sol.sum();
   return sol;
 }
 
 void rDIIS::solve_F(arma::mat & F) {
-  arma::vec sol;
-  while(true) {
-    sol=get_w();
-    if(std::abs(sol(sol.n_elem-1))<=sqrt(DBL_EPSILON)) {
-      if(verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n",(int) stack.size()-1);
+  helfem::Vector sol;
+  while (true) {
+    sol = get_w();
+    if (std::abs(sol(sol.size() - 1)) <= std::sqrt(DBL_EPSILON)) {
+      if (verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n", (int) stack.size() - 1);
       erase_last();
       PiF_update();
-    } else
+    } else {
       break;
+    }
   }
 
-  // Form weighted Fock matrix
-  F.zeros();
-  for(size_t i=0;i<stack.size();i++)
-    F+=sol(i)*stack[i].F;
+  helfem::Matrix Fout = helfem::Matrix::Zero(stack[0].F.rows(), stack[0].F.cols());
+  for (size_t i = 0; i < stack.size(); ++i)
+    Fout += sol(i) * stack[i].F;
+  F = helfem::to_arma(Fout);
 }
 
 void uDIIS::solve_F(arma::mat & Fa, arma::mat & Fb) {
-  arma::vec sol;
-  while(true) {
-    sol=get_w();
-    if(std::abs(sol(sol.n_elem-1))<=sqrt(DBL_EPSILON)) {
-      if(verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n",(int) stack.size()-1);
+  helfem::Vector sol;
+  while (true) {
+    sol = get_w();
+    if (std::abs(sol(sol.size() - 1)) <= std::sqrt(DBL_EPSILON)) {
+      if (verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n", (int) stack.size() - 1);
       erase_last();
       PiF_update();
-    } else
+    } else {
       break;
+    }
   }
 
-  // Form weighted Fock matrix
-  Fa.zeros();
-  Fb.zeros();
-  for(size_t i=0;i<stack.size();i++) {
-    Fa+=sol(i)*stack[i].Fa;
-    Fb+=sol(i)*stack[i].Fb;
+  helfem::Matrix Fao = helfem::Matrix::Zero(stack[0].Fa.rows(), stack[0].Fa.cols());
+  helfem::Matrix Fbo = helfem::Matrix::Zero(stack[0].Fb.rows(), stack[0].Fb.cols());
+  for (size_t i = 0; i < stack.size(); ++i) {
+    Fao += sol(i) * stack[i].Fa;
+    Fbo += sol(i) * stack[i].Fb;
   }
+  Fa = helfem::to_arma(Fao);
+  Fb = helfem::to_arma(Fbo);
 }
 
 void rDIIS::solve_P(arma::mat & P) {
-  arma::vec sol;
-  while(true) {
-    sol=get_w();
-    if(std::abs(sol(sol.n_elem-1))<=sqrt(DBL_EPSILON)) {
-      if(verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n",(int) stack.size()-1);
+  helfem::Vector sol;
+  while (true) {
+    sol = get_w();
+    if (std::abs(sol(sol.size() - 1)) <= std::sqrt(DBL_EPSILON)) {
+      if (verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n", (int) stack.size() - 1);
       erase_last();
       PiF_update();
-    } else
+    } else {
       break;
+    }
   }
 
-  // Form weighted density matrix
-  P.zeros();
-  for(size_t i=0;i<stack.size();i++)
-    P+=sol(i)*stack[i].P;
+  helfem::Matrix Pout = helfem::Matrix::Zero(stack[0].P.rows(), stack[0].P.cols());
+  for (size_t i = 0; i < stack.size(); ++i)
+    Pout += sol(i) * stack[i].P;
+  P = helfem::to_arma(Pout);
 }
 
 void uDIIS::solve_P(arma::mat & Pa, arma::mat & Pb) {
-  arma::vec sol;
-  while(true) {
-    sol=get_w();
-    if(std::abs(sol(sol.n_elem-1))<=sqrt(DBL_EPSILON)) {
-      if(verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n",(int) stack.size()-1);
+  helfem::Vector sol;
+  while (true) {
+    sol = get_w();
+    if (std::abs(sol(sol.size() - 1)) <= std::sqrt(DBL_EPSILON)) {
+      if (verbose) printf("Weight on last matrix too small, reducing to %i matrices.\n", (int) stack.size() - 1);
       erase_last();
       PiF_update();
-    } else
+    } else {
       break;
+    }
   }
 
-  // Form weighted density matrix
-  Pa.zeros();
-  Pb.zeros();
-  for(size_t i=0;i<stack.size();i++) {
-    Pa+=sol(i)*stack[i].Pa;
-    Pb+=sol(i)*stack[i].Pb;
+  helfem::Matrix Pao = helfem::Matrix::Zero(stack[0].Pa.rows(), stack[0].Pa.cols());
+  helfem::Matrix Pbo = helfem::Matrix::Zero(stack[0].Pb.rows(), stack[0].Pb.cols());
+  for (size_t i = 0; i < stack.size(); ++i) {
+    Pao += sol(i) * stack[i].Pa;
+    Pbo += sol(i) * stack[i].Pb;
   }
+  Pa = helfem::to_arma(Pao);
+  Pb = helfem::to_arma(Pbo);
 }
+
+// -------- ADIIS: parabolic backtracking line search on x -> c(x) = x.^2 / dot(x,x) --------
 
 static void find_minE(const std::vector< std::pair<double,double> > & steps, double & Emin, size_t & imin) {
-  Emin=steps[0].second;
-  imin=0;
-  for(size_t i=1;i<steps.size();i++)
-    if(steps[i].second < Emin) {
-      Emin=steps[i].second;
-      imin=i;
+  Emin = steps[0].second;
+  imin = 0;
+  for (size_t i = 1; i < steps.size(); ++i)
+    if (steps[i].second < Emin) {
+      Emin = steps[i].second;
+      imin = i;
     }
 }
 
-static arma::vec compute_c(const arma::vec & x) {
-  // Compute contraction coefficients
-  return x%x/arma::dot(x,x);
+static helfem::Vector compute_c(const helfem::Vector & x) {
+  return x.array().square().matrix() / x.dot(x);
 }
 
-static arma::mat compute_jac(const arma::vec & x) {
-  // Compute jacobian of transformation: jac(i,j) = dc_i / dx_j
+helfem::Vector DIIS::get_w_adiis() const {
+  const Eigen::Index N = PiF.size();
 
-  // Compute coefficients
-  arma::vec c(compute_c(x));
-  double xnorm=arma::dot(x,x);
+  if (N == 1) return helfem::Vector::Ones(1);
 
-  arma::mat jac(c.n_elem,c.n_elem);
-  for(size_t i=0;i<c.n_elem;i++) {
-    double ci=c(i);
-    double xi=x(i);
+  helfem::Vector x = helfem::Vector::Ones(N) / static_cast<double>(N);
 
-    for(size_t j=0;j<c.n_elem;j++) {
-      double xj=x(j);
-
-      jac(i,j)=-ci*2.0*xj/xnorm;
-    }
-
-    // Extra term on diagonal
-    jac(i,i)+=2.0*xi/xnorm;
-  }
-
-  return jac;
-}
-
-arma::vec DIIS::get_w_adiis() const {
-  // Number of parameters
-  size_t N=PiF.n_elem;
-
-  if(N==1) {
-    // Trivial case.
-    arma::vec ret(1);
-    ret.ones();
-    return ret;
-  }
-
-  // Starting point: equal weights on all matrices
-  arma::vec x=arma::ones<arma::vec>(N)/N;
-
-  // BFGS accelerator
   LBFGS bfgs;
+  double steplen = 0.01;
+  const double fac = 2.0;
 
-  // Step size
-  double steplen=0.01, fac=2.0;
+  for (size_t iiter = 0; iiter < 1000; ++iiter) {
+    const helfem::Vector g = get_dEdx_adiis(x);
+    if (g.norm() <= 1e-7) break;
 
-  for(size_t iiter=0;iiter<1000;iiter++) {
-    // Get gradient
-    //double E(get_E_adiis(x));
-    arma::vec g(get_dEdx_adiis(x));
-    if(arma::norm(g,2)<=1e-7) {
-      break;
-    }
+    bfgs.update(x, g);
+    const helfem::Vector sd = -bfgs.solve();
 
-    // Search direction
-    bfgs.update(x,g);
-    arma::vec sd(-bfgs.solve());
-
-    // Do a line search on the search direction
     std::vector< std::pair<double, double> > steps;
-    // First, we try a fraction of the current step length
-    {
-      std::pair<double, double> p;
-      p.first=steplen/fac;
-      p.second=get_E_adiis(x+sd*p.first);
-      steps.push_back(p);
-    }
-    // Next, we try the current step length
-    {
-      std::pair<double, double> p;
-      p.first=steplen;
-      p.second=get_E_adiis(x+sd*p.first);
-      steps.push_back(p);
-    }
+    steps.push_back({steplen / fac, get_E_adiis(x + sd * (steplen / fac))});
+    steps.push_back({steplen,       get_E_adiis(x + sd * steplen)});
 
-    // Minimum energy and index
     double Emin;
     size_t imin;
-
-    while(true) {
-      // Sort the steps in length
-      std::sort(steps.begin(),steps.end());
-
-      // Find the minimum energy
-      find_minE(steps,Emin,imin);
-
-      // Where is the minimum?
-      if(imin==0 || imin==steps.size()-1) {
-	// Need smaller step
-	std::pair<double,double> p;
-	if(imin==0) {
-	  p.first=steps[imin].first/fac;
-	  if(steps[imin].first<DBL_EPSILON)
-	    break;
-	} else {
-	  p.first=steps[imin].first*fac;
-	}
-	p.second=get_E_adiis(x+sd*p.first);
-	steps.push_back(p);
+    while (true) {
+      std::sort(steps.begin(), steps.end());
+      find_minE(steps, Emin, imin);
+      if (imin == 0 || imin == steps.size() - 1) {
+        std::pair<double, double> p;
+        if (imin == 0) {
+          p.first = steps[imin].first / fac;
+          if (steps[imin].first < DBL_EPSILON) break;
+        } else {
+          p.first = steps[imin].first * fac;
+        }
+        p.second = get_E_adiis(x + sd * p.first);
+        steps.push_back(p);
       } else {
-	// Optimum is somewhere in the middle
-	break;
+        break;
       }
     }
 
-    if((imin!=0) && (imin!=steps.size()-1)) {
-      // Interpolate: A b = y
-      arma::mat A(3,3);
-      arma::vec y(3);
-      for(size_t i=0;i<3;i++) {
-	A(i,0)=1.0;
-	A(i,1)=steps[imin+i-1].first;
-	A(i,2)=std::pow(A(i,1),2);
-
-	y(i)=steps[imin+i-1].second;
+    if (imin != 0 && imin != steps.size() - 1) {
+      // Parabolic interpolation A b = y.
+      helfem::Matrix A(3, 3);
+      helfem::Vector y(3);
+      for (size_t i = 0; i < 3; ++i) {
+        A(i, 0) = 1.0;
+        A(i, 1) = steps[imin + i - 1].first;
+        A(i, 2) = std::pow(A(i, 1), 2);
+        y(i)    = steps[imin + i - 1].second;
       }
-
-      arma::mat b;
-      if(arma::solve(b,A,y) && b(2)>sqrt(DBL_EPSILON)) {
-	// Success in solution and parabola gives minimum.
-
-	// The minimum of the parabola is at
-	double x0=-b(1)/(2*b(2));
-
-	// Is this an interpolation?
-	if(A(0,1) < x0 && x0 < A(2,1)) {
-	  // Do the calculation with the interpolated step
-	  std::pair<double,double> p;
-	  p.first=x0;
-	  p.second=get_E_adiis(x+sd*p.first);
-	  steps.push_back(p);
-
-	  // Find the minimum energy
-	  find_minE(steps,Emin,imin);
-	}
+      Eigen::ColPivHouseholderQR<helfem::Matrix> qr(A);
+      const helfem::Vector b = qr.solve(y);
+      if (qr.info() == Eigen::Success && b(2) > std::sqrt(DBL_EPSILON)) {
+        const double x0 = -b(1) / (2 * b(2));
+        if (A(0, 1) < x0 && x0 < A(2, 1)) {
+          steps.push_back({x0, get_E_adiis(x + sd * x0)});
+          find_minE(steps, Emin, imin);
+        }
       }
     }
 
-    if(steps[imin].first<DBL_EPSILON)
-      break;
-
-    // Switch to the minimum geometry
-    x+=steps[imin].first*sd;
-    // Store optimal step length
-    steplen=steps[imin].first;
-
-    //printf("Step %i: energy decreased by %e, gradient norm %e\n",(int) iiter+1,steps[imin].second-E,arma::norm(g,2)); fflush(stdout);
+    if (steps[imin].first < DBL_EPSILON) break;
+    x += steps[imin].first * sd;
+    steplen = steps[imin].first;
   }
 
-  // Calculate weights
   return compute_c(x);
 }
 
-double DIIS::get_E_adiis(const arma::vec & x) const {
-  // Consistency check
-  if(x.n_elem != PiF.n_elem) {
+double DIIS::get_E_adiis(const helfem::Vector & x) const {
+  if (x.size() != PiF.size())
     throw std::domain_error("Incorrect number of parameters.\n");
-  }
-
-  arma::vec c(compute_c(x));
-
-  // Compute energy
-  double Eval=0.0;
-  Eval+=2.0*arma::dot(c,PiF);
-  Eval+=arma::as_scalar(arma::trans(c)*PiFj*c);
-
-  return Eval;
+  const helfem::Vector c = compute_c(x);
+  return 2.0 * c.dot(PiF) + (c.transpose() * PiFj * c)(0);
 }
 
-arma::vec DIIS::get_dEdx_adiis(const arma::vec & x) const {
-  // Compute contraction coefficients
-  arma::vec c(compute_c(x));
+helfem::Vector DIIS::get_dEdx_adiis(const helfem::Vector & x) const {
+  const helfem::Vector c = compute_c(x);
+  const helfem::Vector dEdc = 2.0 * PiF + PiFj * c + PiFj.transpose() * c;
 
-  // Compute derivative of energy
-  arma::vec dEdc=2.0*PiF + PiFj*c + arma::trans(PiFj)*c;
-
-  // Compute jacobian of transformation: jac(i,j) = dc_i / dx_j
-  arma::mat jac(compute_jac(x));
-
-  // Finally, compute dEdx by plugging in Jacobian of transformation
-  // dE/dx_i = dc_j/dx_i dE/dc_j
-  return arma::trans(jac)*dEdc;
+  // Jacobian jac(i, j) = dc_i / dx_j, then dEdx = jac^T dEdc.
+  const double xnorm = x.dot(x);
+  helfem::Matrix jac(c.size(), c.size());
+  for (Eigen::Index i = 0; i < c.size(); ++i) {
+    for (Eigen::Index j = 0; j < c.size(); ++j)
+      jac(i, j) = -c(i) * 2.0 * x(j) / xnorm;
+    jac(i, i) += 2.0 * x(i) / xnorm;
+  }
+  return jac.transpose() * dEdc;
 }

--- a/src/general/diis.h
+++ b/src/general/diis.h
@@ -17,37 +17,30 @@
 #ifndef ERKALE_DIIS
 #define ERKALE_DIIS
 
+// Phase 5.17: internal state migrated to Eigen. Public API (constructors,
+// update, solve_F, solve_P) still takes arma::mat & for compat with
+// SCF drivers; bridging happens at the class boundary.
 #include <armadillo>
+#include <Matrix.h>
 #include <vector>
 
 /// Spin-polarized entry
 typedef struct {
-  /// Alpha density matrix
-  arma::mat Pa;
-  /// Alpha Fock matrix
-  arma::mat Fa;
-  /// Beta density matrix
-  arma::mat Pb;
-  /// Beta Fock matrix
-  arma::mat Fb;
-  /// Energy
+  helfem::Matrix Pa;
+  helfem::Matrix Fa;
+  helfem::Matrix Pb;
+  helfem::Matrix Fb;
   double E;
-
-  /// DIIS error matrix
-  arma::vec err;
+  /// DIIS error vector (vectorised error matrix)
+  helfem::Vector err;
 } diis_pol_entry_t;
 
 /// Spin-unpolarized entry
 typedef struct {
-  /// Density matrix
-  arma::mat P;
-  /// Fock matrix
-  arma::mat F;
-  /// Energy
+  helfem::Matrix P;
+  helfem::Matrix F;
   double E;
-
-  /// DIIS error matrix
-  arma::vec err;
+  helfem::Vector err;
 } diis_unpol_entry_t;
 
 /// Helper for sort
@@ -100,133 +93,79 @@ bool operator<(const diis_unpol_entry_t & lhs, const diis_unpol_entry_t & rhs);
 
 class DIIS {
  protected:
-  /// Overlap matrix
-  arma::mat S;
-  /// Half-inverse overlap matrix
-  arma::mat Sinvh;
+  helfem::Matrix S;
+  helfem::Matrix Sinvh;
 
-  /// Use DIIS?
   bool usediis;
-  /// Use ADIIS?
   bool useadiis;
-  /// Verbose operation?
   bool verbose;
 
-  /// When to start using DIIS weights
   double diiseps;
-  /// When to start using DIIS exclusively
   double diisthr;
-  /// Counter for not using DIIS
   int cooloff;
 
-  /// Maximum amount of matrices to store
   size_t imax;
-  /// Get energies
-  virtual arma::vec get_energies() const=0;
-  /// Get errors
-  virtual arma::mat get_diis_error() const=0;
-  /// Reduce size of stack by one
-  virtual void erase_last()=0;
+  virtual helfem::Vector get_energies() const = 0;
+  virtual helfem::Matrix get_diis_error() const = 0;
+  virtual void erase_last() = 0;
 
-  // Helpers for speeding up ADIIS evaluation
-  /// < P_i - P_n | F(D_n) >   or   < Pa_i - Pa_n | Fa(P_n) > + < Pb_i - Pb_n | Fb(P_n) >
-  arma::vec PiF;
-  /// < P_i - P_n | F(D_j) - F(D_n) >   or    < Pa_i - Pa_n | Fa(P_j) - Fa(P_n) > + < Pb_i - Pb_n | Fb(P_j) - Fb(P_n) >
-  arma::mat PiFj;
+  helfem::Vector PiF;
+  helfem::Matrix PiFj;
 
-  /// Compute weights
-  arma::vec get_w();
-  /// Compute DIIS weights
-  arma::vec get_w_diis() const;
-  /// Compute DIIS weights, worker routine
-  arma::vec get_w_diis_wrk(const arma::mat & err) const;
-  /// Compute ADIIS weights
-  arma::vec get_w_adiis() const;
-
-  /// Solve coefficients
-  arma::vec get_c_adiis(bool verbose=false) const;
+  helfem::Vector get_w();
+  helfem::Vector get_w_diis() const;
+  helfem::Vector get_w_diis_wrk(const helfem::Matrix & err) const;
+  helfem::Vector get_w_adiis() const;
 
  public:
-  /// Constructor
+  // Public API still arma-typed for compat with SCF drivers.
   DIIS(const arma::mat & S, const arma::mat & Sinvh, bool usediis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
-  /// Destructor
   virtual ~DIIS();
 
-  /// Clear Fock matrices and errors
-  virtual void clear()=0;
+  virtual void clear() = 0;
 
-  /// Compute energy with contraction coefficients \f$ c_i = x_i^2 / \left[ \sum_j x_j^2 \right] \f$
-  double get_E_adiis(const arma::vec & x) const;
-  /// Compute derivative of energy wrt contraction coefficients
-  arma::vec get_dEdx_adiis(const arma::vec & x) const;
+  double get_E_adiis(const helfem::Vector & x) const;
+  helfem::Vector get_dEdx_adiis(const helfem::Vector & x) const;
 };
 
 /// Spin-restricted DIIS
 class rDIIS: protected DIIS {
-  /// Fock matrices in AO basis
   std::vector<diis_unpol_entry_t> stack;
 
-  /// Get energies
-  arma::vec get_energies() const;
-  /// Get errors
-  arma::mat get_diis_error() const;
-  /// Reduce size of stack by one
+  helfem::Vector get_energies() const;
+  helfem::Matrix get_diis_error() const;
   void erase_last();
-  /// ADIIS update
   void PiF_update();
 
  public:
-  /// Constructor
   rDIIS(const arma::mat & S, const arma::mat & Sinvh, bool usediis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
-  /// Destructor
   ~rDIIS();
 
-  /// Add matrices to stack
+  // Public API still arma-typed.
   void update(const arma::mat & F, const arma::mat & P, double E, double & error);
-
-  /// Compute new Fock matrix
   void solve_F(arma::mat & F);
-
-  /// Compute new density matrix
   void solve_P(arma::mat & P);
-
-  /// Clear Fock matrices and errors
   void clear();
 };
 
 /// Spin-unrestricted DIIS
 class uDIIS: protected DIIS {
-  /// Fock matrices in AO basis - spin polarized
   std::vector<diis_pol_entry_t> stack;
 
-  /// Get energies
-  arma::vec get_energies() const;
-  /// Get errors
-  arma::mat get_diis_error() const;
-  /// Reduce size of stack by one
+  helfem::Vector get_energies() const;
+  helfem::Matrix get_diis_error() const;
   void erase_last();
-  /// ADIIS update
   void PiF_update();
 
-  /// Combine alpha and beta errors?
   bool combine;
 
  public:
-  /// Constructor
   uDIIS(const arma::mat & S, const arma::mat & Sinvh, bool combine, bool usediis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
-  /// Destructor
   ~uDIIS();
 
-  /// Add matrices to stack
   void update(const arma::mat & Fa, const arma::mat & Fb, const arma::mat & Pa, const arma::mat & Pb, double E, double & error);
-
-  /// Compute new Fock matrix
   void solve_F(arma::mat & Fa, arma::mat & Fb);
-
-  /// Compute new density matrix
   void solve_P(arma::mat & Pa, arma::mat & Pb);
-
-  /// Clear Fock matrices and errors
   void clear();
 };
 

--- a/src/general/lbfgs.cpp
+++ b/src/general/lbfgs.cpp
@@ -15,70 +15,52 @@
  * for the full license text.
  */
 
+// Phase 5.17: LBFGS migrated arma -> Eigen. No external callers
+// outside diis.cpp, so no bridging is needed.
+
 #include "lbfgs.h"
 
-LBFGS::LBFGS(size_t nmax_) : nmax(nmax_) {
-}
+LBFGS::LBFGS(size_t nmax_) : nmax(nmax_) {}
+LBFGS::~LBFGS() {}
 
-LBFGS::~LBFGS() {
-}
-
-void LBFGS::update(const arma::vec & x, const arma::vec & g) {
+void LBFGS::update(const helfem::Vector & x, const helfem::Vector & g) {
   xk.push_back(x);
   gk.push_back(g);
-
-  if(xk.size()>nmax) {
+  if (xk.size() > nmax) {
     xk.erase(xk.begin());
     gk.erase(gk.begin());
   }
 }
 
-arma::vec LBFGS::apply_diagonal_hessian(const arma::vec & q) const {
-  if(xk.size()>=2) {
-    arma::vec s=xk[xk.size()-1]-xk[xk.size()-2];
-    arma::vec y=gk[gk.size()-1]-gk[gk.size()-2];
-
-    return arma::dot(s,y)/arma::dot(y,y)*q;
-
-  } else
-    // Unit diagonal Hessian
-    return q;
+helfem::Vector LBFGS::apply_diagonal_hessian(const helfem::Vector & q) const {
+  if (xk.size() >= 2) {
+    const helfem::Vector s = xk.back() - xk[xk.size() - 2];
+    const helfem::Vector y = gk.back() - gk[gk.size() - 2];
+    return (s.dot(y) / y.dot(y)) * q;
+  }
+  return q;
 }
 
-arma::vec LBFGS::solve() const {
-  // Algorithm 9.1 in Nocedal's book
-  size_t k=gk.size()-1;
-  arma::vec q(gk[k]);
+helfem::Vector LBFGS::solve() const {
+  // Algorithm 9.1 in Nocedal.
+  const size_t k = gk.size() - 1;
+  helfem::Vector q = gk[k];
 
-  std::vector<arma::vec> sk(k);
-  for(size_t i=0;i<k;i++)
-    sk[i]=xk[i+1]-xk[i];
-  std::vector<arma::vec> yk(k);
-  for(size_t i=0;i<k;i++)
-    yk[i]=gk[i+1]-gk[i];
+  std::vector<helfem::Vector> sk(k), yk(k);
+  for (size_t i = 0; i < k; ++i) sk[i] = xk[i + 1] - xk[i];
+  for (size_t i = 0; i < k; ++i) yk[i] = gk[i + 1] - gk[i];
 
-  // Alpha_i
   std::vector<double> alphai(k);
-
-  // First part
-  for(size_t i=k-1;i<k;i--) {
-    // Alpha_i
-    alphai[i]=arma::dot(sk[i],q)/arma::dot(yk[i],sk[i]);
-    // Update q
-    q-=alphai[i]*yk[i];
+  for (size_t i = k - 1; i < k; --i) {  // relies on size_t wraparound
+    alphai[i] = sk[i].dot(q) / yk[i].dot(sk[i]);
+    q -= alphai[i] * yk[i];
   }
 
-  // Apply diagonal Hessian
-  arma::vec r(apply_diagonal_hessian(q));
-
-  // Second part
-  for(size_t i=0;i<k;i++) {
-    // Beta
-    double beta=arma::dot(yk[i],r)/arma::dot(yk[i],sk[i]);
-    // Update r
-    r+=sk[i]*(alphai[i]-beta);
+  helfem::Vector r = apply_diagonal_hessian(q);
+  for (size_t i = 0; i < k; ++i) {
+    const double beta = yk[i].dot(r) / yk[i].dot(sk[i]);
+    r += sk[i] * (alphai[i] - beta);
   }
-
   return r;
 }
 
@@ -86,5 +68,3 @@ void LBFGS::clear() {
   xk.clear();
   gk.clear();
 }
-
-

--- a/src/general/lbfgs.h
+++ b/src/general/lbfgs.h
@@ -18,7 +18,9 @@
 #ifndef ERKALE_LBFGS
 #define ERKALE_LBFGS
 
-#include <armadillo>
+// Phase 5.17: LBFGS migrated to Eigen.
+#include <Matrix.h>
+#include <vector>
 
 class LBFGS {
  protected:
@@ -26,12 +28,12 @@ class LBFGS {
   size_t nmax;
 
   /// Coordinates x_k
-  std::vector<arma::vec> xk;
+  std::vector<helfem::Vector> xk;
   /// Gradients g_k
-  std::vector<arma::vec> gk;
+  std::vector<helfem::Vector> gk;
 
   /// Apply diagonal Hessian: r = H_0 q
-  virtual arma::vec apply_diagonal_hessian(const arma::vec & q) const;
+  virtual helfem::Vector apply_diagonal_hessian(const helfem::Vector & q) const;
 
  public:
   /// Constructor
@@ -40,9 +42,9 @@ class LBFGS {
   virtual ~LBFGS();
 
   /// Update
-  void update(const arma::vec & x, const arma::vec & g);
+  void update(const helfem::Vector & x, const helfem::Vector & g);
   /// Solve for new search direction
-  arma::vec solve() const;
+  helfem::Vector solve() const;
   /// Clear stack
   void clear();
 };


### PR DESCRIPTION
## Summary

Migrates the DIIS/ADIIS convergence accelerator and its LBFGS line-search helper. Internal state and math are Eigen; the DIIS class public API (constructors, \`update\`, \`solve_F\`, \`solve_P\`) stays \`arma::mat &\` for compat with the SCF drivers, bridging at the class boundary.

**LBFGS** (\`src/general/lbfgs.{h,cpp}\`): no external callers outside \`diis.cpp\`, so migrated fully — signatures too. Public API now takes \`helfem::Vector\`.

**DIIS** (\`src/general/diis.{h,cpp}\`) fully migrated internally:
- Member state: \`S\`, \`Sinvh\`, \`PiF\`, \`PiFj\` → \`helfem::Matrix\` / \`Vector\`
- \`diis_pol_entry_t\`, \`diis_unpol_entry_t\`: \`Pa\`, \`Fa\`, \`Pb\`, \`Fb\`, \`err\` now \`helfem::Matrix\` / \`Vector\`
- All internal helpers (\`get_energies\`, \`get_diis_error\`, \`get_w\`, \`get_w_diis*\`, \`get_w_adiis\`, \`get_E_adiis\`, \`get_dEdx_adiis\`, \`PiF_update\`) → Eigen
- Constructor takes \`arma::mat const&\`, converts once via \`helfem::to_eigen\`
- \`update(const arma::mat & F, ...)\` bridges \`F\`, \`P\` and stores \`helfem::Matrix\` in the stack
- \`solve_F\` / \`solve_P\` assemble in Eigen and bridge via \`helfem::to_arma\` at the boundary

## Implementation notes

| arma idiom | Eigen replacement |
|---|---|
| \`F * P * S; errmat -= errmat.t()\` | \`errmat -= errmat.transpose().eval()\` (alias break) |
| \`arma::vectorise(errmat)\` | column-major memcpy into Vector (new \`vectorise()\` helper) |
| \`errmat.max(max(abs(...)))\` | \`errmat.cwiseAbs().maxCoeff()\` |
| \`arma::trace(A*B)\` | \`(A*B).trace()\` |
| \`arma::svd(U, sval, V, B, \"std\")\` | \`Eigen::JacobiSVD\` (\`ComputeThinU/V\`) |
| \`arma::solve(b, A, y)\` | \`Eigen::ColPivHouseholderQR\`.\`solve(y)\`; \`qr.info()\` gate |
| \`arma::dot(x, y)\` | \`x.dot(y)\` |
| \`x % x / dot(x, x)\` | \`x.array().square().matrix() / x.dot(x)\` |
| \`arma::as_scalar(c^T PiFj c)\` | \`(c.transpose() * PiFj * c)(0)\` |
| \`v.t().print()\` (verbose logs) | \`std::cout << v.transpose()\` |

LBFGS: Nocedal Algorithm 9.1 rewritten in Eigen using \`dot()\` inner products and \`+=\`/\`-=\`; identical control flow.

## Caller bridges

None outside the DIIS class boundary. The DIIS public API is unchanged for the SCF drivers (\`atomic/main\`, \`diatomic/main\`, \`sadatom/solver\`); each call site continues to pass \`arma::mat\`.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (vs prior −14.5728772811244909; ~1e-13 drift from \`JacobiSVD\` vs \`arma::svd\` summation — well below SCF threshold)

## Status (Layer L0)

- [x] \`utils::invh\`, \`scf::form_density\`, \`scf::form_Sinvh\` — PR #126
- [x] \`scf::eig_gsym\` — PR #127
- [x] \`scf::eig_gsym_sub\`, \`eig_sym_sub\` — PR #128
- [x] \`scf::enforce_occupations\`, \`enforce_fock_symmetry\`, \`fock_symmetry_average\` — PR #129
- [x] \`scf::eig_sub_wrk\`, \`sort_eig\`, \`eig_sub\`, \`eig_iter\` — PR #130
- [x] \`scf::perturbation_matrix\`, \`parse_xc_params\` — PR #131
- [x] \`scf::form_NOs\`, \`ROHF_update\` — PR #132
- [x] **\`src/general/lbfgs.cpp\` + \`diis.cpp\` (internals)** — this PR
- [ ] \`src/general/lcao.cpp\`

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic preserves to 13 sig digits