### PR TITLE
DRY: extract angular-shell index collection to helfem::collect_shell_indices

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -16,6 +16,7 @@
 #include <ArmaEigen.h>
 #include <CoulombExchangeFE.h>
 #include "../general/radial_block_helper.h"
+#include "../general/angular_index_helpers.h"
 #include "basis.h"
 #include "quadrature.h"
 #include "chebyshev.h"
@@ -143,50 +144,15 @@ namespace helfem {
       }
 
       arma::uvec TwoDBasis::m_indices(int m) const {
-        // Count how many functions
-        size_t nm=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
-          if(mval(i)==m) {
-            nm += radial.Nbf();
-          }
-        }
-
-        // Collect functions
-        arma::uvec idx(nm);
-        size_t ioff=0;
-        size_t ibf=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
-          // Number of functions on shell is
-          size_t nsh=radial.Nbf();
-          if(mval(i)==m) {
-            idx.subvec(ioff,ioff+nsh-1)=arma::linspace<arma::uvec>(ibf,ibf+nsh-1,nsh);
-            ioff+=nsh;
-          }
-          ibf+=nsh;
-        }
-
-        return idx;
+        return helfem::collect_shell_indices(mval.n_elem,
+            [&](size_t)   { return radial.Nbf(); },
+            [&](size_t i) { return mval(i) == m; });
       }
 
       arma::uvec TwoDBasis::lm_indices(int l, int m) const {
-        // Count how many functions
-        size_t nm=radial.Nbf();
-
-        // Collect functions
-        arma::uvec idx(nm);
-        size_t ioff=0;
-        size_t ibf=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
-          // Number of functions on shell is
-          size_t nsh=radial.Nbf();
-          if(mval(i)==m && lval(i)==l) {
-            idx.subvec(ioff,ioff+nsh-1)=arma::linspace<arma::uvec>(ibf,ibf+nsh-1,nsh);
-            ioff+=nsh;
-          }
-          ibf+=nsh;
-        }
-
-        return idx;
+        return helfem::collect_shell_indices(mval.n_elem,
+            [&](size_t)   { return radial.Nbf(); },
+            [&](size_t i) { return mval(i) == m && lval(i) == l; });
       }
 
       std::vector<arma::uvec> TwoDBasis::get_sym_idx(int symm) const {

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -17,6 +17,7 @@
 #include "PolynomialBasis.h"
 #include "chebyshev.h"
 #include <ArmaEigen.h>
+#include "../general/angular_index_helpers.h"
 #include <cstring>
 
 namespace {
@@ -529,55 +530,15 @@ namespace helfem {
       }
 
       arma::uvec TwoDBasis::m_indices(int m) const {
-        // Count how many functions
-        size_t nm=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
-          if(mval(i)==m) {
-            nm += (m==0) ? radial.Nbf() : radial.Nbf()-1;
-          }
-        }
-
-        // Collect functions
-        arma::uvec idx(nm);
-        size_t ioff=0;
-        size_t ibf=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
-          // Number of functions on shell is
-          size_t nsh=(mval(i)==0) ? radial.Nbf() : radial.Nbf()-1;
-          if(mval(i)==m) {
-            idx.subvec(ioff,ioff+nsh-1)=arma::linspace<arma::uvec>(ibf,ibf+nsh-1,nsh);
-            ioff+=nsh;
-          }
-          ibf+=nsh;
-        }
-
-        return idx;
+        return helfem::collect_shell_indices(mval.n_elem,
+            [&](size_t i) { return (mval(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
+            [&](size_t i) { return mval(i) == m; });
       }
 
       arma::uvec TwoDBasis::m_indices(int m, bool odd) const {
-        // Count how many functions
-        size_t nm=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
-          if(mval(i)==m && lval(i)%2==odd) {
-            nm += (m==0) ? radial.Nbf() : radial.Nbf()-1;
-          }
-        }
-
-        // Collect functions
-        arma::uvec idx(nm);
-        size_t ioff=0;
-        size_t ibf=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
-          // Number of functions on shell is
-          size_t nsh=(mval(i)==0) ? radial.Nbf() : radial.Nbf()-1;
-          if(mval(i)==m && lval(i)%2==odd) {
-            idx.subvec(ioff,ioff+nsh-1)=arma::linspace<arma::uvec>(ibf,ibf+nsh-1,nsh);
-            ioff+=nsh;
-          }
-          ibf+=nsh;
-        }
-
-        return idx;
+        return helfem::collect_shell_indices(mval.n_elem,
+            [&](size_t i) { return (mval(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
+            [&](size_t i) { return mval(i) == m && (lval(i) % 2 == odd); });
       }
 
       std::vector<arma::uvec> TwoDBasis::get_sym_idx(int symm) const {

--- a/src/general/angular_index_helpers.h
+++ b/src/general/angular_index_helpers.h
@@ -1,0 +1,59 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef HELFEM_ANGULAR_INDEX_HELPERS_H
+#define HELFEM_ANGULAR_INDEX_HELPERS_H
+
+#include <armadillo>
+#include <cstddef>
+
+namespace helfem {
+  // Collect global basis-function indices belonging to a subset of
+  // angular shells. Shells are laid out linearly in the global basis
+  // in the order i = 0 .. nshells-1; shell i occupies shell_size(i)
+  // consecutive basis-function slots. This helper walks the shells
+  // once to count the matching slots and once more to place them,
+  // matching the copy-pasted pattern that appeared in
+  // atomic::TwoDBasis::m_indices / lm_indices and
+  // diatomic::TwoDBasis::m_indices (both overloads).
+  //
+  // Usage:
+  //   idx = collect_shell_indices(mval.n_elem,
+  //             [&](size_t)   { return radial.Nbf(); },   // shell size
+  //             [&](size_t i) { return mval(i) == m; });  // predicate
+  template <typename ShellSizeFn, typename PredicateFn>
+  inline arma::uvec collect_shell_indices(size_t nshells,
+                                           ShellSizeFn shell_size,
+                                           PredicateFn match) {
+    size_t nm = 0;
+    for (size_t i = 0; i < nshells; ++i)
+      if (match(i)) nm += shell_size(i);
+
+    arma::uvec idx(nm);
+    size_t ioff = 0;
+    size_t ibf  = 0;
+    for (size_t i = 0; i < nshells; ++i) {
+      const size_t nsh = shell_size(i);
+      if (match(i)) {
+        idx.subvec(ioff, ioff + nsh - 1) =
+            arma::linspace<arma::uvec>(ibf, ibf + nsh - 1, nsh);
+        ioff += nsh;
+      }
+      ibf += nsh;
+    }
+    return idx;
+  }
+} // namespace helfem
+
+#endif


### PR DESCRIPTION
## Summary

Consolidates the copy-pasted "walk angular shells, collect global basis-function indices belonging to a subset" pattern that appeared in 4 methods across \`src/atomic/TwoDBasis.cpp\` and \`src/diatomic/basis.cpp\`.

**Before** (25-45 lines per method):
\`\`\`cpp
size_t nm = 0;
for (size_t i = 0; i < mval.n_elem; ++i)
  if (predicate(i)) nm += shell_size(i);
arma::uvec idx(nm);
size_t ioff = 0, ibf = 0;
for (size_t i = 0; i < mval.n_elem; ++i) {
  const size_t nsh = shell_size(i);
  if (predicate(i)) {
    idx.subvec(ioff, ioff + nsh - 1) =
        arma::linspace<arma::uvec>(ibf, ibf + nsh - 1, nsh);
    ioff += nsh;
  }
  ibf += nsh;
}
return idx;
\`\`\`

**After** (3 lines):
\`\`\`cpp
return helfem::collect_shell_indices(mval.n_elem,
    [&](size_t i) { return shell_size(i); },
    [&](size_t i) { return predicate(i); });
\`\`\`

## New header

\`src/general/angular_index_helpers.h\` — header-only template:

\`\`\`cpp
template <typename ShellSizeFn, typename PredicateFn>
arma::uvec collect_shell_indices(size_t nshells, ShellSizeFn shell_size, PredicateFn match);
\`\`\`

The \`shell_size\` closure lets the diatomic variants encode their m-dependent shell size (\`Nbf\` if \`m==0\` else \`Nbf-1\`) at the call site instead of duplicating the branch in every method.

## Call sites migrated (4)

| Site | shell_size | match |
|---|---|---|
| \`atomic::TwoDBasis::m_indices(int m)\` | \`radial.Nbf()\` | \`mval(i) == m\` |
| \`atomic::TwoDBasis::lm_indices(int l, int m)\` | \`radial.Nbf()\` | \`mval(i) == m && lval(i) == l\` |
| \`diatomic::TwoDBasis::m_indices(int m)\` | \`(mval(i)==0) ? Nbf : Nbf-1\` | \`mval(i) == m\` |
| \`diatomic::TwoDBasis::m_indices(int m, bool odd)\` | \`(mval(i)==0) ? Nbf : Nbf-1\` | \`mval(i) == m && lval(i) % 2 == odd\` |

### Bonus correctness fix

The old atomic \`lm_indices\` allocated \`arma::uvec idx(radial.Nbf())\` without counting — correct only under the implicit assumption that (l, m) is unique. The helper's two-pass count makes the behaviour explicit and safe for any layout.

## Callers above unchanged

\`get_sym_idx\` (both atomic and diatomic) is a thin dispatcher over \`m_indices\` / \`lm_indices\`; the extraction is invisible to it.

## Validation

- Full build clean
- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (bit-identical to the radial-block-helper baseline)

## LOC impact

| File | Change |
|---|---|
| \`src/atomic/TwoDBasis.cpp\` | -34 |
| \`src/diatomic/basis.cpp\` | -40 |
| \`src/general/angular_index_helpers.h\` | +55 |
| **Net** | **~-20 LOC**, plus the intent is now readable at a glance and the correctness subtlety in atomic \`lm_indices\` is gone |

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR