### PR TITLE
DRY: extract shared SCF-driver helpers to helfem::scf_driver

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -20,6 +20,7 @@
 #include "../general/elements.h"
 #include "../general/timer.h"
 #include "../general/scf_helpers.h"
+#include "../general/scf_driver_common.h"
 #include <ArmaEigen.h>
 #include "basis.h"
 #include "dftgrid.h"
@@ -48,13 +49,10 @@ void classify_orbitals(const arma::mat & C, const arma::ivec & lvals, const arma
   }
 }
 
-void normalize_matrix(arma::mat & M, const arma::vec & norm) {
-  if(M.n_rows != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
-  if(M.n_cols != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
-  for(size_t i=0;i<M.n_rows;i++)
-    for(size_t j=0;j<M.n_cols;j++)
-      M(i,j)*=norm(i)*norm(j);
-}
+// normalize_matrix, gram_schmidt, report_ortho_deviation and
+// report_halfoverlap_error moved to helfem::scf_driver in
+// ../general/scf_driver_common.h.
+using helfem::scf_driver::normalize_matrix;
 
 int main(int argc, char **argv) {
   cmdline::parser parser;
@@ -439,19 +437,11 @@ int main(int argc, char **argv) {
   arma::mat Sinvh(basis.Sinvh(!diag,symm));
   chkpt.write("Sinvh",Sinvh);
   printf("Half-inverse formed in %.6f\n",timer.get());
-  {
-    arma::mat Smo(Sinvh.t()*S*Sinvh);
-    Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
-    printf("Orbital orthonormality deviation is %e\n",arma::norm(Smo,"fro"));
-  }
+  helfem::scf_driver::report_ortho_deviation(S, Sinvh);
   arma::mat Sh(basis.Shalf(!diag,symm));
   chkpt.write("Sh",Sh);
   printf("Half-overlap formed in %.6f\n",timer.get());
-  {
-    arma::mat Smo(Sh.t()*Sinvh);
-    Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
-    printf("Half-overlap error is %e\n",arma::norm(Smo,"fro"));
-  }
+  helfem::scf_driver::report_halfoverlap_error(Sh, Sinvh);
 
   // Form nuclear attraction energy matrix
   Timer tnuc;
@@ -598,17 +588,8 @@ int main(int argc, char **argv) {
 	Cb=P*C;
 
 	// Run Gram-Schmidt to make sure orbitals are orthonormal
-	for(int ia=0;ia<nela;ia++) {
-	  for(int ja=0;ja<ia;ja++)
-	    Ca.col(ia)-= Ca.col(ja)*(arma::trans(Ca.col(ja))*S*Ca.col(ia));
-	  Ca.col(ia) /= sqrt(arma::as_scalar(arma::trans(Ca.col(ia))*S*Ca.col(ia)));
-	}
-
-	for(int ib=0;ib<nelb;ib++) {
-	  for(int jb=0;jb<ib;jb++)
-	    Cb.col(ib) -= Cb.col(jb)*(arma::trans(Cb.col(jb))*S*Cb.col(ib));
-	  Cb.col(ib) /= sqrt(arma::as_scalar(arma::trans(Cb.col(ib))*S*Cb.col(ib)));
-	}
+	helfem::scf_driver::gram_schmidt(Ca, S, nela);
+	helfem::scf_driver::gram_schmidt(Cb, S, nelb);
 
 	// Read in orbital energies
 	loadchk.read("Ea",Ea);

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -21,6 +21,7 @@
 #include "utils.h"
 #include "../general/elements.h"
 #include "../general/scf_helpers.h"
+#include "../general/scf_driver_common.h"
 #include "../general/model_potential.h"
 #include "basis.h"
 #include "dftgrid.h"
@@ -73,13 +74,10 @@ void classify_orbitals(const arma::mat & C, const arma::ivec & mvals, const std:
   }
 }
 
-void normalize_matrix(arma::mat & M, const arma::vec & norm) {
-  if(M.n_rows != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
-  if(M.n_cols != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
-  for(size_t i=0;i<M.n_rows;i++)
-    for(size_t j=0;j<M.n_cols;j++)
-      M(i,j)*=norm(i)*norm(j);
-}
+// normalize_matrix, gram_schmidt, report_ortho_deviation and
+// report_halfoverlap_error moved to helfem::scf_driver in
+// ../general/scf_driver_common.h.
+using helfem::scf_driver::normalize_matrix;
 
 int main(int argc, char **argv) {
   cmdline::parser parser;
@@ -469,19 +467,11 @@ int main(int argc, char **argv) {
   arma::mat Sinvh(basis.Sinvh(!diag,symm));
   chkpt.write("Sinvh",Sinvh);
   printf("Half-inverse formed in %.6f\n",timer.get());
-  {
-    arma::mat Smo(Sinvh.t()*S*Sinvh);
-    Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
-    printf("Orbital orthonormality deviation is %e\n",arma::norm(Smo,"fro"));
-  }
+  helfem::scf_driver::report_ortho_deviation(S, Sinvh);
   arma::mat Sh(basis.Shalf(!diag,symm));
   chkpt.write("Sh",Sh);
   printf("Half-overlap formed in %.6f\n",timer.get());
-  {
-    arma::mat Smo(Sh.t()*Sinvh);
-    Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
-    printf("Half-overlap error is %e\n",arma::norm(Smo,"fro"));
-  }
+  helfem::scf_driver::report_halfoverlap_error(Sh, Sinvh);
 
   // Form nuclear attraction energy matrix
   Timer tnuc;
@@ -644,17 +634,8 @@ int main(int argc, char **argv) {
         Cb=P*C;
 
         // Run Gram-Schmidt to make sure orbitals are orthonormal
-        for(int ia=0;ia<nela;ia++) {
-          for(int ja=0;ja<ia;ja++)
-            Ca.col(ia)-= Ca.col(ja)*(arma::trans(Ca.col(ja))*S*Ca.col(ia));
-          Ca.col(ia) /= sqrt(arma::as_scalar(arma::trans(Ca.col(ia))*S*Ca.col(ia)));
-        }
-
-        for(int ib=0;ib<nelb;ib++) {
-          for(int jb=0;jb<ib;jb++)
-            Cb.col(ib) -= Cb.col(jb)*(arma::trans(Cb.col(jb))*S*Cb.col(ib));
-          Cb.col(ib) /= sqrt(arma::as_scalar(arma::trans(Cb.col(ib))*S*Cb.col(ib)));
-        }
+        helfem::scf_driver::gram_schmidt(Ca, S, nela);
+        helfem::scf_driver::gram_schmidt(Cb, S, nelb);
 
         // Read in orbital energies
         loadchk.read("Ea",Ea);

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -1,0 +1,68 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef HELFEM_SCF_DRIVER_COMMON_H
+#define HELFEM_SCF_DRIVER_COMMON_H
+
+// Shared building blocks for the atomic and diatomic SCF drivers.
+// Extracted from src/atomic/main.cpp and src/diatomic/main.cpp
+// (both files kept byte-identical copies of these).
+
+#include <armadillo>
+#include <cstdio>
+#include <stdexcept>
+
+namespace helfem {
+  namespace scf_driver {
+    /// In-place symmetric scaling M(i, j) *= norm(i) * norm(j),
+    /// used by both drivers to renormalise Fock / density blocks.
+    inline void normalize_matrix(arma::mat & M, const arma::vec & norm) {
+      if (M.n_rows != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
+      if (M.n_cols != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
+      for (size_t i = 0; i < M.n_rows; ++i)
+        for (size_t j = 0; j < M.n_cols; ++j)
+          M(i, j) *= norm(i) * norm(j);
+    }
+
+    /// Gram-Schmidt reorthonormalise the first nocc columns of C
+    /// against the overlap S. Used after re-loading orbitals from a
+    /// checkpoint or projecting between bases so subsequent SCF
+    /// iterations start from a strictly orthonormal set.
+    inline void gram_schmidt(arma::mat & C, const arma::mat & S, int nocc) {
+      for (int i = 0; i < nocc; ++i) {
+        for (int j = 0; j < i; ++j)
+          C.col(i) -= C.col(j) * (arma::trans(C.col(j)) * S * C.col(i));
+        C.col(i) /= std::sqrt(arma::as_scalar(arma::trans(C.col(i)) * S * C.col(i)));
+      }
+    }
+
+    /// Report orbital-orthonormality deviation ||Sinvh^T S Sinvh - I||_F.
+    /// Both drivers print this immediately after Sinvh is formed.
+    inline void report_ortho_deviation(const arma::mat & S, const arma::mat & Sinvh) {
+      arma::mat Smo(Sinvh.t() * S * Sinvh);
+      Smo -= arma::eye<arma::mat>(Smo.n_rows, Smo.n_cols);
+      printf("Orbital orthonormality deviation is %e\n", arma::norm(Smo, "fro"));
+    }
+
+    /// Report half-overlap consistency ||Sh^T Sinvh - I||_F. Both
+    /// drivers print this immediately after Sh is formed.
+    inline void report_halfoverlap_error(const arma::mat & Sh, const arma::mat & Sinvh) {
+      arma::mat Smo(Sh.t() * Sinvh);
+      Smo -= arma::eye<arma::mat>(Smo.n_rows, Smo.n_cols);
+      printf("Half-overlap error is %e\n", arma::norm(Smo, "fro"));
+    }
+  } // namespace scf_driver
+} // namespace helfem
+
+#endif


### PR DESCRIPTION
## Summary

Consolidates the small byte-identical helper blocks that lived in both \`src/atomic/main.cpp\` and \`src/diatomic/main.cpp\`.

## New header

\`src/general/scf_driver_common.h\` — header-only, inline utilities in \`namespace helfem::scf_driver\`:

| Helper | Purpose |
|---|---|
| \`normalize_matrix(M, norm)\` | In-place symmetric scaling \`M(i, j) *= norm(i) * norm(j)\` |
| \`gram_schmidt(C, S, nocc)\` | Gram-Schmidt reorthonormalisation of the first nocc columns of C against S |
| \`report_ortho_deviation(S, Sinvh)\` | Print \`\|\|Sinvh^T S Sinvh - I\|\|_F\` |
| \`report_halfoverlap_error(Sh, Sinvh)\` | Print \`\|\|Sh^T Sinvh - I\|\|_F\` |

## Call sites migrated (4 per driver)

- \`normalize_matrix\`: free-function definition removed; added \`using helfem::scf_driver::normalize_matrix;\` so existing free-function callers in each main.cpp continue to compile unchanged
- **Sinvh block**: two anonymous blocks \`{arma::mat Smo(...); ...}\` that printed the ortho / half-overlap deviation replaced by single-line \`report_*\` calls
- **Gram-Schmidt block**: two 6-line double-loops (one for alpha, one for beta) replaced with two \`gram_schmidt\` calls

## Numerics unchanged

The helpers are byte-identical extractions from the atomic version (which matched the diatomic version). No control-flow or floating-point change.

## Validation

- Full build clean
- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (bit-identical to the angular-index-helpers baseline)

## LOC impact

| File | Change |
|---|---|
| \`src/atomic/main.cpp\` | -22 |
| \`src/diatomic/main.cpp\` | -22 |
| \`src/general/scf_driver_common.h\` | +65 |

Net absolute LOC is roughly flat, but each duplicated block is now a **single named call** and the intent is readable at a glance.

## Deferred

The bigger DRY opportunities in \`main.cpp\` (the ~35-line checkpoint Fock projection pattern, the SCF convergence loop shell, orbital slicing & printing) are deferred to follow-up PRs — they need a proper template driver, not just header-only helpers.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR