### PR TITLE
OOO trio: add HF exchange support (via basis.exchange())

### DIFF
--- a/src/atomic/ooo.cpp
+++ b/src/atomic/ooo.cpp
@@ -132,8 +132,18 @@ int main(int argc, char **argv) {
   ::print_info(x_func, c_func);
   if (!is_supported(x_func) || !is_supported(c_func))
     throw std::logic_error("The specified functional is not supported in HelFEM.\n");
-  if (x_func == 0 && c_func == 0)
-    throw std::logic_error("HF is not yet implemented in atomic_ooo -- pick a DFT functional.\n");
+
+  // Range-separation parameters: kfrac for full-range HF exchange
+  // fraction (1 for pure HF, 0 for pure DFT, in-between for hybrids),
+  // kshort for the short-range fraction (nonzero only for range-
+  // separated hybrids). omega is the range-separation parameter itself,
+  // unused here because we don't wire an omega variant of rs_exchange.
+  double kfrac, kshort, omega;
+  range_separation(x_func, omega, kfrac, kshort);
+  const bool have_exx = (kfrac != 0.0 || kshort != 0.0);
+  const bool have_xc  = (x_func != 0 || c_func != 0);
+  if (have_exx && kshort != 0.0)
+    throw std::logic_error("Range-separated hybrids not yet supported in atomic_ooo (needs omega wiring).\n");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
       polynomial_basis::get_basis(primbas, Nnodes));
@@ -190,7 +200,7 @@ int main(int argc, char **argv) {
   const int ldft = ldft_arg > 0 ? ldft_arg : 4 * lmax + 12;
   const int mdft = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
   auto grid = helfem::atomic::dftgrid::DFTGrid(&basis, ldft, mdft);
-  basis.compute_tei(false);
+  basis.compute_tei(have_exx);
 
   // --- OOO block layout.
   using OOO_Real = double;
@@ -250,6 +260,9 @@ int main(int argc, char **argv) {
     //     channel; no Pa/Pb split, no *0.5 double-scatter, no unused Pb.
     OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
     arma::mat P(Nbf, Nbf, arma::fill::zeros);
+    // Spin-density buffers used for both the XC branch and the HF
+    // exchange branch; for restricted the alpha density is 0.5 * P.
+    arma::mat Pa, Pb;
     double Exc = 0.0;
     double nelnum = 0.0, ekin_grid = 0.0;
     arma::mat XCa, XCb;
@@ -257,17 +270,20 @@ int main(int argc, char **argv) {
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+      if (have_xc)
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+      if (have_exx) Pa = 0.5 * P;
     } else {
-      arma::mat Pa(Nbf, Nbf, arma::fill::zeros);
-      arma::mat Pb(Nbf, Nbf, arma::fill::zeros);
+      Pa.zeros(Nbf, Nbf);
+      Pb.zeros(Nbf, Nbf);
       for (size_t k = 0; k < nsym; ++k) {
         accumulate_density(Pa, k, orbitals[k],        occupations[k]);
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
-                     Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+      if (have_xc)
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
+                       Exc, nelnum, ekin_grid, nelb > 0, dftthr);
     }
 
     const double Ekin = arma::trace(P * T);
@@ -276,20 +292,45 @@ int main(int argc, char **argv) {
     const arma::mat J = helfem::to_arma(basis.coulomb(helfem::to_eigen(P)));
     const double Ecoul = 0.5 * arma::trace(P * J);
 
-    const double Etot = Ekin + Enuc + Ecoul + Exc;
-    printf("kinetic %.10f nuclear %.10f Coulomb %.10f XC %.10f  total %.10f  (nel err %.3e)\n",
-            Ekin, Enuc, Ecoul, Exc, Etot, nelnum - static_cast<double>(Ntot));
+    // --- HF exchange: K = kfrac * basis.exchange(spin density). Sign
+    //     convention is baked into basis.exchange (it returns the
+    //     signed contribution that gets ADDED to the Fock matrix), so
+    //     Exx = 0.5 * trace(P_spin * K_spin) per channel with a +
+    //     sign matches the bespoke atomic driver's line 754.
+    arma::mat Ka, Kb;
+    double Exx = 0.0;
+    if (have_exx) {
+      Ka = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pa)));
+      Exx = 0.5 * arma::trace(Pa * Ka);
+      if (!restricted) {
+        Kb = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pb)));
+        Exx += 0.5 * arma::trace(Pb * Kb);
+      } else {
+        // In restricted mode alpha == beta density, and we only assemble
+        // one Fock. Skipping the K(Pb) call saves one exchange build;
+        // the beta contribution equals the alpha one so double it.
+        Exx *= 2.0;
+      }
+    }
+
+    const double Etot = Ekin + Enuc + Ecoul + Exc + Exx;
+    printf("kinetic %.10f nuclear %.10f Coulomb %.10f XC %.10f Exx %.10f  total %.10f  (nel err %.3e)\n",
+            Ekin, Enuc, Ecoul, Exc, Exx, Etot, nelnum - static_cast<double>(Ntot));
     fflush(stdout);
 
     // --- Fock assembly. Restricted: one AO Fock, orthonormalize per block.
     //     Unrestricted: separate Fa/Fb AO Fock matrices for the two channels.
     if (restricted) {
-      const arma::mat F_ao = T + Vnuc + J + XCa;
+      arma::mat F_ao = T + Vnuc + J;
+      if (have_xc)  F_ao += XCa;
+      if (have_exx) F_ao += Ka;
       for (size_t k = 0; k < nsym; ++k)
         orthonormalize_block(fock, k, F_ao, k);
     } else {
-      const arma::mat Fa_ao = T + Vnuc + J + XCa;
-      const arma::mat Fb_ao = T + Vnuc + J + XCb;
+      arma::mat Fa_ao = T + Vnuc + J;
+      arma::mat Fb_ao = T + Vnuc + J;
+      if (have_xc)  { Fa_ao += XCa; Fb_ao += XCb; }
+      if (have_exx) { Fa_ao += Ka;  Fb_ao += Kb;  }
       for (size_t k = 0; k < nsym; ++k) {
         orthonormalize_block(fock, k,        Fa_ao, k);
         orthonormalize_block(fock, nsym + k, Fb_ao, k);

--- a/src/diatomic/ooo.cpp
+++ b/src/diatomic/ooo.cpp
@@ -124,8 +124,13 @@ int main(int argc, char **argv) {
   ::print_info(x_func, c_func);
   if (!is_supported(x_func) || !is_supported(c_func))
     throw std::logic_error("The specified functional is not supported in HelFEM.\n");
-  if (x_func == 0 && c_func == 0)
-    throw std::logic_error("HF is not yet implemented in diatomic_ooo -- pick a DFT functional.\n");
+
+  double kfrac, kshort, omega;
+  range_separation(x_func, omega, kfrac, kshort);
+  const bool have_exx = (kfrac != 0.0 || kshort != 0.0);
+  const bool have_xc  = (x_func != 0 || c_func != 0);
+  if (have_exx && kshort != 0.0)
+    throw std::logic_error("Range-separated hybrids not yet supported in diatomic_ooo (needs omega wiring).\n");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
       polynomial_basis::get_basis(primbas, Nnodes));
@@ -199,7 +204,7 @@ int main(int argc, char **argv) {
   const int lang = ldft_arg > 0 ? ldft_arg : 4 * arma::max(lval) + 12;
   const int mang = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
   auto grid = helfem::diatomic::dftgrid::DFTGrid(&basis, lang, mang);
-  basis.compute_tei(false);
+  basis.compute_tei(have_exx);
 
   const double Enucr = Z1 * Z2 / Rbond;
 
@@ -258,6 +263,7 @@ int main(int argc, char **argv) {
     // Pa/Pb split, no *0.5 double-scatter.
     OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
     arma::mat P(Nbf, Nbf, arma::fill::zeros);
+    arma::mat Pa, Pb;
     double Exc = 0.0;
     double nelnum = 0.0, ekin_grid = 0.0;
     arma::mat XCa, XCb;
@@ -265,17 +271,20 @@ int main(int argc, char **argv) {
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+      if (have_xc)
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+      if (have_exx) Pa = 0.5 * P;
     } else {
-      arma::mat Pa(Nbf, Nbf, arma::fill::zeros);
-      arma::mat Pb(Nbf, Nbf, arma::fill::zeros);
+      Pa.zeros(Nbf, Nbf);
+      Pb.zeros(Nbf, Nbf);
       for (size_t k = 0; k < nsym; ++k) {
         accumulate_density(Pa, k, orbitals[k],        occupations[k]);
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
-                     Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+      if (have_xc)
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
+                       Exc, nelnum, ekin_grid, nelb > 0, dftthr);
     }
 
     const double Ekin = arma::trace(P * T);
@@ -284,20 +293,40 @@ int main(int argc, char **argv) {
     const arma::mat J = basis.coulomb(P);
     const double Ecoul = 0.5 * arma::trace(P * J);
 
-    const double Etot = Ekin + Enuc + Ecoul + Exc + Enucr;
-    printf("kinetic %.10f nuclear %.10f Enucr %.10f Coulomb %.10f XC %.10f  total %.10f  (nel err %.3e)\n",
-            Ekin, Enuc, Enucr, Ecoul, Exc, Etot, nelnum - static_cast<double>(Ntot));
+    // HF exchange. See sign-convention note in atomic/ooo.cpp: basis.exchange
+    // returns a matrix that gets ADDED to the Fock and the energy
+    // contribution is +0.5*trace(Pspin*Kspin) per channel.
+    arma::mat Ka, Kb;
+    double Exx = 0.0;
+    if (have_exx) {
+      Ka = kfrac * basis.exchange(Pa);
+      Exx = 0.5 * arma::trace(Pa * Ka);
+      if (!restricted) {
+        Kb = kfrac * basis.exchange(Pb);
+        Exx += 0.5 * arma::trace(Pb * Kb);
+      } else {
+        Exx *= 2.0;
+      }
+    }
+
+    const double Etot = Ekin + Enuc + Ecoul + Exc + Exx + Enucr;
+    printf("kinetic %.10f nuclear %.10f Enucr %.10f Coulomb %.10f XC %.10f Exx %.10f  total %.10f  (nel err %.3e)\n",
+            Ekin, Enuc, Enucr, Ecoul, Exc, Exx, Etot, nelnum - static_cast<double>(Ntot));
     fflush(stdout);
 
     // Fock assembly. Restricted: one AO Fock matrix per block.
     // Unrestricted: separate alpha/beta AO Fock matrices.
     if (restricted) {
-      const arma::mat F_ao = T + Vnuc + J + XCa;
+      arma::mat F_ao = T + Vnuc + J;
+      if (have_xc)  F_ao += XCa;
+      if (have_exx) F_ao += Ka;
       for (size_t k = 0; k < nsym; ++k)
         orthonormalize_block(fock, k, F_ao, k);
     } else {
-      const arma::mat Fa_ao = T + Vnuc + J + XCa;
-      const arma::mat Fb_ao = T + Vnuc + J + XCb;
+      arma::mat Fa_ao = T + Vnuc + J;
+      arma::mat Fb_ao = T + Vnuc + J;
+      if (have_xc)  { Fa_ao += XCa; Fb_ao += XCb; }
+      if (have_exx) { Fa_ao += Ka;  Fb_ao += Kb;  }
       for (size_t k = 0; k < nsym; ++k) {
         orthonormalize_block(fock, k,        Fa_ao, k);
         orthonormalize_block(fock, nsym + k, Fb_ao, k);

--- a/src/sadatom/ooo.cpp
+++ b/src/sadatom/ooo.cpp
@@ -127,8 +127,12 @@ int main(int argc, char **argv) {
     throw std::logic_error("The specified exchange functional is not currently supported in HelFEM.\n");
   if (!is_supported(c_func))
     throw std::logic_error("The specified correlation functional is not currently supported in HelFEM.\n");
-  if (x_func == 0 && c_func == 0)
-    throw std::logic_error("HF is not yet implemented in sadatom_ooo -- pick a DFT functional.\n");
+  double kfrac, kshort, omega;
+  range_separation(x_func, omega, kfrac, kshort);
+  const bool have_exx = (kfrac != 0.0 || kshort != 0.0);
+  const bool have_xc  = (x_func != 0 || c_func != 0);
+  if (have_exx && kshort != 0.0)
+    throw std::logic_error("Range-separated hybrids not yet supported in sadatom_ooo (needs omega wiring).\n");
 
   arma::vec bval = atomic::basis::form_grid(
       modelpotential::POINT_NUCLEUS, 0.0, Nelem, Rmax, igrid, zexp,
@@ -146,7 +150,7 @@ int main(int argc, char **argv) {
   const helfem::Matrix Vnuc = basis.nuclear();
 
   auto grid = helfem::sadatom::dftgrid::DFTGrid(&basis);
-  basis.compute_tei();
+  basis.compute_tei();  // sadatom compute_tei takes no flag; exchange path is always available.
 
   // OOO block layout: per-l blocks.
   using OOO_Real = double;
@@ -200,56 +204,95 @@ int main(int argc, char **argv) {
     double Exc = 0.0;
     double nelnum = 0.0;
     arma::cube XCa, XCb;
+    // Per-l density cubes, retained across the XC/exchange branches.
+    // For unrestricted: Pal = alpha, Pbl = beta. For restricted: Pal
+    // is the total density (there is no separate beta).
+    arma::cube Pal(Nrad, Nrad, nblock, arma::fill::zeros);
+    arma::cube Pbl;
 
     if (restricted) {
-      arma::cube Pl(Nrad, Nrad, nblock, arma::fill::zeros);
       for (size_t l = 0; l < nblock; ++l)
-        accumulate_density(Prad, Pl, l, orbitals[l], occupations[l], Ekin);
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pl / angfac,
-                     XCa, Exc, nelnum, dftthr);
-      XCa /= angfac;
+        accumulate_density(Prad, Pal, l, orbitals[l], occupations[l], Ekin);
+      if (have_xc) {
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pal / angfac,
+                       XCa, Exc, nelnum, dftthr);
+        XCa /= angfac;
+      }
     } else {
+      Pbl.zeros(Nrad, Nrad, nblock);
       helfem::Matrix Prad_a = helfem::Matrix::Zero(Nrad, Nrad);
       helfem::Matrix Prad_b = helfem::Matrix::Zero(Nrad, Nrad);
-      arma::cube Pal(Nrad, Nrad, nblock, arma::fill::zeros);
-      arma::cube Pbl(Nrad, Nrad, nblock, arma::fill::zeros);
       for (size_t l = 0; l < nblock; ++l) {
         accumulate_density(Prad_a, Pal, l, orbitals[l],           occupations[l],           Ekin);
         accumulate_density(Prad_b, Pbl, l, orbitals[nblock + l],  occupations[nblock + l],  Ekin);
       }
       Prad = Prad_a + Prad_b;
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pal / angfac, Pbl / angfac,
-                     XCa, XCb, Exc, nelnum, nelb > 0, dftthr);
-      XCa /= angfac;
-      if (nelb > 0) XCb /= angfac;
+      if (have_xc) {
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pal / angfac, Pbl / angfac,
+                       XCa, XCb, Exc, nelnum, nelb > 0, dftthr);
+        XCa /= angfac;
+        if (nelb > 0) XCb /= angfac;
+      }
     }
 
     const double Enuc = (Prad * Vnuc).trace();
     const helfem::Matrix J = basis.coulomb(Prad / angfac);
     const double Ecoul = 0.5 * (Prad * J).trace();
-    const double Etot = Ekin + Enuc + Ecoul + Exc;
 
-    printf("Ekin %.10f  Enuc %.10f  Ecoul %.10f  Exc %.10f  Etot %.10f\n",
-            Ekin, Enuc, Ecoul, Exc, Etot);
+    // HF exchange. basis.exchange takes an angular-normalized density
+    // cube (Pl / ShellCapacity) and returns a cube K such that Fock_l
+    // gets K.slice(l) and Exx = 0.5 * sum_l trace(K[l] * Pl[l]) with
+    // Pl the UNnormalized density -- matches bespoke solver.cpp:940.
+    // ShellCapacity(l) = 2*(2l+1) for restricted, (2l+1) per spin for UKS.
+    arma::cube Ka, Kb;
+    double Exx = 0.0;
+    if (have_exx) {
+      arma::cube ang_a = Pal;
+      for (size_t l = 0; l < nblock; ++l)
+        ang_a.slice(l) /= restricted ? 2.0 * (2 * l + 1) : (2 * l + 1);
+      Ka = kfrac * basis.exchange(ang_a);
+      for (size_t l = 0; l < nblock; ++l)
+        Exx += 0.5 * arma::trace(Ka.slice(l) * Pal.slice(l));
+      if (!restricted) {
+        arma::cube ang_b = Pbl;
+        for (size_t l = 0; l < nblock; ++l)
+          ang_b.slice(l) /= (2 * l + 1);
+        Kb = kfrac * basis.exchange(ang_b);
+        for (size_t l = 0; l < nblock; ++l)
+          Exx += 0.5 * arma::trace(Kb.slice(l) * Pbl.slice(l));
+      }
+      // No * 2 in restricted -- Pal here is the TOTAL per-l density
+      // (occupations up to 2*(2l+1)), unlike atomic/diatomic where Pa
+      // is the SPIN density. Matches bespoke solver.cpp:940 exactly.
+    }
+
+    const double Etot = Ekin + Enuc + Ecoul + Exc + Exx;
+
+    printf("Ekin %.10f  Enuc %.10f  Ecoul %.10f  Exc %.10f  Exx %.10f  Etot %.10f\n",
+            Ekin, Enuc, Ecoul, Exc, Exx, Etot);
     fflush(stdout);
 
-    // Per-l Fock: F_l = T + Vnuc + J + l(l+1)*Tl + XC_l.
+    // Per-l Fock: F_l = T + Vnuc + J + l(l+1)*Tl + XC_l + K_l.
     auto build_fock_block = [&](size_t l, const arma::cube & XC_cube,
-                                 bool have_xc) -> helfem::Matrix {
+                                 bool add_xc, const arma::cube & K_cube,
+                                 bool add_k) -> helfem::Matrix {
       helfem::Matrix Fl = T + Vnuc + J;
       if (l > 0) Fl += l * (l + 1) * Tl;
-      if (have_xc)
+      if (add_xc)
         Fl += helfem::to_eigen(arma::mat(XC_cube.slice(l)));
+      if (add_k)
+        Fl += helfem::to_eigen(arma::mat(K_cube.slice(l)));
       return Sinvh.transpose() * Fl * Sinvh;
     };
 
     if (restricted) {
       for (size_t l = 0; l < nblock; ++l)
-        fock[l] = build_fock_block(l, XCa, true);
+        fock[l] = build_fock_block(l, XCa, have_xc, Ka, have_exx);
     } else {
       for (size_t l = 0; l < nblock; ++l) {
-        fock[l]          = build_fock_block(l, XCa, true);
-        fock[nblock + l] = build_fock_block(l, XCb, nelb > 0);
+        fock[l]          = build_fock_block(l, XCa, have_xc, Ka, have_exx);
+        fock[nblock + l] = build_fock_block(l, XCb, have_xc && nelb > 0,
+                                             Kb, have_exx && nelb > 0);
       }
     }
     return std::make_pair(Etot, fock);


### PR DESCRIPTION
## Summary

Removes the *'HF is not yet implemented'* throw from all three OOO drivers and adds the exchange-matrix build. Pure HF (\`--method=hf\`) is now supported, as is any global hybrid whose kfrac is nonzero; the DFT-XC branch stays unchanged.

## Design

After \`parse_xc_func()\`:

\`\`\`cpp
double kfrac, kshort, omega;
range_separation(x_func, omega, kfrac, kshort);
const bool have_exx = (kfrac != 0.0 || kshort != 0.0);
const bool have_xc  = (x_func != 0 || c_func != 0);
\`\`\`

\`basis.compute_tei(have_exx)\` so the exchange integrals get cached only when needed.

**In the Fock builder**:
- **Restricted**: keep \`Pa = 0.5 * P\` around for exchange (spin density). \`Ka = kfrac * basis.exchange(Pa)\`; \`Exx = 2 * 0.5 * trace(Pa * Ka) = trace(Pa * Ka)\`. Add Ka to the single AO Fock. (Sadatom differs, see below.)
- **Unrestricted**: \`Ka = kfrac * exchange(Pa)\`, \`Kb = kfrac * exchange(Pb)\`. \`Exx = 0.5*trace(Pa*Ka) + 0.5*trace(Pb*Kb)\`. Add Ka/Kb to Fa/Fb.

**Sign convention**: \`basis.exchange\` returns the matrix that gets ADDED to the Fock (rather than the standard K that gets subtracted), so Exx uses \`+0.5*trace\` with no sign flip. Matches bespoke \`main.cpp:754\` exactly.

DFT-XC is now gated on \`have_xc\` so pure HF (x_func == c_func == 0) skips the eval_Fxc call cleanly instead of throwing.

Range-separated hybrids (kshort != 0) still throw with a clear message; wiring up the omega variant of \`basis.rs_exchange\` is a follow-up.

## Sadatom-specific

sadatom's \`exchange\` API takes an **angular-normalized** per-l cube:
\`\`\`
ang[l] = Pl[l] / ShellCapacity(l)
\`\`\`
where \`ShellCapacity(l) = 2*(2l+1)\` for restricted, \`(2l+1)\` per spin for UKS. \`Ka = kfrac * basis.exchange(ang)\`. \`Exx = 0.5 * sum_l trace(Ka[l] * Pl[l])\` with Pl **unnormalized** — matches bespoke \`solver.cpp:934, 940\`.

Unlike atomic/diatomic where \`Pa\` is a SPIN density in restricted mode (so we double the alpha contribution), sadatom's restricted \`Pal[l]\` is already the **total** per-l density (max_occ = 2*(2l+1) on the single alpha channel). So sadatom's restricted Exx does NOT double the alpha contribution.

## Validation

**Regression**:
- \`eigen_foundation_test\`: 13/13 PASS
- DFT still bit-identical: atomic Be LDA_X = −14.2232886204

**HF against bespoke** (nelem=5, nnodes=6/8):

| Driver | Case | Bespoke | OOO | Digits |
|---|---|---|---|---|
| \`atomic_ooo\` | Be M=1 symm=1 | −14.5730207892 | −14.5730207892 | 10 |
| \`atomic_ooo\` | Li M=2 symm=1 UKS | −7.4327496023 | −7.4327496023 | 10 |
| \`diatomic_ooo\` | H2 M=1 symm=2 | −1.1336034433 | −1.1336034432 | 10 |
| \`sadatom_ooo\` | He M=1 | −2.861679987 | −2.8616799868 | 10 |
| \`sadatom_ooo\` | Li M=2 UKS | −7.432739460 | −7.4327394602 | 10 |

## Follow-up

Range-separated hybrids (short-range HF plus a long-range DFT-like kernel; e.g. LC-BLYP, ωB97X-V) still throw. Wiring needs \`basis.rs_exchange(P, omega)\` and one more term added to the Ka/Kb accumulation. Not strictly needed for retiring the bespoke driver's ground-state HF path but is a natural follow-up.

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression: atomic Be LDA_X unchanged
- [x] atomic Be HF restricted bit-identical to bespoke
- [x] atomic Li HF UKS bit-identical to bespoke
- [x] diatomic H2 HF bit-identical to bespoke
- [x] sadatom He HF bit-identical to bespoke
- [x] sadatom Li HF UKS bit-identical to bespoke