### PR TITLE
cmake: enable POSITION_INDEPENDENT_CODE globally on static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ project (helfem CXX)
 # C++ standard is set per-target via target_compile_features(... cxx_std_17)
 # rather than globally.
 
+# helfem-common / helfem / legendre / lib1dfem are all STATIC libraries.
+# When a downstream project links any of them into a shared library
+# (e.g. the pybind11 _helfem module, or an external libatomscf shared
+# lib), the static archives need position-independent code -- otherwise
+# `ld -shared` refuses with `R_X86_64_32 ... can not be used when
+# making a shared object; recompile with -fPIC`. Set PIC globally so
+# every static archive is safe to consume from a shared object.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Ensure we are building out-of-source so that the tests work (issue 120)
 get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
 get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)


### PR DESCRIPTION
## Summary

Fix a downstream build failure: linking any of \`helfem-common\`, \`helfem\`, \`legendre\`, or \`lib1dfem\` into a shared library dies with:

\`\`\`
R_X86_64_32 against '.rodata.str1.1' can not be used when making a shared object;
recompile with -fPIC
\`\`\`

Set \`CMAKE_POSITION_INDEPENDENT_CODE ON\` at the top of the project so every static archive is safe to link into a shared object. Standard practice for libraries meant to be consumed by others.

## Symptoms that this fix resolves

- The pybind11 \`_helfem\` module (python/CMakeLists.txt) works only on build environments where the compiler default (e.g. Fedora GCC with \`-fPIE\`) happens to accept the archive. On stricter builds it fails.
- Downstream libraries built on top of libhelfem (\`libatomscf\` and similar shared consumer libs) hit the same failure.

## Validation

Fresh build tree from a clean directory: \`-fPIC\` now shows up in \`CMakeFiles/helfem-common.dir/flags.make\`. \`libhelfem-common.a\` builds cleanly.