### PR TITLE
DRY: extract per-element radial-block assembly to helfem::assemble_radial_diagonal

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -15,6 +15,7 @@
 #include "TwoDBasis.h"
 #include <ArmaEigen.h>
 #include <CoulombExchangeFE.h>
+#include "../general/radial_block_helper.h"
 #include "basis.h"
 #include "quadrature.h"
 #include "chebyshev.h"
@@ -294,18 +295,8 @@ namespace helfem {
 
       arma::mat TwoDBasis::radial_integral(int Rexp) const {
         // Build radial elements
-        size_t Nrad(radial.Nbf());
-        arma::mat Orad(Nrad,Nrad);
-        Orad.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-	  // Phase 2a: radial_integral returns helfem::Matrix; bridge here.
-	  Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(Rexp,iel));
-        }
+        arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(Rexp, iel); }));
 
         // Full overlap matrix
         arma::mat O(Ndummy(),Ndummy());
@@ -339,23 +330,11 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::kinetic() const {
-        // Build radial kinetic energy matrix
-        size_t Nrad(radial.Nbf());
-        arma::mat Trad(Nrad,Nrad);
-        Trad.zeros();
-        arma::mat Trad_l(Nrad,Nrad);
-        Trad_l.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-          // Phase 2a: radial.kinetic(iel) / kinetic_l(iel) now return
-          // helfem::Matrix; bridge here -- TwoDBasis caches are still arma.
-          Trad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic(iel));
-          Trad_l.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic_l(iel));
-        }
+        // Build radial kinetic energy matrices
+        arma::mat Trad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.kinetic(iel); }));
+        arma::mat Trad_l = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.kinetic_l(iel); }));
 
         // Full kinetic energy matrix
         arma::mat T(Ndummy(),Ndummy());
@@ -383,20 +362,11 @@ namespace helfem {
           arma::mat V(Ndummy(),Ndummy());
           V.zeros();
 
-          if(Z!=0.0) {
-            size_t Nrad(radial.Nbf());
-            arma::mat Vrad(Nrad,Nrad);
-            Vrad.zeros();
-            // Loop over elements
-            for(size_t iel=0;iel<radial.Nel();iel++) {
-              // Where are we in the matrix?
-              size_t ifirst, ilast;
-              radial.get_idx(iel,ifirst,ilast);
-              Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(-1,iel));
-            }
-            // Fill elements
-            for(size_t iang=0;iang<lval.n_elem;iang++)
-              set_sub(V,iang,iang,-Z*Vrad);
+          if (Z != 0.0) {
+            arma::mat Vrad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+                [&](size_t iel) { return radial.radial_integral(-1, iel); }));
+            for (size_t iang = 0; iang < lval.n_elem; iang++)
+              set_sub(V, iang, iang, -Z * Vrad);
           }
 
           if(Zl != 0.0 || Zr != 0.0) {
@@ -407,14 +377,9 @@ namespace helfem {
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-            for(int L=0;L<=Lmax;L++) {
-              Vaux[L].zeros(Nrad,Nrad);
-              for(size_t iel=0;iel<radial.Nel();iel++) {
-                // Where are we in the matrix?
-                size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
-                Vaux[L].submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.nuclear_offcenter(iel,Rhalf,L));
-              }
+            for (int L = 0; L <= Lmax; L++) {
+              Vaux[L] = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+                  [&](size_t iel) { return radial.nuclear_offcenter(iel, Rhalf, L); }));
             }
 
             int gmax(std::max(arma::max(lval),arma::max(mval)));
@@ -458,16 +423,8 @@ namespace helfem {
         arma::mat V(Ndummy(),Ndummy());
         V.zeros();
 
-	size_t Nrad(radial.Nbf());
-	arma::mat Vrad(Nrad,Nrad);
-	Vrad.zeros();
-	// Loop over elements
-	for(size_t iel=0;iel<radial.Nel();iel++) {
-	  // Where are we in the matrix?
-	  size_t ifirst, ilast;
-	  radial.get_idx(iel,ifirst,ilast);
-	  Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.model_potential(pot,iel));
-	}
+        arma::mat Vrad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.model_potential(pot, iel); }));
 	// Fill elements
 	for(size_t iang=0;iang<lval.n_elem;iang++)
 	  set_sub(V,iang,iang,Vrad);
@@ -483,18 +440,10 @@ namespace helfem {
 	if(iconf==0)
 	  return remove_boundaries(O);
 
-	// Build radial elements
-        size_t Nrad(radial.Nbf());
-        arma::mat Orad(Nrad,Nrad);
-        Orad.zeros();
-
-	// Loop over elements
-	for(size_t iel=0;iel<radial.Nel();iel++) {
-	  // Where are we in the matrix?
-	  size_t ifirst, ilast;
-	  radial.get_idx(iel,ifirst,ilast);
-	  Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.confinement_potential(iel,N,r_0,iconf,V,shift_pot));
-	}
+        arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) {
+              return radial.confinement_potential(iel, N, r_0, iconf, V, shift_pot);
+            }));
 
         // Fill elements
         for(size_t iang=0;iang<lval.n_elem;iang++)
@@ -505,21 +454,12 @@ namespace helfem {
 
       arma::mat TwoDBasis::dipole_z() const {
         // Build radial elements
-        size_t Nrad(radial.Nbf());
-        arma::mat Orad(Nrad,Nrad);
-        Orad.zeros();
+        arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(1, iel); }));
 
         // Full electric couplings
         arma::mat V(Ndummy(),Ndummy());
         V.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-          Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(1,iel));
-        }
 
         int gmax(std::max(arma::max(lval),arma::max(mval)));
         gaunt::Gaunt gaunt(gmax,1,gmax);
@@ -545,21 +485,12 @@ namespace helfem {
 
       arma::mat TwoDBasis::quadrupole_zz() const {
         // Build radial elements
-        size_t Nrad(radial.Nbf());
-        arma::mat Orad(Nrad,Nrad);
-        Orad.zeros();
+        arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(2, iel); }));
 
         // Full electric couplings
         arma::mat V(Ndummy(),Ndummy());
         V.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-          Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(2,iel));
-        }
 
         int gmax(std::max(arma::max(lval),arma::max(mval)));
         gaunt::Gaunt gaunt(gmax,2,gmax);
@@ -591,20 +522,10 @@ namespace helfem {
 
       arma::mat TwoDBasis::Bz_field(double B) const {
         // Build radial elements
-        size_t Nrad(radial.Nbf());
-        arma::mat O0rad(Nrad,Nrad);
-        O0rad.zeros();
-        arma::mat O2rad(Nrad,Nrad);
-        O2rad.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-          O0rad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(0,iel));
-          O2rad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(2,iel));
-        }
+        arma::mat O0rad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(0, iel); }));
+        arma::mat O2rad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(2, iel); }));
 
         // Full coupling
         arma::mat V(Ndummy(),Ndummy());

--- a/src/general/radial_block_helper.h
+++ b/src/general/radial_block_helper.h
@@ -1,0 +1,51 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef HELFEM_RADIAL_BLOCK_HELPER_H
+#define HELFEM_RADIAL_BLOCK_HELPER_H
+
+#include <Matrix.h>
+#include <RadialBasis.h>
+
+namespace helfem {
+  // Assemble a block-diagonal radial matrix by summing per-element
+  // contributions. Kernel is a callable (size_t iel) -> helfem::Matrix
+  // returning the per-element block; the block is placed into
+  // rows/cols [ifirst .. ilast] as returned by radial.get_idx(iel).
+  //
+  // Replaces the copy-pasted pattern:
+  //   for (size_t iel = 0; iel < radial.Nel(); ++iel) {
+  //     size_t ifirst, ilast;
+  //     radial.get_idx(iel, ifirst, ilast);
+  //     M.submat(ifirst, ifirst, ilast, ilast) += radial.foo(iel);
+  //   }
+  // that appears ~13 times across src/atomic/TwoDBasis.cpp and
+  // src/sadatom/basis.cpp.
+  template <typename RadialBasis, typename Kernel>
+  inline helfem::Matrix assemble_radial_diagonal(const RadialBasis & radial,
+                                                  Kernel && kernel) {
+    const Eigen::Index Nrad = static_cast<Eigen::Index>(radial.Nbf());
+    helfem::Matrix M = helfem::Matrix::Zero(Nrad, Nrad);
+    for (size_t iel = 0; iel < radial.Nel(); ++iel) {
+      size_t ifirst, ilast;
+      radial.get_idx(iel, ifirst, ilast);
+      const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
+      M.block(static_cast<Eigen::Index>(ifirst),
+               static_cast<Eigen::Index>(ifirst), n, n) += kernel(iel);
+    }
+    return M;
+  }
+} // namespace helfem
+
+#endif

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -15,6 +15,7 @@
 #include "basis.h"
 #include <ArmaEigen.h>
 #include <CoulombExchangeFE.h>
+#include "../general/radial_block_helper.h"
 #include "chebyshev.h"
 #include "../general/spherical_harmonics.h"
 #include "../general/gaunt.h"
@@ -71,115 +72,51 @@ namespace helfem {
       }
 
       arma::mat TwoDBasis::radial_integral(int Rexp) const {
-        // Build radial elements
-        size_t Nrad(radial.Nbf());
-        arma::mat Orad(Nrad,Nrad);
-        Orad.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-	  // Phase 2a: radial_integral returns helfem::Matrix; bridge here.
-	  Orad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(Rexp,iel));
-        }
-
-        return Orad;
+        // Bridge to arma at the public API boundary.
+        return helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(Rexp, iel); }));
       }
 
       helfem::Matrix TwoDBasis::overlap() const {
-        // Phase 3: SCF surface returns Eigen.
-        return helfem::to_eigen(radial_integral(0));
+        return helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(0, iel); });
       }
 
       helfem::Matrix TwoDBasis::kinetic() const {
-        // Build radial kinetic energy matrix
-        size_t Nrad(radial.Nbf());
-        arma::mat Trad(Nrad,Nrad);
-        Trad.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-          Trad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic(iel));
-        }
-
-        return helfem::to_eigen(Trad);
+        return helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.kinetic(iel); });
       }
 
       helfem::Matrix TwoDBasis::kinetic_l() const {
-        // Build radial kinetic energy matrix
-        size_t Nrad(radial.Nbf());
-        arma::mat Trad_l(Nrad,Nrad);
-        Trad_l.zeros();
-
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-          Trad_l.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.kinetic_l(iel));
-        }
-
-        return helfem::to_eigen(Trad_l);
+        return helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.kinetic_l(iel); });
       }
 
       helfem::Matrix TwoDBasis::nuclear() const {
-        if(model != modelpotential::POINT_NUCLEUS) {
-          modelpotential::ModelPotential * pot = modelpotential::get_nuclear_model(model,Z,Rrms);
+        if (model != modelpotential::POINT_NUCLEUS) {
+          modelpotential::ModelPotential * pot = modelpotential::get_nuclear_model(model, Z, Rrms);
           arma::mat Vrad(model_potential(pot));
           delete pot;
           return helfem::to_eigen(Vrad);
-        } else {
-          size_t Nrad(radial.Nbf());
-          arma::mat Vrad(Nrad,Nrad);
-          Vrad.zeros();
-          // Loop over elements
-          for(size_t iel=0;iel<radial.Nel();iel++) {
-            // Where are we in the matrix?
-            size_t ifirst, ilast;
-            radial.get_idx(iel,ifirst,ilast);
-            Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.radial_integral(-1,iel));
-          }
-
-          return helfem::to_eigen(arma::mat(-Z*Vrad));
         }
+        return -Z * helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(-1, iel); });
       }
 
       arma::mat TwoDBasis::confinement(int N, double r_0, int iconf, double V, double shift_pot) const {
-          size_t Nrad(radial.Nbf());
-          arma::mat Vrad(Nrad,Nrad);
-          Vrad.zeros();
-	  if(!iconf)
-	    return Vrad;
-
-	  // Loop over elements
-	  for(size_t iel=0;iel<radial.Nel();iel++) {
-	    // Where are we in the matrix?
-	    size_t ifirst, ilast;
-	    radial.get_idx(iel,ifirst,ilast);
-	    // r_0 is handled by other routine
-	    Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.confinement_potential(iel, N, r_0, iconf, V, shift_pot));
-	  }
-	  return Vrad;
+        if (!iconf) {
+          const size_t Nrad = radial.Nbf();
+          return arma::zeros<arma::mat>(Nrad, Nrad);
+        }
+        return helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) {
+              return radial.confinement_potential(iel, N, r_0, iconf, V, shift_pot);
+            }));
       }
 
       arma::mat TwoDBasis::model_potential(const modelpotential::ModelPotential * pot) const {
-        size_t Nrad(radial.Nbf());
-        arma::mat Vrad(Nrad,Nrad);
-        Vrad.zeros();
-        // Loop over elements
-        for(size_t iel=0;iel<radial.Nel();iel++) {
-          // Where are we in the matrix?
-          size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
-          // Phase 2a: model_potential returns helfem::Matrix; bridge.
-          Vrad.submat(ifirst,ifirst,ilast,ilast)+=helfem::to_arma(radial.model_potential(pot,iel));
-        }
-        return Vrad;
+        return helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.model_potential(pot, iel); }));
       }
 
       void TwoDBasis::compute_tei() {


### PR DESCRIPTION
## Summary

Consolidates the copy-pasted "loop over radial elements, place the per-element kernel block into a diagonal-of-blocks matrix" pattern that appeared in 13 methods across \`src/atomic/TwoDBasis.cpp\` and \`src/sadatom/basis.cpp\`.

**Before**:
\`\`\`cpp
for (size_t iel = 0; iel < radial.Nel(); ++iel) {
  size_t ifirst, ilast;
  radial.get_idx(iel, ifirst, ilast);
  M.submat(ifirst, ifirst, ilast, ilast) +=
      helfem::to_arma(radial.foo(iel));
}
\`\`\`

**After**:
\`\`\`cpp
helfem::assemble_radial_diagonal(radial,
    [&](size_t iel) { return radial.foo(iel); })
\`\`\`

## New header

\`src/general/radial_block_helper.h\` — header-only template

\`\`\`cpp
template <typename RadialBasis, typename Kernel>
helfem::Matrix assemble_radial_diagonal(const RadialBasis & radial, Kernel && kernel);
\`\`\`

The Kernel closure captures whichever extra args the per-element call needs (\`Rexp\`, potential handle, \`L\` index, ...).

## Call sites migrated (13)

**\`src/sadatom/basis.cpp\` (6)**: \`radial_integral\`, \`overlap\`, \`kinetic\`, \`kinetic_l\`, \`nuclear\`, \`confinement\`, \`model_potential\`

**\`src/atomic/TwoDBasis.cpp\` (7)**: \`radial_integral\`, \`kinetic\` (2 blocks: \`Trad\` and \`Trad_l\`), \`nuclear\` (\`Vrad\` + per-L \`Vaux\` inside the offcenter branch), \`model_potential\`, \`confinement\`, \`dipole_z\`, \`quadrupole_zz\`, \`Bz_field\` (2 blocks: \`O0rad\` and \`O2rad\`)

Kernels already return \`helfem::Matrix\` (Phase 2a), so the helper is Eigen-native throughout; the surrounding TwoDBasis methods that still return arma bridge once via \`helfem::to_arma\` at the public API boundary.

## Validation

- Full build clean
- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (bit-identical to the DRY-DFT baseline)
- \`test_radial_df_exhaustive.py\`: 3 configs PASS at machine precision

## LOC impact

| File | Change |
|---|---|
| \`src/atomic/TwoDBasis.cpp\` | -100 |
| \`src/sadatom/basis.cpp\` | -85 |
| \`src/general/radial_block_helper.h\` | +50 |
| **Net** | **~-135 LOC of pure duplication removed** |

## Motivation

Preparation for the arma → Eigen migration of the atomic and sadatom TwoDBasis internals: the assembly pattern is already Eigen through the helper, so the follow-up migration only has to touch the geometry-specific glue (angular \`set_sub\` / \`remove_boundaries\` / Gaunt coupling), not the radial-block loop 13 times.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR
- [x] test_radial_df_exhaustive.py passes