### PR TITLE
RadialBasis: eval_orbs base virtual takes Eigen input, returns Eigen

### DIFF
--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -139,14 +139,17 @@ namespace helfem {
         /// Evaluate the NAO orbitals (columns of C_orb in the NAO basis)
         /// at radius r. Internally promotes to the underlying basis via
         /// C_promoted = C * C_orb and delegates to underlying.eval_orbs.
-        arma::vec eval_orbs(const arma::mat & C_orb, double r) const override {
-          if (C_orb.n_rows != Nbf()) {
+        helfem::Vector eval_orbs(const helfem::Matrix & C_orb, double r) const override {
+          if (static_cast<size_t>(C_orb.rows()) != Nbf()) {
             std::ostringstream oss;
-            oss << "NAORadialBasis::eval_orbs: C_orb has " << C_orb.n_rows
+            oss << "NAORadialBasis::eval_orbs: C_orb has " << C_orb.rows()
                 << " rows but NAO Nbf() = " << Nbf() << "\n";
             throw std::logic_error(oss.str());
           }
-          return underlying_->eval_orbs(C_ * C_orb, r);
+          // Promote C to the underlying basis via C_ * C_orb (arma
+          // stays for the C_ storage), then bridge to Eigen for the
+          // Phase 5.23 eval_orbs interface.
+          return underlying_->eval_orbs(helfem::to_eigen(arma::mat(C_ * helfem::to_arma(C_orb))), r);
         }
 
         // ---------------------------------------------------------------

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -57,7 +57,8 @@ namespace helfem {
         virtual helfem::Matrix nuclear() const = 0;
 
         /// Evaluate orbitals (columns of C) at a given r.
-        virtual arma::vec eval_orbs(const arma::mat & C, double r) const = 0;
+        /// Phase 5.23: Eigen-typed argument + return.
+        virtual helfem::Vector eval_orbs(const helfem::Matrix & C, double r) const = 0;
       };
 
       /// Finite-element radial basis set.
@@ -292,8 +293,8 @@ namespace helfem {
         /// Evaluate second derivatives of basis functions at given points
         /// (Phase 5.21: Eigen return).
         helfem::Matrix get_lf(const arma::vec & x, size_t iel) const;
-        /// Evaluate orbitals at a given point
-        arma::vec eval_orbs(const arma::mat & C, double r) const override;
+        /// Evaluate orbitals at a given point (Phase 5.23: Eigen-typed).
+        helfem::Vector eval_orbs(const helfem::Matrix & C, double r) const override;
 
         /// Get quadrature weights in element (Phase 5.20: Eigen return).
         helfem::Vector get_wrad(size_t iel) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -577,29 +577,29 @@ namespace helfem {
 
       // get_taylor() has been removed in favour of fem.eval_over_r().
 
-      arma::vec FEMRadialBasis::eval_orbs(const arma::mat & C, double r) const {
+      helfem::Vector FEMRadialBasis::eval_orbs(const helfem::Matrix & C, double r) const {
         if(r > fem.element_end(fem.get_nelem()-1)) {
-          // The wave function is zero here
-          arma::vec val(C.n_cols, arma::fill::zeros);
-          return val;
-        } else {
-          // Find the element we are in
-          size_t iel = fem.find_element(r);
-          // Find the value of the primitive coordinate
-          helfem::Vector r_e(1); r_e(0) = r;
-          helfem::Vector xe = fem.eval_prim(r_e, iel);
-          arma::vec x(xe.size()); std::memcpy(x.memptr(), xe.data(), sizeof(double) * xe.size());
-
-          // Evaluate the basis functions in the element (Phase 5.21:
-          // get_bf returns Eigen; bridge here because the rest of
-          // eval_orbs is arma-typed).
-          arma::mat val(eigen_mat_to_arma(get_bf(x, iel)));
-          // Figure out the corresponding indices of the basis functions
-          size_t ifirst, ilast;
-          get_idx(iel, ifirst, ilast);
-          arma::mat Csub(C.rows(ifirst, ilast));
-          return (val*Csub).t();
+          // Wave function is zero beyond the practical infinity.
+          return helfem::Vector::Zero(C.cols());
         }
+        // Find the element and evaluate the primitive coordinate.
+        const size_t iel = fem.find_element(r);
+        helfem::Vector r_e(1); r_e(0) = r;
+        const helfem::Vector xe = fem.eval_prim(r_e, iel);
+
+        // Basis functions in the element (get_bf still takes an arma::vec
+        // input; bridge once at the call site).
+        arma::vec x(xe.size());
+        std::memcpy(x.memptr(), xe.data(), sizeof(double) * (size_t) xe.size());
+        const helfem::Matrix val = get_bf(x, iel);
+
+        // Slice C over the element's basis-function index range and
+        // return the row-vector product transposed to a column.
+        size_t ifirst, ilast;
+        get_idx(iel, ifirst, ilast);
+        const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
+        const helfem::Matrix Csub = C.block(ifirst, 0, n, C.cols());
+        return (val * Csub).transpose();
       }
 
       helfem::Matrix FEMRadialBasis::get_bf(const arma::vec & x, size_t iel) const {

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -452,7 +452,7 @@ namespace helfem {
       }
 
       arma::vec TwoDBasis::eval_orbs(const arma::mat & C, double r) const {
-        return radial.eval_orbs(C,r);
+        return helfem::to_arma(radial.eval_orbs(helfem::to_eigen(C), r));
       }
 
       size_t TwoDBasis::get_rad_Nel() const {


### PR DESCRIPTION
## Summary

Continues the RadialBasis arma-audit (task #19) with the last remaining arma spot in the BASE virtual interface:

\`\`\`cpp
virtual arma::vec  eval_orbs(const arma::mat & C, double r) const = 0;
    ->
virtual helfem::Vector eval_orbs(const helfem::Matrix & C, double r) const = 0;
\`\`\`

The base class \`RadialBasis\` is now arma-**FREE** on its public virtual surface (\`overlap\` / \`kinetic\` / \`kinetic_l\` / \`nuclear\` / \`eval_orbs\` all Eigen-typed) — the base is ready for consumers that want to implement \`RadialBasis\` without pulling in Armadillo at all.

## Derived overrides

**FEMRadialBasis::eval_orbs** signature changes to match. The impl still forwards to \`get_bf(arma::vec, iel)\` at one interior point (that per-x-point overload keeps its arma input for now; a follow-up can migrate it too), with a single arma bridge for the x vector.

**NAORadialBasis::eval_orbs** signature changes to match. Its impl still holds an \`arma::mat C_\` (NAO coefficient matrix) but converts once at the call boundary via \`helfem::to_arma(C_orb)\` for the matrix product then bridges back with \`helfem::to_eigen\`.

## Caller bridges

Only one non-derived caller: \`sadatom::basis::TwoDBasis::eval_orbs\` is a wrapper that forwards to \`radial.eval_orbs\`. It keeps its \`arma::mat\` / \`arma::vec\` public surface (used by \`diatomic/twodquadrature.cpp\`) and bridges to Eigen once at the \`radial.eval_orbs\` call.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)
- Li HF nuclear-density observables: **13.81489 / −82.88938** (unchanged)
- Li HF Etot: **−7.432739460** (unchanged)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged (atomic, sadatom, diatomic)
- [x] NAORadialBasis override recompiles + matches base signature