### PR TITLE
atomic_ooo + diatomic_ooo: eliminate redundant work in the restricted Fock path

### DIFF
--- a/src/atomic/ooo.cpp
+++ b/src/atomic/ooo.cpp
@@ -211,8 +211,33 @@ int main(int argc, char **argv) {
     }
   }
 
-  auto scatter_add = [&](arma::mat & P_full, const arma::mat & P_k, const arma::uvec & idx) {
-    P_full(idx, idx) += P_k;
+  // Accumulate a per-block density (C_k * diag(occ_k) * C_k^T) into the
+  // full-Nbf density matrix P_full through the block's basis-function
+  // scatter index dsym[k].
+  auto accumulate_density = [&](arma::mat & P_full, size_t k,
+                                 const helfem::Matrix & orb_e,
+                                 const helfem::Vector & occ_e) {
+    if (!dsym[k].n_elem) return;
+    const arma::mat orb  = helfem::to_arma(orb_e);
+    const arma::vec occ  = helfem::to_arma(occ_e);
+    const arma::mat C_k  = Sinvh_arma[k] * orb;
+    const arma::mat P_k  = C_k * arma::diagmat(occ) * C_k.t();
+    P_full(dsym[k], dsym[k]) += P_k;
+  };
+
+  // Extract F_full(dsym[k], dsym[k]), transform to the block's
+  // orthonormal basis via Sinvh_k^T . F_k . Sinvh_k, and stash into
+  // fock[b] as helfem::Matrix.
+  auto orthonormalize_block =
+      [&](OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock, size_t b,
+          const arma::mat & F_full, size_t k) {
+    if (!dsym[k].n_elem) {
+      fock[b] = helfem::Matrix::Zero(0, 0);
+      return;
+    }
+    const arma::mat Fk_sub = F_full(dsym[k], dsym[k]);
+    const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
+    fock[b] = helfem::to_eigen(F_orth);
   };
 
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
@@ -220,67 +245,54 @@ int main(int argc, char **argv) {
     const auto & orbitals    = dm.first;
     const auto & occupations = dm.second;
 
-    // Assemble AO-basis alpha/beta densities from per-block orbitals.
-    arma::mat Pa(Nbf, Nbf, arma::fill::zeros);
-    arma::mat Pb(Nbf, Nbf, arma::fill::zeros);
-    for (size_t t = 0; t < nparttype; ++t) {
+    // --- Density assembly. Restricted mode has a single closed-shell
+    //     channel with max_occ = 2, so P comes straight from the alpha
+    //     channel; no Pa/Pb split, no *0.5 double-scatter, no unused Pb.
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
+    arma::mat P(Nbf, Nbf, arma::fill::zeros);
+    double Exc = 0.0;
+    double nelnum = 0.0, ekin_grid = 0.0;
+    arma::mat XCa, XCb;
+
+    if (restricted) {
+      for (size_t k = 0; k < nsym; ++k)
+        accumulate_density(P, k, orbitals[k], occupations[k]);
+      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+    } else {
+      arma::mat Pa(Nbf, Nbf, arma::fill::zeros);
+      arma::mat Pb(Nbf, Nbf, arma::fill::zeros);
       for (size_t k = 0; k < nsym; ++k) {
-        if (!dsym[k].n_elem) continue;
-        const size_t b = t * nsym + k;
-        const arma::mat orb_k  = helfem::to_arma(orbitals[b]);
-        const arma::vec occ_k  = helfem::to_arma(occupations[b]);
-        const arma::mat C_k    = Sinvh_arma[k] * orb_k;
-        const arma::mat P_k    = C_k * arma::diagmat(occ_k) * C_k.t();
-        if (restricted) {
-          const arma::mat Pha = 0.5 * P_k;
-          scatter_add(Pa, Pha, dsym[k]);
-          scatter_add(Pb, Pha, dsym[k]);
-        } else if (t == 0) {
-          scatter_add(Pa, P_k, dsym[k]);
-        } else {
-          scatter_add(Pb, P_k, dsym[k]);
-        }
+        accumulate_density(Pa, k, orbitals[k],        occupations[k]);
+        accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
+      P = Pa + Pb;
+      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
+                     Exc, nelnum, ekin_grid, nelb > 0, dftthr);
     }
-    const arma::mat P = Pa + Pb;
 
     const double Ekin = arma::trace(P * T);
     const double Enuc = arma::trace(P * Vnuc);
 
-    const helfem::Matrix P_e = helfem::to_eigen(P);
-    const arma::mat J = helfem::to_arma(basis.coulomb(P_e));
+    const arma::mat J = helfem::to_arma(basis.coulomb(helfem::to_eigen(P)));
     const double Ecoul = 0.5 * arma::trace(P * J);
-
-    double Exc = 0.0;
-    double nelnum = 0.0, ekin_grid = 0.0;
-    arma::mat XCa, XCb;
-    if (restricted) {
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
-      XCb = XCa;
-    } else {
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
-                     Exc, nelnum, ekin_grid, nelb > 0, dftthr);
-    }
 
     const double Etot = Ekin + Enuc + Ecoul + Exc;
     printf("kinetic %.10f nuclear %.10f Coulomb %.10f XC %.10f  total %.10f  (nel err %.3e)\n",
             Ekin, Enuc, Ecoul, Exc, Etot, nelnum - static_cast<double>(Ntot));
     fflush(stdout);
 
-    const arma::mat Fa_ao = T + Vnuc + J + XCa;
-    const arma::mat Fb_ao = restricted ? Fa_ao : arma::mat(T + Vnuc + J + XCb);
-
-    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
-    for (size_t t = 0; t < nparttype; ++t) {
-      const arma::mat & F_ao = (t == 0) ? Fa_ao : Fb_ao;
+    // --- Fock assembly. Restricted: one AO Fock, orthonormalize per block.
+    //     Unrestricted: separate Fa/Fb AO Fock matrices for the two channels.
+    if (restricted) {
+      const arma::mat F_ao = T + Vnuc + J + XCa;
+      for (size_t k = 0; k < nsym; ++k)
+        orthonormalize_block(fock, k, F_ao, k);
+    } else {
+      const arma::mat Fa_ao = T + Vnuc + J + XCa;
+      const arma::mat Fb_ao = T + Vnuc + J + XCb;
       for (size_t k = 0; k < nsym; ++k) {
-        if (!dsym[k].n_elem) {
-          fock[t * nsym + k] = helfem::Matrix::Zero(0, 0);
-          continue;
-        }
-        const arma::mat Fk_sub = F_ao(dsym[k], dsym[k]);
-        const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
-        fock[t * nsym + k] = helfem::to_eigen(F_orth);
+        orthonormalize_block(fock, k,        Fa_ao, k);
+        orthonormalize_block(fock, nsym + k, Fb_ao, k);
       }
     }
     return std::make_pair(Etot, fock);

--- a/src/diatomic/ooo.cpp
+++ b/src/diatomic/ooo.cpp
@@ -221,8 +221,31 @@ int main(int argc, char **argv) {
     }
   }
 
-  auto scatter_add = [&](arma::mat & P_full, const arma::mat & P_k, const arma::uvec & idx) {
-    P_full(idx, idx) += P_k;
+  // Accumulate a per-block density into the full-Nbf density matrix
+  // P_full through the block's basis-function scatter index dsym[k].
+  auto accumulate_density = [&](arma::mat & P_full, size_t k,
+                                 const helfem::Matrix & orb_e,
+                                 const helfem::Vector & occ_e) {
+    if (!dsym[k].n_elem) return;
+    const arma::mat orb  = helfem::to_arma(orb_e);
+    const arma::vec occ  = helfem::to_arma(occ_e);
+    const arma::mat C_k  = Sinvh_arma[k] * orb;
+    const arma::mat P_k  = C_k * arma::diagmat(occ) * C_k.t();
+    P_full(dsym[k], dsym[k]) += P_k;
+  };
+
+  // Extract F_full(dsym[k], dsym[k]), transform to the block's
+  // orthonormal basis via Sinvh_k^T . F_k . Sinvh_k, stash into fock[b].
+  auto orthonormalize_block =
+      [&](OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock, size_t b,
+          const arma::mat & F_full, size_t k) {
+    if (!dsym[k].n_elem) {
+      fock[b] = helfem::Matrix::Zero(0, 0);
+      return;
+    }
+    const arma::mat Fk_sub = F_full(dsym[k], dsym[k]);
+    const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
+    fock[b] = helfem::to_eigen(F_orth);
   };
 
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
@@ -230,29 +253,30 @@ int main(int argc, char **argv) {
     const auto & orbitals    = dm.first;
     const auto & occupations = dm.second;
 
-    // Assemble AO Pa / Pb from per-block orbitals.
-    arma::mat Pa(Nbf, Nbf, arma::fill::zeros);
-    arma::mat Pb(Nbf, Nbf, arma::fill::zeros);
-    for (size_t t = 0; t < nparttype; ++t) {
+    // Density assembly. Restricted mode has a single closed-shell channel
+    // with max_occ = 2, so P comes straight from the alpha channel; no
+    // Pa/Pb split, no *0.5 double-scatter.
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
+    arma::mat P(Nbf, Nbf, arma::fill::zeros);
+    double Exc = 0.0;
+    double nelnum = 0.0, ekin_grid = 0.0;
+    arma::mat XCa, XCb;
+
+    if (restricted) {
+      for (size_t k = 0; k < nsym; ++k)
+        accumulate_density(P, k, orbitals[k], occupations[k]);
+      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+    } else {
+      arma::mat Pa(Nbf, Nbf, arma::fill::zeros);
+      arma::mat Pb(Nbf, Nbf, arma::fill::zeros);
       for (size_t k = 0; k < nsym; ++k) {
-        if (!dsym[k].n_elem) continue;
-        const size_t b = t * nsym + k;
-        const arma::mat orb_k = helfem::to_arma(orbitals[b]);
-        const arma::vec occ_k = helfem::to_arma(occupations[b]);
-        const arma::mat C_k = Sinvh_arma[k] * orb_k;
-        const arma::mat P_k = C_k * arma::diagmat(occ_k) * C_k.t();
-        if (restricted) {
-          const arma::mat Pha = 0.5 * P_k;
-          scatter_add(Pa, Pha, dsym[k]);
-          scatter_add(Pb, Pha, dsym[k]);
-        } else if (t == 0) {
-          scatter_add(Pa, P_k, dsym[k]);
-        } else {
-          scatter_add(Pb, P_k, dsym[k]);
-        }
+        accumulate_density(Pa, k, orbitals[k],        occupations[k]);
+        accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
+      P = Pa + Pb;
+      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
+                     Exc, nelnum, ekin_grid, nelb > 0, dftthr);
     }
-    const arma::mat P = Pa + Pb;
 
     const double Ekin = arma::trace(P * T);
     const double Enuc = arma::trace(P * Vnuc);
@@ -260,36 +284,23 @@ int main(int argc, char **argv) {
     const arma::mat J = basis.coulomb(P);
     const double Ecoul = 0.5 * arma::trace(P * J);
 
-    double Exc = 0.0;
-    double nelnum = 0.0, ekin_grid = 0.0;
-    arma::mat XCa, XCb;
-    if (restricted) {
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
-      XCb = XCa;
-    } else {
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
-                     Exc, nelnum, ekin_grid, nelb > 0, dftthr);
-    }
-
     const double Etot = Ekin + Enuc + Ecoul + Exc + Enucr;
     printf("kinetic %.10f nuclear %.10f Enucr %.10f Coulomb %.10f XC %.10f  total %.10f  (nel err %.3e)\n",
             Ekin, Enuc, Enucr, Ecoul, Exc, Etot, nelnum - static_cast<double>(Ntot));
     fflush(stdout);
 
-    const arma::mat Fa_ao = T + Vnuc + J + XCa;
-    const arma::mat Fb_ao = restricted ? Fa_ao : arma::mat(T + Vnuc + J + XCb);
-
-    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
-    for (size_t t = 0; t < nparttype; ++t) {
-      const arma::mat & F_ao = (t == 0) ? Fa_ao : Fb_ao;
+    // Fock assembly. Restricted: one AO Fock matrix per block.
+    // Unrestricted: separate alpha/beta AO Fock matrices.
+    if (restricted) {
+      const arma::mat F_ao = T + Vnuc + J + XCa;
+      for (size_t k = 0; k < nsym; ++k)
+        orthonormalize_block(fock, k, F_ao, k);
+    } else {
+      const arma::mat Fa_ao = T + Vnuc + J + XCa;
+      const arma::mat Fb_ao = T + Vnuc + J + XCb;
       for (size_t k = 0; k < nsym; ++k) {
-        if (!dsym[k].n_elem) {
-          fock[t * nsym + k] = helfem::Matrix::Zero(0, 0);
-          continue;
-        }
-        const arma::mat Fk_sub = F_ao(dsym[k], dsym[k]);
-        const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
-        fock[t * nsym + k] = helfem::to_eigen(F_orth);
+        orthonormalize_block(fock, k,        Fa_ao, k);
+        orthonormalize_block(fock, nsym + k, Fb_ao, k);
       }
     }
     return std::make_pair(Etot, fock);


### PR DESCRIPTION
## Summary

The Fock builder in both drivers previously did unnecessary Pa/Pb bookkeeping in **restricted** mode:
- Split every per-block contribution \`P_k\` into \`0.5 * P_k\`, scattered into BOTH \`Pa\` and \`Pb\`.
- Summed \`Pa + Pb → P\`.
- Called \`grid.eval_Fxc(..., P, XCa, ...)\` and then \`XCb = XCa\`.
- Copied \`Fa_ao → Fb_ao\` in restricted mode.

None of this is needed — OOO already models a closed shell as a **single** particle-type channel with \`max_occupation = 2\` per orbital, so the alpha channel alone IS the full density. Build \`P\` directly, call the closed-shell \`eval_Fxc(..., P, XCa, ...)\` overload, and assemble one AO Fock matrix per block. The unrestricted path keeps Pa/Pb and the spin-polarized \`eval_Fxc\` overload.

## Design

Both drivers now use the same shape:

\`\`\`cpp
if (restricted) {
  for k: accumulate_density(P, k, orb[k], occ[k]);
  eval_Fxc(..., P, XCa, ...);
  F_ao = T + V + J + XCa;
  for k: orthonormalize_block(fock, k, F_ao, k);
} else {
  for k: accumulate_density(Pa, k, orb[k],        occ[k]);
  for k: accumulate_density(Pb, k, orb[nsym + k], occ[nsym + k]);
  P = Pa + Pb;
  eval_Fxc(..., Pa, Pb, XCa, XCb, ..., nelb>0, ...);
  Fa_ao = T + V + J + XCa;   Fb_ao = T + V + J + XCb;
  for k: orthonormalize_block(fock, k,        Fa_ao, k);
  for k: orthonormalize_block(fock, nsym + k, Fb_ao, k);
}
\`\`\`

Two small lambdas capture the per-block density accumulation and orthonormalization:

\`\`\`cpp
accumulate_density(P_full, k, orb_e, occ_e):
  orb    = to_arma(orb_e); occ = to_arma(occ_e);
  C_k    = Sinvh_k * orb; P_k = C_k * diag(occ) * C_k^T;
  P_full(dsym[k], dsym[k]) += P_k;

orthonormalize_block(fock, b, F_full, k):
  fock[b] = to_eigen(Sinvh_k^T * F_full(dsym[k], dsym[k]) * Sinvh_k);
\`\`\`

Same restricted / unrestricted branching as the bespoke atomic and diatomic drivers (main.cpp:773-778).

## Validation

**Regression**:
- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)

**All six OOO test cases from PR #148 / #147 still converge to the same bit-identical energies**:

| Case | Energy |
|---|---|
| atomic Be M=1 symm=1 restricted | −14.2232886204 |
| atomic Li M=2 symm=1 unrestricted | −7.1934008434 |
| atomic C M=3 symm=2 unrestricted | −37.1121492978 |
| diatomic H2 M=1 symm=2 restricted | −1.0436626091 |
| diatomic H2+ M=2 symm=1 unrestricted | −0.5607327464 |
| diatomic BH M=1 symm=1 restricted | −22.4717637229 |

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression: He gensap HF and Be atomic HF unchanged
- [x] All six OOO test cases still bit-identical to bespoke