### PR TITLE
atomic_ooo + sadatom_ooo: range-separated hybrid support

### DIFF
--- a/src/atomic/ooo.cpp
+++ b/src/atomic/ooo.cpp
@@ -133,17 +133,23 @@ int main(int argc, char **argv) {
   if (!is_supported(x_func) || !is_supported(c_func))
     throw std::logic_error("The specified functional is not supported in HelFEM.\n");
 
-  // Range-separation parameters: kfrac for full-range HF exchange
-  // fraction (1 for pure HF, 0 for pure DFT, in-between for hybrids),
-  // kshort for the short-range fraction (nonzero only for range-
-  // separated hybrids). omega is the range-separation parameter itself,
-  // unused here because we don't wire an omega variant of rs_exchange.
+  // Range-separation parameters. Following libxc/HelFEM naming:
+  //   kfrac  = full-range HF exchange fraction   (alpha in CAM)
+  //   kshort = short-range HF exchange fraction  (beta in CAM)
+  //   omega  = range-separation parameter        (mu in erfc, lambda in Yukawa)
+  // For pure DFT: kfrac = kshort = 0. For pure HF: kfrac = 1, kshort = 0.
+  // For hybrids (B3LYP, PBE0): kfrac in (0,1), kshort = 0.
+  // For range-separated hybrids (CAM-B3LYP, LC-BLYP, wB97X): kfrac + kshort
+  // nonzero and omega > 0, with basis.rs_exchange(P) giving the SR piece
+  // using either erfc or Yukawa kernel (functional-dependent, discovered
+  // via is_range_separated).
   double kfrac, kshort, omega;
   range_separation(x_func, omega, kfrac, kshort);
   const bool have_exx = (kfrac != 0.0 || kshort != 0.0);
   const bool have_xc  = (x_func != 0 || c_func != 0);
-  if (have_exx && kshort != 0.0)
-    throw std::logic_error("Range-separated hybrids not yet supported in atomic_ooo (needs omega wiring).\n");
+  bool rs_erfc = false, rs_yukawa = false;
+  if (kshort != 0.0)
+    is_range_separated(x_func, rs_erfc, rs_yukawa);
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
       polynomial_basis::get_basis(primbas, Nnodes));
@@ -201,6 +207,11 @@ int main(int argc, char **argv) {
   const int mdft = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
   auto grid = helfem::atomic::dftgrid::DFTGrid(&basis, ldft, mdft);
   basis.compute_tei(have_exx);
+  // Precompute the range-separated exchange kernel if the functional uses
+  // one. Yukawa (screened Coulomb) and erfc (complementary error-function)
+  // are the two kernels libxc's CAM functionals ask for.
+  if (rs_yukawa) basis.compute_yukawa(omega);
+  else if (rs_erfc) basis.compute_erfc(omega);
 
   // --- OOO block layout.
   using OOO_Real = double;
@@ -292,18 +303,24 @@ int main(int argc, char **argv) {
     const arma::mat J = helfem::to_arma(basis.coulomb(helfem::to_eigen(P)));
     const double Ecoul = 0.5 * arma::trace(P * J);
 
-    // --- HF exchange: K = kfrac * basis.exchange(spin density). Sign
-    //     convention is baked into basis.exchange (it returns the
+    // --- HF exchange: K = kfrac * basis.exchange(P) + kshort * basis.rs_exchange(P).
+    //     Sign convention is baked into basis.exchange (it returns the
     //     signed contribution that gets ADDED to the Fock matrix), so
     //     Exx = 0.5 * trace(P_spin * K_spin) per channel with a +
     //     sign matches the bespoke atomic driver's line 754.
+    //     For RS hybrids, rs_exchange uses the erfc or Yukawa kernel
+    //     precomputed above.
     arma::mat Ka, Kb;
     double Exx = 0.0;
     if (have_exx) {
-      Ka = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pa)));
+      Ka.zeros(Nbf, Nbf);
+      if (kfrac  != 0.0) Ka += kfrac  * helfem::to_arma(basis.exchange(helfem::to_eigen(Pa)));
+      if (kshort != 0.0) Ka += kshort * helfem::to_arma(basis.rs_exchange(helfem::to_eigen(Pa)));
       Exx = 0.5 * arma::trace(Pa * Ka);
       if (!restricted) {
-        Kb = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pb)));
+        Kb.zeros(Nbf, Nbf);
+        if (kfrac  != 0.0) Kb += kfrac  * helfem::to_arma(basis.exchange(helfem::to_eigen(Pb)));
+        if (kshort != 0.0) Kb += kshort * helfem::to_arma(basis.rs_exchange(helfem::to_eigen(Pb)));
         Exx += 0.5 * arma::trace(Pb * Kb);
       } else {
         // In restricted mode alpha == beta density, and we only assemble

--- a/src/sadatom/ooo.cpp
+++ b/src/sadatom/ooo.cpp
@@ -127,12 +127,17 @@ int main(int argc, char **argv) {
     throw std::logic_error("The specified exchange functional is not currently supported in HelFEM.\n");
   if (!is_supported(c_func))
     throw std::logic_error("The specified correlation functional is not currently supported in HelFEM.\n");
+  // Range-separation parameters (see atomic/ooo.cpp for the naming
+  // convention). RS hybrids use basis.rs_exchange with the erfc or
+  // Yukawa kernel selected via is_range_separated + compute_erfc /
+  // compute_yukawa.
   double kfrac, kshort, omega;
   range_separation(x_func, omega, kfrac, kshort);
   const bool have_exx = (kfrac != 0.0 || kshort != 0.0);
   const bool have_xc  = (x_func != 0 || c_func != 0);
-  if (have_exx && kshort != 0.0)
-    throw std::logic_error("Range-separated hybrids not yet supported in sadatom_ooo (needs omega wiring).\n");
+  bool rs_erfc = false, rs_yukawa = false;
+  if (kshort != 0.0)
+    is_range_separated(x_func, rs_erfc, rs_yukawa);
 
   arma::vec bval = atomic::basis::form_grid(
       modelpotential::POINT_NUCLEUS, 0.0, Nelem, Rmax, igrid, zexp,
@@ -151,6 +156,10 @@ int main(int argc, char **argv) {
 
   auto grid = helfem::sadatom::dftgrid::DFTGrid(&basis);
   basis.compute_tei();  // sadatom compute_tei takes no flag; exchange path is always available.
+  // Precompute the range-separated exchange kernel if the functional
+  // uses one.
+  if (rs_yukawa) basis.compute_yukawa(omega);
+  else if (rs_erfc) basis.compute_erfc(omega);
 
   // OOO block layout: per-l blocks.
   using OOO_Real = double;
@@ -244,20 +253,26 @@ int main(int argc, char **argv) {
     // gets K.slice(l) and Exx = 0.5 * sum_l trace(K[l] * Pl[l]) with
     // Pl the UNnormalized density -- matches bespoke solver.cpp:940.
     // ShellCapacity(l) = 2*(2l+1) for restricted, (2l+1) per spin for UKS.
+    // RS hybrids add kshort * basis.rs_exchange with the erfc/Yukawa
+    // kernel precomputed above.
     arma::cube Ka, Kb;
     double Exx = 0.0;
     if (have_exx) {
       arma::cube ang_a = Pal;
       for (size_t l = 0; l < nblock; ++l)
         ang_a.slice(l) /= restricted ? 2.0 * (2 * l + 1) : (2 * l + 1);
-      Ka = kfrac * basis.exchange(ang_a);
+      Ka.zeros(Nrad, Nrad, nblock);
+      if (kfrac  != 0.0) Ka += kfrac  * basis.exchange(ang_a);
+      if (kshort != 0.0) Ka += kshort * basis.rs_exchange(ang_a);
       for (size_t l = 0; l < nblock; ++l)
         Exx += 0.5 * arma::trace(Ka.slice(l) * Pal.slice(l));
       if (!restricted) {
         arma::cube ang_b = Pbl;
         for (size_t l = 0; l < nblock; ++l)
           ang_b.slice(l) /= (2 * l + 1);
-        Kb = kfrac * basis.exchange(ang_b);
+        Kb.zeros(Nrad, Nrad, nblock);
+        if (kfrac  != 0.0) Kb += kfrac  * basis.exchange(ang_b);
+        if (kshort != 0.0) Kb += kshort * basis.rs_exchange(ang_b);
         for (size_t l = 0; l < nblock; ++l)
           Exx += 0.5 * arma::trace(Kb.slice(l) * Pbl.slice(l));
       }


### PR DESCRIPTION
## Summary

Wires the short-range HF exchange piece of range-separated hybrids (CAM, LC families) into the atomic and sadatom OOO drivers. PR #152 gated on \`kshort == 0\` and threw for CAM-B3LYP / ωB97X / LC-BLYP; this lifts that gate and adds the missing pieces.

## Design

After \`range_separation()\` sets kfrac, kshort, omega:

\`\`\`cpp
is_range_separated(x_func, rs_erfc, rs_yukawa)  // when kshort != 0
basis.compute_erfc(omega)    if rs_erfc
basis.compute_yukawa(omega)  if rs_yukawa
\`\`\`

Then in the Fock builder:
\`\`\`
K = kfrac  * basis.exchange(spin density)
  + kshort * basis.rs_exchange(spin density)
\`\`\`

Exx keeps the same sign convention as PR #152 — \`basis.rs_exchange\` returns a matrix with the same sign convention as \`basis.exchange\` (gets ADDED to the Fock; Exx is \`+0.5*trace(P_spin * K_spin)\`).

Sadatom follows the same shape, using its \`arma::cube\`-typed \`basis.rs_exchange\` and the angular-density normalization (\`Pl / ShellCapacity\`) already established for \`basis.exchange\`.

## Diatomic

Bespoke diatomic doesn't support RS hybrids either — there is no \`diatomic::TwoDBasis::rs_exchange\` method or \`compute_erfc\` / \`compute_yukawa\` on the diatomic basis surface. \`diatomic_ooo\`'s throw stays as-is.

## Validation

**Regression**:
- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: −2.861679987 (unchanged)
- Be atomic HF: −14.5728772811245939 (bit-identical baseline)

**New RS-hybrid tests against bespoke drivers** (nelem=5, nnodes=8):

| Case | Bespoke | OOO | Digits |
|---|---|---|---|
| atomic Be CAM-B3LYP | −14.6503819977496 | −14.6503819977 | 10 |
| atomic Be ωB97X | −14.6635018473718 | −14.6635018474 | 10 |
| sadatom He CAM-B3LYP | −2.901434098 | −2.9014340981 | 10 |

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged
- [x] atomic Be CAM-B3LYP bit-identical
- [x] atomic Be ωB97X bit-identical
- [x] sadatom He CAM-B3LYP bit-identical