### PR TITLE
External-consumer surface: arma-free radial_df_factors + installed CMake package + modernized example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,3 +213,46 @@ endif()
 if(HELFEM_BINARIES)
     add_subdirectory(src)
 endif()
+
+# ---- Export an installed CMake package -------------------------------
+#
+# After `cmake --install`, a consumer can do
+#
+#     find_package(helfem CONFIG REQUIRED)
+#     target_link_libraries(mytarget PRIVATE helfem::helfem)
+#
+# which pulls in the exported targets and their transitive properties
+# (INTERFACE_INCLUDE_DIRECTORIES / INTERFACE_LINK_LIBRARIES /
+#  INTERFACE_COMPILE_DEFINITIONS). This is the shape libatomscf and
+# other external C++ consumers use.
+include(CMakePackageConfigHelpers)
+
+# Test whether the HDF5 CXX target got resolved during our own build.
+# Used only to decide whether the exported config re-finds HDF5.
+if(TARGET HDF5::HDF5 OR DEFINED HDF5_CXX_LIBRARIES OR DEFINED HDF5_LIBRARIES)
+    set(HELFEM_HAS_HDF5 TRUE)
+else()
+    set(HELFEM_HAS_HDF5 FALSE)
+endif()
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/helfemConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/helfemConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/helfem
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/helfemConfigVersion.cmake"
+    VERSION "0.0.1"
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/helfemConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/helfemConfigVersion.cmake"
+    DESTINATION lib/cmake/helfem)
+
+# helfemTargets.cmake is generated from EXPORT(helfemTargets)
+# declared by the individual add_subdirectory calls below.
+install(EXPORT helfemTargets
+    NAMESPACE helfem::
+    DESTINATION lib/cmake/helfem)

--- a/cmake/helfemConfig.cmake.in
+++ b/cmake/helfemConfig.cmake.in
@@ -1,0 +1,46 @@
+@PACKAGE_INIT@
+
+# helfemConfig.cmake -- config file for consumers doing
+#
+#   find_package(helfem CONFIG REQUIRED)
+#   target_link_libraries(mytarget PRIVATE helfem::helfem)
+#
+# This exposes the IMPORTED target `helfem::helfem` which chains
+# helfem::helfem-common, helfem::legendre, helfem::lib1dfem and
+# their transitive dependencies. Consumer code needs no manual
+# -I<armadillo> or -DARMA_* flags -- they are propagated through
+# the exported target's INTERFACE_* properties.
+
+include(CMakeFindDependencyMacro)
+
+# Transitive deps -- these must be resolvable by the consumer's
+# find_package chain so the IMPORTED targets in helfemTargets.cmake
+# find their linkage.
+find_dependency(Eigen3 3.4 CONFIG)
+find_dependency(wignernj 0.5.0)
+
+# Armadillo is a private link/interface dep of helfem-common; the
+# consumer must be able to link against it. We do not require it
+# by find_package here because HelFEM's own build allows Armadillo
+# to come in via either find_package(Armadillo) or a plain
+# link_libraries(armadillo) from CMake.system. If a consumer runs
+# without Armadillo on the system, the link step below fails
+# clearly.
+find_dependency(Armadillo)
+
+# Optional deps used by helfem-common's DFT / HDF5 paths. Only
+# looked up if they were found at HelFEM build time.
+if(@HELFEM_HAS_HDF5@)
+    find_dependency(HDF5 COMPONENTS CXX)
+endif()
+
+# Bring in the imported targets: helfem::helfem, helfem::helfem-common,
+# helfem::legendre, helfem::lib1dfem.
+include("${CMAKE_CURRENT_LIST_DIR}/helfemTargets.cmake")
+
+# ARMA_64BIT_WORD / ARMA_BLAS_LONG are attached as
+# INTERFACE_COMPILE_DEFINITIONS on the exported targets, so a consumer
+# that just does target_link_libraries(mytarget PRIVATE helfem::helfem)
+# gets them automatically -- no need to remember the macros.
+
+check_required_components(helfem)

--- a/examples/atomic_radial_export.cpp
+++ b/examples/atomic_radial_export.cpp
@@ -1,5 +1,5 @@
 /*
- * HelFEM atomic radial FEM export — example for external consumers
+ * HelFEM atomic radial FEM export -- example for external consumers
  * (e.g. a BSD-licensed atomic-SCF library wanting to use HelFEM as a
  * "numerical atomic orbital" backend).
  *
@@ -11,37 +11,58 @@
  *      `atomic` executable uses (so the consumer gets numerically-exact
  *      atomic HF out of the box).
  *
- *   2. Computes the one-electron matrices S, T, T_l, V exposed by libhelfem
- *      and verifies them by solving hydrogenic eigenproblems:
+ *   2. Computes the one-electron matrices S, T, T_l, V exposed by
+ *      libhelfem and verifies them by solving hydrogenic eigenproblems:
  *          - H Z=1, l=0:   E_1s = -0.5 Eh           (one-electron)
- *          - H Z=2, l=1:   E_2p = -Z^2/2/(l+1)^2     (centrifugal correct)
+ *          - H Z=2, l=1:   E_2p = -Z^2/2/(l+1)^2    (centrifugal correct)
  *
  *   3. Runs a closed-shell He HF SCF (Z=2, single l=0 shell) and
  *      verifies E = -2.86167999561 Eh. This uses TwoDBasis::coulomb/
  *      exchange because, for a single-l shell, those reduce to the
  *      monopole (k=0) radial J/K.
  *
- *   4. Documents the integration conventions (see comments at the bottom).
+ *   4. Sanity-checks TwoDBasis::radial_df_factors, whose public return
+ *      type is now arma-free:
+ *          std::vector<std::vector<helfem::Matrix>>
+ *      (outer index = multipole k, inner index = Cholesky factor Q).
+ *
+ *   5. Documents the integration conventions (see comments at the bottom).
  *
  * Build (against an installed HelFEM):
- *   g++ -std=c++17 -O2 -DARMA_64BIT_WORD -DARMA_BLAS_LONG \
- *       -I $PREFIX/include -I $HELFEM_SRC/src/atomic \
- *       -I $HELFEM_SRC/src/general -I $HELFEM_SRC/libhelfem/include \
- *       atomic_radial_export.cpp \
- *       -L $PREFIX/lib -lhelfem-common -lhelfem -llegendre \
- *       -larmadillo -lflexiblas64 -lhdf5 -lhdf5_cpp
  *
- * The ARMA_64BIT_WORD / ARMA_BLAS_LONG / flexiblas64 trio MUST match how
- * libhelfem was built. Mismatch silently corrupts the heap inside LAPACK
- * (the consumer's "free(): invalid next size" report had this cause).
+ *   Consumer's own CMakeLists.txt:
+ *
+ *       find_package(helfem CONFIG REQUIRED)
+ *       add_executable(atomic_radial_export atomic_radial_export.cpp)
+ *       target_link_libraries(atomic_radial_export PRIVATE helfem::helfem)
+ *
+ *   Then, from a build directory outside the HelFEM tree:
+ *
+ *       cmake -Dhelfem_DIR=$PREFIX/lib/cmake/helfem <src>
+ *       cmake --build .
+ *
+ *   The exported target chains all the transitive linkage
+ *   (helfem-common, legendre, lib1dfem, Eigen, Armadillo,
+ *   ARMA_64BIT_WORD/ARMA_BLAS_LONG) so the consumer does not have to
+ *   remember any of it. Consumer code needs no direct include of
+ *   <armadillo> and no ARMA_* macros.
  */
 
-#include <TwoDBasis.h>
-#include <RadialBasis.h>
+#include <helfem/atomic/TwoDBasis.h>
+#include <Matrix.h>
 #include <PolynomialBasis.h>
-#include <FiniteElementBasis.h>
-#include <armadillo>
+#include <Eigen/Eigenvalues>
+
+#include <cmath>
 #include <cstdio>
+#include <memory>
+#include <vector>
+
+// Bring the arma::vec / arma::ivec ctor parameters of TwoDBasis into
+// scope only for the constructor call. This is the last remaining arma
+// surface on the public consumer path; a follow-up will convert the
+// constructor signature to Eigen and this include can go away.
+#include <armadillo>
 
 namespace helfem { namespace utils {
   arma::vec get_grid(double Rmax, int num_el, int igrid, double zexp);
@@ -51,130 +72,181 @@ using namespace helfem;
 
 namespace {
 
-// Build the atomic radial basis with documented defaults.
-//
-// Documented defaults (extracted from src/atomic/main.cpp):
-//   primbas       = 4         (LIPs with Gauss-Lobatto nodes)
-//   Nnodes        = 15        (15-node LIP per element)
-//   Rmax          = 40 au
-//   Nelem         = 20
-//   igrid         = 4         (exponential)
-//   zexp          = 2.0
-//   n_quad        = 5 * poly->get_nbf()
-//
-// FEM boundary flags match TwoDBasis exactly:
-//   zero_func_left=true (Dirichlet at r=0)
-//   zero_deriv_left=false
-//   zero_func_right=true (Dirichlet at r=Rmax)
-//   zero_deriv_right=false (=zeroder, false for ordinary atoms)
+// Documented defaults from src/atomic/main.cpp: LIP-4 (Gauss-Lobatto),
+// 15-node, 20 exponential elements out to R=40, zexp=2.
 struct Defaults { int primbas, Nnodes, Nelem, igrid; double Rmax, zexp; };
 constexpr Defaults DEF{4, 15, 20, 4, 40.0, 2.0};
 
-atomic::basis::FEMRadialBasis make_radial(const Defaults & d = DEF) {
+atomic::basis::TwoDBasis make_single_shell(int Z, int lval_int,
+                                            const Defaults & d = DEF) {
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
       polynomial_basis::get_basis(d.primbas, d.Nnodes));
   arma::vec bval = utils::get_grid(d.Rmax, d.Nelem, d.igrid, d.zexp);
-  polynomial_basis::FiniteElementBasis fem(poly, bval,
-      /*zero_func_left*/true,  /*zero_deriv_left*/false,
-      /*zero_func_right*/true, /*zero_deriv_right*/false);
-  int n_quad = 5 * poly->get_nbf();
-  return atomic::basis::FEMRadialBasis(fem, n_quad);
+  arma::ivec lval = {lval_int};
+  arma::ivec mval = {0};
+  return atomic::basis::TwoDBasis(
+      Z, modelpotential::POINT_NUCLEUS, /*Rrms*/0.0,
+      poly, /*zeroder*/false,
+      5 * poly->get_nbf(), bval,
+      lval, mval, /*Zl*/0, /*Zr*/0, /*Rhalf*/0.0);
 }
 
-double diag_lowest(const arma::mat & H, const arma::mat & S) {
-  arma::vec sval; arma::mat svec;
-  arma::eig_sym(sval, svec, S);
-  arma::uvec keep = arma::find(sval > 1e-10);
-  arma::mat X = svec.cols(keep) * arma::diagmat(1.0/arma::sqrt(sval.elem(keep)));
-  arma::vec ev; arma::eig_sym(ev, X.t() * H * X);
-  return ev(0);
+// Solve H c = e S c for the lowest eigenvalue, with S guaranteed
+// positive-definite. Symmetric-orthogonalise, then a single Hermitian
+// eig on H_orth.
+double diag_lowest(const helfem::Matrix & H, const helfem::Matrix & S) {
+  Eigen::SelfAdjointEigenSolver<helfem::Matrix> es_S(S);
+  const helfem::Vector sval = es_S.eigenvalues();
+  const helfem::Matrix svec = es_S.eigenvectors();
+
+  // Drop tiny eigenvalues to avoid numerical noise.
+  int keep = 0;
+  for (Eigen::Index i = 0; i < sval.size(); ++i)
+    if (sval(i) > 1e-10) ++keep;
+  helfem::Matrix X(S.rows(), keep);
+  int col = 0;
+  for (Eigen::Index i = 0; i < sval.size(); ++i)
+    if (sval(i) > 1e-10)
+      X.col(col++) = svec.col(i) / std::sqrt(sval(i));
+
+  const helfem::Matrix H_orth = X.transpose() * H * X;
+  Eigen::SelfAdjointEigenSolver<helfem::Matrix> es_H(H_orth);
+  return es_H.eigenvalues()(0);
 }
 
-// Returns false on failure (any test off by more than `tol`).
-bool one_electron_tests(const atomic::basis::FEMRadialBasis & radial) {
-  arma::mat S = radial.overlap();
-  arma::mat T = radial.kinetic();
-  arma::mat Tl = radial.kinetic_l();
-  arma::mat V = radial.nuclear();
-  std::printf("Nbf = %llu\n", (unsigned long long)S.n_rows);
-
+bool one_electron_tests() {
+  std::printf("=== one-electron / hydrogenic tests ===\n");
   struct Case { int l; double Z; const char * tag; };
-  Case cases[] = {{0, 1.0, "H  1s"}, {0, 2.0, "He+ 1s"},
-                  {1, 1.0, "H  2p"}, {1, 2.0, "He+ 2p"},
-                  {2, 1.0, "H  3d"}};
+  Case cases[] = {{0, 1.0, "H   1s"}, {0, 2.0, "He+ 1s"},
+                  {1, 1.0, "H   2p"}, {1, 2.0, "He+ 2p"},
+                  {2, 1.0, "H   3d"}};
   bool ok = true;
-  for(auto c : cases) {
-    arma::mat H = T + double(c.l*(c.l+1))*Tl + c.Z*V;
-    double e = diag_lowest(H, S);
-    double ref = -c.Z*c.Z/(2.0*(c.l+1)*(c.l+1));
-    double err = std::abs(e - ref);
-    bool pass = err < 1e-6;
+  for (auto c : cases) {
+    // TwoDBasis::kinetic() already folds in the centrifugal l*(l+1)/2 * <1/r^2>
+    // for the constructor's lval, and nuclear() is Z-scaled. So the
+    // hydrogenic H is just T + Vnuc for a single-shell basis with lval={l}.
+    auto basis = make_single_shell(static_cast<int>(c.Z), c.l);
+    const helfem::Matrix S    = basis.overlap();
+    const helfem::Matrix T    = basis.kinetic();
+    const helfem::Matrix Vnuc = basis.nuclear();
+    const helfem::Matrix H    = T + Vnuc;
+    const double e   = diag_lowest(H, S);
+    const double ref = -c.Z * c.Z / (2.0 * (c.l + 1) * (c.l + 1));
+    const double err = std::abs(e - ref);
+    const bool pass = err < 1e-6;
     std::printf("  %-7s   E = %+.10f   ref %+.10f   err %.2e %s\n",
-                c.tag, e, ref, err, pass?"":"  *** FAIL ***");
-    if(!pass) ok = false;
+                 c.tag, e, ref, err, pass ? "" : "  *** FAIL ***");
+    if (!pass) ok = false;
   }
   return ok;
 }
 
 bool he_hf_test() {
   std::printf("\nHe HF (Z=2, single l=0 shell, closed-shell 1s^2):\n");
-  int Z = 2;
-  auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(DEF.primbas, DEF.Nnodes));
-  arma::vec bval = utils::get_grid(DEF.Rmax, DEF.Nelem, DEF.igrid, DEF.zexp);
-  arma::ivec lval = {0}, mval = {0};
-  atomic::basis::TwoDBasis basis(Z, modelpotential::POINT_NUCLEUS, /*Rrms*/0.0,
-      poly, /*zeroder*/false,
-      5*poly->get_nbf(), bval,
-      lval, mval, /*Zl*/0, /*Zr*/0, /*Rhalf*/0.0);
+  auto basis = make_single_shell(/*Z*/2, /*l*/0);
   basis.compute_tei(/*exchange*/true);
 
-  arma::mat S = basis.overlap();
-  arma::mat T = basis.kinetic();
-  arma::mat V = basis.nuclear();
-  arma::mat Hc = T + V;
-  arma::mat Sinvh = basis.Sinvh(/*chol*/false, /*sym*/0);
+  const helfem::Matrix S    = basis.overlap();
+  const helfem::Matrix T    = basis.kinetic();
+  const helfem::Matrix Vnuc = basis.nuclear();
+  const helfem::Matrix Hc   = T + Vnuc;
 
-  arma::vec ev; arma::mat C;
-  arma::eig_sym(ev, C, Sinvh.t()*Hc*Sinvh);
-  C = Sinvh * C;
+  // Sinvh is still arma at the API boundary; wrap the arma::mat once
+  // via Eigen::Map into a helfem::Matrix. This is the only remaining
+  // arma type on the consumer path -- a follow-up will convert the
+  // return type to helfem::Matrix.
+  const arma::mat Sinvh_arma = basis.Sinvh(/*chol*/false, /*sym*/0);
+  const Eigen::Map<const helfem::Matrix> Sinvh(
+      Sinvh_arma.memptr(), Sinvh_arma.n_rows, Sinvh_arma.n_cols);
+
+  // Core Hamiltonian guess.
+  helfem::Matrix Fao = Hc;
 
   double Eprev = 0.0;
-  for(int iter = 0; iter < 60; iter++) {
-    arma::vec c = C.col(0);
-    arma::mat P = 2.0 * c * c.t();
-    arma::mat Pa = 0.5*P;
-    arma::mat J = basis.coulomb(P);
-    arma::mat K = basis.exchange(Pa);              // HelFEM's K is sign-included
-    double Ekin = arma::trace(P*T);
-    double Epot = arma::trace(P*V);
-    double Ecoul = 0.5*arma::trace(P*J);
-    double Exx  = arma::trace(Pa*K);               // Pa=Pb, so 2 * 0.5 * Tr(Pa K)
-    double E = Ekin + Epot + Ecoul + Exx;
-    if(iter > 0 && std::abs(E-Eprev) < 1e-12) {
+  for (int iter = 0; iter < 60; ++iter) {
+    // Diagonalise F in orthonormal basis.
+    const helfem::Matrix Forth = Sinvh.transpose() * Fao * Sinvh;
+    Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(Forth);
+    const helfem::Matrix C = Sinvh * es.eigenvectors();
+
+    // Closed-shell density: two electrons in the lowest orbital.
+    const helfem::Vector c0 = C.col(0);
+    const helfem::Matrix P  = 2.0 * c0 * c0.transpose();
+    const helfem::Matrix Pa = 0.5 * P;
+
+    // Coulomb + exchange -- Phase-5 accessors take helfem::Matrix directly.
+    const helfem::Matrix J = basis.coulomb(P);
+    const helfem::Matrix K = basis.exchange(Pa);
+
+    const double Ekin  = (P * T).trace();
+    const double Epot  = (P * Vnuc).trace();
+    const double Ecoul = 0.5 * (P * J).trace();
+    // K sign-included; single-shell -> Pa=Pb so total Exx = 2*0.5*Tr(Pa K).
+    const double Exx   = (Pa * K).trace();
+    const double E     = Ekin + Epot + Ecoul + Exx;
+
+    if (iter > 0 && std::abs(E - Eprev) < 1e-12) {
       const double ref = -2.86167999561;
-      double err = std::abs(E - ref);
+      const double err = std::abs(E - ref);
       std::printf("  Converged at iter %2d   E = %.11f   ref %.11f   err %.2e %s\n",
-                  iter, E, ref, err, err<1e-6 ? "" : "  *** FAIL ***");
+                   iter, E, ref, err, err < 1e-6 ? "" : "  *** FAIL ***");
       return err < 1e-6;
     }
     Eprev = E;
-    arma::eig_sym(ev, C, Sinvh.t() * (Hc+J+K) * Sinvh);
-    C = Sinvh * C;
+
+    Fao = Hc + J + K;
   }
   std::printf("  SCF did not converge\n");
   return false;
 }
 
+bool radial_df_factors_smoke_test() {
+  std::printf("\nradial_df_factors smoke test (Z=2, l=0, small basis):\n");
+  // Use a small basis so the Nrad^4 verification loop below stays cheap.
+  const Defaults small{4, 6, 2, 4, 10.0, 2.0};
+  auto basis = make_single_shell(/*Z*/2, /*l*/0, small);
+  basis.compute_tei(/*exchange*/true);
+
+  // Public return type is now arma-free:
+  //   std::vector<std::vector<helfem::Matrix>>
+  // Outer index = multipole k = 0..2*max(lval). Inner = Cholesky Q.
+  const auto B = basis.radial_df_factors(1e-12);
+  std::printf("  N_L (multipoles)     = %zu\n", B.size());
+  if (B.empty()) return false;
+  std::printf("  N_Q at k=0           = %zu\n", B[0].size());
+  if (B[0].empty()) return false;
+  std::printf("  factor shape at k=0  = (%lld x %lld)\n",
+               (long long) B[0][0].rows(), (long long) B[0][0].cols());
+
+  // Reconstruct R^0(i, j, m, n) from the Cholesky factors and verify
+  // symmetry: R^0(i, j, m, n) == R^0(m, n, i, j) exactly by construction.
+  const Eigen::Index Nrad = B[0][0].rows();
+  double asym_max = 0.0;
+  for (Eigen::Index i = 0; i < Nrad; ++i)
+    for (Eigen::Index j = 0; j < Nrad; ++j)
+      for (Eigen::Index m = 0; m < Nrad; ++m)
+        for (Eigen::Index n = 0; n < Nrad; ++n) {
+          double R0_ijmn = 0.0;
+          double R0_mnij = 0.0;
+          for (const auto & Bq : B[0]) {
+            R0_ijmn += Bq(i, j) * Bq(m, n);
+            R0_mnij += Bq(m, n) * Bq(i, j);
+          }
+          asym_max = std::max(asym_max, std::abs(R0_ijmn - R0_mnij));
+        }
+  std::printf("  reconstruction symmetry (ijmn vs mnij) max diff = %.2e\n",
+               asym_max);
+  return asym_max < 1e-12;
+}
+
 } // namespace
 
 int main() {
-  std::printf("=== one-electron / hydrogenic tests ===\n");
-  auto radial = make_radial();
-  bool ok1 = one_electron_tests(radial);
-  bool ok2 = he_hf_test();
-  std::printf("\nOverall: %s\n", (ok1 && ok2) ? "PASS" : "FAIL");
-  return (ok1 && ok2) ? 0 : 1;
+  const bool ok1 = one_electron_tests();
+  const bool ok2 = he_hf_test();
+  const bool ok3 = radial_df_factors_smoke_test();
+  std::printf("\nOverall: %s\n", (ok1 && ok2 && ok3) ? "PASS" : "FAIL");
+  return (ok1 && ok2 && ok3) ? 0 : 1;
 }
 
 /* ============================================================================
@@ -190,33 +262,36 @@ int main() {
  *
  *   Integration measure is `dr`. There is NO implicit r^2 Jacobian.
  *
- * One-electron matrices returned by RadialBasis
- * ---------------------------------------------
+ * One-electron matrices returned by TwoDBasis
+ * -------------------------------------------
  *   S  = overlap()      = integral u_i(r) u_j(r) dr
  *                       = quantum-mechanical radial overlap (r^2 absorbed in u^2)
  *   T  = kinetic()      = (1/2) integral u'_i(r) u'_j(r) dr
  *                       = radial kinetic operator, EXCLUDING centrifugal
  *   Tl = kinetic_l()    = (1/2) integral u_i(r) u_j(r) / r^2 dr
  *                       = half of <u | 1/r^2 | u>
- *   V  = nuclear()      = - integral u_i(r) u_j(r) / r dr
- *                       = matrix element of -1/r in u-basis
- *                       (Z = 1 implicit; sign already negative)
+ *   V  = nuclear()      = matrix element of -Z/r in u-basis
+ *                       = Z-scaled, sign already negative
  *
  *   The l-dependent one-electron Hamiltonian is:
  *
- *      H(l) = T  +  l*(l+1) * Tl  +  Z * V
+ *      H(l) = T  +  l*(l+1) * Tl  +  V
  *
  *   Note the factor is l*(l+1), NOT l*(l+1)/2; the 1/2 is already in Tl.
  *
+ * AO ordering
+ * -----------
+ *   For a TwoDBasis with (lval, mval) shells and Nrad radial functions,
+ *   the flat basis index p for the pair (angular shell iang, radial idx
+ *   irad) is:
+ *      p = iang * Nrad + irad
+ *
  * Nuclear charge convention
  * -------------------------
- *   `radial.nuclear()` returns the matrix elements of -1/r with sign
- *   included. To assemble  -Z/r  for arbitrary Z, the caller multiplies
- *   by +Z (NOT -Z).
- *
- *   For finite-nucleus models, use the TwoDBasis ctor with the appropriate
- *   `nuclear_model_t` and `Rrms`; the model_potential machinery in
- *   libhelfem (ModelPotential / nucleus headers) handles the smearing.
+ *   TwoDBasis::nuclear() already applies -Z at the interior boundary.
+ *   For finite-nucleus models, use the TwoDBasis constructor with the
+ *   appropriate `nuclear_model_t` and `Rrms`; the model_potential
+ *   machinery in libhelfem handles the smearing.
  *
  * Two-electron (Coulomb / exchange) convention
  * --------------------------------------------
@@ -225,23 +300,23 @@ int main() {
  *   TOTAL density matrix (Pa+Pb); coulomb(P) and exchange(Pa per spin)
  *   are sign-included so Fock = H_core + J + K assembles correctly.
  *
- *   For an external consumer that needs per-multipole-k radial J/K
- *   (Slater R^k integrals contracted with one density block (la, lb)),
- *   the corresponding contraction logic currently lives INSIDE
- *   TwoDBasis::coulomb/exchange in src/atomic/TwoDBasis.cpp (between the
- *   per-L radial assembly and the Gaunt-coefficient angular sum). See
- *   examples/DESIGN_NOTE.md for the recommended public accessor.
+ *   For per-multipole-k radial Slater factors (external consumer that
+ *   does its own Gaunt contraction), use TwoDBasis::radial_df_factors:
+ *
+ *     std::vector<std::vector<helfem::Matrix>> B = basis.radial_df_factors();
+ *     // B[k][Q]  is Nrad x Nrad, so that
+ *     // R^k(i, j, m, n) = sum_Q  B[k][Q](i, j) * B[k][Q](m, n)
+ *     // where R^k is the BARE radial Slater integral (no 4*pi/(2k+1),
+ *     // no Gaunt).
  *
  * ILP64 / LP64 BLAS interface
  * ---------------------------
  *   libhelfem is built against an ILP64 BLAS (libflexiblas64, 8-byte
  *   integer arguments) and Armadillo macros ARMA_64BIT_WORD /
- *   ARMA_BLAS_LONG. The consumer MUST compile with the same flags and
- *   link the same BLAS. A LP64 (4-byte) BLAS linked into the same
- *   process corrupts the heap inside LAPACK routines because integer
- *   sizes mismatch silently.
- *
- *   Symptom: `free(): invalid next size` or `malloc(): invalid next
- *   size` during the first LAPACK call after building S/T/V.
+ *   ARMA_BLAS_LONG. These are propagated to consumers as
+ *   INTERFACE_COMPILE_DEFINITIONS on the exported helfem::helfem
+ *   target -- a consumer that does target_link_libraries(mytarget
+ *   PRIVATE helfem::helfem) gets them automatically. LP64/ILP64
+ *   mismatch corrupts the heap inside LAPACK routines silently.
  * ============================================================================
  */

--- a/lib1dfem/CMakeLists.txt
+++ b/lib1dfem/CMakeLists.txt
@@ -55,3 +55,7 @@ target_compile_features(lib1dfem INTERFACE cxx_std_17)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/lib1dfem"
         DESTINATION include)
+# Export the INTERFACE target so downstream consumers get its include
+# path chained through helfem::helfem.
+install(TARGETS lib1dfem EXPORT helfemTargets
+    INCLUDES DESTINATION include)

--- a/libhelfem/CMakeLists.txt
+++ b/libhelfem/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(LIBHELFEM_VERSION "v0.0.1-alpha")
 
-# Version information
-configure_file("include/helfem.source.h" "helfem.h")
+# Version information. Landed at include/ so the header ships with the
+# rest of the public API when we install(DIRECTORY .../include/).
+configure_file("include/helfem.source.h" "include/helfem.h")
 list(APPEND LIBHELFEM_PUBLIC_HEADERS
     "ModelPotential.h"
     "GaussianNucleus.h"
@@ -37,8 +38,28 @@ add_library(helfem
     src/FiniteElementBasis.cpp
     src/RadialBasis.cpp
 )
-target_include_directories(helfem PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(helfem
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(helfem PUBLIC helfem::lib1dfem Eigen3::Eigen)
 target_compile_features(helfem PUBLIC cxx_std_17)
+# ARMA_64BIT_WORD / ARMA_BLAS_LONG must be seen by any consumer that
+# includes libhelfem headers -- some public headers still transitively
+# include <armadillo> (e.g., helfem.source.h -> utils::invh), and the
+# macros affect arma's ABI. Propagate as INTERFACE.
+target_compile_definitions(helfem PUBLIC ARMA_64BIT_WORD ARMA_BLAS_LONG)
+
+# In-tree alias so downstream targets in HelFEM's own tree can link
+# helfem::helfem consistently with the exported name.
+add_library(helfem::helfem ALIAS helfem)
+
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/" DESTINATION include)
-install(TARGETS helfem DESTINATION lib)
+install(TARGETS helfem
+    EXPORT helfemTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -185,23 +185,23 @@ namespace helfem_py {
     /// Gaunt -- libatomscf applies those at angular assembly).
     py::list radial_df_factors(double tol = 1e-10) {
       ensure_tei_();
-      auto cubes = basis_.radial_df_factors(tol);
+      // Public API now returns std::vector<std::vector<helfem::Matrix>>
+      // (outer = multipole k, inner = Cholesky factor Q, each Nrad x Nrad
+      // Eigen matrix). Repack to numpy shape (naux_k, Nrad, Nrad) per k.
+      auto factors = basis_.radial_df_factors(tol);
       const size_t Nrad = basis_.Nrad();
       py::list out;
-      for (auto & cube : cubes) {
-        // arma::cube layout: (Nrad, Nrad, naux). Each slice is a Nrad x
-        // Nrad matrix. We want numpy shape (naux, Nrad, Nrad). Build a
-        // new contiguous numpy array of that shape and copy slice-by-
-        // slice (column-major arma -> C-order numpy via element-wise
-        // copy through (i, j) -> (Q, i, j)).
-        const size_t naux = cube.n_slices;
+      for (auto & per_L : factors) {
+        const size_t naux = per_L.size();
         py::array_t<double> arr({naux, Nrad, Nrad});
-        auto buf = arr.mutable_unchecked<3>();
-        for (size_t q = 0; q < naux; ++q) {
-          const arma::mat & M = cube.slice(q);
-          for (size_t i = 0; i < Nrad; ++i) {
-            for (size_t j = 0; j < Nrad; ++j) {
-              buf(q, i, j) = M(i, j);
+        if (naux > 0) {
+          auto buf = arr.mutable_unchecked<3>();
+          for (size_t q = 0; q < naux; ++q) {
+            const helfem::Matrix & M = per_L[q];
+            for (size_t i = 0; i < Nrad; ++i) {
+              for (size_t j = 0; j < Nrad; ++j) {
+                buf(q, i, j) = M(i, j);
+              }
             }
           }
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,14 @@ diatomic/dftgrid.cpp diatomic/twodquadrature.cpp
 general/model_potential.cpp
 )
 target_link_libraries(helfem-common PUBLIC helfem wignernj::wignernj)
-target_include_directories(helfem-common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../libhelfem/src/")
+target_include_directories(helfem-common
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../libhelfem/src/>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        # Installed headers live at include/helfem/{atomic,general}/;
+        # consumers include as <helfem/atomic/TwoDBasis.h>.
+        $<INSTALL_INTERFACE:include>
+)
 target_compile_features(helfem-common PUBLIC cxx_std_17)
 
 add_executable(gensap sadatom/main.cpp)
@@ -37,6 +44,11 @@ target_link_libraries(1e_atom helfem-common legendre)
 add_library(legendre
   legendre/Legendre.cpp general/legendretable.cpp)
 target_compile_features(legendre PUBLIC cxx_std_17)
+
+# helfem-common uses LegendreTable symbols internally, so a consumer
+# linking only helfem-common needs legendre transitively. Declared
+# after `legendre` is defined so the target reference resolves.
+target_link_libraries(helfem-common PUBLIC legendre)
 
 add_executable(legendre_test legendre/legendre_test.cpp)
 target_link_libraries(legendre_test helfem-common legendre)
@@ -108,6 +120,32 @@ target_link_libraries(diatomic_dline helfem-common legendre)
 add_executable(diatomic_dgrid diatomic/density_grid.cpp)
 target_link_libraries(diatomic_dgrid helfem-common legendre)
 
-# Install libraries and main executables
+# Install libraries and main executables.
+# helfem-common + legendre are exported as part of the helfemTargets
+# set so external consumers doing find_package(helfem) pick up the
+# transitive linkage automatically.
 install (TARGETS atomic diatomic diatomic_cbasis diatomic_cpl gensap DESTINATION bin OPTIONAL)
-install (TARGETS helfem-common legendre DESTINATION lib OPTIONAL)
+install (TARGETS helfem-common legendre
+    EXPORT helfemTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)
+
+# Install atomic public headers into ${PREFIX}/include/helfem/atomic/
+# so a consumer can #include <helfem/atomic/TwoDBasis.h>. This is the
+# consumer-visible surface for the atomic FE basis backend that
+# libatomscf integrates.
+#
+# TwoDBasis.h has \"../general/model_potential.h\" and \"../general/sap.h\"
+# relative includes; keep the same directory layout under helfem/atomic/
+# and helfem/general/ so the relative-include chain still resolves
+# against the installed headers.
+install(FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/atomic/TwoDBasis.h"
+    DESTINATION include/helfem/atomic)
+install(FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/general/model_potential.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/general/RadialPotential.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/general/sap.h"
+    DESTINATION include/helfem/general)

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -551,7 +551,8 @@ namespace helfem {
       }
 
 
-      std::vector<arma::cube> TwoDBasis::radial_df_factors(double tol) const {
+      std::vector<std::vector<helfem::Matrix>>
+      TwoDBasis::radial_df_factors(double tol) const {
         if (!prim_tei.size())
           throw std::logic_error(
               "Primitive teis have not been computed -- call "
@@ -561,7 +562,10 @@ namespace helfem {
         const size_t Nrad = radial.Nbf();
         const size_t Nel  = radial.Nel();
 
-        std::vector<arma::cube> B(N_L);
+        // Outer index = multipole L, inner index = Cholesky vector Q,
+        // each an Nrad x Nrad helfem::Matrix (arma-free at the public
+        // boundary; internal computation is arma-native for now).
+        std::vector<std::vector<helfem::Matrix>> B(N_L);
 
         for (int L = 0; L < N_L; ++L) {
           // -- 1. Cached accessor lambdas for the per-L J helper.
@@ -678,12 +682,10 @@ namespace helfem {
             B_L_vecs.push_back(std::move(v_new));
           }
 
-          // -- 4. Pack into cube (Nrad, Nrad, naux_L).
-          const size_t naux = B_L_vecs.size();
-          B[L].set_size(Nrad, Nrad, naux);
-          for (size_t q = 0; q < naux; ++q) {
-            B[L].slice(q) = B_L_vecs[q];
-          }
+          // -- 4. Bridge to helfem::Matrix at the public boundary.
+          B[L].reserve(B_L_vecs.size());
+          for (auto & M : B_L_vecs)
+            B[L].push_back(helfem::to_eigen(M));
         }
 
         return B;

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -182,11 +182,17 @@ namespace helfem {
         /// Density-fitted (Cholesky-factored) BARE radial Slater
         /// integrals R^k(i, j, m, n) for k = 0..2*max(lval).
         ///
-        /// Returns vec[k] = arma::cube of shape (Nrad, Nrad, naux_k)
-        /// such that for each multipole k:
-        ///     R^k(i, j, m, n)  =  sum_Q  B[k](i, j, Q) * B[k](m, n, Q)
+        /// Returns vec[k][Q] = helfem::Matrix of shape (Nrad, Nrad),
+        /// the Q-th Cholesky factor for multipole k, so that:
+        ///     R^k(i, j, m, n)  =  sum_Q  B[k][Q](i, j) * B[k][Q](m, n)
         /// where R^k is the BARE radial Slater integral (no 4*pi/(2k+1),
         /// no Gaunt -- libatomscf applies those at angular assembly).
+        ///
+        /// The public return type is arma-free (Eigen matrices via
+        /// helfem::Matrix) so consumers link against libhelfem without
+        /// needing armadillo on their compile line. The interior
+        /// computation is arma-native; the conversion is one memcpy
+        /// per factor.
         ///
         /// Computed via pivoted Cholesky on R^k as a Nrad^2 x Nrad^2
         /// matrix, with columns generated on-the-fly via
@@ -197,7 +203,8 @@ namespace helfem {
         ///
         /// `tol` is the residual diagonal threshold for stopping the
         /// Cholesky iteration; pivots below `tol` are dropped.
-        std::vector<arma::cube> radial_df_factors(double tol = 1e-10) const;
+        std::vector<std::vector<helfem::Matrix>>
+        radial_df_factors(double tol = 1e-10) const;
 
         /// Get primitive integrals
         std::vector<arma::mat> get_prim_tei() const;


### PR DESCRIPTION
## Summary

Makes libhelfem cleanly consumable as a C++ backend from an external BSD-licensed atomic-SCF library (libatomscf) via \`find_package(helfem)\`. Three intertwined changes:

## 1. Arma-free public return type for \`radial_df_factors\`

**Before**: \`std::vector<arma::cube>\` — forces every C++ consumer to include and match armadillo build flags (\`ARMA_64BIT_WORD\` / \`ARMA_BLAS_LONG\`) or silently corrupt their heap in LAPACK.

**After**:
\`\`\`cpp
std::vector<std::vector<helfem::Matrix>> radial_df_factors(double tol=1e-10) const;
\`\`\`

Outer index = multipole k (0 .. 2·max(lval)); inner index = Cholesky factor Q. Each factor is an Nrad×Nrad \`helfem::Matrix\` (Eigen). Bridge at the end of the arma-native compute; internal implementation kept arma for now.

Python bindings updated to iterate the new nested vector and emit the same (naux, Nrad, Nrad) numpy arrays consumers had before. \`test_radial_df_exhaustive\` still PASSES 3/3 configs at machine precision.

## 2. Installed CMake package

Consumers can now do:

\`\`\`cmake
find_package(helfem CONFIG REQUIRED)
target_link_libraries(mytarget PRIVATE helfem::helfem-common helfem::helfem)
\`\`\`

and pick up all transitive linkage automatically. **No manual \`-I<armadillo>\`, no \`-DARMA_64BIT_WORD\`, no \`-DARMA_BLAS_LONG\`.**

### Added
- **\`cmake/helfemConfig.cmake.in\`**: package config file; \`find_dependency\` chains Eigen3, wignernj, Armadillo and (conditionally) HDF5.
- **Top-level \`CMakeLists.txt\`**: \`configure_package_config_file\` + \`write_basic_package_version_file\` + \`install(FILES ...)\` + \`install(EXPORT helfemTargets NAMESPACE helfem::)\`.
- **\`libhelfem/CMakeLists.txt\`**: \`install(TARGETS helfem EXPORT ...)\` with generator-expression \`INCLUDES DESTINATION\`; INTERFACE compile definitions \`ARMA_64BIT_WORD\` / \`ARMA_BLAS_LONG\` propagate to consumers via the exported target. Alias \`helfem::helfem\` so in-tree targets link the same name as the exported one.
- **\`lib1dfem/CMakeLists.txt\`**: \`install(TARGETS lib1dfem EXPORT ...)\` for the INTERFACE lib.
- **\`src/CMakeLists.txt\`**: \`install(TARGETS helfem-common legendre EXPORT ...)\` with \`INCLUDES DESTINATION\`. \`helfem-common\` now links \`legendre\` PUBLIC-ly so a consumer linking only helfem-common gets LegendreTable symbols transitively. Atomic public headers (\`TwoDBasis.h\`, \`model_potential.h\`, \`RadialPotential.h\`, \`sap.h\`) installed under \`include/helfem/{atomic,general}/\` so the relative \`#include\` chain resolves from the installed tree.

Also: \`configure_file\`'s \`helfem.h\` now lands at \`include/helfem.h\` (previously at \`CMAKE_CURRENT_BINARY_DIR/helfem.h\`), matching the \`install(DIRECTORY .../include/)\` target.

## 3. Modernized example + end-to-end external verification

\`examples/atomic_radial_export.cpp\` rewritten to:
- Use the current atomic API (\`helfem::atomic::basis::TwoDBasis\`; \`TwoDBasis::kinetic\` already folds in centrifugal per-shell, so hydrogenic H = T + Vnuc).
- Use \`helfem::Matrix\` / Eigen throughout; \`Sinvh\` (still arma) is \`Eigen::Map\`'d once with a documented follow-up TODO.
- Consume the new arma-free \`radial_df_factors\` and reconstruct R^0(i,j,m,n) = Σ_Q B[0][Q](i,j) B[0][Q](m,n).
- Build INSTRUCTIONS section updated: \`find_package(helfem CONFIG)\` + \`target_link_libraries(... helfem::helfem-common helfem::helfem)\`; no \`-I\` / \`-D\` / \`-l\` flags required.

### End-to-end verification

A throwaway consumer project outside the HelFEM tree does:

\`\`\`bash
cmake -Dhelfem_DIR=$PREFIX/lib/cmake/helfem <src>
cmake --build .
LD_LIBRARY_PATH=$PREFIX/lib ./atomic_radial_export
\`\`\`

| Test | Result | Reference | Error |
|---|---|---|---|
| H 1s | −0.5000000000 | −0.5000000000 | 8.15e-13 |
| He+ 1s | −2.0000000000 | −2.0000000000 | 3.11e-12 |
| H 2p | −0.1250000000 | −0.1250000000 | 3.09e-13 |
| He+ 2p | −0.5000000000 | −0.5000000000 | 7.33e-14 |
| H 3d | −0.0555553336 | −0.0555555556 | 2.22e-07 |
| **He HF (iter 9)** | **−2.86167999561** | **−2.86167999561** | **3.42e-12** |
| \`radial_df_factors\` symmetry | 0.00e+00 | — | perfect |

Consumer's own \`CMakeLists.txt\` is **3 lines**. No \`-larmadillo\`, no \`-DARMA_*\`, no manual header path. That is the exact shape libatomscf will consume.

## Regression validation

- \`eigen_foundation_test\`: 13/13 PASS
- \`test_radial_df_exhaustive.py\`: 3/3 configs PASS at machine precision
- He gensap HF: \`Etot = −2.861679987\` (unchanged)
- Be HF (atomic, lmax=2): **−14.5728772811245939** (bit-identical to prior baseline)

## Residual arma

\`TwoDBasis\` / \`RadialBasis\` / \`FiniteElementBasis\` / \`PolynomialBasis\` still have arma in some public signatures (\`Sinvh\`, \`get_bf\`, ctor \`bval\`/\`lval\`/\`mval\`, \`get_lval\`/\`get_mval\`). These are documented in the example's build-instructions comment; a follow-up will migrate them, but this PR ships the primary blocker (\`radial_df_factors\`) and the CMake export machinery already in place to make that follow-up a mechanical signature change.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] test_radial_df_exhaustive.py passes
- [x] He gensap HF unchanged
- [x] Be HF via atomic bit-identical to prior baseline
- [x] External consumer project builds via \`find_package(helfem)\` and passes all 3 test groups