### PR TITLE
RadialBasis: get_wrad(w,iel) + get_r(x,iel) inputs Eigen — RadialBasis.h now arma-FREE

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -36,10 +36,6 @@ namespace helfem {
         virtual size_t Nbf() const = 0;
 
         /// Overlap matrix S_{ij} = integral u_i(r) u_j(r) dr.
-        /// Eigen-typed -- first method migrated from arma::mat as part
-        /// of Phase 2a of the v2 Eigen migration arc. The other base
-        /// virtuals (kinetic, kinetic_l, nuclear) follow in subsequent
-        /// PRs.
         virtual helfem::Matrix overlap() const = 0;
         /// Radial kinetic matrix (1/2) integral u'_i(r) u'_j(r) dr.
         /// EXCLUDES the centrifugal term -- caller adds l*(l+1) * kinetic_l().
@@ -289,18 +285,16 @@ namespace helfem {
         /// Evaluate orbitals at a given point (Phase 5.23: Eigen-typed).
         helfem::Vector eval_orbs(const helfem::Matrix & C, double r) const override;
 
-        /// Get quadrature weights in element (Phase 5.20: Eigen return).
+        /// Get quadrature weights in element.
         helfem::Vector get_wrad(size_t iel) const;
         /// Get quadrature weights in element from user-supplied weight
-        /// vector (arma-typed input kept for chemistry-layer callers;
-        /// Eigen return per Phase 5.20).
-        helfem::Vector get_wrad(const arma::vec & w, size_t iel) const;
-        /// Get r values at quadrature points in element (Phase 5.20: Eigen return).
+        /// vector (Phase 5.25: Eigen input + return).
+        helfem::Vector get_wrad(const helfem::Vector & w, size_t iel) const;
+        /// Get r values at quadrature points in element.
         helfem::Vector get_r(size_t iel) const;
         /// Get r values at user-supplied x points in element
-        /// (arma-typed input kept for chemistry-layer callers; Eigen
-        /// return per Phase 5.20).
-        helfem::Vector get_r(const arma::vec & x, size_t iel) const;
+        /// (Phase 5.25: Eigen input + return).
+        helfem::Vector get_r(const helfem::Vector & x, size_t iel) const;
 	/// Get r value
         double get_r(double x, size_t iel) const;
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -648,27 +648,19 @@ namespace helfem {
       }
 
       helfem::Vector FEMRadialBasis::get_wrad(size_t iel) const {
-        // Phase 5.20: internal wq is Eigen; scale in Eigen and return.
-        return fem.scaling_factor(iel) * wq;
+        return get_wrad(wq, iel);
       }
 
-      helfem::Vector FEMRadialBasis::get_wrad(const arma::vec & w, size_t iel) const {
-        // Chemistry-layer callers still pass arma::vec weights; bridge
-        // once to Eigen and scale. Return type is Eigen per Phase 5.20.
-        const double s = fem.scaling_factor(iel);
-        helfem::Vector out(w.n_elem);
-        for (arma::uword i = 0; i < w.n_elem; ++i) out(i) = s * w(i);
-        return out;
+      helfem::Vector FEMRadialBasis::get_wrad(const helfem::Vector & w, size_t iel) const {
+        return fem.scaling_factor(iel) * w;
       }
 
       helfem::Vector FEMRadialBasis::get_r(size_t iel) const {
-        // Phase 5.20: eval_coord returns Eigen; return directly.
-        return fem.eval_coord(xq, iel);
+        return get_r(xq, iel);
       }
 
-      helfem::Vector FEMRadialBasis::get_r(const arma::vec & x, size_t iel) const {
-        // Bridge input to Eigen once; return Eigen per Phase 5.20.
-        return fem.eval_coord(arma_to_eigen_vec(x), iel);
+      helfem::Vector FEMRadialBasis::get_r(const helfem::Vector & x, size_t iel) const {
+        return fem.eval_coord(x, iel);
       }
 
       double FEMRadialBasis::get_r(double x, size_t iel) const {

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -684,14 +684,14 @@ namespace helfem {
         radial.get_idx(iel,ifirst,ilast);
         // Density matrix
         arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
-        // Phase 5.24: radial.get_bf / get_r per-x-point overloads now
-        // take an Eigen vector; bridge once at the call boundary.
+        // Phase 5.24/5.25: radial.get_bf / get_r per-x-point overloads
+        // take Eigen vectors; bridge once at the call boundary.
         const helfem::Vector xe = helfem::to_eigen(x);
         arma::mat bf(helfem::to_arma(radial.get_bf(xe, iel)));
 
         arma::vec density = arma::diagvec(bf*Psub*bf.t());
         if(rsqweight)
-          density %= arma::square(helfem::to_arma(radial.get_r(x, iel)));
+          density %= arma::square(helfem::to_arma(radial.get_r(xe, iel)));
         return density;
       }
 
@@ -777,7 +777,7 @@ namespace helfem {
             throw std::logic_error(oss.str());
           }
           // Position of maximum is
-          rmax = radial.get_r((a+b)/2, iel)(0);
+          rmax = radial.get_r(helfem::to_eigen(arma::vec((a+b)/2)), iel)(0);
         }
 
         return rmax;
@@ -853,7 +853,7 @@ namespace helfem {
           // Coordinate is
           arma::vec cen=((a+b)/2);
           // Position of maximum is
-          rvdw = arma::as_scalar(helfem::to_arma(radial.get_r(cen,iel)));
+          rvdw = radial.get_r(helfem::to_eigen(cen), iel)(0);
         }
 
         return rvdw;


### PR DESCRIPTION
## Summary

Mirror of PR #159 for the two remaining per-user-vector overloads:

| Signature | Before | After |
|---|---|---|
| \`get_wrad(w, iel)\` | \`const arma::vec &\` | \`const helfem::Vector &\` |
| \`get_r(x, iel)\` | \`const arma::vec &\` | \`const helfem::Vector &\` |

## Interior simplifications

The no-arg overloads forward to the per-vector overload with the internal \`wq\` / \`xq\` (both already \`helfem::Vector\` post Phase 5.6). Every \`arma_to_eigen_vec\` bridge in these paths is gone.

## Caller bridges

Two call sites in \`src/sadatom/basis.cpp\`:
- \`electron_density(const arma::vec & x, iel, Prad, rsqweight)\` now bridges the \`arma::vec x\` once into \`helfem::Vector xe\` and uses it for both \`get_bf\` and \`get_r\`.
- \`vdw_radius\` uses \`get_r((a+b)/2, iel)(0)\` and \`get_r(cen, iel)(0)\` at two golden-section-search endpoints; both bridged.

## 🎯 Header is now arma-FREE

\`libhelfem/include/RadialBasis.h\` no longer contains \`arma::\` in any code position (\`grep\` returns zero). The final change was removing a stale historical comment on \`overlap()\` that mentioned \`arma::mat\` as the pre-migration return type. **This closes task #19 for \`RadialBasis.h\`.**

Task #19 continues with \`FiniteElementBasis.h\` (ctor \`bval\` + \`get_basis(bas, iel)\`); \`PolynomialBasis.h\` was already clean.

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)
- Li HF nuclear-density observables: **13.81489 / −82.88938** (unchanged)
- Li HF vdW radii: **4.320544 / 6.455981 bohr** (unchanged)
- Li HF Etot: **−7.432739460** (unchanged)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged
- [x] Density + vdW observables unchanged
- [x] No \`arma::\` code references remaining in RadialBasis.h