### PR TITLE
diatomic: guard TwoDBasis::lmind/LMind against libstdc++ hardened operator[]

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -1315,6 +1315,13 @@ namespace helfem {
         }
         // Index is
         size_t idx(low-lm_map.begin());
+        // When check==false callers use idx == lm_map.size() as a
+        // "not-found sentinel". Do not touch lm_map[idx] in that path
+        // -- with libstdc++'s hardened operator[] (GCC 16 default) an
+        // OOB access on operator[] is a hard abort even though the value
+        // would just be compared and discarded.
+        if (idx == lm_map.size())
+          return idx;
         if(check && (lm_map[idx].first != L || lm_map[idx].second != M)) {
           std::ostringstream oss;
           oss << "Map error: tried to get L = " << L << ", M = " << M << " but got instead L = " << lm_map[idx].first << ", M = " << lm_map[idx].second << "!\n";
@@ -1335,6 +1342,9 @@ namespace helfem {
         }
         // Index is
         size_t idx(low-LM_map.begin());
+        // See lmind() above: guard the operator[] access when idx == size.
+        if (idx == LM_map.size())
+          return idx;
         if(check && (LM_map[idx].first != L || LM_map[idx].second != M)) {
           std::ostringstream oss;
           oss << "Map error: tried to get L = " << L << ", M = " << M << " but got instead L = " << LM_map[idx].first << ", M = " << LM_map[idx].second << "!\n";


### PR DESCRIPTION
## Summary

Fix a latent out-of-bounds read in \`TwoDBasis::lmind\` and \`TwoDBasis::LMind\`. Both compute \`idx = std::lower_bound(...) - begin()\` and then access \`lm_map[idx]\` / \`LM_map[idx]\` to verify the entry matches the requested (L, M) pair.

When the caller passes \`check=false\` (used as the "try to find, but if missing return an OOB index as a sentinel" pattern by internal diatomic code paths) and the (L, M) pair is not in the table, \`low\` equals \`end()\` and \`idx\` equals \`size()\`. The code then does \`lm_map[size()]\`, which is undefined behaviour.

Under **GCC 16** (which enables libstdc++'s hardened \`std::vector\` \`operator[]\` by default), the OOB access is now caught with

\`\`\`
Assertion '__n < this->size()' failed.
\`\`\`

and aborts the process before the following \`if\` branch would otherwise skip the check block. This crash blocks every diatomic executable run (both \`diatomic\` and the new \`diatomic_ooo\`, which share the same basis setup).

## Fix

After computing \`idx\`, return early with the sentinel value when \`idx == container.size()\`. The following \`operator[]\` access is only reached when we know the index is in-range.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)

The \`Map error: tried to get L = 3, M = 0 but got instead L = 4, M = 0\` logic error in the \`check==true\` path is a **separate** pre-existing bug in the diatomic basis setup uncovered by GCC 16 tightening; that one is out of scope for this fix.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He gensap HF unchanged
- [x] Be atomic HF bit-identical to prior baseline