### PR TITLE
v2: Eigen Phase 5.18 -- src/general/lcao arma -> Eigen (final L0 file)

### DIFF
--- a/src/general/lcao.cpp
+++ b/src/general/lcao.cpp
@@ -35,11 +35,11 @@ namespace helfem {
       return std::pow(2,l+2) * std::pow(alpha,(2*l+3)/4.0) * std::pow(r,l) * exp(-alpha*r*r) / ( std::pow(2.0*M_PI,0.25) * sqrt(double_factorial(2*l+1)));
     }
 
-    arma::mat radial_GTO(const arma::vec & r, int l, const arma::vec & alpha) {
-      arma::mat gto(r.n_elem, alpha.n_elem);
-      for(size_t j=0;j<alpha.n_elem;j++)
-        for(size_t i=0;i<r.n_elem;i++)
-          gto(i,j)=radial_GTO(r(i),l,alpha(j));
+    helfem::Matrix radial_GTO(const helfem::Vector & r, int l, const helfem::Vector & alpha) {
+      helfem::Matrix gto(r.size(), alpha.size());
+      for (Eigen::Index j = 0; j < alpha.size(); ++j)
+        for (Eigen::Index i = 0; i < r.size(); ++i)
+          gto(i, j) = radial_GTO(r(i), l, alpha(j));
       return gto;
     }
 
@@ -48,11 +48,11 @@ namespace helfem {
       return std::pow(2*zeta,l+1.5)/sqrt(factorial(2*l+2)) * std::pow(r,l) * exp(-zeta*r);
     }
 
-    arma::mat radial_STO(const arma::vec & r, int l, const arma::vec & alpha) {
-      arma::mat gto(r.n_elem, alpha.n_elem);
-      for(size_t j=0;j<alpha.n_elem;j++)
-        for(size_t i=0;i<r.n_elem;i++)
-          gto(i,j)=radial_STO(r(i),l,alpha(j));
+    helfem::Matrix radial_STO(const helfem::Vector & r, int l, const helfem::Vector & alpha) {
+      helfem::Matrix gto(r.size(), alpha.size());
+      for (Eigen::Index j = 0; j < alpha.size(); ++j)
+        for (Eigen::Index i = 0; i < r.size(); ++i)
+          gto(i, j) = radial_STO(r(i), l, alpha(j));
       return gto;
     }
   }

--- a/src/general/lcao.h
+++ b/src/general/lcao.h
@@ -15,18 +15,20 @@
 #ifndef LCAO_H
 #define LCAO_H
 
-#include <armadillo>
+// Phase 5.18: lcao migrated arma -> Eigen. The vector overloads have
+// no in-tree callers; all callers use the scalar overloads.
+#include <Matrix.h>
 
 namespace helfem {
   namespace lcao {
-    /// Evaluate radial GTO
+    /// Evaluate radial GTO (scalar)
     double radial_GTO(double r, int l, double alpha);
-    /// Evaluate radial GTO
-    arma::mat radial_GTO(const arma::vec & r, int l, const arma::vec & alpha);
-    /// Evaluate radial STO
+    /// Evaluate radial GTO (vectorised over r and alpha)
+    helfem::Matrix radial_GTO(const helfem::Vector & r, int l, const helfem::Vector & alpha);
+    /// Evaluate radial STO (scalar)
     double radial_STO(double r, int l, double zeta);
-    /// Evaluate radial STO
-    arma::mat radial_STO(const arma::vec & r, int l, const arma::vec & zeta);
+    /// Evaluate radial STO (vectorised over r and zeta)
+    helfem::Matrix radial_STO(const helfem::Vector & r, int l, const helfem::Vector & zeta);
   }
 }
 


### PR DESCRIPTION
## Summary

Migrates \`helfem::lcao::radial_GTO\` and \`radial_STO\` to Eigen. Scalar overloads keep double signatures; the vectorised overloads now take/return \`helfem::Vector\` / \`helfem::Matrix\`.

\`\`\`cpp
double lcao::radial_GTO(double r, int l, double alpha);
helfem::Matrix lcao::radial_GTO(const helfem::Vector & r, int l,
                                const helfem::Vector & alpha);
double lcao::radial_STO(double r, int l, double zeta);
helfem::Matrix lcao::radial_STO(const helfem::Vector & r, int l,
                                const helfem::Vector & zeta);
\`\`\`

## Implementation

| arma idiom | Eigen replacement |
|---|---|
| \`arma::mat gto(r.n_elem, alpha.n_elem)\` | \`helfem::Matrix gto(r.size(), alpha.size())\` |
| \`size_t\` index loops | \`Eigen::Index\` loops |

\`double_factorial\` / \`factorial\` helpers unchanged (pure math).

## Caller bridges

None. All 6 in-tree callers (\`src/diatomic/twodquadrature.cpp\`, \`src/sadatom/solver.cpp\`) call the scalar \`(double, int, double)\` overloads, which are unchanged. The vectorised arma overloads had no in-tree callers.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (bit-identical to 5.17 baseline)

## Layer L0 (SCF utilities) is now COMPLETE

- [x] \`utils::invh\`, \`scf::form_density\`, \`scf::form_Sinvh\` — PR #126
- [x] \`scf::eig_gsym\` — PR #127
- [x] \`scf::eig_gsym_sub\`, \`eig_sym_sub\` — PR #128
- [x] \`scf::enforce_occupations\`, \`enforce_fock_symmetry\`, \`fock_symmetry_average\` — PR #129
- [x] \`scf::eig_sub_wrk\`, \`sort_eig\`, \`eig_sub\`, \`eig_iter\` — PR #130
- [x] \`scf::perturbation_matrix\`, \`parse_xc_params\` — PR #131
- [x] \`scf::form_NOs\`, \`ROHF_update\` — PR #132
- [x] \`src/general/lbfgs.cpp\` + \`diis.cpp\` internals — PR #133
- [x] **\`src/general/lcao.cpp\`** — this PR

## Next layers of the full arma removal arc

- [ ] L1: DFT grid integration (\`atomic\`/\`sadatom\`/\`diatomic\` \`dftgrid.cpp\`)
- [ ] L2: TwoDBasis internals (atomic + sadatom)
- [ ] L3: Diatomic basis internals + twodquadrature
- [ ] L4: SCF drivers (\`main.cpp\` ×3, \`sadatom/solver.cpp\`)
- [ ] L5: I/O (\`checkpoint.cpp\` HDF5 binding)
- [ ] L6: libhelfem leaves (\`get_bf\`/\`df\`/\`lf\` etc.)
- [ ] L7: cleanup — remove armadillo dependency

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR