### PR TITLE
RadialBasis: leaf accessors get_xq/get_bval/get_wrad/get_r return Eigen

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -92,10 +92,10 @@ namespace helfem {
 
         /// Get number of quadrature points
         int get_nquad() const;
-        /// Get quadrature points
-        arma::vec get_xq() const;
-        /// Get boundary values
-        arma::vec get_bval() const;
+        /// Get quadrature points (Phase 5.20: Eigen at the public boundary).
+        helfem::Vector get_xq() const;
+        /// Get boundary values (Phase 5.20: Eigen at the public boundary).
+        helfem::Vector get_bval() const;
         /// Get polynomial basis identifier
         int get_poly_id() const;
         /// Get number of nodes in polynomial basis
@@ -290,14 +290,18 @@ namespace helfem {
         /// Evaluate orbitals at a given point
         arma::vec eval_orbs(const arma::mat & C, double r) const override;
 
-        /// Get quadrature weights
-        arma::vec get_wrad(size_t iel) const;
-        /// Get quadrature weights
-        arma::vec get_wrad(const arma::vec & w, size_t iel) const;
-        /// Get r values
-        arma::vec get_r(size_t iel) const;
-        /// Get r values
-        arma::vec get_r(const arma::vec & x, size_t iel) const;
+        /// Get quadrature weights in element (Phase 5.20: Eigen return).
+        helfem::Vector get_wrad(size_t iel) const;
+        /// Get quadrature weights in element from user-supplied weight
+        /// vector (arma-typed input kept for chemistry-layer callers;
+        /// Eigen return per Phase 5.20).
+        helfem::Vector get_wrad(const arma::vec & w, size_t iel) const;
+        /// Get r values at quadrature points in element (Phase 5.20: Eigen return).
+        helfem::Vector get_r(size_t iel) const;
+        /// Get r values at user-supplied x points in element
+        /// (arma-typed input kept for chemistry-layer callers; Eigen
+        /// return per Phase 5.20).
+        helfem::Vector get_r(const arma::vec & x, size_t iel) const;
 	/// Get r value
         double get_r(double x, size_t iel) const;
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -70,9 +70,9 @@ namespace helfem {
         return (int) xq.size();
       }
 
-      arma::vec FEMRadialBasis::get_xq() const {
-        // Phase 5.6: xq is Eigen; bridge to arma for the public accessor.
-        return eigen_vec_to_arma(xq);
+      helfem::Vector FEMRadialBasis::get_xq() const {
+        // Phase 5.20: xq storage is Eigen; return it directly at the public boundary.
+        return xq;
       }
 
       size_t FEMRadialBasis::Nbf() const {
@@ -95,10 +95,9 @@ namespace helfem {
         fem.get_idx(iel, ifirst, ilast);
       }
 
-      arma::vec FEMRadialBasis::get_bval() const {
-        // Phase 5.4: fem.get_bval() is Eigen; bridge here -- RadialBasis
-        // keeps its arma::vec surface for downstream chemistry-layer code.
-        return eigen_vec_to_arma(fem.get_bval());
+      helfem::Vector FEMRadialBasis::get_bval() const {
+        // Phase 5.20: fem.get_bval() is Eigen; return directly.
+        return fem.get_bval();
       }
 
       int FEMRadialBasis::get_poly_id() const {
@@ -403,7 +402,7 @@ namespace helfem {
 	    throw std::logic_error("Junquera confinement potential requires N >= 1!");
 	  if(V<=0)
 	    throw std::logic_error("Cannot have attractive Junquera potential!\n");
-	  return junq_confinement(iel, N, V, arma::max(get_bval()), shift_pot);
+	  return junq_confinement(iel, N, V, get_bval().maxCoeff(), shift_pot);
 	} else
 	  throw std::logic_error("Case not implemented!\n");
       }
@@ -655,23 +654,28 @@ namespace helfem {
         return lapl;
       }
 
-      arma::vec FEMRadialBasis::get_wrad(size_t iel) const {
-        return get_wrad(eigen_vec_to_arma(wq), iel);
+      helfem::Vector FEMRadialBasis::get_wrad(size_t iel) const {
+        // Phase 5.20: internal wq is Eigen; scale in Eigen and return.
+        return fem.scaling_factor(iel) * wq;
       }
 
-      arma::vec FEMRadialBasis::get_wrad(const arma::vec & w, size_t iel) const {
-        // This is just the radial rule, no r^2 factor included here
-        return fem.scaling_factor(iel) * w;
+      helfem::Vector FEMRadialBasis::get_wrad(const arma::vec & w, size_t iel) const {
+        // Chemistry-layer callers still pass arma::vec weights; bridge
+        // once to Eigen and scale. Return type is Eigen per Phase 5.20.
+        const double s = fem.scaling_factor(iel);
+        helfem::Vector out(w.n_elem);
+        for (arma::uword i = 0; i < w.n_elem; ++i) out(i) = s * w(i);
+        return out;
       }
 
-      arma::vec FEMRadialBasis::get_r(size_t iel) const {
-        return get_r(eigen_vec_to_arma(xq), iel);
+      helfem::Vector FEMRadialBasis::get_r(size_t iel) const {
+        // Phase 5.20: eval_coord returns Eigen; return directly.
+        return fem.eval_coord(xq, iel);
       }
 
-      arma::vec FEMRadialBasis::get_r(const arma::vec & x, size_t iel) const {
-        const helfem::Vector r_e = fem.eval_coord(arma_to_eigen_vec(x), iel);
-        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
-        return r;
+      helfem::Vector FEMRadialBasis::get_r(const arma::vec & x, size_t iel) const {
+        // Bridge input to Eigen once; return Eigen per Phase 5.20.
+        return fem.eval_coord(arma_to_eigen_vec(x), iel);
       }
 
       double FEMRadialBasis::get_r(double x, size_t iel) const {

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -117,7 +117,7 @@ namespace helfem {
       }
 
       arma::vec TwoDBasis::get_bval() const {
-        return radial.get_bval();
+        return helfem::to_arma(radial.get_bval());
       }
 
       int TwoDBasis::get_poly_id() const {
@@ -1230,7 +1230,7 @@ namespace helfem {
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
         // Evaluate radial functions
-        arma::vec r(radial.get_r(iel));
+        arma::vec r(helfem::to_arma(radial.get_r(iel)));
         arma::mat frad(radial.get_bf(iel));
         arma::mat drad(radial.get_df(iel));
         arma::mat lrad(radial.get_lf(iel));
@@ -1284,11 +1284,11 @@ namespace helfem {
       }
 
       arma::vec TwoDBasis::get_wrad(size_t iel) const {
-        return radial.get_wrad(iel);
+        return helfem::to_arma(radial.get_wrad(iel));
       }
 
       arma::vec TwoDBasis::get_r(size_t iel) const {
-        return radial.get_r(iel);
+        return helfem::to_arma(radial.get_r(iel));
       }
 
       arma::vec TwoDBasis::nuclear_density(const arma::mat & P0) const {

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -153,8 +153,8 @@ int main(int argc, char **argv) {
   // Get the radii and quadrature weights as well
   std::vector<arma::vec> r(radial.Nel()), wr(radial.Nel());
   for(size_t iel=0;iel<radial.Nel();iel++) {
-    r[iel]=radial.get_r(iel);
-    wr[iel]=radial.get_wrad(iel);
+    r[iel]=helfem::to_arma(radial.get_r(iel));
+    wr[iel]=helfem::to_arma(radial.get_wrad(iel));
   }
   size_t Npts=r[0].n_rows;
 

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -460,11 +460,11 @@ namespace helfem {
       }
 
       arma::vec TwoDBasis::get_wrad(size_t iel) const {
-        return radial.get_wrad(iel);
+        return helfem::to_arma(radial.get_wrad(iel));
       }
 
       arma::vec TwoDBasis::get_r(size_t iel) const {
-        return radial.get_r(iel);
+        return helfem::to_arma(radial.get_r(iel));
       }
 
       double TwoDBasis::nuclear_density(const arma::mat & P) const {
@@ -479,7 +479,7 @@ namespace helfem {
         std::vector<arma::vec> w(radial.Nel());
         size_t ntot=1;
         for(size_t iel=0;iel<radial.Nel();iel++) {
-          w[iel]=radial.get_wrad(iel);
+          w[iel]=helfem::to_arma(radial.get_wrad(iel));
           ntot+=w[iel].n_elem;
         }
         arma::vec wt(ntot);
@@ -519,7 +519,7 @@ namespace helfem {
         // Form potential
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Initialize potential
-          r[iel]=radial.get_r(iel);
+          r[iel]=helfem::to_arma(radial.get_r(iel));
           V[iel].zeros(r[iel].n_elem);
 
           // Get the density in the element
@@ -557,7 +557,7 @@ namespace helfem {
       arma::vec TwoDBasis::radii() const {
         std::vector<arma::vec> r(radial.Nel());
         for(size_t iel=0;iel<radial.Nel();iel++) {
-          r[iel]=radial.get_r(iel);
+          r[iel]=helfem::to_arma(radial.get_r(iel));
         }
 
         size_t Npts=r[0].n_elem;
@@ -684,12 +684,12 @@ namespace helfem {
 
         arma::vec density = arma::diagvec(bf*Psub*bf.t());
         if(rsqweight)
-          density %= arma::square(radial.get_r(x, iel));
+          density %= arma::square(helfem::to_arma(radial.get_r(x, iel)));
         return density;
       }
 
       arma::vec TwoDBasis::electron_density(size_t iel, const arma::mat & Prad, bool rsqweight) const {
-        return electron_density(radial.get_xq(), iel, Prad, rsqweight);
+        return electron_density(helfem::to_arma(radial.get_xq()), iel, Prad, rsqweight);
       }
 
       arma::vec TwoDBasis::electron_density(const arma::mat & Prad, bool rsqweight) const {
@@ -719,7 +719,7 @@ namespace helfem {
         }
 
         // Quadrature points
-        arma::vec xq = radial.get_xq();
+        arma::vec xq = helfem::to_arma(radial.get_xq());
 
         // Find the element with the maximum density
         arma::uword iel;
@@ -770,7 +770,7 @@ namespace helfem {
             throw std::logic_error(oss.str());
           }
           // Position of maximum is
-          rmax = arma::as_scalar(radial.get_r((a+b)/2,iel));
+          rmax = radial.get_r((a+b)/2, iel)(0);
         }
 
         return rmax;
@@ -799,7 +799,7 @@ namespace helfem {
         // Now find the position in the element where the density is = vdw_threshold.
         // Evaluate the difference in density from the threshold value.
         // Quadrature points
-        arma::vec xq = radial.get_xq();
+        arma::vec xq = helfem::to_arma(radial.get_xq());
         arma::vec diff = angfac*electron_density(xq, iel, Prad, rsqweight);
         diff-=vdw_threshold*arma::ones<arma::vec>(diff.n_elem);
         diff=arma::abs(diff);
@@ -846,7 +846,7 @@ namespace helfem {
           // Coordinate is
           arma::vec cen=((a+b)/2);
           // Position of maximum is
-          rvdw = arma::as_scalar(radial.get_r(cen,iel));
+          rvdw = arma::as_scalar(helfem::to_arma(radial.get_r(cen,iel)));
         }
 
         return rvdw;
@@ -898,7 +898,7 @@ namespace helfem {
 	    break;
 	}
 
-	return arma::as_scalar(radial.get_r(m, ielement));
+	return radial.get_r(m, ielement);
       }
 
       arma::vec TwoDBasis::electron_density_gradient(const arma::mat & Prad) const {
@@ -941,7 +941,7 @@ namespace helfem {
           arma::mat bf(radial.get_bf(iel));
           arma::mat df(radial.get_df(iel));
           arma::mat lf(radial.get_lf(iel));
-          arma::vec r(radial.get_r(iel));
+          arma::vec r(helfem::to_arma(radial.get_r(iel)));
 
           // Laplacian is df^2/dr^2 + 2/r df/dr
           l[iel]=2.0*(arma::diagvec(df*Psub*df.t()) + arma::diagvec(bf*Psub*lf.t())) + 4.0*arma::diagvec(bf*Psub*df.t())/r;
@@ -975,7 +975,7 @@ namespace helfem {
           radial.get_idx(iel,ifirst,ilast);
 
           // Radii
-          arma::vec r(radial.get_r(iel));
+          arma::vec r(helfem::to_arma(radial.get_r(iel)));
 
           // Density matrix
           arma::mat Psub(P.submat(ifirst,ifirst,ilast,ilast));


### PR DESCRIPTION
## Summary

Continues the RadialBasis arma-audit (task #19) with the four leaf accessors whose internal storage was ALREADY Eigen post Phase 5.4 / 5.6 but whose return types were still arma:

| Signature | Before | After |
|---|---|---|
| \`FEMRadialBasis::get_xq()\` | \`arma::vec\` | \`helfem::Vector\` |
| \`FEMRadialBasis::get_bval()\` | \`arma::vec\` | \`helfem::Vector\` |
| \`FEMRadialBasis::get_wrad(iel)\` | \`arma::vec\` | \`helfem::Vector\` |
| \`FEMRadialBasis::get_wrad(w, iel)\` | \`arma::vec\` | \`helfem::Vector\` |
| \`FEMRadialBasis::get_r(iel)\` | \`arma::vec\` | \`helfem::Vector\` |
| \`FEMRadialBasis::get_r(x, iel)\` | \`arma::vec\` | \`helfem::Vector\` |

The single-scalar overload \`FEMRadialBasis::get_r(double x, iel)\` already returned \`double\`; left alone.

## Interior simplifications

- \`get_xq()\` / \`get_bval()\` previously did \`eigen_vec_to_arma(...)\` on the internally Eigen fields just to satisfy the arma return type. That copy is now gone.
- \`get_wrad(iel)\` previously bridged \`wq\` to arma then multiplied by the scaling factor; now it scales the Eigen vector in place.
- \`get_r(iel)\` / \`get_r(x, iel)\` reuse the Eigen-typed \`FiniteElementBasis::eval_coord\` return directly.
- \`RadialBasis.cpp\`: \`junq_confinement\`'s \`arma::max(get_bval())\` call is replaced by \`get_bval().maxCoeff()\` (Eigen equivalent).

## Caller bridges

All existing chemistry-layer callers were arma-typed, so each gets a \`helfem::to_arma(...)\` wrap around the accessor call:

- \`src/atomic/TwoDBasis.cpp\` — get_bval, get_r, get_wrad
- \`src/sadatom/basis.cpp\` — get_wrad, get_r (many), get_xq (also the \`get_r(double,iel)\` double overload no longer needs \`arma::as_scalar(...)\`)
- \`src/sadatom/1e.cpp\` — get_r, get_wrad in the \`arma::vec\` aggregate init

Diatomic uses its own class \`helfem::diatomic::basis::RadialBasis\` (NOT \`FEMRadialBasis\`), so \`diatomic/TwoDBasis::get_r/wrad/bval\` stay arma throughout for now — a separate follow-up sweep.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)
- H2 LDA_X diatomic: **−1.0436626091** (bit-identical baseline)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged across atomic, sadatom, diatomic