### PR TITLE
RadialBasis: per-x-point evaluator inputs Eigen + drop dead radial_integral overload

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -117,10 +117,6 @@ namespace helfem {
         void get_idx(size_t iel, size_t &ifirst, size_t &ilast) const;
 
         /// Compute radial matrix elements <r^n> in element (overlap is n=0,
-        /// nuclear is n=-1)
-        arma::mat radial_integral(const arma::mat &bf_c, int n,
-                                  size_t iel) const;
-        /// Compute radial matrix elements <r^n> in element (overlap is n=0,
         /// nuclear is n=-1). Eigen-typed (Phase 2a migration).
         helfem::Matrix radial_integral(int n, size_t iel, double x_left = -1.0, double x_right = 1.0) const;
 
@@ -276,23 +272,20 @@ namespace helfem {
         /// Compute projection (Eigen; Phase 2a).
         helfem::Matrix overlap(const FEMRadialBasis &rh) const;
 
-        /// Evaluate basis functions at quadrature points (Phase 5.21: Eigen return).
+        /// Evaluate basis functions at quadrature points (Eigen return).
         helfem::Matrix get_bf(size_t iel) const;
-        /// Evaluate basis functions at given points (arma-typed input kept
-        /// for chemistry-layer callers; Eigen return per Phase 5.21).
-        helfem::Matrix get_bf(const arma::vec & x, size_t iel) const;
-        /// Evaluate derivatives of basis functions at quadrature points
-        /// (Phase 5.21: Eigen return).
+        /// Evaluate basis functions at given points (Phase 5.24: Eigen input + return).
+        helfem::Matrix get_bf(const helfem::Vector & x, size_t iel) const;
+        /// Evaluate derivatives of basis functions at quadrature points (Eigen return).
         helfem::Matrix get_df(size_t iel) const;
         /// Evaluate derivatives of basis functions at given points
-        /// (Phase 5.21: Eigen return).
-        helfem::Matrix get_df(const arma::vec & x, size_t iel) const;
-        /// Evaluate second derivatives of basis functions at quadrature points
-        /// (Phase 5.21: Eigen return).
+        /// (Phase 5.24: Eigen input + return).
+        helfem::Matrix get_df(const helfem::Vector & x, size_t iel) const;
+        /// Evaluate second derivatives of basis functions at quadrature points (Eigen return).
         helfem::Matrix get_lf(size_t iel) const;
         /// Evaluate second derivatives of basis functions at given points
-        /// (Phase 5.21: Eigen return).
-        helfem::Matrix get_lf(const arma::vec & x, size_t iel) const;
+        /// (Phase 5.24: Eigen input + return).
+        helfem::Matrix get_lf(const helfem::Vector & x, size_t iel) const;
         /// Evaluate orbitals at a given point (Phase 5.23: Eigen-typed).
         helfem::Vector eval_orbs(const helfem::Matrix & C, double r) const override;
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -137,13 +137,13 @@ namespace helfem {
             return rb->get_fem().eval_d2f(x, iel);
           };
           case BK::R0: return [rb](helfem::Vector x, size_t iel) {
-            return rb->get_bf(eigen_vec_to_arma(x), iel);
+            return rb->get_bf(x, iel);
           };
           case BK::R1: return [rb](helfem::Vector x, size_t iel) {
-            return rb->get_df(eigen_vec_to_arma(x), iel);
+            return rb->get_df(x, iel);
           };
           case BK::R2: return [rb](helfem::Vector x, size_t iel) {
-            return rb->get_lf(eigen_vec_to_arma(x), iel);
+            return rb->get_lf(x, iel);
           };
         }
         throw std::logic_error("FEMRadialBasis::matrix_element: unknown BasisKind\n");
@@ -568,11 +568,7 @@ namespace helfem {
       }
 
       helfem::Matrix FEMRadialBasis::get_bf(size_t iel) const {
-        // Phase 5.21: forward to the arma-input overload with the
-        // internal xq bridged to arma once. The bridge cost is one
-        // copy of the quadrature-point vector; the returned matrix
-        // is Eigen already.
-        return get_bf(eigen_vec_to_arma(xq), iel);
+        return get_bf(xq, iel);
       }
 
       // get_taylor() has been removed in favour of fem.eval_over_r().
@@ -587,11 +583,8 @@ namespace helfem {
         helfem::Vector r_e(1); r_e(0) = r;
         const helfem::Vector xe = fem.eval_prim(r_e, iel);
 
-        // Basis functions in the element (get_bf still takes an arma::vec
-        // input; bridge once at the call site).
-        arma::vec x(xe.size());
-        std::memcpy(x.memptr(), xe.data(), sizeof(double) * (size_t) xe.size());
-        const helfem::Matrix val = get_bf(x, iel);
+        // Basis functions in the element -- Eigen throughout after Phase 5.24.
+        const helfem::Matrix val = get_bf(xe, iel);
 
         // Slice C over the element's basis-function index range and
         // return the row-vector product transposed to a column.
@@ -602,14 +595,12 @@ namespace helfem {
         return (val * Csub).transpose();
       }
 
-      helfem::Matrix FEMRadialBasis::get_bf(const arma::vec & x, size_t iel) const {
-        // Phase 5.21: internals were already Eigen; return directly
-        // without the arma bridge that Phase 5.3 introduced.
-        const helfem::Vector xe = arma_to_eigen_vec(x);
+      helfem::Matrix FEMRadialBasis::get_bf(const helfem::Vector & x, size_t iel) const {
+        // Phase 5.24: input is Eigen; no arma bridge at either end.
         if (iel == 0)
-          return fem.eval_over_r(xe, 0, iel);
-        helfem::Matrix val = fem.eval_f(xe, iel);
-        const helfem::Vector r = fem.eval_coord(xe, iel);
+          return fem.eval_over_r(x, 0, iel);
+        helfem::Matrix val = fem.eval_f(x, iel);
+        const helfem::Vector r = fem.eval_coord(x, iel);
         for (Eigen::Index ifun = 0; ifun < val.cols(); ++ifun)
           for (Eigen::Index ir = 0; ir < val.rows(); ++ir)
             val(ir, ifun) /= r(ir);
@@ -617,16 +608,15 @@ namespace helfem {
       }
 
       helfem::Matrix FEMRadialBasis::get_df(size_t iel) const {
-        return get_df(eigen_vec_to_arma(xq), iel);
+        return get_df(xq, iel);
       }
 
-      helfem::Matrix FEMRadialBasis::get_df(const arma::vec & x, size_t iel) const {
-        const helfem::Vector xe = arma_to_eigen_vec(x);
+      helfem::Matrix FEMRadialBasis::get_df(const helfem::Vector & x, size_t iel) const {
         if (iel == 0)
-          return fem.eval_over_r(xe, 1, iel);
-        helfem::Matrix fval = fem.eval_f (xe, iel);
-        helfem::Matrix dval = fem.eval_df(xe, iel);
-        const helfem::Vector r = fem.eval_coord(xe, iel);
+          return fem.eval_over_r(x, 1, iel);
+        helfem::Matrix fval = fem.eval_f (x, iel);
+        helfem::Matrix dval = fem.eval_df(x, iel);
+        const helfem::Vector r = fem.eval_coord(x, iel);
         helfem::Matrix der(fval.rows(), fval.cols());
         for (Eigen::Index ifun = 0; ifun < der.cols(); ++ifun)
           for (Eigen::Index ir = 0; ir < der.rows(); ++ir) {
@@ -637,17 +627,16 @@ namespace helfem {
       }
 
       helfem::Matrix FEMRadialBasis::get_lf(size_t iel) const {
-        return get_lf(eigen_vec_to_arma(xq), iel);
+        return get_lf(xq, iel);
       }
 
-      helfem::Matrix FEMRadialBasis::get_lf(const arma::vec & x, size_t iel) const {
-        const helfem::Vector xe = arma_to_eigen_vec(x);
+      helfem::Matrix FEMRadialBasis::get_lf(const helfem::Vector & x, size_t iel) const {
         if (iel == 0)
-          return fem.eval_over_r(xe, 2, iel);
-        helfem::Matrix fval = fem.eval_f  (xe, iel);
-        helfem::Matrix dval = fem.eval_df (xe, iel);
-        helfem::Matrix lval = fem.eval_d2f(xe, iel);
-        const helfem::Vector r = fem.eval_coord(xe, iel);
+          return fem.eval_over_r(x, 2, iel);
+        helfem::Matrix fval = fem.eval_f  (x, iel);
+        helfem::Matrix dval = fem.eval_df (x, iel);
+        helfem::Matrix lval = fem.eval_d2f(x, iel);
+        const helfem::Vector r = fem.eval_coord(x, iel);
         helfem::Matrix lapl(fval.rows(), fval.cols());
         for (Eigen::Index ifun = 0; ifun < lapl.cols(); ++ifun)
           for (Eigen::Index ir = 0; ir < lapl.rows(); ++ir) {

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -684,7 +684,10 @@ namespace helfem {
         radial.get_idx(iel,ifirst,ilast);
         // Density matrix
         arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
-        arma::mat bf(helfem::to_arma(radial.get_bf(x, iel)));
+        // Phase 5.24: radial.get_bf / get_r per-x-point overloads now
+        // take an Eigen vector; bridge once at the call boundary.
+        const helfem::Vector xe = helfem::to_eigen(x);
+        arma::mat bf(helfem::to_arma(radial.get_bf(xe, iel)));
 
         arma::vec density = arma::diagvec(bf*Psub*bf.t());
         if(rsqweight)


### PR DESCRIPTION
## Summary

Two related cleanups on \`FEMRadialBasis\`'s public surface.

## Input-type migration

The per-x-point evaluator overloads now take an Eigen vector:

| Signature | Before | After |
|---|---|---|
| \`get_bf(x, iel)\` | \`const arma::vec &\` | \`const helfem::Vector &\` |
| \`get_df(x, iel)\` | \`const arma::vec &\` | \`const helfem::Vector &\` |
| \`get_lf(x, iel)\` | \`const arma::vec &\` | \`const helfem::Vector &\` |

Together with PR #156 (return types) and PR #155 (get_xq), the six-method \`get_bf\`/\`get_df\`/\`get_lf\` family is now **Eigen-native on both input and output**; the internal implementations no longer call \`arma_to_eigen_vec\`.

**Downstream simplifications**:
- The no-x overloads (\`get_bf(iel)\` / etc.) forward directly to the per-x-point overload with the internal \`xq\` (which Phase 5.6 already stores as \`helfem::Vector\`) — one less arma bridge per call.
- \`eval_orbs\`'s internal \`get_bf\` call drops its \`arma::vec x\` bridge (was two lines of memcpy + arma::vec allocation).
- The \`matrix_element\` \`make_evaluator\` R0/R1/R2 lambdas previously wrapped \`get_bf\` with \`eigen_vec_to_arma\`; that wrap goes away.

## Dead-overload deletion

The declaration
\`\`\`cpp
arma::mat radial_integral(const arma::mat & bf_c, int n, size_t iel) const;
\`\`\`
never had an implementation in \`RadialBasis.cpp\` and had zero callers in the tree (all \`radial_integral\` usage is via the Eigen-typed \`(n, iel[, x_left, x_right])\` overload added in Phase 2a). Deleted.

## Caller bridges

Only one caller of the per-x-point overload:

\`\`\`
src/sadatom/basis.cpp:687
  arma::mat bf(helfem::to_arma(radial.get_bf(x, iel)));
->
  const helfem::Vector xe = helfem::to_eigen(x);
  arma::mat bf(helfem::to_arma(radial.get_bf(xe, iel)));
\`\`\`

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)
- Li HF electron-density-at-nucleus: **13.81489 / −82.88938** (unchanged)
- Li HF Etot: **−7.432739460** (unchanged)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged
- [x] Density observables unchanged