### PR TITLE
diatomic: fix lm_map/LM_map insertion when new key sorts after end

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -375,25 +375,34 @@ namespace helfem {
                 Lmax=std::max(Lmax,L);
                 Mmax=std::max(Mmax,std::abs(M));
 
-                // L|M|
+                // L|M|. lmind returns idx == lm_map.size() when the
+                // requested (L, |M|) sorts AFTER every existing entry
+                // (e.g. right after the first push_back). Do not touch
+                // lm_map[idx] in that case -- under GCC 16's hardened
+                // std::vector::operator[] that is a hard abort; under
+                // older libstdc++ it silently returned garbage that
+                // happened to compare unequal to p, so the map was
+                // built correctly by luck.
                 p.second=std::abs(M);
-                if(!lm_map.size())
+                if(!lm_map.size()) {
                   lm_map.push_back(p);
-                else {
+                } else {
                   size_t idx=lmind(L,M,false);
-                  if(!(lm_map[idx]==p))
-                    // Insert at lower bound
+                  if (idx == lm_map.size())
+                    lm_map.push_back(p);
+                  else if (!(lm_map[idx]==p))
                     lm_map.insert(lm_map.begin()+idx,p);
                 }
 
-                // LM
+                // LM (same guard as above).
                 p.second=M;
-                if(!LM_map.size())
+                if(!LM_map.size()) {
                   LM_map.push_back(p);
-                else {
+                } else {
                   size_t idx=LMind(L,M,false);
-                  if(!(LM_map[idx]==p))
-                    // Insert at lower bound
+                  if (idx == LM_map.size())
+                    LM_map.push_back(p);
+                  else if (!(LM_map[idx]==p))
                     LM_map.insert(LM_map.begin()+idx,p);
                 }
               }


### PR DESCRIPTION
## Summary

Fix the actual latent OOB read that GCC 16's hardened \`std::vector::operator[]\` was crashing on during diatomic basis construction. Follow-up to PR #144, which addressed the symptom but not the caller.

## Root cause

The map-building loop in \`TwoDBasis\` constructor uses this pattern:

\`\`\`cpp
size_t idx = lmind(L, M, false);  // idx == size() when key sorts after end
if (!(lm_map[idx] == p))          // <-- OOB when idx == size()
  lm_map.insert(begin() + idx, p);
\`\`\`

When the new (L, |M|) key sorts **after** every existing entry — which happens naturally as the map is being filled from an empty state (right after the first \`push_back\`, the next call for a larger L already sorts past everything) — \`lmind\` returns \`idx == lm_map.size()\`. The line then reads \`lm_map[size()]\`, which is undefined behaviour.

### Historically silent

Pre-GCC-16 libstdc++ \`operator[]\` at \`size()\` just returned a garbage element, which almost always compared unequal to \`p\`, so the following \`insert\` path was taken and the map came out correct **by accident**.

Under GCC 16 the OOB access is a hard abort:

\`\`\`
Assertion '__n < this->size()' failed.
\`\`\`

blocking every diatomic executable run during basis construction.

## Fix

PR #144 sentinelled \`lmind\`/\`LMind\` to return \`size()\` on not-found, but the caller here still touched \`lm_map[idx]\` with the sentinel index, re-breaking the exact same way. This PR fixes the caller: handle \`idx == size()\` explicitly as "insert at end" via \`push_back\`, before touching \`lm_map[idx]\`.

## Validation

**Regression**:
- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)

**Diatomic** (previously always crashed on GCC 16):

H2 LDA (Z1=H, Z2=H, Rbond=1.4, nelem=5, lmax=3, mmax=0, nnodes=6, method=lda_x, restricted=1, nela=1, nelb=1):

\`\`\`
Total energy is -1.0436626091 (converged, 13 iterations)
\`\`\`

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He gensap HF unchanged
- [x] Be atomic HF bit-identical
- [x] Diatomic H2 LDA runs to convergence (previously hard-aborted)