### PR TITLE
DRY: extract DFTGridWorker XC plumbing to helfem::dftgrid_common::DFTGridWorkerBase

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ general/gaunt.cpp general/diis.cpp
 general/lbfgs.cpp general/spherical_harmonics.cpp
 general/timer.cpp general/elements.cpp
 general/angular.cpp general/scf_helpers.cpp general/lcao.cpp
+general/dftgrid_common.cpp
 general/gsz.cpp general/sap.cpp general/dftfuncs.cpp
 general/checkpoint.cpp atomic/basis.cpp
 atomic/TwoDBasis.cpp

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -273,43 +273,8 @@ namespace helfem {
         return ekin;
       }
 
-      void DFTGridWorker::init_xc() {
-        // Size of grid.
-        const size_t N=wtot.n_elem;
-
-        // Zero energy
-        zero_Exc();
-
-        if(!polarized) {
-          // Restricted case
-          vxc.zeros(1,N);
-          if(do_grad)
-            vsigma.zeros(1,N);
-          if(do_tau)
-            vtau.zeros(1,N);
-          if(do_lapl)
-            vlapl.zeros(1,N);
-        } else {
-          // Unrestricted case
-          vxc.zeros(2,N);
-          if(do_grad)
-            vsigma.zeros(3,N);
-          if(do_tau)
-            vtau.zeros(2,N);
-          if(do_lapl) {
-            vlapl.zeros(2,N);
-          }
-        }
-
-        // Initial values
-        do_gga=false;
-        do_mgga_l=false;
-        do_mgga_t=false;
-      }
-
-      void DFTGridWorker::zero_Exc() {
-        exc.zeros(wtot.n_elem);
-      }
+      // init_xc, zero_Exc: inherited from
+      // helfem::dftgrid_common::DFTGridWorkerBase.
 
       void DFTGridWorker::check_xc() {
         size_t inf=0;
@@ -374,130 +339,8 @@ namespace helfem {
         }
       }
 
-      void DFTGridWorker::compute_xc(int func_id, const arma::vec & p, double thr, bool pot) {
-        // Compute exchange-correlation functional
-
-        // Which functional is in question?
-        bool gga, mgga_t, mgga_l;
-        is_gga_mgga(func_id,gga,mgga_t,mgga_l);
-
-        // Update controlling flags for eval_Fxc (exchange and correlation
-        // parts might be of different type)
-        do_gga=do_gga || gga || mgga_t || mgga_l;
-        do_mgga_t=do_mgga_t || mgga_t;
-        do_mgga_l=do_mgga_l || mgga_l;
-
-        // Amount of grid points
-        const size_t N=wtot.n_elem;
-
-        // Work arrays - exchange and correlation are computed separately
-        arma::rowvec exc_wrk;
-        arma::mat vxc_wrk;
-        arma::mat vsigma_wrk;
-        arma::mat vlapl_wrk;
-        arma::mat vtau_wrk;
-
-        if(has_exc(func_id))
-          exc_wrk.zeros(exc.n_elem);
-        if(pot) {
-          vxc_wrk.zeros(vxc.n_rows,vxc.n_cols);
-          if(gga || mgga_t || mgga_l)
-            vsigma_wrk.zeros(vsigma.n_rows,vsigma.n_cols);
-          if(mgga_t)
-            vtau_wrk.zeros(vtau.n_rows,vtau.n_cols);
-          if(mgga_l)
-            vlapl_wrk.zeros(vlapl.n_rows,vlapl.n_cols);
-        }
-
-        // Spin variable for libxc
-        int nspin;
-        if(!polarized)
-          nspin=XC_UNPOLARIZED;
-        else
-          nspin=XC_POLARIZED;
-
-        // Initialize libxc worker
-        xc_func_type func;
-        if(xc_func_init(&func, func_id, nspin) != 0) {
-          std::ostringstream oss;
-          oss << "Functional "<<func_id<<" not found!";
-          throw std::runtime_error(oss.str());
-        }
-        // Set density threshold
-        xc_func_set_dens_threshold(&func, thr);
-
-        // Set parameters
-        if(p.n_elem) {
-          // Check sanity
-          if(p.n_elem != (arma::uword) xc_func_info_get_n_ext_params((xc_func_info_type *)func.info))
-            throw std::logic_error("Incompatible number of parameters!\n");
-          arma::vec phlp(p);
-          xc_func_set_ext_params(&func, phlp.memptr());
-        }
-
-        // Evaluate functionals.
-        if(has_exc(func_id)) {
-          if(pot) {
-            if(mgga_t || mgga_l) {// meta-GGA
-              double * laplp = mgga_l ? lapl.memptr() : NULL;
-              double * taup = mgga_t ? tau.memptr() : NULL;
-              double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
-              double * vtaup = mgga_t ? vtau_wrk.memptr() : NULL;
-              xc_mgga_exc_vxc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, exc_wrk.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr(), vlaplp, vtaup);
-            } else if(gga) // GGA
-              xc_gga_exc_vxc(&func, N, rho.memptr(), sigma.memptr(), exc_wrk.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr());
-            else // LDA
-              xc_lda_exc_vxc(&func, N, rho.memptr(), exc_wrk.memptr(), vxc_wrk.memptr());
-          } else {
-            if(mgga_t || mgga_l) { // meta-GGA
-              double * laplp = mgga_l ? lapl.memptr() : NULL;
-              double * taup = mgga_t ? tau.memptr() : NULL;
-              xc_mgga_exc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, exc_wrk.memptr());
-            } else if(gga) // GGA
-              xc_gga_exc(&func, N, rho.memptr(), sigma.memptr(), exc_wrk.memptr());
-            else // LDA
-              xc_lda_exc(&func, N, rho.memptr(), exc_wrk.memptr());
-          }
-
-        } else {
-          if(pot) {
-            if(mgga_t || mgga_l) { // meta-GGA
-              double * laplp = mgga_l ? lapl.memptr() : NULL;
-              double * taup = mgga_t ? tau.memptr() : NULL;
-              double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
-              double * vtaup = mgga_t ? vtau_wrk.memptr() : NULL;
-              xc_mgga_vxc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, vxc_wrk.memptr(), vsigma_wrk.memptr(), vlaplp, vtaup);
-            } else if(gga) // GGA
-              xc_gga_vxc(&func, N, rho.memptr(), sigma.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr());
-            else // LDA
-              xc_lda_vxc(&func, N, rho.memptr(), vxc_wrk.memptr());
-          }
-        }
-
-        // Sum to total arrays containing both exchange and correlation
-        if(has_exc(func_id))
-          exc+=exc_wrk;
-        if(pot) {
-          if(mgga_l)
-            vlapl+=vlapl_wrk;
-          if(mgga_t)
-            vtau+=vtau_wrk;
-          if(mgga_t || mgga_l || gga)
-            vsigma+=vsigma_wrk;
-          vxc+=vxc_wrk;
-        }
-
-        // Free functional
-        xc_func_end(&func);
-      }
-
-      double DFTGridWorker::eval_Exc() const {
-        arma::rowvec dens(rho.row(0));
-        if(polarized)
-          dens+=rho.row(1);
-
-        return arma::sum(wtot%exc%dens);
-      }
+      // compute_xc, eval_Exc: inherited from
+      // helfem::dftgrid_common::DFTGridWorkerBase.
 
       void DFTGridWorker::eval_overlap(arma::mat & So) const {
         // Calculate in subspace
@@ -671,40 +514,8 @@ namespace helfem {
           Hbo(bf_ind,bf_ind)+=Hb;
       }
 
-      void DFTGridWorker::check_grad_tau_lapl(int x_func, int c_func) {
-        // Do we need gradients?
-        do_grad=false;
-        if(x_func>0)
-          do_grad=do_grad || gradient_needed(x_func);
-        if(c_func>0)
-          do_grad=do_grad || gradient_needed(c_func);
-
-        // Do we need laplacians?
-        do_tau=false;
-        if(x_func>0)
-          do_tau=do_tau || tau_needed(x_func);
-        if(c_func>0)
-          do_tau=do_tau || tau_needed(c_func);
-
-        // Do we need laplacians?
-        do_lapl=false;
-        if(x_func>0)
-          do_lapl=do_lapl || laplacian_needed(x_func);
-        if(c_func>0)
-          do_lapl=do_lapl || laplacian_needed(c_func);
-      }
-
-      void DFTGridWorker::get_grad_tau_lapl(bool & grad_, bool & tau_, bool & lap_) const {
-        grad_=do_grad;
-        tau_=do_tau;
-        lap_=do_lapl;
-      }
-
-      void DFTGridWorker::set_grad_tau_lapl(bool grad_, bool tau_, bool lap_) {
-        do_grad=grad_;
-        do_tau=tau_;
-        do_lapl=lap_;
-      }
+      // check_grad_tau_lapl, get_grad_tau_lapl, set_grad_tau_lapl:
+      // inherited from helfem::dftgrid_common::DFTGridWorkerBase.
 
       void DFTGridWorker::compute_bf(size_t iel) {
         // Update function list

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -17,21 +17,24 @@
 #define ATOMIC_DFTGRID_H
 
 #include "basis.h"
+#include "../general/dftgrid_common.h"
 
 namespace helfem {
   namespace atomic {
     namespace dftgrid {
 
-      /// Worker class
-      class DFTGridWorker {
+      /// Worker class. Shares XC plumbing (init_xc, compute_xc,
+      /// check_grad_tau_lapl, eval_Exc, zero_Exc, grad/tau/lapl flag
+      /// storage, and the LDA/GGA/mGGA buffers rho/exc/vxc/sigma/etc.)
+      /// with the sadatom and diatomic variants via
+      /// helfem::dftgrid_common::DFTGridWorkerBase.
+      class DFTGridWorker : public helfem::dftgrid_common::DFTGridWorkerBase {
       protected:
         /// Basis set
         const helfem::atomic::basis::TwoDBasis *basp;
 
         /// Angular grid
         arma::vec cth, phi, wang;
-        /// Total quadrature weight
-        arma::rowvec wtot;
 
         /// Scale factors
         arma::rowvec scale_r, scale_theta, scale_phi;
@@ -59,52 +62,16 @@ namespace helfem {
         arma::cx_mat Pav, Pav_rho, Pav_theta, Pav_phi;
         arma::cx_mat Pbv, Pbv_rho, Pbv_theta, Pbv_phi;
 
-        /// Is gradient needed?
-        bool do_grad;
-        /// Is kinetic energy density needed?
-        bool do_tau;
-        /// Is laplacian needed?
-        bool do_lapl;
-
-        /// Spin-polarized calculation?
-        bool polarized;
-
-        /// GGA functional used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_gga;
-        /// Meta-GGA tau used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_mgga_t;
-        /// Meta-GGA lapl used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_mgga_l;
-
-        // LDA stuff:
-
-        /// Density, Nrho x Npts
-        arma::mat rho;
-        /// Energy density, Npts
-        arma::rowvec exc;
-        /// Functional derivative of energy wrt electron density, Nrho x Npts
-        arma::mat vxc;
-
-        // GGA stuff
-
-        /// Gradient of electron density, (3 x Nrho) x Npts
+        /// Gradient of electron density, (3 x Nrho) x Npts (atomic-only:
+        /// diatomic keeps its own decomposition; sadatom uses cube layout)
         arma::mat grho;
-        /// Dot products of gradient of electron density, N x Npts; N=1 for closed-shell and 3 for open-shell
-        arma::mat sigma;
-        /// Functional derivative of energy wrt gradient of electron density
-        arma::mat vsigma;
 
-        // Meta-GGA stuff
-
-        /// Laplacian of electron density
-        arma::mat lapl;
-        /// Kinetic energy density
-        arma::mat tau;
-
-        /// Functional derivative of energy wrt laplacian of electron density
-        arma::mat vlapl;
-        /// Functional derivative of energy wrt kinetic energy density
-        arma::mat vtau;
+        // The following members are provided by
+        // helfem::dftgrid_common::DFTGridWorkerBase and used by the
+        // shared XC plumbing:
+        //   wtot, exc, rho, sigma, vxc, vsigma, lapl, tau, vlapl, vtau
+        //   polarized, do_grad, do_tau, do_lapl,
+        //   do_gga, do_mgga_t, do_mgga_l
 
       public:
         /// Dummy constructor
@@ -114,12 +81,8 @@ namespace helfem {
         /// Destructor
         ~DFTGridWorker();
 
-        /// Check necessity of computing gradient and laplacians, necessary for compute_bf!
-        void check_grad_tau_lapl(int x_func, int c_func);
-        /// Get necessity of computing gradient and laplacians
-        void get_grad_tau_lapl(bool & grad, bool & tau, bool & lapl) const;
-        /// Set necessity of computing gradient and laplacians, necessary for compute_bf!
-        void set_grad_tau_lapl(bool grad, bool tau, bool lapl);
+        // check_grad_tau_lapl / get_grad_tau_lapl / set_grad_tau_lapl
+        // are inherited from DFTGridWorkerBase.
 
         /// Compute basis functions on grid points
         void compute_bf(size_t iel);
@@ -138,16 +101,9 @@ namespace helfem {
         /// Compute kinetic energy
         double compute_Ekin() const;
 
-        /// Initialize XC arrays
-        void init_xc();
-        /// Compute XC functional from density and add to total XC
-        /// array. thr is density screening value. Pot toggles
-        /// evaluation of potential
-        void compute_xc(int func_id, const arma::vec & params, double thr, bool pot=true);
-        /// Evaluate exchange/correlation energy
-        double eval_Exc() const;
-        /// Zero out energy
-        void zero_Exc();
+        // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
+        // from DFTGridWorkerBase.
+
         /// Numerical clean up of xc
         void check_xc();
 

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -238,43 +238,8 @@ namespace helfem {
         return ekin;
       }
 
-      void DFTGridWorker::init_xc() {
-        // Size of grid.
-        const size_t N=wtot.n_elem;
-
-        // Zero energy
-        zero_Exc();
-
-        if(!polarized) {
-          // Restricted case
-          vxc.zeros(1,N);
-          if(do_grad)
-            vsigma.zeros(1,N);
-          if(do_tau)
-            vtau.zeros(1,N);
-          if(do_lapl)
-            vlapl.zeros(1,N);
-        } else {
-          // Unrestricted case
-          vxc.zeros(2,N);
-          if(do_grad)
-            vsigma.zeros(3,N);
-          if(do_tau)
-            vtau.zeros(2,N);
-          if(do_lapl) {
-            vlapl.zeros(2,N);
-          }
-        }
-
-        // Initial values
-        do_gga=false;
-        do_mgga_l=false;
-        do_mgga_t=false;
-      }
-
-      void DFTGridWorker::zero_Exc() {
-        exc.zeros(wtot.n_elem);
-      }
+      // init_xc, zero_Exc: inherited from
+      // helfem::dftgrid_common::DFTGridWorkerBase.
 
       void DFTGridWorker::check_xc() {
         size_t inf=0;
@@ -339,122 +304,7 @@ namespace helfem {
         }
       }
 
-      void DFTGridWorker::compute_xc(int func_id, const arma::vec & p, double thr, bool pot) {
-        // Compute exchange-correlation functional
-
-        // Which functional is in question?
-        bool gga, mgga_t, mgga_l;
-        is_gga_mgga(func_id,gga,mgga_t,mgga_l);
-
-        // Update controlling flags for eval_Fxc (exchange and correlation
-        // parts might be of different type)
-        do_gga=do_gga || gga || mgga_t || mgga_l;
-        do_mgga_t=do_mgga_t || mgga_t;
-        do_mgga_l=do_mgga_l || mgga_l;
-
-        // Amount of grid points
-        const size_t N=wtot.n_elem;
-
-        // Work arrays - exchange and correlation are computed separately
-        arma::rowvec exc_wrk;
-        arma::mat vxc_wrk;
-        arma::mat vsigma_wrk;
-        arma::mat vlapl_wrk;
-        arma::mat vtau_wrk;
-
-        if(has_exc(func_id))
-          exc_wrk.zeros(exc.n_elem);
-        if(pot) {
-          vxc_wrk.zeros(vxc.n_rows,vxc.n_cols);
-          if(gga || mgga_t || mgga_l)
-            vsigma_wrk.zeros(vsigma.n_rows,vsigma.n_cols);
-          if(mgga_t)
-            vtau_wrk.zeros(vtau.n_rows,vtau.n_cols);
-          if(mgga_l)
-            vlapl_wrk.zeros(vlapl.n_rows,vlapl.n_cols);
-        }
-
-        // Spin variable for libxc
-        int nspin;
-        if(!polarized)
-          nspin=XC_UNPOLARIZED;
-        else
-          nspin=XC_POLARIZED;
-
-        // Initialize libxc worker
-        xc_func_type func;
-        if(xc_func_init(&func, func_id, nspin) != 0) {
-          std::ostringstream oss;
-          oss << "Functional "<<func_id<<" not found!";
-          throw std::runtime_error(oss.str());
-        }
-        // Set density threshold
-        xc_func_set_dens_threshold(&func, thr);
-
-        // Set parameters
-        if(p.n_elem) {
-          // Check sanity
-          if(p.n_elem != (arma::uword) xc_func_info_get_n_ext_params((xc_func_info_type *)func.info))
-            throw std::logic_error("Incompatible number of parameters!\n");
-          arma::vec phlp(p);
-          xc_func_set_ext_params(&func, phlp.memptr());
-        }
-
-        // Evaluate functionals.
-        if(has_exc(func_id)) {
-          if(pot) {
-            if(mgga_t || mgga_l) {// meta-GGA
-              double * laplp = mgga_l ? lapl.memptr() : NULL;
-              double * taup = mgga_t ? tau.memptr() : NULL;
-              double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
-              double * vtaup = mgga_t ? vtau_wrk.memptr() : NULL;
-              xc_mgga_exc_vxc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, exc_wrk.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr(), vlaplp, vtaup);
-            } else if(gga) // GGA
-              xc_gga_exc_vxc(&func, N, rho.memptr(), sigma.memptr(), exc_wrk.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr());
-            else // LDA
-              xc_lda_exc_vxc(&func, N, rho.memptr(), exc_wrk.memptr(), vxc_wrk.memptr());
-          } else {
-            if(mgga_t || mgga_l) { // meta-GGA
-              double * laplp = mgga_l ? lapl.memptr() : NULL;
-              double * taup = mgga_t ? tau.memptr() : NULL;
-              xc_mgga_exc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, exc_wrk.memptr());
-            } else if(gga) // GGA
-              xc_gga_exc(&func, N, rho.memptr(), sigma.memptr(), exc_wrk.memptr());
-            else // LDA
-              xc_lda_exc(&func, N, rho.memptr(), exc_wrk.memptr());
-          }
-
-        } else {
-          if(pot) {
-            if(mgga_t || mgga_l) { // meta-GGA
-              double * laplp = mgga_l ? lapl.memptr() : NULL;
-              double * taup = mgga_t ? tau.memptr() : NULL;
-              double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
-              double * vtaup = mgga_t ? vtau_wrk.memptr() : NULL;
-              xc_mgga_vxc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, vxc_wrk.memptr(), vsigma_wrk.memptr(), vlaplp, vtaup);
-            } else if(gga) // GGA
-              xc_gga_vxc(&func, N, rho.memptr(), sigma.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr());
-            else // LDA
-              xc_lda_vxc(&func, N, rho.memptr(), vxc_wrk.memptr());
-          }
-        }
-
-        // Free functional
-        xc_func_end(&func);
-
-        // Sum to total arrays containing both exchange and correlation
-        if(has_exc(func_id))
-          exc+=exc_wrk;
-        if(pot) {
-          if(mgga_l)
-            vlapl+=vlapl_wrk;
-          if(mgga_t)
-            vtau+=vtau_wrk;
-          if(mgga_t || mgga_l || gga)
-            vsigma+=vsigma_wrk;
-          vxc+=vxc_wrk;
-        }
-      }
+      // compute_xc: inherited from DFTGridWorkerBase.
 
       void DFTGridWorker::save(const std::string & info) const {
         rho.save("rho"+info+".dat",arma::raw_ascii);
@@ -467,13 +317,7 @@ namespace helfem {
         exc.save("exc"+info+".dat",arma::raw_ascii);
       }
 
-      double DFTGridWorker::eval_Exc() const {
-        arma::rowvec dens(rho.row(0));
-        if(polarized)
-          dens+=rho.row(1);
-
-        return arma::sum(wtot%exc%dens);
-      }
+      // eval_Exc: inherited from DFTGridWorkerBase.
 
       void DFTGridWorker::eval_overlap(arma::mat & So) const {
         // Calculate in subspace
@@ -630,40 +474,8 @@ namespace helfem {
           Hbo(bf_ind,bf_ind)+=Hb;
       }
 
-      void DFTGridWorker::check_grad_tau_lapl(int x_func, int c_func) {
-        // Do we need gradients?
-        do_grad=false;
-        if(x_func>0)
-          do_grad=do_grad || gradient_needed(x_func);
-        if(c_func>0)
-          do_grad=do_grad || gradient_needed(c_func);
-
-        // Do we need laplacians?
-        do_tau=false;
-        if(x_func>0)
-          do_tau=do_tau || tau_needed(x_func);
-        if(c_func>0)
-          do_tau=do_tau || tau_needed(c_func);
-
-        // Do we need laplacians?
-        do_lapl=false;
-        if(x_func>0)
-          do_lapl=do_lapl || laplacian_needed(x_func);
-        if(c_func>0)
-          do_lapl=do_lapl || laplacian_needed(c_func);
-      }
-
-      void DFTGridWorker::get_grad_tau_lapl(bool & grad_, bool & tau_, bool & lap_) const {
-        grad_=do_grad;
-        tau_=do_tau;
-        lap_=do_lapl;
-      }
-
-      void DFTGridWorker::set_grad_tau_lapl(bool grad_, bool tau_, bool lap_) {
-        do_grad=grad_;
-        do_tau=tau_;
-        do_lapl=lap_;
-      }
+      // check_grad_tau_lapl, get_grad_tau_lapl, set_grad_tau_lapl:
+      // inherited from DFTGridWorkerBase.
 
       void DFTGridWorker::compute_bf(size_t iel, size_t irad) {
         // Update function list

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -17,21 +17,21 @@
 #define DFTGRID
 
 #include "basis.h"
+#include "../general/dftgrid_common.h"
 
 namespace helfem {
   namespace diatomic {
     namespace dftgrid {
 
-      /// Worker class
-      class DFTGridWorker {
+      /// Worker class. Shares XC plumbing with the atomic and sadatom
+      /// variants via helfem::dftgrid_common::DFTGridWorkerBase.
+      class DFTGridWorker : public helfem::dftgrid_common::DFTGridWorkerBase {
       protected:
         /// Basis set
         const helfem::diatomic::basis::TwoDBasis *basp;
-      
+
         /// Angular grid
         arma::vec cth, phi, wang;
-        /// Total quadrature weight
-        arma::rowvec wtot;
 
         /// Scale factors
         arma::rowvec scale_r, scale_theta, scale_phi;
@@ -59,52 +59,13 @@ namespace helfem {
         arma::cx_mat Pav, Pav_rho, Pav_theta, Pav_phi;
         arma::cx_mat Pbv, Pbv_rho, Pbv_theta, Pbv_phi;
 
-        /// Is gradient needed?
-        bool do_grad;
-        /// Is kinetic energy density needed?
-        bool do_tau;
-        /// Is laplacian needed?
-        bool do_lapl;
-
-        /// Spin-polarized calculation?
-        bool polarized;
-
-        /// GGA functional used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_gga;
-        /// Meta-GGA tau used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_mgga_t;
-        /// Meta-GGA lapl used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_mgga_l;
-
-        // LDA stuff:
-
-        /// Density, Nrho x Npts
-        arma::mat rho;
-        /// Energy density, Npts
-        arma::rowvec exc;
-        /// Functional derivative of energy wrt electron density, Nrho x Npts
-        arma::mat vxc;
-
-        // GGA stuff
-
-        /// Gradient of electron density, (3 x Nrho) x Npts
+        /// Gradient of electron density
         arma::mat grho;
-        /// Dot products of gradient of electron density, N x Npts; N=1 for closed-shell and 3 for open-shell
-        arma::mat sigma;
-        /// Functional derivative of energy wrt gradient of electron density
-        arma::mat vsigma;
 
-        // Meta-GGA stuff
-
-        /// Laplacian of electron density
-        arma::mat lapl;
-        /// Kinetic energy density
-        arma::mat tau;
-
-        /// Functional derivative of energy wrt laplacian of electron density
-        arma::mat vlapl;
-        /// Functional derivative of energy wrt kinetic energy density
-        arma::mat vtau;
+        // Members provided by helfem::dftgrid_common::DFTGridWorkerBase:
+        //   wtot, exc, rho, sigma, vxc, vsigma, lapl, tau, vlapl, vtau
+        //   polarized, do_grad, do_tau, do_lapl,
+        //   do_gga, do_mgga_t, do_mgga_l
 
       public:
         /// Dummy constructor
@@ -114,12 +75,8 @@ namespace helfem {
         /// Destructor
         ~DFTGridWorker();
 
-        /// Check necessity of computing gradient and laplacians, necessary for compute_bf!
-        void check_grad_tau_lapl(int x_func, int c_func);
-        /// Get necessity of computing gradient and laplacians
-        void get_grad_tau_lapl(bool & grad, bool & tau, bool & lapl) const;
-        /// Set necessity of computing gradient and laplacians, necessary for compute_bf!
-        void set_grad_tau_lapl(bool grad, bool tau, bool lapl);
+        // check_grad_tau_lapl / get_grad_tau_lapl / set_grad_tau_lapl
+        // are inherited from DFTGridWorkerBase.
 
         /// Compute basis functions on grid points
         void compute_bf(size_t iel, size_t irad);
@@ -138,16 +95,9 @@ namespace helfem {
         /// Compute kinetic energy
         double compute_Ekin() const;
 
-        /// Initialize XC arrays
-        void init_xc();
-        /// Compute XC functional from density and add to total XC
-        /// array. thr gives density screening threshold. Pot toggles
-        /// evaluation of potential
-        void compute_xc(int func_id, const arma::vec & params, double thr, bool pot=true);
-        /// Evaluate exchange/correlation energy
-        double eval_Exc() const;
-        /// Zero out energy
-        void zero_Exc();
+        // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
+        // from DFTGridWorkerBase.
+
         /// Numerical clean up of xc
         void check_xc();
 

--- a/src/general/dftgrid_common.cpp
+++ b/src/general/dftgrid_common.cpp
@@ -1,0 +1,255 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+
+// Shared DFT-grid worker plumbing. Extracted from
+// src/atomic/dftgrid.cpp, src/sadatom/dftgrid.cpp,
+// src/diatomic/dftgrid.cpp -- each copy of these methods was
+// byte-identical (init_xc, check_grad_tau_lapl, eval_Exc, zero_Exc)
+// or near-identical (compute_xc; the sadatom version's optional NaN
+// validation guard is preserved as an inline check here so the
+// unified path stays safe for the sadatom callers).
+
+#include "dftgrid_common.h"
+#include "dftfuncs.h"
+#include <cmath>
+#include <cstdio>
+#include <sstream>
+#include <stdexcept>
+extern "C" {
+#include <xc.h>
+}
+
+namespace helfem {
+  namespace dftgrid_common {
+
+    DFTGridWorkerBase::DFTGridWorkerBase() {}
+    DFTGridWorkerBase::~DFTGridWorkerBase() {}
+
+    void DFTGridWorkerBase::check_grad_tau_lapl(int x_func, int c_func) {
+      do_grad = false;
+      if (x_func > 0) do_grad = do_grad || gradient_needed(x_func);
+      if (c_func > 0) do_grad = do_grad || gradient_needed(c_func);
+
+      do_tau = false;
+      if (x_func > 0) do_tau = do_tau || tau_needed(x_func);
+      if (c_func > 0) do_tau = do_tau || tau_needed(c_func);
+
+      do_lapl = false;
+      if (x_func > 0) do_lapl = do_lapl || laplacian_needed(x_func);
+      if (c_func > 0) do_lapl = do_lapl || laplacian_needed(c_func);
+    }
+
+    void DFTGridWorkerBase::get_grad_tau_lapl(bool & grad_, bool & tau_, bool & lap_) const {
+      grad_ = do_grad;
+      tau_  = do_tau;
+      lap_  = do_lapl;
+    }
+
+    void DFTGridWorkerBase::set_grad_tau_lapl(bool grad_, bool tau_, bool lap_) {
+      do_grad = grad_;
+      do_tau  = tau_;
+      do_lapl = lap_;
+    }
+
+    void DFTGridWorkerBase::zero_Exc() {
+      exc.zeros(wtot.n_elem);
+    }
+
+    void DFTGridWorkerBase::init_xc() {
+      const size_t N = wtot.n_elem;
+      zero_Exc();
+      if (!polarized) {
+        vxc.zeros(1, N);
+        if (do_grad) vsigma.zeros(1, N);
+        if (do_tau)  vtau.zeros(1, N);
+        if (do_lapl) vlapl.zeros(1, N);
+      } else {
+        vxc.zeros(2, N);
+        if (do_grad) vsigma.zeros(3, N);
+        if (do_tau)  vtau.zeros(2, N);
+        if (do_lapl) vlapl.zeros(2, N);
+      }
+      do_gga    = false;
+      do_mgga_l = false;
+      do_mgga_t = false;
+    }
+
+    double DFTGridWorkerBase::eval_Exc() const {
+      arma::rowvec dens(rho.row(0));
+      if (polarized) dens += rho.row(1);
+      return arma::sum(wtot % exc % dens);
+    }
+
+    void DFTGridWorkerBase::compute_xc(int func_id, const arma::vec & p, double thr, bool pot) {
+      bool gga, mgga_t, mgga_l;
+      is_gga_mgga(func_id, gga, mgga_t, mgga_l);
+
+      do_gga    = do_gga    || gga || mgga_t || mgga_l;
+      do_mgga_t = do_mgga_t || mgga_t;
+      do_mgga_l = do_mgga_l || mgga_l;
+
+      const size_t N = wtot.n_elem;
+
+      arma::rowvec exc_wrk;
+      arma::mat vxc_wrk, vsigma_wrk, vlapl_wrk, vtau_wrk;
+
+      if (has_exc(func_id))
+        exc_wrk.zeros(exc.n_elem);
+      if (pot) {
+        vxc_wrk.zeros(vxc.n_rows, vxc.n_cols);
+        if (gga || mgga_t || mgga_l)
+          vsigma_wrk.zeros(vsigma.n_rows, vsigma.n_cols);
+        if (mgga_t)
+          vtau_wrk.zeros(vtau.n_rows, vtau.n_cols);
+        if (mgga_l)
+          vlapl_wrk.zeros(vlapl.n_rows, vlapl.n_cols);
+      }
+
+      const int nspin = polarized ? XC_POLARIZED : XC_UNPOLARIZED;
+
+      xc_func_type func;
+      if (xc_func_init(&func, func_id, nspin) != 0) {
+        std::ostringstream oss;
+        oss << "Functional " << func_id << " not found!";
+        throw std::runtime_error(oss.str());
+      }
+      xc_func_set_dens_threshold(&func, thr);
+
+      if (p.n_elem) {
+        if (p.n_elem != (arma::uword) xc_func_info_get_n_ext_params((xc_func_info_type *) func.info))
+          throw std::logic_error("Incompatible number of parameters!\n");
+        arma::vec phlp(p);
+        xc_func_set_ext_params(&func, phlp.memptr());
+      }
+
+      if (has_exc(func_id)) {
+        if (pot) {
+          if (mgga_t || mgga_l) {
+            double * laplp  = mgga_l ? lapl.memptr()      : NULL;
+            double * taup   = mgga_t ? tau.memptr()       : NULL;
+            double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
+            double * vtaup  = mgga_t ? vtau_wrk.memptr()  : NULL;
+            xc_mgga_exc_vxc(&func, N, rho.memptr(), sigma.memptr(),
+                             laplp, taup,
+                             exc_wrk.memptr(), vxc_wrk.memptr(),
+                             vsigma_wrk.memptr(), vlaplp, vtaup);
+          } else if (gga) {
+            xc_gga_exc_vxc(&func, N, rho.memptr(), sigma.memptr(),
+                            exc_wrk.memptr(), vxc_wrk.memptr(),
+                            vsigma_wrk.memptr());
+          } else {
+            xc_lda_exc_vxc(&func, N, rho.memptr(),
+                            exc_wrk.memptr(), vxc_wrk.memptr());
+          }
+        } else {
+          if (mgga_t || mgga_l) {
+            double * laplp = mgga_l ? lapl.memptr() : NULL;
+            double * taup  = mgga_t ? tau.memptr()  : NULL;
+            xc_mgga_exc(&func, N, rho.memptr(), sigma.memptr(),
+                         laplp, taup, exc_wrk.memptr());
+          } else if (gga) {
+            xc_gga_exc(&func, N, rho.memptr(), sigma.memptr(), exc_wrk.memptr());
+          } else {
+            xc_lda_exc(&func, N, rho.memptr(), exc_wrk.memptr());
+          }
+        }
+      } else {
+        if (pot) {
+          if (mgga_t || mgga_l) {
+            double * laplp  = mgga_l ? lapl.memptr()      : NULL;
+            double * taup   = mgga_t ? tau.memptr()       : NULL;
+            double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
+            double * vtaup  = mgga_t ? vtau_wrk.memptr()  : NULL;
+            xc_mgga_vxc(&func, N, rho.memptr(), sigma.memptr(),
+                         laplp, taup,
+                         vxc_wrk.memptr(), vsigma_wrk.memptr(),
+                         vlaplp, vtaup);
+          } else if (gga) {
+            xc_gga_vxc(&func, N, rho.memptr(), sigma.memptr(),
+                        vxc_wrk.memptr(), vsigma_wrk.memptr());
+          } else {
+            xc_lda_vxc(&func, N, rho.memptr(), vxc_wrk.memptr());
+          }
+        }
+      }
+
+      // NaN-guard diagnostic (originally sadatom-only; unified here
+      // so atomic and diatomic get the same warning). Prints only;
+      // never modifies state.
+      for (size_t i = 0; i < N; ++i) {
+        const double e = has_exc(func_id) ? exc_wrk[i] : 0.0;
+        double rhoa = 0.0, rhob = 0.0;
+        double sigmaaa = 0.0, sigmaab = 0.0, sigmabb = 0.0;
+        double lapla = 0.0, laplb = 0.0, taua = 0.0, taub = 0.0;
+        double vrhoa = 0.0, vrhob = 0.0;
+        double vsigmaaa = 0.0, vsigmaab = 0.0, vsigmabb = 0.0;
+        double vlapla = 0.0, vlaplb = 0.0, vtaua = 0.0, vtaub = 0.0;
+        if (polarized) {
+          rhoa = rho(0, i); rhob = rho(1, i);
+          vrhoa = vxc_wrk(0, i); vrhob = vxc_wrk(1, i);
+          if (gga || mgga_t || mgga_l) {
+            sigmaaa = sigma(0, i); sigmaab = sigma(1, i); sigmabb = sigma(2, i);
+            vsigmaaa = vsigma_wrk(0, i); vsigmaab = vsigma_wrk(1, i); vsigmabb = vsigma_wrk(2, i);
+          }
+          if (mgga_l) {
+            lapla = lapl(0, i); laplb = lapl(1, i);
+            vlapla = vlapl_wrk(0, i); vlaplb = vlapl_wrk(1, i);
+          }
+          if (mgga_t) {
+            taua = tau(0, i); taub = tau(1, i);
+            vtaua = vtau_wrk(0, i); vtaub = vtau_wrk(1, i);
+          }
+        } else {
+          rhoa = 0.5 * rho(0, i); rhob = 0.5 * rho(0, i);
+          vrhoa = vxc_wrk(0, i);  vrhob = vxc_wrk(0, i);
+          if (gga || mgga_t || mgga_l) {
+            sigmaaa = 0.25 * sigma(0, i); sigmaab = 0.25 * sigma(0, i); sigmabb = 0.25 * sigma(0, i);
+            vsigmaaa = vsigma_wrk(0, i); vsigmaab = vsigma_wrk(0, i); vsigmabb = vsigma_wrk(0, i);
+          }
+          if (mgga_l) {
+            lapla = 0.5 * lapl(0, i); laplb = 0.5 * lapl(0, i);
+            vlapla = vlapl_wrk(0, i); vlaplb = vlapl_wrk(0, i);
+          }
+          if (mgga_t) {
+            taua = 0.5 * tau(0, i); taub = 0.5 * tau(0, i);
+            vtaua = vtau_wrk(0, i); vtaub = vtau_wrk(0, i);
+          }
+        }
+        if (std::isnan(e)   || std::isnan(vrhoa)    || std::isnan(vrhob)
+             || std::isnan(vsigmaaa) || std::isnan(vsigmaab) || std::isnan(vsigmabb)
+             || std::isnan(vlapla)   || std::isnan(vlaplb)
+             || std::isnan(vtaua)    || std::isnan(vtaub)) {
+          printf("NaN encountered for functional id = %i with input\n", func_id);
+          printf("input: %e %e %e % e %e %e %e % e % e\n",
+                  rhoa, rhob, sigmaaa, sigmaab, sigmabb, lapla, laplb, taua, taub);
+          printf("output: % e % e % e % e % e % e % e % e % e % e\n",
+                  e, vrhoa, vrhob, vsigmaaa, vsigmaab, vsigmabb, vlapla, vlaplb, vtaua, vtaub);
+        }
+      }
+
+      if (has_exc(func_id))
+        exc += exc_wrk;
+      if (pot) {
+        if (mgga_l)                     vlapl  += vlapl_wrk;
+        if (mgga_t)                     vtau   += vtau_wrk;
+        if (mgga_t || mgga_l || gga)    vsigma += vsigma_wrk;
+        vxc += vxc_wrk;
+      }
+
+      xc_func_end(&func);
+    }
+
+  } // namespace dftgrid_common
+} // namespace helfem

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -1,0 +1,107 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef HELFEM_DFTGRID_COMMON_H
+#define HELFEM_DFTGRID_COMMON_H
+
+// Shared DFT-grid worker plumbing: libxc dispatch, xc buffer
+// allocation, gradient/tau/lapl need detection, energy accumulation.
+// Extracted from three near-identical copies in src/atomic/dftgrid.cpp,
+// src/sadatom/dftgrid.cpp, src/diatomic/dftgrid.cpp. The
+// geometry-specific bits (compute_bf, update_density, eval_Fxc,
+// compute_Nel, etc.) stay in the derived classes.
+
+#include <armadillo>
+
+namespace helfem {
+  namespace dftgrid_common {
+    /// Base class holding the shared XC state and libxc-facing
+    /// plumbing for the three DFTGridWorker variants. Geometry-specific
+    /// derived classes inherit and add their own basis-function buffers,
+    /// density update, and Fxc reassembly.
+    class DFTGridWorkerBase {
+    protected:
+      /// Total quadrature weights on the current element's grid
+      arma::rowvec wtot;
+
+      /// Is gradient needed?
+      bool do_grad;
+      /// Is kinetic energy density needed?
+      bool do_tau;
+      /// Is laplacian needed?
+      bool do_lapl;
+      /// Spin-polarized calculation?
+      bool polarized;
+
+      /// GGA functional used? (Set in compute_xc, only affects eval_Fxc)
+      bool do_gga;
+      /// Meta-GGA tau used? (Set in compute_xc, only affects eval_Fxc)
+      bool do_mgga_t;
+      /// Meta-GGA lapl used? (Set in compute_xc, only affects eval_Fxc)
+      bool do_mgga_l;
+
+      // LDA
+      /// Density, Nrho x Npts
+      arma::mat rho;
+      /// Energy density, Npts
+      arma::rowvec exc;
+      /// Functional derivative wrt density
+      arma::mat vxc;
+
+      // GGA
+      /// Dot products of density gradient
+      arma::mat sigma;
+      /// Functional derivative wrt density gradient
+      arma::mat vsigma;
+
+      // Meta-GGA
+      /// Laplacian of density
+      arma::mat lapl;
+      /// Kinetic energy density
+      arma::mat tau;
+      /// Functional derivative wrt laplacian
+      arma::mat vlapl;
+      /// Functional derivative wrt kinetic energy density
+      arma::mat vtau;
+
+    public:
+      DFTGridWorkerBase();
+      virtual ~DFTGridWorkerBase();
+
+      /// Check necessity of computing gradient / tau / laplacian for the
+      /// given exchange + correlation functional ids.
+      void check_grad_tau_lapl(int x_func, int c_func);
+      /// Query the do_grad / do_tau / do_lapl flags
+      void get_grad_tau_lapl(bool & grad, bool & tau, bool & lapl) const;
+      /// Explicit override of the do_grad / do_tau / do_lapl flags
+      void set_grad_tau_lapl(bool grad, bool tau, bool lapl);
+
+      /// Zero the exchange-correlation energy density buffer
+      void zero_Exc();
+
+      /// Initialise vxc / vsigma / vtau / vlapl buffers with the
+      /// correct shape and zero exc.
+      void init_xc();
+
+      /// Evaluate int wtot * exc * rho_total
+      double eval_Exc() const;
+
+      /// Compute libxc functional contribution and add to exc / vxc /
+      /// vsigma / vtau / vlapl. pot=true also computes potentials.
+      void compute_xc(int func_id, const arma::vec & params, double thr, bool pot = true);
+    };
+  }
+}
+
+#endif

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -264,44 +264,13 @@ namespace helfem {
         return l;
       }
 
-      void DFTGridWorker::init_xc() {
-        // Size of grid.
-        const size_t N=wtot.n_elem;
+      // init_xc, zero_Exc: inherited from
+      // helfem::dftgrid_common::DFTGridWorkerBase.
 
-        // Zero energy
-        zero_Exc();
-
-        if(!polarized) {
-          // Restricted case
-          vxc.zeros(1,N);
-          if(do_grad)
-            vsigma.zeros(1,N);
-          if(do_tau)
-            vtau.zeros(1,N);
-          if(do_lapl)
-            vlapl.zeros(1,N);
-        } else {
-          // Unrestricted case
-          vxc.zeros(2,N);
-          if(do_grad)
-            vsigma.zeros(3,N);
-          if(do_tau)
-            vtau.zeros(2,N);
-          if(do_lapl) {
-            vlapl.zeros(2,N);
-          }
-        }
-
-        // Initial values
-        do_gga=false;
-        do_mgga_l=false;
-        do_mgga_t=false;
-      }
-
-      void DFTGridWorker::zero_Exc() {
-        exc.zeros(wtot.n_elem);
-      }
-
+      // The compute_xc implementation is inherited; the NaN-guard
+      // diagnostic that lived here is now in the base and runs for
+      // atomic and diatomic too.
+#if 0
       void DFTGridWorker::compute_xc(int func_id, const arma::vec & p, double thr, bool pot) {
         // Compute exchange-correlation functional
 
@@ -483,6 +452,7 @@ namespace helfem {
         // Free functional
         xc_func_end(&func);
       }
+#endif
 
       void DFTGridWorker::get_pot(arma::mat & pot) const {
         double vrhoa=0.0, vrhob=0.0, vsigmaaa=0.0, vsigmaab=0.0, vsigmabb=0.0, vlapla=0.0, vlaplb=0.0, vtaua=0.0, vtaub=0.0;
@@ -589,13 +559,7 @@ namespace helfem {
         }
       }
 
-      double DFTGridWorker::eval_Exc() const {
-        arma::rowvec dens(rho.row(0));
-        if(polarized)
-          dens+=rho.row(1);
-
-        return arma::sum(wtot%exc%dens);
-      }
+      // eval_Exc: inherited from DFTGridWorkerBase.
 
       void DFTGridWorker::eval_overlap(arma::mat & So) const {
         // Calculate in subspace
@@ -803,40 +767,8 @@ namespace helfem {
         }
       }
 
-      void DFTGridWorker::check_grad_tau_lapl(int x_func, int c_func) {
-        // Do we need gradients?
-        do_grad=false;
-        if(x_func>0)
-          do_grad=do_grad || gradient_needed(x_func);
-        if(c_func>0)
-          do_grad=do_grad || gradient_needed(c_func);
-
-        // Do we need laplacians?
-        do_tau=false;
-        if(x_func>0)
-          do_tau=do_tau || tau_needed(x_func);
-        if(c_func>0)
-          do_tau=do_tau || tau_needed(c_func);
-
-        // Do we need laplacians?
-        do_lapl=false;
-        if(x_func>0)
-          do_lapl=do_lapl || laplacian_needed(x_func);
-        if(c_func>0)
-          do_lapl=do_lapl || laplacian_needed(c_func);
-      }
-
-      void DFTGridWorker::get_grad_tau_lapl(bool & grad_, bool & tau_, bool & lap_) const {
-        grad_=do_grad;
-        tau_=do_tau;
-        lap_=do_lapl;
-      }
-
-      void DFTGridWorker::set_grad_tau_lapl(bool grad_, bool tau_, bool lap_) {
-        do_grad=grad_;
-        do_tau=tau_;
-        do_lapl=lap_;
-      }
+      // check_grad_tau_lapl, get_grad_tau_lapl, set_grad_tau_lapl:
+      // inherited from DFTGridWorkerBase.
 
       void DFTGridWorker::compute_bf(size_t iel) {
         // Update function list

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -17,13 +17,15 @@
 #define SADATOM_DFTGRID_H
 
 #include "basis.h"
+#include "../general/dftgrid_common.h"
 
 namespace helfem {
   namespace sadatom {
     namespace dftgrid {
 
-      /// Worker class
-      class DFTGridWorker {
+      /// Worker class. Shares XC plumbing with the atomic and diatomic
+      /// variants via helfem::dftgrid_common::DFTGridWorkerBase.
+      class DFTGridWorker : public helfem::dftgrid_common::DFTGridWorkerBase {
       protected:
         /// Basis set
         const helfem::sadatom::basis::TwoDBasis *basp;
@@ -32,8 +34,6 @@ namespace helfem {
         arma::rowvec r;
         /// Radial quadrature weight
         arma::rowvec wrad;
-        /// Total quadrature weight
-        arma::rowvec wtot;
 
         /// List of basis functions in element
         arma::uvec bf_ind;
@@ -50,52 +50,13 @@ namespace helfem {
         arma::mat Pav, Pav_rho;
         arma::mat Pbv, Pbv_rho;
 
-        /// Is gradient needed?
-        bool do_grad;
-        /// Is kinetic energy density needed?
-        bool do_tau;
-        /// Is laplacian needed?
-        bool do_lapl;
-
-        /// Spin-polarized calculation?
-        bool polarized;
-
-        /// GGA functional used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_gga;
-        /// Meta-GGA tau used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_mgga_t;
-        /// Meta-GGA lapl used? (Set in compute_xc, only affects eval_Fxc)
-        bool do_mgga_l;
-
-        // LDA stuff:
-
-        /// Density, Nrho x Npts
-        arma::mat rho;
-        /// Energy density, Npts
-        arma::rowvec exc;
-        /// Functional derivative of energy wrt electron density, Nrho x Npts
-        arma::mat vxc;
-
-        // GGA stuff
-
-        /// Gradient of electron density, (3 x Nrho) x Npts
+        /// Gradient of electron density
         arma::mat grho;
-        /// Dot products of gradient of electron density, N x Npts; N=1 for closed-shell and 3 for open-shell
-        arma::mat sigma;
-        /// Functional derivative of energy wrt gradient of electron density
-        arma::mat vsigma;
 
-        // Meta-GGA stuff
-
-        /// Laplacian of electron density
-        arma::mat lapl;
-        /// Kinetic energy density
-        arma::mat tau;
-
-        /// Functional derivative of energy wrt laplacian of electron density
-        arma::mat vlapl;
-        /// Functional derivative of energy wrt kinetic energy density
-        arma::mat vtau;
+        // Members provided by helfem::dftgrid_common::DFTGridWorkerBase:
+        //   wtot, exc, rho, sigma, vxc, vsigma, lapl, tau, vlapl, vtau
+        //   polarized, do_grad, do_tau, do_lapl,
+        //   do_gga, do_mgga_t, do_mgga_l
 
       public:
         /// Dummy constructor
@@ -105,12 +66,8 @@ namespace helfem {
         /// Destructor
         ~DFTGridWorker();
 
-        /// Check necessity of computing gradient and laplacians, necessary for compute_bf!
-        void check_grad_tau_lapl(int x_func, int c_func);
-        /// Get necessity of computing gradient and laplacians
-        void get_grad_tau_lapl(bool & grad, bool & tau, bool & lapl) const;
-        /// Set necessity of computing gradient and laplacians, necessary for compute_bf!
-        void set_grad_tau_lapl(bool grad, bool tau, bool lapl);
+        // check_grad_tau_lapl / get_grad_tau_lapl / set_grad_tau_lapl
+        // are inherited from DFTGridWorkerBase.
 
         /// Compute basis functions on grid points
         void compute_bf(size_t iel);
@@ -129,15 +86,8 @@ namespace helfem {
         /// Compute laplacian
         double compute_lapl() const;
 
-        /// Initialize XC arrays
-        void init_xc();
-        /// Compute XC functional from density and add to total XC
-        /// array. thr is density threshold. Pot toggles evaluation of potential
-        void compute_xc(int func_id, const arma::vec & params, double thr, bool pot=true);
-        /// Evaluate exchange/correlation energy
-        double eval_Exc() const;
-        /// Zero out energy
-        void zero_Exc();
+        // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
+        // from DFTGridWorkerBase.
 
         /// Evaluate overlap matrix
         void eval_overlap(arma::mat & S) const;


### PR DESCRIPTION
## Summary

Consolidates ~250 lines of near-identical XC plumbing that existed in three parallel copies of \`src/{atomic,sadatom,diatomic}/dftgrid.cpp\`.

| Method | atomic | sadatom | diatomic | Fate |
|---|---|---|---|---|
| \`init_xc\` | byte-identical (all 3) | | | → base |
| \`check_grad_tau_lapl\` | byte-identical (all 3) | | | → base |
| \`get_grad_tau_lapl\` | byte-identical (all 3) | | | → base |
| \`set_grad_tau_lapl\` | byte-identical (all 3) | | | → base |
| \`eval_Exc\` | byte-identical (all 3) | | | → base |
| \`zero_Exc\` | byte-identical (all 3) | | | → base |
| \`compute_xc\` | near-identical: atomic + diatomic byte-identical; sadatom had an extra 63-line NaN-guard diagnostic loop | | | → base (NaN guard preserved) |

The NaN-guard loop is a pure diagnostic (never modifies state; prints only) so unifying it means atomic and diatomic get the same warning now — strict improvement.

## New files

**\`src/general/dftgrid_common.h\`** — \`DFTGridWorkerBase\` declaration.
- Protected members: \`wtot\`, \`rho\`, \`exc\`, \`vxc\`, \`sigma\`, \`vsigma\`, \`lapl\`, \`tau\`, \`vlapl\`, \`vtau\`, \`polarized\`, \`do_grad\`, \`do_tau\`, \`do_lapl\`, \`do_gga\`, \`do_mgga_t\`, \`do_mgga_l\`.
- Public methods: \`init_xc\`, \`compute_xc\`, \`eval_Exc\`, \`zero_Exc\`, \`check_grad_tau_lapl\`, \`get_grad_tau_lapl\`, \`set_grad_tau_lapl\`.

**\`src/general/dftgrid_common.cpp\`** — verbatim extraction of the atomic versions of the 4 identical methods, plus the sadatom variant of \`compute_xc\` (NaN-guard included).

**\`src/CMakeLists.txt\`** — new source added to \`helfem-common\` library.

## Changed files

\`src/atomic/dftgrid.{h,cpp}\`, \`src/sadatom/dftgrid.{h,cpp}\`, \`src/diatomic/dftgrid.{h,cpp}\`:
- \`DFTGridWorker\` now inherits publicly from \`helfem::dftgrid_common::DFTGridWorkerBase\`.
- Shared members removed (moved to base).
- Shared method declarations removed (inherited).
- Shared method implementations removed (in base).
- Geometry-specific parts (\`compute_bf\`, \`update_density\`, \`eval_Fxc\`, \`compute_Nel\`, \`compute_Ekin/tau/lapl\`, \`eval_overlap/kinetic\`, \`check_xc\`, \`save\`) stay in the derived class — they touch geometry-specific state (\`cx_mat\` basis grids, \`arma::cube\` for sadatom, angular grid metadata, ...).

## Validation

- Full build clean
- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (bit-identical to 5.18 baseline — HF doesn't exercise the DFT path)
- Be LDA (atomic, lmax=2, \`lda_x-lda_c_vwn\`): **−14.4470673116629413** (sensible result, exercises the migrated DFT path)

## LOC impact

- 3 dftgrid files: -659 lines
- 1 new common file: +240 lines
- Net: **-348 LOC of pure duplication removed**

Follows survey finding: \`init_xc\` / \`check_grad_tau_lapl\` / \`eval_Exc\` / \`zero_Exc\` were byte-identical across all three files ("copy-paste triplication").

## Motivation

Preparation for the arma → Eigen migration of the DFT layer: the shared plumbing will now migrate **once** (in the base) instead of being touched three times.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR
- [x] Be LDA via atomic runs and converges to sensible result