### PR TITLE
libhelfem: delete stale binary-dir helfem.h at configure time

### DIFF
--- a/libhelfem/CMakeLists.txt
+++ b/libhelfem/CMakeLists.txt
@@ -2,6 +2,16 @@ set(LIBHELFEM_VERSION "v0.0.1-alpha")
 
 # Version information. Landed at include/ so the header ships with the
 # rest of the public API when we install(DIRECTORY .../include/).
+#
+# Older configurations of this file placed the generated helfem.h at
+# CMAKE_CURRENT_BINARY_DIR/helfem.h (no `include/` prefix). Existing
+# build trees still have that stale copy sitting there, and the
+# include search path picks it up before the freshly configured file
+# under include/. Result: consumers see the OLD arma::vec get_grid
+# declaration and fail to link against the new helfem::Vector one.
+# Delete the stale copy at configure time so incremental rebuilds
+# into pre-existing build directories just work.
+file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/helfem.h")
 configure_file("include/helfem.source.h" "include/helfem.h")
 list(APPEND LIBHELFEM_PUBLIC_HEADERS
     "ModelPotential.h"


### PR DESCRIPTION
## Summary

Fixes a broken-incremental-build issue that hits anyone who had a HelFEM build tree configured BEFORE PR #143 landed and now runs \`git pull && make\`.

## Root cause

PR #143 moved the \`configure_file\` destination for \`helfem.h\` from \`CMAKE_CURRENT_BINARY_DIR/helfem.h\` to \`CMAKE_CURRENT_BINARY_DIR/include/helfem.h\` so the header ships with the rest of the public API when we do \`install(DIRECTORY .../include/)\`.

For fresh build trees this is fine. For existing build trees, the OLD stale \`helfem.h\` at \`\$BUILDDIR/libhelfem/helfem.h\` is still sitting there. Reconfigure never deletes it, and the include search path picks it up before the freshly configured file under \`include/\`.

Consumers then see the OLD \`arma::vec get_grid\` declaration and blow up at build time:

\`\`\`
/objdir/libhelfem/helfem.h:53:15: note: old declaration
  'arma::vec helfem::utils::get_grid(double, int, int, double)'
grid.cpp:25:16: error: ambiguating new declaration of
  'helfem::Vector helfem::utils::get_grid(...)'
\`\`\`

## Fix

\`file(REMOVE ...)\` the stale copy up front in \`libhelfem/CMakeLists.txt\`, so incremental rebuilds into pre-existing build directories just work. The remove is a no-op on fresh trees.

## Workaround for anyone currently blocked

\`rm \$BUILDDIR/libhelfem/helfem.h && make\` — but with this PR merged, that manual step is no longer needed.

## Validation

Repro: start from a build tree containing a stale \`\$BUILDDIR/libhelfem/helfem.h\` with the old arma-typed declaration (I simulated one with \`touch\` + old content after configuring). Reconfigure runs \`file(REMOVE ...)\` before \`configure_file\`, so the stale file is gone by the time the include search kicks in; build succeeds through libhelfem cleanly.