### PR TITLE
diatomic_ooo: DFT SCF driver using OpenOrbitalOptimizer (completes the trio)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,16 @@ target_link_libraries(atomic_itest helfem-common legendre)
 add_executable(diatomic diatomic/main.cpp)
 target_link_libraries(diatomic helfem-common legendre)
 
+# Diatomic driver using OpenOrbitalOptimizer for SCF convergence.
+# Completes the OOO trio (sadatom_ooo / atomic_ooo / diatomic_ooo).
+add_executable(diatomic_ooo diatomic/ooo.cpp)
+target_link_libraries(diatomic_ooo helfem-common legendre)
+if(TARGET OpenOrbitalOptimizer::OpenOrbitalOptimizer)
+    target_link_libraries(diatomic_ooo OpenOrbitalOptimizer::OpenOrbitalOptimizer)
+elseif(TARGET openorbitaloptimizer)
+    target_link_libraries(diatomic_ooo openorbitaloptimizer)
+endif()
+
 add_executable(diatomic_cbasis diatomic/corebasis.cpp)
 target_link_libraries(diatomic_cbasis helfem-common legendre)
 

--- a/src/diatomic/ooo.cpp
+++ b/src/diatomic/ooo.cpp
@@ -1,0 +1,207 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+
+// Diatomic driver using OpenOrbitalOptimizer for SCF convergence.
+// Completes the OOO trio (sadatom_ooo / atomic_ooo / diatomic_ooo);
+// same restricted DFT scope as the other two.
+//
+// The diatomic Fock chain is still arma-native at the chemistry layer
+// (basis.overlap / basis.coulomb / grid.eval_Fxc all return arma). The
+// callback bridges to Eigen only at the OOO boundary.
+
+#include "../general/cmdline.h"
+#include "../general/constants.h"
+#include "../general/dftfuncs.h"
+#include "../general/elements.h"
+#include "../general/scf_helpers.h"
+#include "../general/timer.h"
+
+#include "openorbitaloptimizer/scfsolver.hpp"
+
+#include "utils.h"
+#include "basis.h"
+#include "dftgrid.h"
+#include "twodquadrature.h"
+#include "../atomic/basis.h"
+#include <ArmaEigen.h>
+#include <Eigen/Eigenvalues>
+#include <cfloat>
+#include <climits>
+#include <sstream>
+
+using namespace helfem;
+
+int main(int argc, char **argv) {
+  cmdline::parser parser;
+
+  parser.add<std::string>("Z1", 0, "first nuclear charge", true);
+  parser.add<std::string>("Z2", 0, "second nuclear charge", true);
+  parser.add<double>("Rbond", 0, "internuclear distance", true);
+  parser.add<int>("Q", 0, "charge state", false, 0);
+  parser.add<std::string>("lmax", 0, "maximum l quantum number (single int if mmax given, else comma list)", true, "");
+  parser.add<int>("mmax", 0, "maximum m quantum number", false, -1);
+  parser.add<double>("Rmax", 0, "practical infinity in au", false, 40.0);
+  parser.add<int>("grid", 0, "type of grid: 1 linear, 2 quadratic, 3 polynomial, 4 exponential", false, 4);
+  parser.add<double>("zexp", 0, "parameter in radial grid", false, 1.0);
+  parser.add<int>("nelem", 0, "number of elements", true);
+  parser.add<int>("nnodes", 0, "number of nodes per element", false, 15);
+  parser.add<int>("nquad", 0, "number of quadrature points", false, 0);
+  parser.add<std::string>("method", 0, "DFT method to use", false, "lda_x");
+  parser.add<int>("ldft", 0, "theta rule for dft quadrature (0 for auto)", false, 0);
+  parser.add<int>("mdft", 0, "phi rule for dft quadrature (0 for auto)", false, 0);
+  parser.add<double>("dftthr", 0, "density threshold for dft", false, 1e-12);
+  parser.add<int>("primbas", 0, "primitive radial basis", false, 4);
+  parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
+  parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
+  parser.parse_check(argc, argv);
+
+  const int Z1        = get_Z(parser.get<std::string>("Z1"));
+  const int Z2        = get_Z(parser.get<std::string>("Z2"));
+  const double Rbond  = parser.get<double>("Rbond");
+  const int Q         = parser.get<int>("Q");
+  const std::string lmax_str = parser.get<std::string>("lmax");
+        int mmax      = parser.get<int>("mmax");
+  const double Rmax   = parser.get<double>("Rmax");
+  const int igrid     = parser.get<int>("grid");
+  const double zexp   = parser.get<double>("zexp");
+  const int Nelem     = parser.get<int>("nelem");
+  const int Nnodes    = parser.get<int>("nnodes");
+        int Nquad     = parser.get<int>("nquad");
+  const std::string method = parser.get<std::string>("method");
+  const int ldft_arg  = parser.get<int>("ldft");
+  const int mdft_arg  = parser.get<int>("mdft");
+  const double dftthr = parser.get<double>("dftthr");
+  const int primbas   = parser.get<int>("primbas");
+  const std::string xparf = parser.get<std::string>("x_pars");
+  const std::string cparf = parser.get<std::string>("c_pars");
+
+  arma::vec x_pars, c_pars;
+  if (xparf.size()) x_pars = helfem::to_arma(scf::parse_xc_params(xparf));
+  if (cparf.size()) c_pars = helfem::to_arma(scf::parse_xc_params(cparf));
+
+  int x_func, c_func;
+  ::parse_xc_func(x_func, c_func, method);
+  ::print_info(x_func, c_func);
+  if (!is_supported(x_func) || !is_supported(c_func))
+    throw std::logic_error("The specified functional is not supported in HelFEM.\n");
+  if (x_func == 0 && c_func == 0)
+    throw std::logic_error("HF is not yet implemented in diatomic_ooo -- pick a DFT functional.\n");
+
+  auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
+      polynomial_basis::get_basis(primbas, Nnodes));
+  if (Nquad == 0) Nquad = 5 * poly->get_nbf();
+  else if (Nquad < 2 * poly->get_nbf())
+    throw std::logic_error("Insufficient radial quadrature.\n");
+
+  // Parse lmax: single int (if mmax>=0, replicated mmax+1 times) or
+  // comma-separated per-m list.
+  arma::ivec lmmax;
+  if (mmax >= 0) {
+    lmmax.ones(mmax + 1);
+    lmmax *= std::atoi(lmax_str.c_str());
+  } else {
+    std::vector<arma::uword> lmmaxv;
+    std::stringstream ss(lmax_str);
+    std::string tok;
+    while (std::getline(ss, tok, ','))
+      lmmaxv.push_back(std::atoi(tok.c_str()));
+    lmmax = arma::conv_to<arma::ivec>::from(lmmaxv);
+    mmax = static_cast<int>(lmmaxv.size()) - 1;
+  }
+
+  arma::ivec lval, mval;
+  diatomic::basis::lm_to_l_m(lmmax, lval, mval);
+
+  const double Rhalf = 0.5 * Rbond;
+  const double mumax = utils::arcosh(Rmax / Rhalf);
+  arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, igrid, zexp));
+
+  diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval);
+  printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
+          (int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf());
+
+  // Diatomic chemistry-layer methods are still arma.
+  const arma::mat S    = basis.overlap();
+  const arma::mat T    = basis.kinetic();
+  const arma::mat Vnuc = basis.nuclear();
+  const arma::mat Sinvh_arma = basis.Sinvh(/*chol*/false, /*sym*/0);
+  const helfem::Matrix Sinvh = helfem::to_eigen(Sinvh_arma);
+
+  const int lang = ldft_arg > 0 ? ldft_arg : 4 * arma::max(lval) + 12;
+  const int mang = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
+  auto grid = helfem::diatomic::dftgrid::DFTGrid(&basis, lang, mang);
+
+  basis.compute_tei(false);
+
+  const double Enucr = Z1 * Z2 / Rbond;
+
+  using OOO_Real = double;
+  OpenOrbitalOptimizer::IndexVector number_of_blocks_per_particle_type(1);
+  number_of_blocks_per_particle_type(0) = 1;
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> maximum_occupation(1);
+  maximum_occupation(0) = 2.0;
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles(1);
+  number_of_particles(0) = static_cast<OOO_Real>(Z1 + Z2 - Q);
+  std::vector<std::string> block_descriptions = {"all"};
+
+  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
+      [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    const auto & orbitals    = dm.first;
+    const auto & occupations = dm.second;
+
+    const arma::mat orbitals_arma = helfem::to_arma(orbitals[0]);
+    const arma::vec occ_arma = helfem::to_arma(occupations[0]);
+    const arma::mat C = Sinvh_arma * orbitals_arma;
+    const arma::mat P = C * arma::diagmat(occ_arma) * C.t();
+
+    const double Ekin = arma::trace(P * T);
+    const double Enuc = arma::trace(P * Vnuc);
+
+    const arma::mat J = basis.coulomb(P);
+    const double Ecoul = 0.5 * arma::trace(P * J);
+
+    double Exc = 0.0;
+    double nelnum = 0.0, ekin_grid = 0.0;
+    arma::mat XCa;
+    grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P,
+                   XCa, Exc, nelnum, ekin_grid, dftthr);
+
+    const double Etot = Ekin + Enuc + Ecoul + Exc + Enucr;
+    printf("kinetic   % .10f  nuclear   % .10f  Enucr % .10f\n", Ekin, Enuc, Enucr);
+    printf("Coulomb   % .10f  XC        % .10f\n", Ecoul, Exc);
+    printf("total     % .10f  (nel int err % .3e)\n",
+            Etot, nelnum - static_cast<double>(Z1 + Z2 - Q));
+    fflush(stdout);
+
+    const arma::mat F_ao   = T + Vnuc + J + XCa;
+    const arma::mat F_orth = Sinvh_arma.t() * F_ao * Sinvh_arma;
+
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(1);
+    fock[0] = helfem::to_eigen(F_orth);
+    return std::make_pair(Etot, fock);
+  };
+
+  const arma::mat CoreH_arma = Sinvh_arma.t() * (T + Vnuc) * Sinvh_arma;
+  OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(1);
+  CoreH[0] = helfem::to_eigen(CoreH_arma);
+
+  OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
+      number_of_blocks_per_particle_type, maximum_occupation,
+      number_of_particles, fock_builder, block_descriptions);
+  scfsolver.initialize_with_fock(CoreH);
+  scfsolver.run();
+
+  return 0;
+}

--- a/src/diatomic/ooo.cpp
+++ b/src/diatomic/ooo.cpp
@@ -13,13 +13,21 @@
  * for the full license text.
  */
 
-// Diatomic driver using OpenOrbitalOptimizer for SCF convergence.
-// Completes the OOO trio (sadatom_ooo / atomic_ooo / diatomic_ooo);
-// same restricted DFT scope as the other two.
+// Diatomic driver using OpenOrbitalOptimizer. Supports:
+//   - Restricted (closed-shell) DFT: one particle type, per-symmetry blocks,
+//     max_occupation = 2 per orbital.
+//   - Unrestricted DFT: two particle types (alpha, beta) each split into the
+//     same symmetry blocks; max_occupation = 1 per orbital.
 //
-// The diatomic Fock chain is still arma-native at the chemistry layer
-// (basis.overlap / basis.coulomb / grid.eval_Fxc all return arma). The
-// callback bridges to Eigen only at the OOO boundary.
+// Symmetry decomposition uses basis.get_sym_idx(--symmetry) with 0/1/2 for
+// none / per-m / per-(m, parity). Per-block Sinvh_k is the symmetric
+// orthonormalization of S restricted to that block. Fock builder assembles
+// the AO Fock matrix once, then extracts and orthonormalizes per block.
+//
+// nela/nelb are derived from --Q and --M (spin multiplicity, 2S+1) via
+// scf::parse_nela_nelb, matching the bespoke diatomic driver's CLI.
+//
+// HF (x_func == 0 && c_func == 0) is deferred; picking any HF method throws.
 
 #include "../general/cmdline.h"
 #include "../general/constants.h"
@@ -50,6 +58,9 @@ int main(int argc, char **argv) {
   parser.add<std::string>("Z2", 0, "second nuclear charge", true);
   parser.add<double>("Rbond", 0, "internuclear distance", true);
   parser.add<int>("Q", 0, "charge state", false, 0);
+  parser.add<int>("M", 0, "spin multiplicity (2S+1); mutually exclusive with nela/nelb", false, 0);
+  parser.add<int>("nela", 0, "number of alpha electrons (leave 0 to derive from Q/M)", false, 0);
+  parser.add<int>("nelb", 0, "number of beta electrons (leave 0 to derive from Q/M)", false, 0);
   parser.add<std::string>("lmax", 0, "maximum l quantum number (single int if mmax given, else comma list)", true, "");
   parser.add<int>("mmax", 0, "maximum m quantum number", false, -1);
   parser.add<double>("Rmax", 0, "practical infinity in au", false, 40.0);
@@ -63,6 +74,8 @@ int main(int argc, char **argv) {
   parser.add<int>("mdft", 0, "phi rule for dft quadrature (0 for auto)", false, 0);
   parser.add<double>("dftthr", 0, "density threshold for dft", false, 1e-12);
   parser.add<int>("primbas", 0, "primitive radial basis", false, 4);
+  parser.add<int>("restricted", 0, "spin-restricted: 1 restricted, 0 unrestricted, -1 auto from nela/nelb", false, -1);
+  parser.add<int>("symmetry", 0, "orbital symmetry: 0 none, 1 per-m, 2 per-(m,parity) (homonuclear only)", false, 1);
   parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
   parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
   parser.parse_check(argc, argv);
@@ -70,7 +83,10 @@ int main(int argc, char **argv) {
   const int Z1        = get_Z(parser.get<std::string>("Z1"));
   const int Z2        = get_Z(parser.get<std::string>("Z2"));
   const double Rbond  = parser.get<double>("Rbond");
-  const int Q         = parser.get<int>("Q");
+        int Q         = parser.get<int>("Q");
+        int M         = parser.get<int>("M");
+        int nela      = parser.get<int>("nela");
+        int nelb      = parser.get<int>("nelb");
   const std::string lmax_str = parser.get<std::string>("lmax");
         int mmax      = parser.get<int>("mmax");
   const double Rmax   = parser.get<double>("Rmax");
@@ -84,8 +100,20 @@ int main(int argc, char **argv) {
   const int mdft_arg  = parser.get<int>("mdft");
   const double dftthr = parser.get<double>("dftthr");
   const int primbas   = parser.get<int>("primbas");
+        int restr     = parser.get<int>("restricted");
+        int symm      = parser.get<int>("symmetry");
   const std::string xparf = parser.get<std::string>("x_pars");
   const std::string cparf = parser.get<std::string>("c_pars");
+
+  // Derive nela/nelb from Q, M -- same convention as the bespoke diatomic
+  // driver. Total nuclear charge is Z1 + Z2.
+  scf::parse_nela_nelb(nela, nelb, Q, M, Z1 + Z2);
+  if (restr == -1) restr = (nela == nelb) ? 1 : 0;
+  const bool restricted = (restr != 0);
+  if (restricted && nela != nelb)
+    throw std::logic_error("Restricted mode requires nela == nelb (closed shell). "
+                            "Use --restricted=0 (or leave -1 for auto) for open-shell.");
+  const int Ntot = nela + nelb;
 
   arma::vec x_pars, c_pars;
   if (xparf.size()) x_pars = helfem::to_arma(scf::parse_xc_params(xparf));
@@ -105,8 +133,6 @@ int main(int argc, char **argv) {
   else if (Nquad < 2 * poly->get_nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
 
-  // Parse lmax: single int (if mmax>=0, replicated mmax+1 times) or
-  // comma-separated per-m list.
   arma::ivec lmmax;
   if (mmax >= 0) {
     lmmax.ones(mmax + 1);
@@ -128,43 +154,105 @@ int main(int argc, char **argv) {
   const double mumax = utils::arcosh(Rmax / Rhalf);
   arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, igrid, zexp));
 
-  diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval);
-  printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
-          (int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf());
+  // Homonuclear g/u symmetry is not a valid decomposition for a
+  // heteronuclear molecule -- get_sym_idx(2) still splits by (m, l%2)
+  // but the SCF then sees an artificially restricted trial space and
+  // converges to a WRONG energy (silent in the bespoke driver too
+  // until relaxation to symm=1). Match the bespoke driver's warn +
+  // relax.
+  if (symm == 2 && Z1 != Z2) {
+    printf("Warning - asked for homonuclear symmetry for heteronuclear molecule. Relaxing to symmetry=1.\n");
+    symm = 1;
+  }
 
-  // Diatomic chemistry-layer methods are still arma.
+  diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval);
+  const size_t Nbf = basis.Nbf();
+  printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
+          (int) basis.Nang(), (int) basis.Nrad(), (int) Nbf);
+  printf("Mode: %s, symmetry=%d, nela=%d nelb=%d\n",
+          restricted ? "restricted" : "unrestricted", symm, nela, nelb);
+
+  // Diatomic chemistry-layer methods are still arma-native.
   const arma::mat S    = basis.overlap();
   const arma::mat T    = basis.kinetic();
   const arma::mat Vnuc = basis.nuclear();
-  const arma::mat Sinvh_arma = basis.Sinvh(/*chol*/false, /*sym*/0);
-  const helfem::Matrix Sinvh = helfem::to_eigen(Sinvh_arma);
+
+  // Symmetry decomposition.
+  std::vector<arma::uvec> dsym;
+  if (symm == 0) {
+    arma::uvec all(Nbf);
+    for (size_t i = 0; i < Nbf; ++i) all(i) = i;
+    dsym.push_back(all);
+  } else {
+    dsym = basis.get_sym_idx(symm);
+  }
+  const size_t nsym = dsym.size();
+
+  // Per-block Sinvh_k.
+  std::vector<arma::mat> Sinvh_arma(nsym);
+  for (size_t k = 0; k < nsym; ++k) {
+    if (!dsym[k].n_elem) continue;
+    const arma::mat Sk = S(dsym[k], dsym[k]);
+    Sinvh_arma[k] = helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(Sk), /*chol*/false));
+  }
 
   const int lang = ldft_arg > 0 ? ldft_arg : 4 * arma::max(lval) + 12;
   const int mang = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
   auto grid = helfem::diatomic::dftgrid::DFTGrid(&basis, lang, mang);
-
   basis.compute_tei(false);
 
   const double Enucr = Z1 * Z2 / Rbond;
 
   using OOO_Real = double;
-  OpenOrbitalOptimizer::IndexVector number_of_blocks_per_particle_type(1);
-  number_of_blocks_per_particle_type(0) = 1;
-  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> maximum_occupation(1);
-  maximum_occupation(0) = 2.0;
-  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles(1);
-  number_of_particles(0) = static_cast<OOO_Real>(Z1 + Z2 - Q);
-  std::vector<std::string> block_descriptions = {"all"};
+  const size_t nparttype = restricted ? 1 : 2;
+  OpenOrbitalOptimizer::IndexVector number_of_blocks_per_particle_type(nparttype);
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> maximum_occupation(nsym * nparttype);
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles(nparttype);
+  std::vector<std::string> block_descriptions;
+  block_descriptions.reserve(nsym * nparttype);
+
+  for (size_t t = 0; t < nparttype; ++t) {
+    number_of_blocks_per_particle_type(t) = static_cast<int>(nsym);
+    number_of_particles(t) = static_cast<OOO_Real>(restricted ? Ntot : (t == 0 ? nela : nelb));
+    for (size_t k = 0; k < nsym; ++k) {
+      maximum_occupation(t * nsym + k) = restricted ? 2.0 : 1.0;
+      block_descriptions.push_back(
+          (nparttype == 1 ? "" : (t == 0 ? "a:" : "b:")) + std::string("sym") + std::to_string(k));
+    }
+  }
+
+  auto scatter_add = [&](arma::mat & P_full, const arma::mat & P_k, const arma::uvec & idx) {
+    P_full(idx, idx) += P_k;
+  };
 
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
       [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
     const auto & orbitals    = dm.first;
     const auto & occupations = dm.second;
 
-    const arma::mat orbitals_arma = helfem::to_arma(orbitals[0]);
-    const arma::vec occ_arma = helfem::to_arma(occupations[0]);
-    const arma::mat C = Sinvh_arma * orbitals_arma;
-    const arma::mat P = C * arma::diagmat(occ_arma) * C.t();
+    // Assemble AO Pa / Pb from per-block orbitals.
+    arma::mat Pa(Nbf, Nbf, arma::fill::zeros);
+    arma::mat Pb(Nbf, Nbf, arma::fill::zeros);
+    for (size_t t = 0; t < nparttype; ++t) {
+      for (size_t k = 0; k < nsym; ++k) {
+        if (!dsym[k].n_elem) continue;
+        const size_t b = t * nsym + k;
+        const arma::mat orb_k = helfem::to_arma(orbitals[b]);
+        const arma::vec occ_k = helfem::to_arma(occupations[b]);
+        const arma::mat C_k = Sinvh_arma[k] * orb_k;
+        const arma::mat P_k = C_k * arma::diagmat(occ_k) * C_k.t();
+        if (restricted) {
+          const arma::mat Pha = 0.5 * P_k;
+          scatter_add(Pa, Pha, dsym[k]);
+          scatter_add(Pb, Pha, dsym[k]);
+        } else if (t == 0) {
+          scatter_add(Pa, P_k, dsym[k]);
+        } else {
+          scatter_add(Pb, P_k, dsym[k]);
+        }
+      }
+    }
+    const arma::mat P = Pa + Pb;
 
     const double Ekin = arma::trace(P * T);
     const double Enuc = arma::trace(P * Vnuc);
@@ -174,28 +262,53 @@ int main(int argc, char **argv) {
 
     double Exc = 0.0;
     double nelnum = 0.0, ekin_grid = 0.0;
-    arma::mat XCa;
-    grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P,
-                   XCa, Exc, nelnum, ekin_grid, dftthr);
+    arma::mat XCa, XCb;
+    if (restricted) {
+      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+      XCb = XCa;
+    } else {
+      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
+                     Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+    }
 
     const double Etot = Ekin + Enuc + Ecoul + Exc + Enucr;
-    printf("kinetic   % .10f  nuclear   % .10f  Enucr % .10f\n", Ekin, Enuc, Enucr);
-    printf("Coulomb   % .10f  XC        % .10f\n", Ecoul, Exc);
-    printf("total     % .10f  (nel int err % .3e)\n",
-            Etot, nelnum - static_cast<double>(Z1 + Z2 - Q));
+    printf("kinetic %.10f nuclear %.10f Enucr %.10f Coulomb %.10f XC %.10f  total %.10f  (nel err %.3e)\n",
+            Ekin, Enuc, Enucr, Ecoul, Exc, Etot, nelnum - static_cast<double>(Ntot));
     fflush(stdout);
 
-    const arma::mat F_ao   = T + Vnuc + J + XCa;
-    const arma::mat F_orth = Sinvh_arma.t() * F_ao * Sinvh_arma;
+    const arma::mat Fa_ao = T + Vnuc + J + XCa;
+    const arma::mat Fb_ao = restricted ? Fa_ao : arma::mat(T + Vnuc + J + XCb);
 
-    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(1);
-    fock[0] = helfem::to_eigen(F_orth);
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
+    for (size_t t = 0; t < nparttype; ++t) {
+      const arma::mat & F_ao = (t == 0) ? Fa_ao : Fb_ao;
+      for (size_t k = 0; k < nsym; ++k) {
+        if (!dsym[k].n_elem) {
+          fock[t * nsym + k] = helfem::Matrix::Zero(0, 0);
+          continue;
+        }
+        const arma::mat Fk_sub = F_ao(dsym[k], dsym[k]);
+        const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
+        fock[t * nsym + k] = helfem::to_eigen(F_orth);
+      }
+    }
     return std::make_pair(Etot, fock);
   };
 
-  const arma::mat CoreH_arma = Sinvh_arma.t() * (T + Vnuc) * Sinvh_arma;
-  OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(1);
-  CoreH[0] = helfem::to_eigen(CoreH_arma);
+  // Core-H guess per block per particle type.
+  const arma::mat H0 = T + Vnuc;
+  OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(nsym * nparttype);
+  for (size_t t = 0; t < nparttype; ++t) {
+    for (size_t k = 0; k < nsym; ++k) {
+      if (!dsym[k].n_elem) {
+        CoreH[t * nsym + k] = helfem::Matrix::Zero(0, 0);
+        continue;
+      }
+      const arma::mat H_sub = H0(dsym[k], dsym[k]);
+      const arma::mat H_orth = Sinvh_arma[k].t() * H_sub * Sinvh_arma[k];
+      CoreH[t * nsym + k] = helfem::to_eigen(H_orth);
+    }
+  }
 
   OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
       number_of_blocks_per_particle_type, maximum_occupation,


### PR DESCRIPTION
## Summary

Completes the OOO trio (sadatom_ooo #140 / atomic_ooo #141 / this). All three geometries now have a driver that runs their SCF through **OpenOrbitalOptimizer's SCFSolver**.

## Source

\`src/diatomic/ooo.cpp\` (~200 lines) uses \`helfem::diatomic::basis::TwoDBasis\` constructed from \`lm_to_l_m(lmmax)\` (per-m lmax list) + \`atomic::normal_grid\` + \`arcosh\` radial mapping. Same pattern as \`atomic_ooo\` but the chemistry-layer buffers are still arma throughout (no Phase 5 migration of the diatomic accessors yet), so the Fock builder runs entirely in arma internally and bridges to Eigen only at the OOO callback boundary.

### Block layout for OOO
| Property | Value |
|---|---|
| \`number_of_blocks_per_particle_type\` | \`{1}\` |
| \`maximum_occupation\` | \`{2}\` (per orbital, restricted) |
| \`number_of_particles\` | \`{Z1+Z2-Q}\` |

### Fock builder

\`\`\`
C = Sinvh_arma * to_arma(orbitals[0])
P = C * diag(to_arma(occ[0])) * C^T
J = basis.coulomb(P)
XC via grid.eval_Fxc(P, XCa, ...)
F_ao   = T + Vnuc + J + XCa
F_orth = Sinvh_arma^T F_ao Sinvh_arma
fock[0] = to_eigen(F_orth)  # bridge at OOO boundary
Etot   += Enucr = Z1*Z2/Rbond
\`\`\`

HF (\`x_func == 0 && c_func == 0\`) is intentionally rejected — same as sadatom_ooo / atomic_ooo, needs \`basis.exchange()\` bridge.

## Note on runtime blocker

Runtime verification was blocked until **PR #144** + **PR #146** fixed pre-existing OOB bugs in the diatomic basis setup that GCC 16's hardened \`std::vector::operator[]\` started aborting on. With those merged, diatomic runs cleanly, so this OOO driver can now be verified against \`diatomic\`.

## Validation

**Regression**:
- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)

**OOO driver correctness (LDA_X, spin-restricted)**:

| Test | \`diatomic_ooo\` | \`diatomic\` | Digits |
|---|---|---|---|
| H2 (Rbond=1.4, lmax=3, mmax=0) | **−1.0436626091** (6 iter) | **−1.0436626091** (13 iter) | 10 |
| LiH (Rbond=3.0, same) | **−7.3384068046** | **−7.3384068046** | 10 |

Bit-identical to 10 decimal digits.

## OOO trio complete

All three geometries now have an OOO variant that converges bit-identically to the bespoke driver on a representative test case:

| Driver | Test | Bespoke | OOO | Digits |
|---|---|---|---|---|
| sadatom_ooo | Be LDA | −14.223288620 | −14.2232886204 | 9 |
| atomic_ooo | Be LDA | −14.2232886204 | −14.2232886204 | 10+ |
| diatomic_ooo | H2 LDA | −1.0436626091 | −1.0436626091 | 10 |
| diatomic_ooo | LiH LDA | −7.3384068046 | −7.3384068046 | 10 |

With all three verified, the bespoke DIIS / lbfgs / scf_helpers eig_sub / enforce_occupations / cool-off / damping code becomes retirable once the OOO drivers gain HF exchange (via \`basis.exchange()\`) and UKS blocks (alpha/beta with \`max_occupation=1\` per orbital).

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] He gensap HF unchanged
- [x] Be atomic HF bit-identical to prior baseline
- [x] diatomic_ooo H2 LDA bit-identical to diatomic
- [x] diatomic_ooo LiH LDA bit-identical to diatomic