### PR TITLE
libhelfem: CoulombExchangeFE.h assemble_J/K helpers Eigen-typed

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -86,19 +86,19 @@ namespace helfem {
 
       // -- Uncached entry points --------------------------------------
 
-      arma::mat assemble_J_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const arma::mat & P_FE);
+      helfem::Matrix assemble_J_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE);
 
-      arma::mat assemble_K_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const arma::mat & P_FE);
+      helfem::Matrix assemble_K_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE);
 
-      arma::mat assemble_J_FE_one_multipole_yukawa(
+      helfem::Matrix assemble_J_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
-          const arma::mat & P_FE);
+          const helfem::Matrix & P_FE);
 
-      arma::mat assemble_K_FE_one_multipole_yukawa(
+      helfem::Matrix assemble_K_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
-          const arma::mat & P_FE);
+          const helfem::Matrix & P_FE);
 
       // -- Cached entry points ----------------------------------------
 
@@ -109,24 +109,24 @@ namespace helfem {
       /// twoe_in_element (= twoe_integral(L, iel) or yukawa_integral) are
       /// supplied by the caller via accessors. Same assembly, no
       /// recomputation -- meant for SCF inner-loop callers.
-      arma::mat assemble_J_FE_one_multipole_cached(
+      helfem::Matrix assemble_J_FE_one_multipole_cached(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & twoe_in_element,
-          const arma::mat & P_FE);
+          const helfem::Matrix & P_FE);
 
       /// As above for K. Note `ktei_in_element` here returns the
       /// EXCHANGE-PERMUTED in-element tensor (i.e.
       ///   utils::exchange_tei(twoe_in_element(iel), Ni, Ni, Ni, Ni))
       /// so SCF-driven callers (TwoDBasis, which precomputes prim_ktei)
       /// can pass the cached permuted form directly with zero overhead.
-      arma::mat assemble_K_FE_one_multipole_cached(
+      helfem::Matrix assemble_K_FE_one_multipole_cached(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & ktei_in_element,
-          const arma::mat & P_FE);
+          const helfem::Matrix & P_FE);
 
       /// Per-(iel, jel) accessor variant of the above K helper, for
       /// kernels whose r1/r2 coupling does NOT factorise into a
@@ -137,10 +137,10 @@ namespace helfem {
       /// available -- O(Nel^2) per call.
       using PerElementPairAccessor =
           std::function<const helfem::Matrix & (size_t iel, size_t jel)>;
-      arma::mat assemble_K_FE_one_multipole_cached_pairwise(
+      helfem::Matrix assemble_K_FE_one_multipole_cached_pairwise(
           const FEMRadialBasis & radial,
           const PerElementPairAccessor & ktei_pairwise,
-          const arma::mat & P_FE);
+          const helfem::Matrix & P_FE);
 
       /// Cholesky-factored variants of the cached J / K helpers. Both
       /// take the SAME per-element J-ordered Cholesky factor of shape
@@ -174,19 +174,19 @@ namespace helfem {
       /// Cross-element pieces are unchanged -- still use the disjoint
       /// r_small / r_big factorisation. Only the in-element 4-index
       /// path is factored.
-      arma::mat assemble_J_FE_one_multipole_cached_chol(
+      helfem::Matrix assemble_J_FE_one_multipole_cached_chol(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & twoe_chol_J,
-          const arma::mat & P_FE);
+          const helfem::Matrix & P_FE);
 
-      arma::mat assemble_K_FE_one_multipole_cached_chol(
+      helfem::Matrix assemble_K_FE_one_multipole_cached_chol(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & twoe_chol_J,
-          const arma::mat & P_FE);
+          const helfem::Matrix & P_FE);
 
       // Inline implementations -- header-only to match the rest of the
       // libhelfem/include/ NAO surface. ~150 LOC total.
@@ -351,15 +351,15 @@ namespace helfem {
       // match the new Eigen-typed accessors and caches. P_FE input and
       // J/K output are still arma (the TwoDBasis SCF assembly is still
       // arma-typed) -- bridged at the entry/exit boundary.
-      inline arma::mat assemble_J_FE_one_multipole_cached(
+      inline helfem::Matrix assemble_J_FE_one_multipole_cached(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & twoe_in_element,
-          const arma::mat & P_FE) {
+          const helfem::Matrix & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        const helfem::Matrix & P_E = P_FE;
         helfem::Matrix J_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
@@ -390,18 +390,18 @@ namespace helfem {
           J_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj)
               += Eigen::Map<const Eigen::MatrixXd>(Jsub_v.data(), Nj, Nj);
         }
-        return helfem::to_arma(J_E);
+        return J_E;
       }
 
-      inline arma::mat assemble_K_FE_one_multipole_cached(
+      inline helfem::Matrix assemble_K_FE_one_multipole_cached(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & ktei_in_element,
-          const arma::mat & P_FE) {
+          const helfem::Matrix & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        const helfem::Matrix & P_E = P_FE;
         helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
@@ -428,16 +428,16 @@ namespace helfem {
             }
           }
         }
-        return helfem::to_arma(K_E);
+        return K_E;
       }
 
-      inline arma::mat assemble_K_FE_one_multipole_cached_pairwise(
+      inline helfem::Matrix assemble_K_FE_one_multipole_cached_pairwise(
           const FEMRadialBasis & radial,
           const PerElementPairAccessor & ktei_pairwise,
-          const arma::mat & P_FE) {
+          const helfem::Matrix & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        const helfem::Matrix & P_E = P_FE;
         helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
@@ -455,7 +455,7 @@ namespace helfem {
                 += Eigen::Map<const Eigen::MatrixXd>(Ksub_v.data(), Ni, Nj);
           }
         }
-        return helfem::to_arma(K_E);
+        return K_E;
       }
 
       // --- Cholesky-factored cached helpers -----------------------------
@@ -463,15 +463,15 @@ namespace helfem {
       // the in-element 4-index contraction is rewritten as a sum of
       // outer products over the Cholesky rank.
 
-      inline arma::mat assemble_J_FE_one_multipole_cached_chol(
+      inline helfem::Matrix assemble_J_FE_one_multipole_cached_chol(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & twoe_chol_J,
-          const arma::mat & P_FE) {
+          const helfem::Matrix & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        const helfem::Matrix & P_E = P_FE;
         helfem::Matrix J_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
@@ -506,18 +506,18 @@ namespace helfem {
           J_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj)
               += Eigen::Map<const Eigen::MatrixXd>(Jsub_v.data(), Nj, Nj);
         }
-        return helfem::to_arma(J_E);
+        return J_E;
       }
 
-      inline arma::mat assemble_K_FE_one_multipole_cached_chol(
+      inline helfem::Matrix assemble_K_FE_one_multipole_cached_chol(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,
           const PerElementAccessor & r_big,
           const PerElementAccessor & twoe_chol_J,
-          const arma::mat & P_FE) {
+          const helfem::Matrix & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix P_E = helfem::to_eigen(P_FE);
+        const helfem::Matrix & P_E = P_FE;
         helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
@@ -553,7 +553,7 @@ namespace helfem {
             }
           }
         }
-        return helfem::to_arma(K_E);
+        return K_E;
       }
 
       // The uncached entry points just wire on-the-fly accessors that
@@ -561,8 +561,8 @@ namespace helfem {
 
       // Phase 2c: scratchpads are now std::vector<helfem::Matrix>; the
       // is_empty check becomes .size() == 0 (Eigen's empty-by-default).
-      inline arma::mat assemble_J_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
+      inline helfem::Matrix assemble_J_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE) {
         // Per-call temporaries to keep the accessor lambdas returning a
         // stable const reference (storing each computed matrix in a
         // capture-list scratchpad).
@@ -587,8 +587,8 @@ namespace helfem {
         return assemble_J_FE_one_multipole_cached(radial, rs, rb, tw, P_FE);
       }
 
-      inline arma::mat assemble_K_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const arma::mat & P_FE) {
+      inline helfem::Matrix assemble_K_FE_one_multipole(
+          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE) {
         std::vector<helfem::Matrix> scratch_small(radial.Nel());
         std::vector<helfem::Matrix> scratch_big  (radial.Nel());
         std::vector<helfem::Matrix> scratch_ktei (radial.Nel());
@@ -616,9 +616,9 @@ namespace helfem {
         return assemble_K_FE_one_multipole_cached(radial, rs, rb, kt, P_FE);
       }
 
-      inline arma::mat assemble_J_FE_one_multipole_yukawa(
+      inline helfem::Matrix assemble_J_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
-          const arma::mat & P_FE) {
+          const helfem::Matrix & P_FE) {
         std::vector<helfem::Matrix> scratch_small(radial.Nel());
         std::vector<helfem::Matrix> scratch_big  (radial.Nel());
         std::vector<helfem::Matrix> scratch_twoe (radial.Nel());
@@ -640,9 +640,9 @@ namespace helfem {
         return assemble_J_FE_one_multipole_cached(radial, rs, rb, tw, P_FE);
       }
 
-      inline arma::mat assemble_K_FE_one_multipole_yukawa(
+      inline helfem::Matrix assemble_K_FE_one_multipole_yukawa(
           const FEMRadialBasis & radial, int L, double lambda,
-          const arma::mat & P_FE) {
+          const helfem::Matrix & P_FE) {
         std::vector<helfem::Matrix> scratch_small(radial.Nel());
         std::vector<helfem::Matrix> scratch_big  (radial.Nel());
         std::vector<helfem::Matrix> scratch_ktei (radial.Nel());

--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -194,11 +194,8 @@ namespace helfem {
           require_shared_fe_(other, "coulomb_radial");
           require_density_shape_(other, D, "coulomb_radial");
           const FEMRadialBasis & fem = underlying_fem_();
-          // The FE-side assembly helpers are still arma; bridge here.
-          const arma::mat P_FE = helfem::to_arma(
-              helfem::Matrix(other.C_ * D * other.C_.transpose()));
-          const helfem::Matrix J_FE = helfem::to_eigen(
-              assemble_J_FE_one_multipole(fem, k, P_FE));
+          const helfem::Matrix P_FE = other.C_ * D * other.C_.transpose();
+          const helfem::Matrix J_FE = assemble_J_FE_one_multipole(fem, k, P_FE);
           return C_.transpose() * J_FE * C_;
         }
 
@@ -210,10 +207,8 @@ namespace helfem {
           require_shared_fe_(other, "exchange_radial");
           require_density_shape_(other, D, "exchange_radial");
           const FEMRadialBasis & fem = underlying_fem_();
-          const arma::mat P_FE = helfem::to_arma(
-              helfem::Matrix(other.C_ * D * other.C_.transpose()));
-          const helfem::Matrix K_FE = helfem::to_eigen(
-              assemble_K_FE_one_multipole(fem, k, P_FE));
+          const helfem::Matrix P_FE = other.C_ * D * other.C_.transpose();
+          const helfem::Matrix K_FE = assemble_K_FE_one_multipole(fem, k, P_FE);
           return C_.transpose() * K_FE * C_;
         }
 
@@ -229,10 +224,9 @@ namespace helfem {
           if (lambda <= 0.0)
             throw std::logic_error("coulomb_radial_yukawa: lambda must be positive.\n");
           const FEMRadialBasis & fem = underlying_fem_();
-          const arma::mat P_FE = helfem::to_arma(
-              helfem::Matrix(other.C_ * D * other.C_.transpose()));
-          const helfem::Matrix J_FE = helfem::to_eigen(
-              assemble_J_FE_one_multipole_yukawa(fem, k, lambda, P_FE));
+          const helfem::Matrix P_FE = other.C_ * D * other.C_.transpose();
+          const helfem::Matrix J_FE =
+              assemble_J_FE_one_multipole_yukawa(fem, k, lambda, P_FE);
           return C_.transpose() * J_FE * C_;
         }
 
@@ -245,10 +239,9 @@ namespace helfem {
           if (lambda <= 0.0)
             throw std::logic_error("exchange_radial_yukawa: lambda must be positive.\n");
           const FEMRadialBasis & fem = underlying_fem_();
-          const arma::mat P_FE = helfem::to_arma(
-              helfem::Matrix(other.C_ * D * other.C_.transpose()));
-          const helfem::Matrix K_FE = helfem::to_eigen(
-              assemble_K_FE_one_multipole_yukawa(fem, k, lambda, P_FE));
+          const helfem::Matrix P_FE = other.C_ * D * other.C_.transpose();
+          const helfem::Matrix K_FE =
+              assemble_K_FE_one_multipole_yukawa(fem, k, lambda, P_FE);
           return C_.transpose() * K_FE * C_;
         }
 

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -638,10 +638,10 @@ namespace helfem {
                   P(i, j) = 0.5;
                   P(j, i) = 0.5;
                 }
-                arma::mat J =
+                arma::mat J = ::helfem::to_arma(
                     helfem::atomic::basis::
                         assemble_J_FE_one_multipole_cached(
-                            radial, rs, rb, tw, P);
+                            radial, rs, rb, tw, ::helfem::to_eigen(P)));
                 D(i, j) = J(i, j);
                 D(j, i) = D(i, j);
               }
@@ -679,9 +679,9 @@ namespace helfem {
               P(i_star, j_star) = 0.5;
               P(j_star, i_star) = 0.5;
             }
-            arma::mat col =
+            arma::mat col = ::helfem::to_arma(
                 helfem::atomic::basis::assemble_J_FE_one_multipole_cached(
-                    radial, rs, rb, tw, P);
+                    radial, rs, rb, tw, ::helfem::to_eigen(P)));
 
             // Subtract projections onto already-found Cholesky vectors.
             for (const auto & V : B_L_vecs) {
@@ -829,9 +829,9 @@ namespace helfem {
             return prim_tei[Nel*Nel*L + iel*Nel + iel];
           };
           for(int M=-std::min(L,Mmax);M<=std::min(L,Mmax);M++) {
-            Jaux[L][M+Mmax] += Lfac *
+            Jaux[L][M+Mmax] += Lfac * ::helfem::to_arma(
               helfem::atomic::basis::assemble_J_FE_one_multipole_cached(
-                radial, rs, rb, tw, Paux[L][M+Mmax]);
+                radial, rs, rb, tw, ::helfem::to_eigen(Paux[L][M+Mmax])));
           }
         }
 
@@ -965,9 +965,9 @@ namespace helfem {
                 auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return prim_ktei[Nel*Nel*Lc + iel*Nel + iel];
                 };
-                K_block +=
+                K_block += ::helfem::to_arma(
                   helfem::atomic::basis::assemble_K_FE_one_multipole_cached(
-                    radial, rs, rb, kt, Rmat[Lc]);
+                    radial, rs, rb, kt, ::helfem::to_eigen(Rmat[Lc])));
               }
               K.submat(jang*Nrad, kang*Nrad,
                        (jang+1)*Nrad-1, (kang+1)*Nrad-1) -= K_block;
@@ -1080,9 +1080,9 @@ namespace helfem {
                   auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
                     return rs_ktei[Nel*Nel*Lc + iel*Nel + iel];
                   };
-                  K_block +=
+                  K_block += ::helfem::to_arma(
                     helfem::atomic::basis::assemble_K_FE_one_multipole_cached(
-                      radial, rs, rb, kt, Rmat[Lc]);
+                      radial, rs, rb, kt, ::helfem::to_eigen(Rmat[Lc])));
                 }
                 K.submat(jang*Nrad, kang*Nrad,
                          (jang+1)*Nrad-1, (kang+1)*Nrad-1) -= K_block;
@@ -1097,9 +1097,9 @@ namespace helfem {
                   auto kt = [&,Lc](size_t iel, size_t jel) -> const helfem::Matrix & {
                     return rs_ktei[Nel*Nel*Lc + iel*Nel + jel];
                   };
-                  K_block +=
+                  K_block += ::helfem::to_arma(
                     helfem::atomic::basis::assemble_K_FE_one_multipole_cached_pairwise(
-                      radial, kt, Rmat[Lc]);
+                      radial, kt, ::helfem::to_eigen(Rmat[Lc])));
                 }
                 K.submat(jang*Nrad, kang*Nrad,
                          (jang+1)*Nrad-1, (kang+1)*Nrad-1) -= K_block;

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -180,9 +180,8 @@ namespace helfem {
         auto tw = [&](size_t iel) -> const helfem::Matrix & {
           return prim_tei[Nel * Nel * L + iel * Nel + iel];
         };
-        return helfem::to_eigen(
-            arma::mat(Lfac * atomic::basis::assemble_J_FE_one_multipole_cached(
-                radial, rs, rb, tw, P)));
+        return Lfac * atomic::basis::assemble_J_FE_one_multipole_cached(
+            radial, rs, rb, tw, helfem::to_eigen(P));
       }
 
       arma::cube TwoDBasis::exchange(const arma::cube & P) const {
@@ -283,8 +282,9 @@ namespace helfem {
               auto kt = [&,Lint](size_t iel) -> const helfem::Matrix & {
                 return prim_ktei[Nel * Nel * Lint + iel * Nel + iel];
               };
-              K.slice(lout) -= atomic::basis::assemble_K_FE_one_multipole_cached(
-                  radial, rs, rb, kt, Prad.slice(L));
+              K.slice(lout) -= helfem::to_arma(
+                  atomic::basis::assemble_K_FE_one_multipole_cached(
+                      radial, rs, rb, kt, helfem::to_eigen(arma::mat(Prad.slice(L)))));
             }
           }
         }
@@ -389,9 +389,9 @@ namespace helfem {
                 auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
                   return rs_ktei[Nel*Nel*Lc + iel*Nel + iel];
                 };
-                K.slice(lout) -=
+                K.slice(lout) -= helfem::to_arma(
                   atomic::basis::assemble_K_FE_one_multipole_cached(
-                    radial, rs, rb, kt, P_L);
+                    radial, rs, rb, kt, helfem::to_eigen(P_L)));
               } else {
                 // Erfc: rs_ktei has cross-element entries (iel != jel)
                 // because the erfc kernel does not factorise. Delegate
@@ -401,9 +401,9 @@ namespace helfem {
                 auto kt = [&,Lc](size_t iel, size_t jel) -> const helfem::Matrix & {
                   return rs_ktei[Nel*Nel*Lc + iel*Nel + jel];
                 };
-                K.slice(lout) -=
+                K.slice(lout) -= helfem::to_arma(
                   atomic::basis::assemble_K_FE_one_multipole_cached_pairwise(
-                    radial, kt, P_L);
+                    radial, kt, helfem::to_eigen(P_L)));
               }
             }
           }
@@ -585,8 +585,8 @@ namespace helfem {
           throw std::logic_error(oss.str());
         }
         const arma::mat P = c * c.t();
-        const arma::mat Jk =
-            atomic::basis::assemble_J_FE_one_multipole(radial, k, P);
+        const arma::mat Jk = helfem::to_arma(
+            atomic::basis::assemble_J_FE_one_multipole(radial, k, helfem::to_eigen(P)));
         return arma::trace(P * Jk);
       }
 


### PR DESCRIPTION
## Summary

Task #17 progress. The full family of one-multipole J/K assembly helpers (10 functions total, both cached and uncached variants, bare Coulomb + Yukawa) migrates from \`arma::mat\` to \`helfem::Matrix\` on both input and output.

## Functions migrated

Signatures (declarations + inline definitions):

| Function | Before | After |
|---|---|---|
| \`assemble_J_FE_one_multipole\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_K_FE_one_multipole\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_J_FE_one_multipole_yukawa\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_K_FE_one_multipole_yukawa\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_J_FE_one_multipole_cached\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_K_FE_one_multipole_cached\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_K_FE_one_multipole_cached_pairwise\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_J_FE_one_multipole_cached_chol\` | \`arma::mat\` | \`helfem::Matrix\` |
| \`assemble_K_FE_one_multipole_cached_chol\` | \`arma::mat\` | \`helfem::Matrix\` |

All P_FE inputs and J/K returns are now \`helfem::Matrix\`; the \`helfem::to_eigen(P_FE)\` at entry and \`helfem::to_arma(J_E)/K_E\` at exit that Phase 2c installed are gone. Interior arithmetic is unchanged — it was already Eigen.

The arma-typed overload of \`utils::exchange_tei\` is **preserved** — it's used exclusively by \`src/diatomic/basis.cpp\` (cached \`prim_ktei\` building) which stays arma-native.

## Callers

In-tree callers all still hold \`arma::mat\` densities / accumulators. Each call site gets one \`helfem::to_eigen(...)\` at the argument and one \`helfem::to_arma(...)\` at the result:

- \`src/atomic/TwoDBasis.cpp\` — 6 sites in the SCF J assembly (Cholesky construction + main J driver + auxiliary field terms) and K assembly (per-thread K blocks over angular momenta; both erfc-pairwise and disjoint).
- \`src/sadatom/basis.cpp\` — 4 sites in the per-l J/K assembly (both the main FE-cached path and one auxiliary <r^k> evaluator).

\`libhelfem/include/NAORadialBasis.h\` — the four \`coulomb_radial\` / \`exchange_radial\` / \`*_yukawa\` methods drop their four \`to_arma(P_FE)\` → assemble → \`to_eigen(J/K_FE)\` round-trips in favour of direct Eigen calls. **Every one-electron and two-electron matrix element on the NAO surface is now pure Eigen.**

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)
- H2 LDA_X diatomic: **−1.0436626091** (bit-identical baseline)

## Task #17 status

Remaining \`arma::\` in \`libhelfem/include\`:
- \`CoulombExchangeFE.h:29\` — \`utils::exchange_tei(arma::mat)\` overload (diatomic-only helper, kept intentionally)
- \`ArmaEigen.h\`, \`Matrix.h\` — bridge layer, arma is by design

**Every libhelfem PUBLIC header the SCF-driver / consumer paths touch** (RadialBasis.h, FiniteElementBasis.h, PolynomialBasis.h, NAORadialBasis.h, GTO.h, STO.h, ModelPotential.h, helfem.source.h, CoulombExchangeFE.h assemble_J/K helpers) **is now arma-free in code.**

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged across atomic, sadatom, diatomic
- [x] Zero \`arma::TYPE\` refs in the migrated function signatures + impls