### PR TITLE
RadialBasis: nuclear_density / nuclear_density_gradient / nuclear_orbital take Eigen

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -310,12 +310,13 @@ namespace helfem {
 	/// Get r value
         double get_r(double x, size_t iel) const;
 
-        /// Evaluate nuclear density
-        double nuclear_density(const arma::mat &P) const;
-        /// Evaluate nuclear density gradient
-        double nuclear_density_gradient(const arma::mat &P) const;
-        /// Evaluate orbitals at nucleus
-        arma::rowvec nuclear_orbital(const arma::mat &C) const;
+        /// Evaluate nuclear density (Phase 5.22: Eigen-typed argument).
+        double nuclear_density(const helfem::Matrix &P) const;
+        /// Evaluate nuclear density gradient (Phase 5.22: Eigen-typed argument).
+        double nuclear_density_gradient(const helfem::Matrix &P) const;
+        /// Evaluate orbitals at nucleus (Phase 5.22: Eigen-typed argument
+        /// and Eigen row-vector return).
+        Eigen::RowVectorXd nuclear_orbital(const helfem::Matrix &C) const;
       };
     } // namespace basis
   }   // namespace atomic

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -686,68 +686,55 @@ namespace helfem {
         return fem.eval_coord(x, iel);
       }
 
-      double FEMRadialBasis::nuclear_density(const arma::mat &Prad) const {
-        if (Prad.n_rows != Nbf() || Prad.n_cols != Nbf())
+      // Nuclear coordinate: primitive basis polynomials belong to [-1,1],
+      // and the physical r=0 corresponds to x=-1 in the first element.
+      // Building this single-x-point vector as an Eigen 1-vector avoids
+      // the arma bridge that Phase 5.3-5.6 introduced.
+      static helfem::Vector nuclear_x() {
+        helfem::Vector x(1); x(0) = -1.0;
+        return x;
+      }
+
+      double FEMRadialBasis::nuclear_density(const helfem::Matrix &Prad) const {
+        if (static_cast<size_t>(Prad.rows()) != Nbf() ||
+            static_cast<size_t>(Prad.cols()) != Nbf())
           throw std::logic_error("nuclear_density expects a radial density matrix\n");
 
-        // Nuclear coordinate
-        arma::vec x(1);
-        // Remember that the primitive basis polynomials belong to [-1,1]
-        x(0) = -1.0;
-
-        // Evaluate derivative at nucleus
-        arma::mat der(eigen_mat_to_arma(fem.eval_df(arma_to_eigen_vec(x), (size_t) 0)));
-
-        // Radial functions in element
+        // Derivative at nucleus.
+        const helfem::Matrix der = fem.eval_df(nuclear_x(), (size_t) 0);
+        // First-element radial index range.
         size_t ifirst, ilast;
         get_idx(0, ifirst, ilast);
-        // Density submatrix
-        arma::mat Psub(Prad.submat(ifirst, ifirst, ilast, ilast));
-        // P_uv B_u'(0) B_v'(0)
-        double den(arma::as_scalar(der * Psub * arma::trans(der)));
-
-        return den;
+        const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
+        // Density submatrix.
+        const helfem::Matrix Psub = Prad.block(ifirst, ifirst, n, n);
+        // P_uv B_u'(0) B_v'(0) -- one number.
+        return (der * Psub * der.transpose()).value();
       }
 
-      double FEMRadialBasis::nuclear_density_gradient(const arma::mat &Prad) const {
-        if (Prad.n_rows != Nbf() || Prad.n_cols != Nbf())
+      double FEMRadialBasis::nuclear_density_gradient(const helfem::Matrix &Prad) const {
+        if (static_cast<size_t>(Prad.rows()) != Nbf() ||
+            static_cast<size_t>(Prad.cols()) != Nbf())
           throw std::logic_error("nuclear_density_gradient expects a radial density matrix\n");
 
-        // Nuclear coordinate
-        arma::vec x(1);
-        // Remember that the primitive basis polynomials belong to [-1,1]
-        x(0) = -1.0;
-
-        // Evaluate derivative at nucleus
-        arma::mat der(eigen_mat_to_arma(fem.eval_df(arma_to_eigen_vec(x), (size_t) 0)));
-        arma::mat lapl(eigen_mat_to_arma(fem.eval_d2f(arma_to_eigen_vec(x), (size_t) 0)));
-
-        // Radial functions in element
+        const helfem::Vector xn = nuclear_x();
+        const helfem::Matrix der  = fem.eval_df (xn, (size_t) 0);
+        const helfem::Matrix lapl = fem.eval_d2f(xn, (size_t) 0);
         size_t ifirst, ilast;
         get_idx(0, ifirst, ilast);
-        // Density submatrix
-        arma::mat Psub(Prad.submat(ifirst, ifirst, ilast, ilast));
-        // P_uv B_u'(0) B_v''(0)
-        double den(arma::as_scalar(der * Psub * arma::trans(lapl)));
-
-        return den;
+        const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
+        const helfem::Matrix Psub = Prad.block(ifirst, ifirst, n, n);
+        // P_uv B_u'(0) B_v''(0) -- one number.
+        return (der * Psub * lapl.transpose()).value();
       }
 
-      arma::rowvec FEMRadialBasis::nuclear_orbital(const arma::mat &C) const {
-        // Nuclear coordinate
-        arma::vec x(1);
-        // Remember that the primitive basis polynomials belong to [-1,1]
-        x(0) = -1.0;
-
-        // Derivative
-        arma::mat der(eigen_mat_to_arma(fem.eval_df(arma_to_eigen_vec(x), (size_t) 0)));
-        // Radial functions in element
+      Eigen::RowVectorXd FEMRadialBasis::nuclear_orbital(const helfem::Matrix &C) const {
+        const helfem::Matrix der = fem.eval_df(nuclear_x(), (size_t) 0);
         size_t ifirst, ilast;
         get_idx(0, ifirst, ilast);
-        // Density submatrix
-        arma::mat Csub(C.rows(ifirst, ilast));
-
-        // C_ui B_u'(0)
+        const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
+        const helfem::Matrix Csub = C.block(ifirst, 0, n, C.cols());
+        // C_ui B_u'(0) -- row vector of length C.cols().
         return der * Csub;
       }
     } // namespace basis

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -1308,7 +1308,7 @@ namespace helfem {
 #endif
         for(size_t iam=0;iam<lval.n_elem;iam++) {
           // Integration over angles yields extra factor 4 pi that must be removed
-          nucden+=radial.nuclear_density(P.submat(Nrad*iam,Nrad*iam,Nrad*(iam+1)-1,Nrad*(iam+1)-1))/(4.0*M_PI);
+          nucden+=radial.nuclear_density(helfem::to_eigen(arma::mat(P.submat(Nrad*iam,Nrad*iam,Nrad*(iam+1)-1,Nrad*(iam+1)-1))))/(4.0*M_PI);
         }
 
         arma::vec den(1);
@@ -1334,7 +1334,7 @@ namespace helfem {
 #endif
         for(size_t iam=0;iam<lval.n_elem;iam++) {
           // Integration over angles yields extra factor 4 pi that must be removed
-          nucden+=radial.nuclear_density_gradient(P.submat(Nrad*iam,Nrad*iam,Nrad*(iam+1)-1,Nrad*(iam+1)-1))/(4.0*M_PI);
+          nucden+=radial.nuclear_density_gradient(helfem::to_eigen(arma::mat(P.submat(Nrad*iam,Nrad*iam,Nrad*(iam+1)-1,Nrad*(iam+1)-1))))/(4.0*M_PI);
         }
 
         arma::vec den(1);

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
       radial.get_idx(iel,ifirst,ilast);
       // Density matrix
       arma::mat Csub(C.rows(ifirst,ilast));
-      arma::mat bf(radial.get_bf(iel));
+      arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
 
       c[iel]=bf*Csub;
     }

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -468,11 +468,11 @@ namespace helfem {
       }
 
       double TwoDBasis::nuclear_density(const arma::mat & P) const {
-        return radial.nuclear_density(P)/(4.0*M_PI);
+        return radial.nuclear_density(helfem::to_eigen(P))/(4.0*M_PI);
       }
 
       double TwoDBasis::nuclear_density_gradient(const arma::mat & P) const {
-        return radial.nuclear_density_gradient(P)/(4.0*M_PI);
+        return radial.nuclear_density_gradient(helfem::to_eigen(P))/(4.0*M_PI);
       }
 
       arma::vec TwoDBasis::quadrature_weights() const {
@@ -608,7 +608,11 @@ namespace helfem {
         Cv.zeros();
         // Values at the nucleus
         {
-          Cv.row(0)=radial.nuclear_orbital(C);
+          {
+            const Eigen::RowVectorXd nrow = radial.nuclear_orbital(helfem::to_eigen(C));
+            for (Eigen::Index j = 0; j < nrow.size(); ++j)
+              Cv(0, j) = nrow(j);
+          }
         }
         // Other points
         for(size_t iel=0;iel<radial.Nel();iel++) {


### PR DESCRIPTION
## Summary

Continues the RadialBasis arma-audit (task #19) with the three nuclear-site accessors:

| Signature | Before | After |
|---|---|---|
| \`nuclear_density(P)\` | \`const arma::mat &P\` → \`double\` | \`const helfem::Matrix &P\` → \`double\` |
| \`nuclear_density_gradient(P)\` | \`const arma::mat &P\` → \`double\` | \`const helfem::Matrix &P\` → \`double\` |
| \`nuclear_orbital(C)\` | \`const arma::mat &C\` → \`arma::rowvec\` | \`const helfem::Matrix &C\` → \`Eigen::RowVectorXd\` |

## Interior simplifications

All three previously built the nuclear coordinate vector as \`arma::vec x(1); x(0) = -1.0;\` then bridged \`fem.eval_df\` / \`eval_d2f\` through \`eigen_mat_to_arma\` just to run one small matrix multiply in arma. The multiplies now run on \`helfem::Matrix\` directly, and a small file-scope helper \`nuclear_x()\` returns the \`{-1.0}\` vector as an Eigen vector once.

Submatrix extraction uses Eigen's \`.block(row, col, nrows, ncols)\` instead of \`arma::submat\`.

## Caller bridges

Chemistry-layer callers keep arma-typed density matrices, so each bridges via \`helfem::to_eigen(...)\` at the call site:

- \`src/atomic/TwoDBasis.cpp\` — 2 sites in \`nuclear_density\` / \`nuclear_density_gradient\` (extracting the per-angular-shell submatrix as an \`arma::mat\` first, then bridging)
- \`src/sadatom/basis.cpp\` — 2 sites in \`TwoDBasis::nuclear_density\`, \`nuclear_density_gradient\` wrappers. For \`nuclear_orbital\`, the result is copied element-by-element into the first row of the \`arma::mat Cv\` the caller assembles

## Also fixes

A latent build failure in \`src/sadatom/1e.cpp\` introduced by PR #156 (get_bf return-type migration to Eigen) that only surfaced when a downstream build turned back on — the file wasn't touched by the previous PR's manual \`git add\`. One-line \`helfem::to_arma\` bridge.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)
- Li HF electron-density-at-nucleus: 13.81489 (unchanged)
- Li HF density gradient: −82.88938 (unchanged)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged
- [x] Nuclear density observables unchanged