### PR TITLE
RadialBasis: get_bf / get_df / get_lf family returns Eigen

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -275,18 +275,23 @@ namespace helfem {
         /// Compute projection (Eigen; Phase 2a).
         helfem::Matrix overlap(const FEMRadialBasis &rh) const;
 
-        /// Evaluate basis functions at quadrature points
-        arma::mat get_bf(size_t iel) const;
-        /// Evaluate basis functions at given points
-        arma::mat get_bf(const arma::vec & x, size_t iel) const;
+        /// Evaluate basis functions at quadrature points (Phase 5.21: Eigen return).
+        helfem::Matrix get_bf(size_t iel) const;
+        /// Evaluate basis functions at given points (arma-typed input kept
+        /// for chemistry-layer callers; Eigen return per Phase 5.21).
+        helfem::Matrix get_bf(const arma::vec & x, size_t iel) const;
         /// Evaluate derivatives of basis functions at quadrature points
-        arma::mat get_df(size_t iel) const;
-        /// Evaluate basis functions at given points
-        arma::mat get_df(const arma::vec & x, size_t iel) const;
+        /// (Phase 5.21: Eigen return).
+        helfem::Matrix get_df(size_t iel) const;
+        /// Evaluate derivatives of basis functions at given points
+        /// (Phase 5.21: Eigen return).
+        helfem::Matrix get_df(const arma::vec & x, size_t iel) const;
         /// Evaluate second derivatives of basis functions at quadrature points
-        arma::mat get_lf(size_t iel) const;
-        /// Evaluate basis functions at given points
-        arma::mat get_lf(const arma::vec & x, size_t iel) const;
+        /// (Phase 5.21: Eigen return).
+        helfem::Matrix get_lf(size_t iel) const;
+        /// Evaluate second derivatives of basis functions at given points
+        /// (Phase 5.21: Eigen return).
+        helfem::Matrix get_lf(const arma::vec & x, size_t iel) const;
         /// Evaluate orbitals at a given point
         arma::vec eval_orbs(const arma::mat & C, double r) const override;
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -137,13 +137,13 @@ namespace helfem {
             return rb->get_fem().eval_d2f(x, iel);
           };
           case BK::R0: return [rb](helfem::Vector x, size_t iel) {
-            return helfem::to_eigen(rb->get_bf(eigen_vec_to_arma(x), iel));
+            return rb->get_bf(eigen_vec_to_arma(x), iel);
           };
           case BK::R1: return [rb](helfem::Vector x, size_t iel) {
-            return helfem::to_eigen(rb->get_df(eigen_vec_to_arma(x), iel));
+            return rb->get_df(eigen_vec_to_arma(x), iel);
           };
           case BK::R2: return [rb](helfem::Vector x, size_t iel) {
-            return helfem::to_eigen(rb->get_lf(eigen_vec_to_arma(x), iel));
+            return rb->get_lf(eigen_vec_to_arma(x), iel);
           };
         }
         throw std::logic_error("FEMRadialBasis::matrix_element: unknown BasisKind\n");
@@ -567,7 +567,11 @@ namespace helfem {
         return quadrature::spherical_potential(Rmin, Rmax, xq, wq, p);
       }
 
-      arma::mat FEMRadialBasis::get_bf(size_t iel) const {
+      helfem::Matrix FEMRadialBasis::get_bf(size_t iel) const {
+        // Phase 5.21: forward to the arma-input overload with the
+        // internal xq bridged to arma once. The bridge cost is one
+        // copy of the quadrature-point vector; the returned matrix
+        // is Eigen already.
         return get_bf(eigen_vec_to_arma(xq), iel);
       }
 
@@ -586,8 +590,10 @@ namespace helfem {
           helfem::Vector xe = fem.eval_prim(r_e, iel);
           arma::vec x(xe.size()); std::memcpy(x.memptr(), xe.data(), sizeof(double) * xe.size());
 
-          // Evaluate the basis functions in the element
-          arma::mat val(get_bf(x, iel));
+          // Evaluate the basis functions in the element (Phase 5.21:
+          // get_bf returns Eigen; bridge here because the rest of
+          // eval_orbs is arma-typed).
+          arma::mat val(eigen_mat_to_arma(get_bf(x, iel)));
           // Figure out the corresponding indices of the basis functions
           size_t ifirst, ilast;
           get_idx(iel, ifirst, ilast);
@@ -596,57 +602,55 @@ namespace helfem {
         }
       }
 
-      arma::mat FEMRadialBasis::get_bf(const arma::vec & x, size_t iel) const {
-        // Phase 5.3: fem.eval_* / eval_coord are Eigen; bridge.
+      helfem::Matrix FEMRadialBasis::get_bf(const arma::vec & x, size_t iel) const {
+        // Phase 5.21: internals were already Eigen; return directly
+        // without the arma bridge that Phase 5.3 introduced.
         const helfem::Vector xe = arma_to_eigen_vec(x);
         if (iel == 0)
-          return eigen_mat_to_arma(fem.eval_over_r(xe, 0, iel));
-        arma::mat val(eigen_mat_to_arma(fem.eval_f(xe, iel)));
-        const helfem::Vector r_e = fem.eval_coord(xe, iel);
-        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
-        for (size_t ifun = 0; ifun < val.n_cols; ifun++)
-          for (size_t ir = 0; ir < x.n_elem; ir++)
+          return fem.eval_over_r(xe, 0, iel);
+        helfem::Matrix val = fem.eval_f(xe, iel);
+        const helfem::Vector r = fem.eval_coord(xe, iel);
+        for (Eigen::Index ifun = 0; ifun < val.cols(); ++ifun)
+          for (Eigen::Index ir = 0; ir < val.rows(); ++ir)
             val(ir, ifun) /= r(ir);
         return val;
       }
 
-      arma::mat FEMRadialBasis::get_df(size_t iel) const {
+      helfem::Matrix FEMRadialBasis::get_df(size_t iel) const {
         return get_df(eigen_vec_to_arma(xq), iel);
       }
 
-      arma::mat FEMRadialBasis::get_df(const arma::vec & x, size_t iel) const {
+      helfem::Matrix FEMRadialBasis::get_df(const arma::vec & x, size_t iel) const {
         const helfem::Vector xe = arma_to_eigen_vec(x);
         if (iel == 0)
-          return eigen_mat_to_arma(fem.eval_over_r(xe, 1, iel));
-        arma::mat fval(eigen_mat_to_arma(fem.eval_f (xe, iel)));
-        arma::mat dval(eigen_mat_to_arma(fem.eval_df(xe, iel)));
-        const helfem::Vector r_e = fem.eval_coord(xe, iel);
-        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
-        arma::mat der(fval.n_rows, fval.n_cols);
-        for (size_t ifun = 0; ifun < der.n_cols; ifun++)
-          for (size_t ir = 0; ir < x.n_elem; ir++) {
+          return fem.eval_over_r(xe, 1, iel);
+        helfem::Matrix fval = fem.eval_f (xe, iel);
+        helfem::Matrix dval = fem.eval_df(xe, iel);
+        const helfem::Vector r = fem.eval_coord(xe, iel);
+        helfem::Matrix der(fval.rows(), fval.cols());
+        for (Eigen::Index ifun = 0; ifun < der.cols(); ++ifun)
+          for (Eigen::Index ir = 0; ir < der.rows(); ++ir) {
             const double invr = 1.0 / r(ir);
             der(ir, ifun) = (-fval(ir, ifun) * invr + dval(ir, ifun)) * invr;
           }
         return der;
       }
 
-      arma::mat FEMRadialBasis::get_lf(size_t iel) const {
+      helfem::Matrix FEMRadialBasis::get_lf(size_t iel) const {
         return get_lf(eigen_vec_to_arma(xq), iel);
       }
 
-      arma::mat FEMRadialBasis::get_lf(const arma::vec & x, size_t iel) const {
+      helfem::Matrix FEMRadialBasis::get_lf(const arma::vec & x, size_t iel) const {
         const helfem::Vector xe = arma_to_eigen_vec(x);
         if (iel == 0)
-          return eigen_mat_to_arma(fem.eval_over_r(xe, 2, iel));
-        arma::mat fval(eigen_mat_to_arma(fem.eval_f  (xe, iel)));
-        arma::mat dval(eigen_mat_to_arma(fem.eval_df (xe, iel)));
-        arma::mat lval(eigen_mat_to_arma(fem.eval_d2f(xe, iel)));
-        const helfem::Vector r_e = fem.eval_coord(xe, iel);
-        arma::vec r(r_e.size()); std::memcpy(r.memptr(), r_e.data(), sizeof(double) * r_e.size());
-        arma::mat lapl(fval.n_rows, fval.n_cols);
-        for (size_t ifun = 0; ifun < lapl.n_cols; ifun++)
-          for (size_t ir = 0; ir < x.n_elem; ir++) {
+          return fem.eval_over_r(xe, 2, iel);
+        helfem::Matrix fval = fem.eval_f  (xe, iel);
+        helfem::Matrix dval = fem.eval_df (xe, iel);
+        helfem::Matrix lval = fem.eval_d2f(xe, iel);
+        const helfem::Vector r = fem.eval_coord(xe, iel);
+        helfem::Matrix lapl(fval.rows(), fval.cols());
+        for (Eigen::Index ifun = 0; ifun < lapl.cols(); ++ifun)
+          for (Eigen::Index ir = 0; ir < lapl.rows(); ++ir) {
             const double invr = 1.0 / r(ir);
             lapl(ir, ifun) = ((2.0 * fval(ir, ifun) * invr - 2.0 * dval(ir, ifun)) * invr
                               + lval(ir, ifun)) * invr;

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -1168,7 +1168,7 @@ namespace helfem {
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
         // Evaluate radial functions
-        arma::mat rad(radial.get_bf(iel));
+        arma::mat rad(helfem::to_arma(radial.get_bf(iel)));
 
         // Form supermatrix
         arma::cx_mat bf(rad.n_rows,lval.n_elem*rad.n_cols);
@@ -1185,8 +1185,8 @@ namespace helfem {
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
         // Evaluate radial functions
-        arma::mat frad(radial.get_bf(iel));
-        arma::mat drad(radial.get_df(iel));
+        arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
+        arma::mat drad(helfem::to_arma(radial.get_df(iel)));
 
         // Form supermatrices
         dr.zeros(frad.n_rows,lval.n_elem*frad.n_cols);
@@ -1231,9 +1231,9 @@ namespace helfem {
 
         // Evaluate radial functions
         arma::vec r(helfem::to_arma(radial.get_r(iel)));
-        arma::mat frad(radial.get_bf(iel));
-        arma::mat drad(radial.get_df(iel));
-        arma::mat lrad(radial.get_lf(iel));
+        arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
+        arma::mat drad(helfem::to_arma(radial.get_df(iel)));
+        arma::mat lrad(helfem::to_arma(radial.get_lf(iel)));
 
         // Form supermatrix
         arma::cx_mat lf(frad.n_rows,lval.n_elem*frad.n_cols,arma::fill::zeros);

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -422,15 +422,15 @@ namespace helfem {
       }
 
       arma::mat TwoDBasis::eval_bf(size_t iel) const {
-        return radial.get_bf(iel);
+        return helfem::to_arma(radial.get_bf(iel));
       }
 
       arma::mat TwoDBasis::eval_df(size_t iel) const {
-        return radial.get_df(iel);
+        return helfem::to_arma(radial.get_df(iel));
       }
 
       arma::mat TwoDBasis::eval_lf(size_t iel) const {
-        return radial.get_lf(iel);
+        return helfem::to_arma(radial.get_lf(iel));
       }
 
       arma::uvec TwoDBasis::bf_list(size_t iel) const {
@@ -598,7 +598,7 @@ namespace helfem {
           radial.get_idx(iel,ifirst,ilast);
           // Density matrix
           arma::mat Csub(C.rows(ifirst,ilast));
-          arma::mat bf(radial.get_bf(iel));
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
 
           c[iel]=bf*Csub;
         }
@@ -626,7 +626,7 @@ namespace helfem {
           radial.get_idx(iel,ifirst,ilast);
           // Density matrix
           arma::mat Csub(C.rows(ifirst,ilast));
-          arma::mat bf(radial.get_df(iel));
+          arma::mat bf(helfem::to_arma(radial.get_df(iel)));
 
           c[iel]=bf*Csub;
         }
@@ -654,7 +654,7 @@ namespace helfem {
           radial.get_idx(iel,ifirst,ilast);
           // Density matrix
           arma::mat Csub(C.rows(ifirst,ilast));
-          arma::mat bf(radial.get_lf(iel));
+          arma::mat bf(helfem::to_arma(radial.get_lf(iel)));
 
           c[iel]=bf*Csub;
         }
@@ -680,7 +680,7 @@ namespace helfem {
         radial.get_idx(iel,ifirst,ilast);
         // Density matrix
         arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
-        arma::mat bf(radial.get_bf(x, iel));
+        arma::mat bf(helfem::to_arma(radial.get_bf(x, iel)));
 
         arma::vec density = arma::diagvec(bf*Psub*bf.t());
         if(rsqweight)
@@ -909,8 +909,8 @@ namespace helfem {
           radial.get_idx(iel,ifirst,ilast);
           // Density matrix
           arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
-          arma::mat bf(radial.get_bf(iel));
-          arma::mat df(radial.get_df(iel));
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
+          arma::mat df(helfem::to_arma(radial.get_df(iel)));
 
           d[iel]=2.0*arma::diagvec(bf*Psub*df.t());
         }
@@ -938,9 +938,9 @@ namespace helfem {
           radial.get_idx(iel,ifirst,ilast);
           // Density matrix
           arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
-          arma::mat bf(radial.get_bf(iel));
-          arma::mat df(radial.get_df(iel));
-          arma::mat lf(radial.get_lf(iel));
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
+          arma::mat df(helfem::to_arma(radial.get_df(iel)));
+          arma::mat lf(helfem::to_arma(radial.get_lf(iel)));
           arma::vec r(helfem::to_arma(radial.get_r(iel)));
 
           // Laplacian is df^2/dr^2 + 2/r df/dr
@@ -982,9 +982,9 @@ namespace helfem {
           arma::mat Psubl(Pl.submat(ifirst,ifirst,ilast,ilast));
 
           // Basis function
-          arma::mat bf(radial.get_bf(iel));
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
           // Basis function derivative
-          arma::mat bf_rho(radial.get_df(iel));
+          arma::mat bf_rho(helfem::to_arma(radial.get_df(iel)));
 
           arma::vec term1(arma::diagvec(bf_rho * Psub * bf_rho.t()));
           arma::vec term2(arma::diagvec(bf * Psubl * bf.t())/arma::square(r));


### PR DESCRIPTION
## Summary

Continues the RadialBasis arma-audit (task #19) with the six basis-function evaluation methods:

| Signature | Before | After |
|---|---|---|
| \`get_bf(iel)\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`get_bf(x, iel)\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`get_df(iel)\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`get_df(x, iel)\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`get_lf(iel)\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`get_lf(x, iel)\` | \`arma::mat\` | \`helfem::Matrix\` |

The per-x-point overloads keep an \`arma::vec\` input for now (the one sadatom caller passes an \`arma::vec x\`); a follow-up can migrate the inputs to \`helfem::Vector\` too.

## Interior simplifications

The three per-x-point overloads previously bridged the Eigen-typed \`fem.eval_f\` / \`eval_df\` / \`eval_d2f\` / \`eval_over_r\` / \`eval_coord\` returns through \`eigen_mat_to_arma\` at every call, and then did arithmetic in arma to divide by r or apply the derivative-of-1/r product rule. Now the arithmetic runs directly on Eigen matrices; no copy through arma.

For \`iel == 0\` (regularity at origin), the return path was:
\`\`\`cpp
return eigen_mat_to_arma(fem.eval_over_r(xe, order, 0));
\`\`\`
which is now just:
\`\`\`cpp
return fem.eval_over_r(xe, order, 0);
\`\`\`

## Caller bridges

Chemistry-layer callers still have \`arma::mat\` locals or return-type contracts, so each gets a \`helfem::to_arma(...)\` wrap around the accessor call:

- \`src/atomic/TwoDBasis.cpp\` — 6 sites (dipole / quadrupole / z-derivative)
- \`src/sadatom/basis.cpp\` — 10 sites (electron density, density gradient, laplacian, radial boundary derivatives)
- \`src/sadatom/1e.cpp\` — 1 site

The \`matrix_element\` \`make_evaluator\` internally constructs functors bound to \`get_bf\`/\`df\`/\`lf\`; those lambdas dropped their \`to_eigen\` wrap since the accessors already return Eigen.

The \`RadialBasis::eval_orbs\` base virtual still returns \`arma::vec\` and constructs an \`arma::mat\` internally from \`get_bf\`; that call is bridged with \`eigen_mat_to_arma\`. \`eval_orbs\` migration is a task follow-up (base virtual + downstream cascade).

Diatomic has its own \`RadialBasis\` class; unaffected.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged