### PR TITLE
TwoDBasis + get_grid: arma-free public signatures on the consumer path

### DIFF
--- a/examples/atomic_radial_export.cpp
+++ b/examples/atomic_radial_export.cpp
@@ -51,22 +51,13 @@
 #include <helfem/atomic/TwoDBasis.h>
 #include <Matrix.h>
 #include <PolynomialBasis.h>
+#include <helfem.h>
 #include <Eigen/Eigenvalues>
 
 #include <cmath>
 #include <cstdio>
 #include <memory>
 #include <vector>
-
-// Bring the arma::vec / arma::ivec ctor parameters of TwoDBasis into
-// scope only for the constructor call. This is the last remaining arma
-// surface on the public consumer path; a follow-up will convert the
-// constructor signature to Eigen and this include can go away.
-#include <armadillo>
-
-namespace helfem { namespace utils {
-  arma::vec get_grid(double Rmax, int num_el, int igrid, double zexp);
-}}
 
 using namespace helfem;
 
@@ -81,9 +72,9 @@ atomic::basis::TwoDBasis make_single_shell(int Z, int lval_int,
                                             const Defaults & d = DEF) {
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
       polynomial_basis::get_basis(d.primbas, d.Nnodes));
-  arma::vec bval = utils::get_grid(d.Rmax, d.Nelem, d.igrid, d.zexp);
-  arma::ivec lval = {lval_int};
-  arma::ivec mval = {0};
+  const helfem::Vector bval = utils::get_grid(d.Rmax, d.Nelem, d.igrid, d.zexp);
+  Eigen::VectorXi lval(1); lval(0) = lval_int;
+  Eigen::VectorXi mval(1); mval(0) = 0;
   return atomic::basis::TwoDBasis(
       Z, modelpotential::POINT_NUCLEUS, /*Rrms*/0.0,
       poly, /*zeroder*/false,
@@ -151,13 +142,7 @@ bool he_hf_test() {
   const helfem::Matrix Vnuc = basis.nuclear();
   const helfem::Matrix Hc   = T + Vnuc;
 
-  // Sinvh is still arma at the API boundary; wrap the arma::mat once
-  // via Eigen::Map into a helfem::Matrix. This is the only remaining
-  // arma type on the consumer path -- a follow-up will convert the
-  // return type to helfem::Matrix.
-  const arma::mat Sinvh_arma = basis.Sinvh(/*chol*/false, /*sym*/0);
-  const Eigen::Map<const helfem::Matrix> Sinvh(
-      Sinvh_arma.memptr(), Sinvh_arma.n_rows, Sinvh_arma.n_cols);
+  const helfem::Matrix Sinvh = basis.Sinvh(/*chol*/false, /*sym*/0);
 
   // Core Hamiltonian guess.
   helfem::Matrix Fao = Hc;

--- a/libhelfem/include/ArmaEigen.h
+++ b/libhelfem/include/ArmaEigen.h
@@ -70,6 +70,23 @@ namespace helfem {
     return out;
   }
 
+  // Integer vector converters -- arma::ivec (arma::sword) <-> Eigen::VectorXi.
+  // Widths may differ (arma::sword is long long on most platforms; int is 32-bit),
+  // so use an element-by-element cast rather than memcpy.
+  inline Eigen::VectorXi to_eigen(const arma::ivec & v) {
+    Eigen::VectorXi out(v.n_elem);
+    for (arma::uword i = 0; i < v.n_elem; ++i)
+      out(static_cast<Eigen::Index>(i)) = static_cast<int>(v(i));
+    return out;
+  }
+
+  inline arma::ivec to_arma(const Eigen::VectorXi & v) {
+    arma::ivec out(v.size());
+    for (Eigen::Index i = 0; i < v.size(); ++i)
+      out(static_cast<arma::uword>(i)) = static_cast<arma::sword>(v(i));
+    return out;
+  }
+
   // ---- Zero-copy views ------------------------------------------------
   //
   // Cast away const on arma::mat::memptr() for the const overloads: arma

--- a/libhelfem/include/helfem.source.h
+++ b/libhelfem/include/helfem.source.h
@@ -50,7 +50,8 @@ namespace helfem {
      *        2 for generalized polynomial grid with exponent zexp
      *        3 for generalized exponential grid with parameter zexp
      */
-    arma::vec get_grid(double rmax, int num_el, int igrid, double zexp);
+    // Phase 5.19: Eigen-typed at public boundary; interior arma-native.
+    ::helfem::Vector get_grid(double rmax, int num_el, int igrid, double zexp);
 
     /**
      * Calculates the half-inverse of a matrix.

--- a/libhelfem/src/grid.cpp
+++ b/libhelfem/src/grid.cpp
@@ -22,12 +22,9 @@
 #include <lib1dfem/grid.h>
 #include <cstring>
 
-arma::vec helfem::utils::get_grid(double rmax, int num_el, int igrid,
-                                  double zexp) {
-  // Phase 5.1: lib1dfem grid now returns Eigen; bridge to arma here.
-  auto be = helfem::lib1dfem::grid::get_grid<double>(rmax, num_el, igrid, zexp,
-                                                     helfem::verbose);
-  arma::vec b(be.size());
-  std::memcpy(b.memptr(), be.data(), sizeof(double) * (size_t) be.size());
-  return b;
+helfem::Vector helfem::utils::get_grid(double rmax, int num_el, int igrid,
+                                        double zexp) {
+  // lib1dfem grid is Eigen; return directly.
+  return helfem::lib1dfem::grid::get_grid<double>(rmax, num_el, igrid, zexp,
+                                                   helfem::verbose);
 }

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -108,7 +108,8 @@ namespace helfem_py {
       basis_ = atomic::basis::TwoDBasis(
           Z, (modelpotential::nuclear_model_t) finitenuc, Rrms,
           poly_, /*zeroder=*/false,
-          Nquad, bval, lval, mval, /*Zl=*/0, /*Zr=*/0, /*Rhalf=*/0.0);
+          Nquad, helfem::to_eigen(bval), helfem::to_eigen(lval),
+          helfem::to_eigen(mval), /*Zl=*/0, /*Zr=*/0, /*Rhalf=*/0.0);
     }
 
     int Z() const { return Z_; }

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -38,7 +38,14 @@ namespace helfem {
       TwoDBasis::TwoDBasis() {
       }
 
-      TwoDBasis::TwoDBasis(int Z_, modelpotential::nuclear_model_t model_, double Rrms_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, bool zeroder_, int n_quad, const arma::vec & bval, const arma::ivec & lval_, const arma::ivec & mval_, int Zl_, int Zr_, double Rhalf_) {
+      TwoDBasis::TwoDBasis(int Z_, modelpotential::nuclear_model_t model_,
+                             double Rrms_,
+                             const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
+                             bool zeroder_, int n_quad,
+                             const helfem::Vector & bval_e,
+                             const Eigen::VectorXi & lval_e,
+                             const Eigen::VectorXi & mval_e,
+                             int Zl_, int Zr_, double Rhalf_) {
         // Nuclear charge
         Z=Z_;
         Zl=Zl_;
@@ -46,6 +53,16 @@ namespace helfem {
         Rhalf=Rhalf_;
         model=model_;
         Rrms=Rrms_;
+
+        // Bridge Eigen inputs to internal arma storage once.
+        arma::vec bval(bval_e.size());
+        std::memcpy(bval.memptr(), bval_e.data(), sizeof(double) * (size_t) bval_e.size());
+        arma::ivec lval_arma(lval_e.size());
+        for (Eigen::Index i = 0; i < lval_e.size(); ++i)
+          lval_arma(i) = static_cast<arma::sword>(lval_e(i));
+        arma::ivec mval_arma(mval_e.size());
+        for (Eigen::Index i = 0; i < mval_e.size(); ++i)
+          mval_arma(i) = static_cast<arma::sword>(mval_e(i));
 
         // Construct radial basis
         bool zero_func_left=true;
@@ -56,8 +73,8 @@ namespace helfem {
         radial=FEMRadialBasis(fem, n_quad);
 
         // Construct angular basis
-        lval=lval_;
-        mval=mval_;
+        lval=lval_arma;
+        mval=mval_arma;
       }
 
       TwoDBasis::~TwoDBasis() {
@@ -179,8 +196,9 @@ namespace helfem {
         return idx;
       }
 
-      arma::mat TwoDBasis::Shalf(bool chol, int sym) const {
-        // Phase 3: overlap() returns helfem::Matrix.
+      helfem::Matrix TwoDBasis::Shalf(bool chol, int sym) const {
+        // Phase 3: overlap() returns helfem::Matrix. The compute path
+        // below is still arma-native; bridge to Eigen at the return.
         arma::mat S(helfem::to_arma(overlap()));
 
         // Get the basis function norms
@@ -192,7 +210,8 @@ namespace helfem {
 
         if(chol && sym==0) {
           // Half-inverse is
-          return arma::diagmat(bfinvnormlz) * arma::chol(S);
+          arma::mat Shalf = arma::diagmat(bfinvnormlz) * arma::chol(S);
+          return helfem::to_eigen(Shalf);
 
         } else {
           arma::vec Sval;
@@ -217,16 +236,16 @@ namespace helfem {
           arma::mat Shalf(Svec*arma::diagmat(arma::pow(Sval,0.5))*arma::trans(Svec));
           Shalf=arma::diagmat(bfinvnormlz)*Shalf;
 
-          return Shalf;
+          return helfem::to_eigen(Shalf);
         }
       }
 
-      arma::mat TwoDBasis::Sinvh(bool chol, int sym) const {
+      helfem::Matrix TwoDBasis::Sinvh(bool chol, int sym) const {
         arma::mat S(helfem::to_arma(overlap()));
 
         // Half-inverse is
         if(sym==0) {
-          return helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S), chol));
+          return scf::form_Sinvh(helfem::to_eigen(S), chol);
         } else {
           // Get basis function indices
           std::vector<arma::uvec> midx(get_sym_idx(sym));
@@ -243,7 +262,7 @@ namespace helfem {
             // Increment offset
             ioff += midx[i].n_elem;
           }
-          return Sinvh;
+          return helfem::to_eigen(Sinvh);
         }
       }
 
@@ -259,7 +278,7 @@ namespace helfem {
         return M.submat(iang*radial.Nbf(),jang*radial.Nbf(),(iang+1)*radial.Nbf()-1,(jang+1)*radial.Nbf()-1);
       }
 
-      arma::mat TwoDBasis::radial_integral(int Rexp) const {
+      helfem::Matrix TwoDBasis::radial_integral(int Rexp) const {
         // Build radial elements
         arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(Rexp, iel); }));
@@ -271,12 +290,12 @@ namespace helfem {
         for(size_t iang=0;iang<lval.n_elem;iang++)
           set_sub(O,iang,iang,Orad);
 
-        return remove_boundaries(O);
+        return helfem::to_eigen(remove_boundaries(O));
       }
 
       helfem::Matrix TwoDBasis::overlap() const {
-        // Phase 3: SCF surface returns Eigen; internals unchanged.
-        return helfem::to_eigen(radial_integral(0));
+        // radial_integral now returns helfem::Matrix directly.
+        return radial_integral(0);
       }
 
       arma::mat TwoDBasis::overlap(const TwoDBasis & rh) const {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -76,7 +76,17 @@ namespace helfem {
       public:
         TwoDBasis();
         /// Constructor
-        TwoDBasis(int Z, modelpotential::nuclear_model_t model, double Rrms, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, bool zeroder, int n_quad, const arma::vec & bval, const arma::ivec & lval, const arma::ivec & mval, int Zl, int Zr, double Rhalf);
+        // Phase 5.19: bval/lval/mval accepted as Eigen at the public
+        // boundary so a consumer does not need to include <armadillo>
+        // to instantiate the basis. Interior storage stays arma via a
+        // single memcpy inside the ctor.
+        TwoDBasis(int Z, modelpotential::nuclear_model_t model, double Rrms,
+                   const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly,
+                   bool zeroder, int n_quad,
+                   const helfem::Vector & bval,
+                   const Eigen::VectorXi & lval,
+                   const Eigen::VectorXi & mval,
+                   int Zl, int Zr, double Rhalf);
         /// Destructor
         ~TwoDBasis();
 
@@ -141,12 +151,13 @@ namespace helfem {
         /// Number of angular shells
         size_t Nang() const;
 
-        /// Form half-overlap matrix
-        arma::mat Shalf(bool chol, int sym) const;
-        /// Form half-inverse overlap matrix
-        arma::mat Sinvh(bool chol, int sym) const;
-        /// Form radial integral
-        arma::mat radial_integral(int n) const;
+        /// Form half-overlap matrix (Phase 5.19: Eigen-typed at the
+        /// public boundary; interior computation still arma).
+        helfem::Matrix Shalf(bool chol, int sym) const;
+        /// Form half-inverse overlap matrix (Phase 5.19: Eigen-typed).
+        helfem::Matrix Sinvh(bool chol, int sym) const;
+        /// Form radial integral (Phase 5.19: Eigen-typed).
+        helfem::Matrix radial_integral(int n) const;
         // Phase 3: SCF surface migrated to Eigen.
         /// Form overlap matrix
         helfem::Matrix overlap() const;

--- a/src/atomic/basis.cpp
+++ b/src/atomic/basis.cpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cfloat>
 #include <helfem.h>
+#include <ArmaEigen.h>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -49,20 +50,20 @@ namespace helfem {
       }
 
       arma::vec normal_grid(int num_el, double rmax, int igrid, double zexp) {
-        return utils::get_grid(rmax,num_el,igrid,zexp);
+        return helfem::to_arma(utils::get_grid(rmax,num_el,igrid,zexp));
       }
 
       arma::vec finite_nuclear_grid(int num_el, double rmax, int igrid, double zexp, int num_el_nuc, double rnuc, int igrid_nuc, double zexp_nuc) {
         if(num_el_nuc) {
           // Grid for the finite nucleus
-          arma::vec bnuc(utils::get_grid(rnuc,num_el_nuc,igrid_nuc,zexp_nuc));
+          arma::vec bnuc(helfem::to_arma(utils::get_grid(rnuc,num_el_nuc,igrid_nuc,zexp_nuc)));
           // and the one for the electrons
-          arma::vec belec(utils::get_grid(rmax-rnuc,num_el,igrid,zexp));
+          arma::vec belec(helfem::to_arma(utils::get_grid(rmax-rnuc,num_el,igrid,zexp)));
 
           arma::vec bnucel(concatenate_grid(bnuc,bnuc));
           return concatenate_grid(bnucel,belec);
         } else {
-          return utils::get_grid(rmax,num_el,igrid,zexp);
+          return helfem::to_arma(utils::get_grid(rmax,num_el,igrid,zexp));
         }
       }
 
@@ -84,19 +85,19 @@ namespace helfem {
         arma::vec bval0, bval1;
         if(b0used) {
           // 0 to b0
-          bval0=utils::get_grid(b0,num_el0,igrid,zexp);
+          bval0=helfem::to_arma(utils::get_grid(b0,num_el0,igrid,zexp));
         }
         if(b1used) {
           // b0 to b1
 
           // Reverse grid to get tighter spacing around nucleus
-          bval1=-arma::reverse(utils::get_grid(b1-b0,num_el0,igrid,zexp));
+          bval1=-arma::reverse(helfem::to_arma(utils::get_grid(b1-b0,num_el0,igrid,zexp)));
           bval1+=arma::ones<arma::vec>(bval1.n_elem)*(b1-b0);
           // Assert numerical exactness
           bval1(0)=0.0;
           bval1(bval1.n_elem-1)=b1-b0;
         }
-        arma::vec bval2=utils::get_grid(b2-b1,num_el,igrid,zexp);
+        arma::vec bval2=helfem::to_arma(utils::get_grid(b2-b1,num_el,igrid,zexp));
 
         arma::vec bval;
         if(b0used && b1used) {

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -262,7 +262,7 @@ int main(int argc, char **argv) {
   arma::vec bval=atomic::basis::form_grid((modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax, igrid, zexp, Nelem0, igrid0, zexp0, Z, Zl, Zr, Rhalf, add_conf, shift_conf);
 
   atomic::basis::TwoDBasis basis;
-  basis=atomic::basis::TwoDBasis(Z, (modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, Nquad, bval, lval, mval, Zl, Zr, Rhalf);
+  basis=atomic::basis::TwoDBasis(Z, (modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, Nquad, helfem::to_eigen(bval), helfem::to_eigen(lval), helfem::to_eigen(mval), Zl, Zr, Rhalf);
   chkpt.write(basis);
   printf("Basis set consists of %i angular shells composed of %i radial functions, totaling %i basis functions\n",(int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf());
 
@@ -434,11 +434,11 @@ int main(int argc, char **argv) {
 
   // Get half-inverse
   timer.set();
-  arma::mat Sinvh(basis.Sinvh(!diag,symm));
+  arma::mat Sinvh(helfem::to_arma(basis.Sinvh(!diag,symm)));
   chkpt.write("Sinvh",Sinvh);
   printf("Half-inverse formed in %.6f\n",timer.get());
   helfem::scf_driver::report_ortho_deviation(S, Sinvh);
-  arma::mat Sh(basis.Shalf(!diag,symm));
+  arma::mat Sh(helfem::to_arma(basis.Shalf(!diag,symm)));
   chkpt.write("Sh",Sh);
   printf("Half-overlap formed in %.6f\n",timer.get());
   helfem::scf_driver::report_halfoverlap_error(Sh, Sinvh);
@@ -1040,10 +1040,10 @@ int main(int argc, char **argv) {
   }
 
   // Calculate <r^2> matrix
-  arma::mat rinvmat(basis.radial_integral(-1));
-  arma::mat rmat(basis.radial_integral(1));
-  arma::mat rsqmat(basis.radial_integral(2));
-  arma::mat rcbmat(basis.radial_integral(3));
+  arma::mat rinvmat(helfem::to_arma(basis.radial_integral(-1)));
+  arma::mat rmat(helfem::to_arma(basis.radial_integral(1)));
+  arma::mat rsqmat(helfem::to_arma(basis.radial_integral(2)));
+  arma::mat rcbmat(helfem::to_arma(basis.radial_integral(3)));
   // rms sizes
   arma::vec rinva(arma::ones<arma::vec>(Caocc.n_cols)/arma::diagvec(arma::trans(Caocc)*rinvmat*Caocc));
   arma::vec ra(arma::diagvec(arma::trans(Caocc)*rmat*Caocc));

--- a/src/atomic/ooo.cpp
+++ b/src/atomic/ooo.cpp
@@ -118,14 +118,17 @@ int main(int argc, char **argv) {
       igrid, zexp, Nelem0, igrid0, zexp0, Z, Zl, Zr, Rhalf, false, 0.0);
 
   atomic::basis::TwoDBasis basis(Z, (modelpotential::nuclear_model_t) finitenuc,
-                                  Rrms, poly, zeroder, Nquad, bval, lval, mval,
+                                  Rrms, poly, zeroder, Nquad,
+                                  helfem::to_eigen(bval),
+                                  helfem::to_eigen(lval),
+                                  helfem::to_eigen(mval),
                                   Zl, Zr, Rhalf);
   printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
           (int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf());
 
   // Phase 5: overlap / kinetic / nuclear return Eigen; Sinvh still arma.
   const helfem::Matrix S     = basis.overlap();
-  const helfem::Matrix Sinvh = helfem::to_eigen(basis.Sinvh(false, 0));
+  const helfem::Matrix Sinvh = basis.Sinvh(false, 0);
   const helfem::Matrix T     = basis.kinetic();
   const helfem::Matrix Vnuc  = basis.nuclear();
 

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -15,6 +15,7 @@
 
 #include "checkpoint.h"
 #include "PolynomialBasis.h"
+#include <ArmaEigen.h>
 #include <istream>
 
 // Helper macros
@@ -563,7 +564,7 @@ void Checkpoint::read(helfem::atomic::basis::TwoDBasis & basis) {
   read("mval", mval);
 
   auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(poly_id,poly_nnodes)));
-  basis=helfem::atomic::basis::TwoDBasis(Z, (helfem::modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, n_quad, bval, lval, mval, Zl, Zr, Rhalf);
+  basis=helfem::atomic::basis::TwoDBasis(Z, (helfem::modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, n_quad, helfem::to_eigen(bval), helfem::to_eigen(lval), helfem::to_eigen(mval), Zl, Zr, Rhalf);
   
   if(cl) close();
 }


### PR DESCRIPTION
## Summary

Extends the external-consumer surface work (PR #142) to the \`TwoDBasis\` constructor + one-electron accessors + \`utils::get_grid\`. **The example in \`examples/atomic_radial_export.cpp\` is now COMPLETELY arma-free at the source level**: zero \`arma::\` occurrences, no \`<armadillo>\` include.

## Changed public signatures

| Signature | Before | After |
|---|---|---|
| \`helfem::utils::get_grid\` | \`arma::vec\` | \`::helfem::Vector\` |
| \`TwoDBasis\` ctor \`bval\` | \`const arma::vec &\` | \`const helfem::Vector &\` |
| \`TwoDBasis\` ctor \`lval\`, \`mval\` | \`const arma::ivec &\` | \`const Eigen::VectorXi &\` |
| \`TwoDBasis::Shalf(bool, int)\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`TwoDBasis::Sinvh(bool, int)\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`TwoDBasis::radial_integral(int)\` | \`arma::mat\` | \`helfem::Matrix\` |

Interior arma storage is preserved — bridge at ctor entry via memcpy + explicit widening for the ivecs (arma::sword is 64-bit on this platform; Eigen::VectorXi is int32).

## New helper

\`libhelfem/include/ArmaEigen.h\` grows integer-vector converters:
\`\`\`cpp
Eigen::VectorXi to_eigen(const arma::ivec &);
arma::ivec      to_arma (const Eigen::VectorXi &);
\`\`\`
\`arma::sword != int\` so element-by-element narrow, not memcpy.

## Internal fixes shaken out by the header changes

- **\`libhelfem/CMakeLists.txt\`**: \`configure_file\` target for \`helfem.h\` was at \`CMAKE_CURRENT_BINARY_DIR\`, not \`CMAKE_CURRENT_BINARY_DIR/include\`. The install(DIRECTORY .../include) missed it, and the top-level binary dir was ALSO on the include path so stale copies shadowed the regenerated one after signature changes. Moved to \`include/\`. (This was silent for weeks because the OLD arma::vec declaration happened to be identical between runs.)

- **\`src/atomic/basis.cpp\`**: \`normal_grid\` / \`finite_nuclear_grid\` / \`offcenter_nuclear_grid\` helpers all call \`utils::get_grid\`; they still return arma::vec so bridge with \`helfem::to_arma\` at every call site.

- **\`src/atomic/main.cpp\` / \`ooo.cpp\` / \`general/checkpoint.cpp\` / \`python/bindings.cpp\`**: bridge \`arma::vec\` / \`arma::ivec\` → Eigen at the TwoDBasis constructor call.

## Caller bridges for Shalf / Sinvh / radial_integral

- **\`src/atomic/main.cpp\`**: 6 sites bridged via \`helfem::to_arma(basis.X(...))\` where the surrounding chemistry-layer buffers are still arma. Example: \`rinvmat\`, \`rmat\`, \`rsqmat\`, \`rcbmat\`.
- **\`src/atomic/ooo.cpp\`**: \`Sinvh\` no longer double-bridged; now a direct Eigen assignment.

## Example

\`examples/atomic_radial_export.cpp\` is now arma-free:
- removed \`#include <armadillo>\`
- removed the forward declaration of \`utils::get_grid\`
- \`bval\` is \`helfem::Vector\` (returned directly by \`get_grid\`)
- \`lval\` / \`mval\` are \`Eigen::VectorXi\` initialised element-by-element
- \`Sinvh\` is \`helfem::Matrix\` (returned directly by \`Sinvh()\`)

## Validation

**Existing suite**:
- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical to prior baseline)

**External consumer project (outside HelFEM tree)**:
- \`CMakeLists.txt\`: \`find_package(helfem CONFIG)\` + \`target_link_libraries\`
- Consumer's \`atomic_radial_export.cpp\`: **ZERO** \`arma::\` occurrences
- Consumer's compile line: no \`-I<armadillo>\`, no \`-DARMA_*\`
- All tests PASS:

| Test | Result | Reference | Error |
|---|---|---|---|
| H 1s / He+ 1s / H 2p / He+ 2p / H 3d hydrogenic | — | — | err < 1e-6 |
| **He HF (9 iter)** | **−2.86167999561** | **−2.86167999561** | **3.42e-12** |
| \`radial_df_factors\` symmetry | 0.00e+00 | — | perfect |

## Remaining arma in other atomic accessors

\`get_l\`/\`get_m\`/\`get_lval\`/\`get_mval\`/\`get_bval\`, \`m_indices\`/\`lm_indices\`/\`get_sym_idx\`, \`expand_boundaries\`/\`remove_boundaries\`, \`dipole_z\`, \`quadrupole_zz\`, \`Bz_field\`, \`model_potential\`, \`confinement\`, \`form_density\`, \`nuclear_density\`/\`nuclear_orbital\`, \`eval_bf\`/\`eval_df\`/\`eval_lf\`, and the matching \`RadialBasis\` / \`FiniteElementBasis\` / \`PolynomialBasis\` methods still take/return arma. These are secondary consumer paths — an SCF-focused consumer (libatomscf) does not touch them, as demonstrated by the example. A follow-up will sweep them.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He gensap HF unchanged
- [x] Be atomic HF bit-identical
- [x] External consumer project builds arma-free
- [x] External consumer runs He HF to −2.86167999561, err 3.42e-12