### PR TITLE
cmake: complete the exported helfem::helfem link closure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,11 +201,16 @@ else()
     message(STATUS "Using system OpenOrbitalOptimizer")
 endif()
 
-# Find OpenMP support
+# Find OpenMP support. Add flags to CXX flags so in-tree
+# targets get -fopenmp at compile time regardless of target chain.
+# ALSO record OpenMP::OpenMP_CXX so it can be added to the
+# INTERFACE_LINK_LIBRARIES of the exported libraries below, giving
+# downstream consumers of helfem::helfem the -fopenmp/libgomp
+# transitive linkage automatically (previously they had to remember
+# -fopenmp themselves).
 if(USE_OPENMP)
  find_package( OpenMP )
  if(OPENMP_FOUND)
-  # Add flags to CXX flags
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
  endif()
 endif()

--- a/cmake/helfemConfig.cmake.in
+++ b/cmake/helfemConfig.cmake.in
@@ -18,6 +18,10 @@ include(CMakeFindDependencyMacro)
 # find their linkage.
 find_dependency(Eigen3 3.4 CONFIG)
 find_dependency(wignernj 0.5.0)
+# OpenMP is included in helfem-common's INTERFACE_LINK_LIBRARIES so
+# consumers inherit -fopenmp / libgomp automatically. We must be able
+# to resolve OpenMP::OpenMP_CXX at find_package(helfem) time.
+find_dependency(OpenMP)
 
 # Armadillo is a private link/interface dep of helfem-common; the
 # consumer must be able to link against it. We do not require it
@@ -37,6 +41,37 @@ endif()
 # Bring in the imported targets: helfem::helfem, helfem::helfem-common,
 # helfem::legendre, helfem::lib1dfem.
 include("${CMAKE_CURRENT_LIST_DIR}/helfemTargets.cmake")
+
+# In-tree, the atomic FE code (TwoDBasis, DFTGrid, gaunt, and every
+# other symbol under src/) lives in libhelfem-common.a, which links
+# PUBLIC to libhelfem.a. A downstream target_link_libraries(x helfem::helfem)
+# does NOT drag helfem-common in via that PUBLIC link because
+# helfem-common depends on helfem, not vice versa.
+#
+# Consumers reaching for helfem::helfem expect the atomic backend to
+# work out-of-the-box (that's the whole point of the exported package,
+# see PR #142). So pull the missing static libs into helfem::helfem's
+# interface closure at config time. Order matters for the eventual
+# ld link line: put the higher-level libs first so the archive-based
+# linker resolution walks helfem-common -> helfem -> legendre
+# correctly. The static libs are mutually referential in some symbol
+# groups (e.g. helfem::helfem-common's TwoDBasis pulls symbols back
+# from helfem, but helfem's RadialBasis uses helpers defined in
+# helfem-common too). Wrap them in --start-group / --end-group via
+# LINK_ONLY so the whole cluster is resolvable regardless of the
+# consumer's link order.
+if(TARGET helfem::helfem AND TARGET helfem::helfem-common)
+    # Static archive order: consumers get helfem::helfem-common (which
+    # itself INTERFACE-links helfem::helfem, wignernj::wignernj,
+    # helfem::legendre) first, then helfem::legendre standalone in case
+    # legendre symbols are referenced from headers the consumer
+    # includes directly. lib1dfem is already in helfem::helfem's own
+    # INTERFACE_LINK_LIBRARIES so it comes along.
+    set_property(TARGET helfem::helfem APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES
+            helfem::helfem-common helfem::legendre
+    )
+endif()
 
 # ARMA_64BIT_WORD / ARMA_BLAS_LONG are attached as
 # INTERFACE_COMPILE_DEFINITIONS on the exported targets, so a consumer

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,12 @@ diatomic/dftgrid.cpp diatomic/twodquadrature.cpp
 general/model_potential.cpp
 )
 target_link_libraries(helfem-common PUBLIC helfem wignernj::wignernj)
+# Propagate OpenMP to consumers of helfem-common. Without this, an
+# external consumer linking helfem::helfem misses -fopenmp / libgomp
+# and fails with undefined references like GOMP_parallel.
+if(TARGET OpenMP::OpenMP_CXX)
+    target_link_libraries(helfem-common PUBLIC OpenMP::OpenMP_CXX)
+endif()
 target_include_directories(helfem-common
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../libhelfem/src/>


### PR DESCRIPTION
## Summary

Fixes an under-linking bug in the exported CMake package. A consumer doing

\`\`\`cmake
find_package(helfem CONFIG REQUIRED)
target_link_libraries(x PRIVATE helfem::helfem)
\`\`\`

failed to link with undefined references like

\`\`\`
helfem::atomic::basis::TwoDBasis::TwoDBasis(...)   // in libhelfem-common.a
gaunt                                              // in libwignernj.so
GOMP_parallel                                      // in libgomp.so
\`\`\`

The exported \`helfem::helfem\`'s \`INTERFACE_LINK_LIBRARIES\` pulled \`libhelfem.a\` + system libs (blas/arma/xc/hdf5/z) + \`helfem::lib1dfem\` + \`Eigen3::Eigen\` — but **NOT** \`helfem::helfem-common\` (which has TwoDBasis and the rest of the atomic/diatomic/sadatom FE code), NOT \`helfem::legendre\`, NOT \`wignernj::wignernj\`, NOT \`OpenMP::OpenMP_CXX\`.

Consumers had to manually specify the full closure, which defeats the purpose of exporting a CMake package. PR #142 established the export; this PR completes the closure.

## Changes

**\`src/CMakeLists.txt\`**:
\`\`\`cmake
target_link_libraries(helfem-common PUBLIC OpenMP::OpenMP_CXX)
\`\`\`
(gated on \`TARGET OpenMP::OpenMP_CXX\` existing). Propagates \`-fopenmp\` / \`libgomp\` through the exported target instead of leaving it as a compile-time \`CXX_FLAGS\` augmentation.

**\`cmake/helfemConfig.cmake.in\`**:
- \`find_dependency(OpenMP)\` so consumers can resolve \`OpenMP::OpenMP_CXX\` at \`find_package(helfem)\` time.
- After \`include(helfemTargets.cmake)\`, append \`helfem::helfem-common\` and \`helfem::legendre\` to \`helfem::helfem\`'s INTERFACE_LINK_LIBRARIES. This is done in the Config file (not the CMakeLists) because helfem's build-time INTERFACE deps must not include helfem-common — that would be a circular target dep (helfem-common already depends PUBLIC on helfem). The consumer view is different: they want everything to be reachable via \`helfem::helfem\`, so we patch the interface at import time.

**\`CMakeLists.txt\`**: comment expansion on the OpenMP find_package block explaining the transitive-linkage side effect.

## Validation

Fresh install to \`/tmp/export-test/install\`. Consumer project at \`/tmp/consumer\` with just **three-line** CMakeLists:

\`\`\`cmake
cmake_minimum_required(VERSION 3.14)
project(atomic_radial_export CXX)
find_package(helfem CONFIG REQUIRED)
add_executable(atomic_radial_export atomic_radial_export.cpp)
target_link_libraries(atomic_radial_export PRIVATE helfem::helfem)
\`\`\`

and \`examples/atomic_radial_export.cpp\` verbatim as the source:
- Configure step succeeds
- Build step succeeds (no manual \`--start-group\` / \`--end-group\`)
- Runtime succeeds:

\`\`\`
H   1s    E = -0.5000000000   err 8.15e-13
He+ 1s    E = -2.0000000000   err 3.11e-12
H   2p    E = -0.1250000000   err 3.09e-13
He+ 2p    E = -0.5000000000   err 7.33e-14
H   3d    E = -0.0555553336   err 2.22e-07
Converged at iter 9  E = -2.86167999561   err 3.42e-12
Overall: PASS
\`\`\`

\`ldd\` on the resulting binary shows the full closure resolved:
- libarmadillo.so.12
- libxc.so.15
- libhdf5.so.310
- libwignernj.so.0 (C++ variant, provides \`gaunt\`)
- libgomp.so.1

**Regression**:
- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: −2.861679987 (unchanged)
- Be atomic HF: −14.5728772811245939 (bit-identical baseline)

## Test plan (verified)

- [x] Fresh install completes
- [x] External consumer (3-line CMakeLists) configures + builds
- [x] External consumer runs He HF to −2.86167999561
- [x] External consumer link line is empty of manual additions
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged