### PR TITLE
DRY: extract checkpoint Fock projection + diagonalization to helfem::scf_driver::project_and_diagonalize

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -514,56 +514,10 @@ int main(int argc, char **argv) {
 	  // Helper
 	  arma::mat SSinvh(S*Sinvh);
 
-	  // Fock matrix
-	  arma::mat F;
-
-	  // Load Fock matrix
-	  loadchk.read("Fa",F);
-	  // Project onto the old orthogonal basis
-	  F=arma::trans(oldSinvh)*F*oldSinvh;
-	  // Project onto the new basis
-	  F=S12*F*arma::trans(S12);
-	  // Go back to original basis
-	  F=SSinvh*F*arma::trans(SSinvh);
-	  // Diagonalize
-	  if(symm)
-	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
-	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
-	      scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
-	      Ea = helfem::to_arma(Ea_e);
-	      Ca = helfem::to_arma(Ca_e);
-	    }
-	  else
-	    { // Phase 5.11 bridge: eig_gsym is Eigen.
-	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
-	      scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
-	      Ea = helfem::to_arma(Ea_e);
-	      Ca = helfem::to_arma(Ca_e);
-	    }
-
-	  // Load Fock matrix
-	  loadchk.read("Fb",F);
-	  // Project onto the old orthogonal basis
-	  F=arma::trans(oldSinvh)*F*oldSinvh;
-	  // Project onto the new basis
-	  F=S12*F*arma::trans(S12);
-	  // Go back to original basis
-	  F=SSinvh*F*arma::trans(SSinvh);
-	  // Diagonalize
-	  if(symm)
-	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
-	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
-	      scf::eig_gsym_sub(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
-	      Eb = helfem::to_arma(Eb_e);
-	      Cb = helfem::to_arma(Cb_e);
-	    }
-	  else
-	    { // Phase 5.11 bridge: eig_gsym is Eigen.
-	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
-	      scf::eig_gsym(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
-	      Eb = helfem::to_arma(Eb_e);
-	      Cb = helfem::to_arma(Cb_e);
-	    }
+	  helfem::scf_driver::project_and_diagonalize(
+	      loadchk, "Fa", oldSinvh, S12, SSinvh, Sinvh, symm, dsym, Ea, Ca);
+	  helfem::scf_driver::project_and_diagonalize(
+	      loadchk, "Fb", oldSinvh, S12, SSinvh, Sinvh, symm, dsym, Eb, Cb);
 	}
         break;
 

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -560,56 +560,10 @@ int main(int argc, char **argv) {
 	  // Helper
 	  arma::mat SSinvh(S*Sinvh);
 
-	  // Fock matrix
-	  arma::mat F;
-
-	  // Load Fock matrix
-	  loadchk.read("Fa",F);
-	  // Project onto the old orthogonal basis
-	  F=arma::trans(oldSinvh)*F*oldSinvh;
-	  // Project onto the new basis
-	  F=S12*F*arma::trans(S12);
-	  // Go back to original basis
-	  F=SSinvh*F*arma::trans(SSinvh);
-	  // Diagonalize
-	  if(symm)
-	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
-	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
-	      scf::eig_gsym_sub(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
-	      Ea = helfem::to_arma(Ea_e);
-	      Ca = helfem::to_arma(Ca_e);
-	    }
-	  else
-	    { // Phase 5.11 bridge: eig_gsym is Eigen.
-	      helfem::Vector Ea_e; helfem::Matrix Ca_e;
-	      scf::eig_gsym(Ea_e, Ca_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
-	      Ea = helfem::to_arma(Ea_e);
-	      Ca = helfem::to_arma(Ca_e);
-	    }
-
-	  // Load Fock matrix
-	  loadchk.read("Fb",F);
-	  // Project onto the old orthogonal basis
-	  F=arma::trans(oldSinvh)*F*oldSinvh;
-	  // Project onto the new basis
-	  F=S12*F*arma::trans(S12);
-	  // Go back to original basis
-	  F=SSinvh*F*arma::trans(SSinvh);
-	  // Diagonalize
-	  if(symm)
-	    { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
-	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
-	      scf::eig_gsym_sub(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
-	      Eb = helfem::to_arma(Eb_e);
-	      Cb = helfem::to_arma(Cb_e);
-	    }
-	  else
-	    { // Phase 5.11 bridge: eig_gsym is Eigen.
-	      helfem::Vector Eb_e; helfem::Matrix Cb_e;
-	      scf::eig_gsym(Eb_e, Cb_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
-	      Eb = helfem::to_arma(Eb_e);
-	      Cb = helfem::to_arma(Cb_e);
-	    }
+	  helfem::scf_driver::project_and_diagonalize(
+	      loadchk, "Fa", oldSinvh, S12, SSinvh, Sinvh, symm, dsym, Ea, Ca);
+	  helfem::scf_driver::project_and_diagonalize(
+	      loadchk, "Fb", oldSinvh, S12, SSinvh, Sinvh, symm, dsym, Eb, Cb);
 	}
         break;
 

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -22,6 +22,11 @@
 #include <armadillo>
 #include <cstdio>
 #include <stdexcept>
+#include <string>
+#include <vector>
+#include "checkpoint.h"
+#include "scf_helpers.h"
+#include <ArmaEigen.h>
 
 namespace helfem {
   namespace scf_driver {
@@ -61,6 +66,38 @@ namespace helfem {
       arma::mat Smo(Sh.t() * Sinvh);
       Smo -= arma::eye<arma::mat>(Smo.n_rows, Smo.n_cols);
       printf("Half-overlap error is %e\n", arma::norm(Smo, "fro"));
+    }
+
+    /// Load a Fock matrix by key, project it through the checkpoint's
+    /// (old) orthonormal basis into the current (new) orthonormal
+    /// basis, transform back to the AO basis, and diagonalise into
+    /// (E, C). Both drivers use this pattern once per spin channel
+    /// when restarting from a checkpoint via Fock projection.
+    ///
+    ///   F <- oldSinvh^T F oldSinvh                       (to old orthonormal)
+    ///   F <- S12 F S12^T                                  (project to new orthonormal)
+    ///   F <- SSinvh F SSinvh^T                            (back to AO)
+    ///   (E, C) <- symm ? eig_gsym_sub(F, Sinvh, dsym) : eig_gsym(F, Sinvh).
+    inline void project_and_diagonalize(
+        Checkpoint & loadchk, const std::string & fock_key,
+        const arma::mat & oldSinvh, const arma::mat & S12,
+        const arma::mat & SSinvh,   const arma::mat & Sinvh,
+        bool symm, const std::vector<arma::uvec> & dsym,
+        arma::vec & E, arma::mat & C) {
+      arma::mat F;
+      loadchk.read(fock_key, F);
+      F = arma::trans(oldSinvh) * F * oldSinvh;
+      F = S12 * F * arma::trans(S12);
+      F = SSinvh * F * arma::trans(SSinvh);
+
+      helfem::Vector E_e;
+      helfem::Matrix C_e;
+      if (symm)
+        helfem::scf::eig_gsym_sub(E_e, C_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
+      else
+        helfem::scf::eig_gsym    (E_e, C_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
+      E = helfem::to_arma(E_e);
+      C = helfem::to_arma(C_e);
     }
   } // namespace scf_driver
 } // namespace helfem


### PR DESCRIPTION
## Summary

Consolidates the ~30-line byte-identical block that appeared in both \`src/atomic/main.cpp\` and \`src/diatomic/main.cpp\` four times (twice per driver, once for alpha and once for beta) during checkpoint-restart via Fock projection.

**The block sequence was**:
\`\`\`cpp
loadchk.read("Fa" or "Fb", F);
F = trans(oldSinvh) * F * oldSinvh;   // to old orthonormal
F = S12 * F * trans(S12);              // project to new orthonormal
F = SSinvh * F * trans(SSinvh);        // back to AO
if (symm) eig_gsym_sub(E, C, F, Sinvh, dsym)
else      eig_gsym    (E, C, F, Sinvh)
\`\`\`

## New helper

\`\`\`cpp
helfem::scf_driver::project_and_diagonalize(
    loadchk, fock_key, oldSinvh, S12, SSinvh, Sinvh, symm, dsym, E, C);
\`\`\`

Encapsulates the load + three-step projection + symmetry-branched Eigen \`eig_gsym[_sub]\` call plus the arma ↔ Eigen bridging that each call site currently spells out inline (from Phase 5.11 / 5.12).

## Call sites migrated (4)

- **\`src/atomic/main.cpp\`**: Fa and Fb during the restart-from-checkpoint Fock-projection branch of \`iguess=0\`
- **\`src/diatomic/main.cpp\`**: same shape

Each block collapsed from ~24 lines (Fa) + ~24 lines (Fb) of load, three matmuls, symm dispatch and 4-line bridge, down to two 2-line calls of \`project_and_diagonalize\`.

## Validation

- Full build clean
- \`eigen_foundation_test\`: 13/13 PASS
- He sadatom HF at lmax=1: **Etot = −2.861679987** (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (bit-identical to the scf-driver-helpers baseline; Be HF doesn't hit the checkpoint-restart branch, but the extraction is behaviour-preserving by construction)

## LOC impact

| File | Change |
|---|---|
| \`src/atomic/main.cpp\` | -46 |
| \`src/diatomic/main.cpp\` | -46 |
| \`src/general/scf_driver_common.h\` | +30 |
| **Net** | **~-62 LOC of pure duplication removed** |

## Header dependency growth

\`scf_driver_common.h\` grows an include on \`checkpoint.h\`, \`scf_helpers.h\` and \`<ArmaEigen.h>\` now that \`project_and_diagonalize\` needs the Eigen bridge; kept the small helpers (\`normalize_matrix\`, \`gram_schmidt\`, \`report_*\`) inline in the same header for locality.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He sadatom HF unchanged
- [x] Be HF via atomic bit-identical to prior PR