### PR TITLE
libhelfem + lib1dfem: strip historical arma migration comments

### DIFF
--- a/lib1dfem/include/lib1dfem/PolynomialBasis.h
+++ b/lib1dfem/include/lib1dfem/PolynomialBasis.h
@@ -30,7 +30,7 @@ namespace polynomial_basis {
 /// GeneralHIPBasis, LegendreBasis) implement eval_prim_dnf, copy,
 /// drop_first, drop_last and may override get_nodes.
 ///
-/// Templated on the scalar type T (Phase 5.2: lib1dfem migrated arma -> Eigen).
+/// Templated on the scalar type T.
 template <typename T>
 class PolynomialBasis {
  protected:

--- a/lib1dfem/include/lib1dfem/chebyshev.h
+++ b/lib1dfem/include/lib1dfem/chebyshev.h
@@ -22,10 +22,9 @@ namespace helfem {
 namespace lib1dfem {
 namespace chebyshev {
 
-// Phase 5.1: lib1dfem primitives migrated arma -> Eigen using the
-// Vec<T> / Mat<T> shorthand from <lib1dfem/types.h>. The libhelfem
-// double-only shim (libhelfem/src/chebyshev.h) bridges arma::vec on
-// the boundary so existing callers compile unchanged.
+// Templated Gauss-Chebyshev quadrature primitives. libhelfem keeps a
+// thin double-only shim at libhelfem/src/chebyshev.h for callers that
+// still spell the output vectors as arma::vec.
 
 /// Modified Gauss-Chebyshev quadrature of the second kind for
 ///     integral_{-1}^{1} f(x) dx

--- a/lib1dfem/include/lib1dfem/types.h
+++ b/lib1dfem/include/lib1dfem/types.h
@@ -18,13 +18,10 @@
 #include <Eigen/Core>
 
 // Shorthand aliases for the dynamic-size Eigen types used throughout
-// lib1dfem (and re-exported by libhelfem). Phase 5.x of the arma -> Eigen
-// migration: the full `Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>`
-// type spelling is unreadable in template-heavy code, so the migrated
-// headers spell vectors and matrices as `Vec<T>` / `Mat<T>` instead.
-//
-// Column-major storage to match arma::mat / arma::vec so the libhelfem
-// boundary shims stay zero-copy at T = double.
+// lib1dfem (and re-exported by libhelfem). The full
+// `Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>` spelling is
+// unreadable in template-heavy code, so vectors and matrices spell as
+// `Vec<T>` / `Mat<T>` instead. Column-major storage.
 
 namespace helfem {
 namespace lib1dfem {
@@ -38,9 +35,8 @@ using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 template <typename T>
 using RowVec = Eigen::Matrix<T, 1, Eigen::Dynamic>;
 
-/// Index vector (signed Eigen::Index = ptrdiff_t). Used wherever the
-/// arma::uvec lived in the v1 code -- typically for the `enabled`
-/// column-selection list on PolynomialBasis subclasses.
+/// Signed index vector -- typically for the `enabled` column-selection
+/// list on PolynomialBasis subclasses.
 using IVec = Eigen::Matrix<Eigen::Index, Eigen::Dynamic, 1>;
 
 } // namespace lib1dfem

--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -26,11 +26,12 @@ namespace helfem {
   // public include path; the symbol is resolved at link time -- callers
   // of these helpers link against libhelfem anyway).
   namespace utils {
+    /// Arma-typed (ij|kl) -> (jk|il) permutation. Used by the diatomic
+    /// prim_ktei build path.
     arma::mat exchange_tei(const arma::mat & tei, size_t Ni, size_t Nj,
                             size_t Nk, size_t Nl);
-    /// Eigen overload (Phase 2c wrap-up): same (ij|kl) -> (jk|il) permutation
-    /// for helfem::Matrix-typed in-element TEIs, avoids the
-    /// to_eigen(to_arma(...)) round-trip the helpers used to do.
+    /// Eigen overload of the same permutation for helfem::Matrix-typed
+    /// in-element TEIs.
     helfem::Matrix exchange_tei(const helfem::Matrix & tei, size_t Ni, size_t Nj,
                                  size_t Nk, size_t Nl);
   }
@@ -297,9 +298,6 @@ namespace helfem {
         for (int L = 0; L < N_L; ++L) {
           for (size_t iel = 0; iel < Nel; ++iel) {
             const size_t Ni = radial.Nprim(iel);
-            // Phase 2c wrap-up: utils::exchange_tei now has an Eigen
-            // overload, so prim_tei (Eigen) -> prim_ktei (Eigen) is
-            // direct -- no arma round-trip.
             prim_ktei[Nel * Nel * (size_t) L + iel * Nel + iel] =
                 helfem::utils::exchange_tei(
                     prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel],
@@ -347,10 +345,6 @@ namespace helfem {
       // NAO use) and cached (look-up-from-SCF-cache, TwoDBasis use)
       // entry points.
 
-      // Phase 2c: assemble helpers migrated to Eigen internals so they
-      // match the new Eigen-typed accessors and caches. P_FE input and
-      // J/K output are still arma (the TwoDBasis SCF assembly is still
-      // arma-typed) -- bridged at the entry/exit boundary.
       inline helfem::Matrix assemble_J_FE_one_multipole_cached(
           const FEMRadialBasis & radial,
           const PerElementAccessor & r_small,

--- a/libhelfem/include/GTO.h
+++ b/libhelfem/include/GTO.h
@@ -47,9 +47,8 @@ namespace helfem {
       /// A contracted GTO basis function: f(r) = sum_i c_i R_i(r).
       struct GTOContracted {
         std::vector<GTOPrimitive> primitives;
-        /// Phase 5.27: Eigen at the consumer boundary. Users can
-        /// construct via `helfem::Vector::Map(data, n)` from any
-        /// double* range without an armadillo dependency.
+        /// Contraction coefficients. Construct via
+        /// `helfem::Vector::Map(data, n)` from any double* range.
         helfem::Vector            contraction;
       };
 
@@ -135,9 +134,7 @@ namespace helfem {
             /*zero_func_right*/true, /*zero_deriv_right*/false);
         atomic::basis::FEMRadialBasis radial(fem, 5 * poly->get_nbf());
         const helfem::Matrix S = radial.overlap();
-        // Quadrature points + weights for the projection integrals. Go
-        // straight to lib1dfem's Eigen-typed templated chebyshev to skip
-        // libhelfem's legacy arma-shim.
+        // Quadrature points + weights for the projection integrals.
         helfem::Vector xq, wq;
         helfem::lib1dfem::chebyshev::chebyshev<double>(
             5 * poly->get_nbf(), xq, wq);

--- a/libhelfem/include/NAORadialBasis.h
+++ b/libhelfem/include/NAORadialBasis.h
@@ -65,9 +65,6 @@ namespace helfem {
         /// Underlying radial basis (typically a FEMRadialBasis).
         std::shared_ptr<const RadialBasis> underlying_;
         /// Orbital coefficient matrix, shape (Nbf_underlying x Nbf_NAO).
-        /// Phase 5.28: Eigen-typed storage; every matrix element flows
-        /// through helfem::Matrix from the underlying basis to the
-        /// downstream Fock builder without an arma round-trip.
         helfem::Matrix C_;
 
        public:

--- a/libhelfem/include/STO.h
+++ b/libhelfem/include/STO.h
@@ -50,9 +50,8 @@ namespace helfem {
       /// will produce an L2-orthonormal NAO basis from them.
       struct STOContracted {
         std::vector<STOPrimitive> primitives;
-        /// Phase 5.27: Eigen at the consumer boundary. Users can
-        /// construct via `helfem::Vector::Map(data, n)` from any
-        /// double* range without an armadillo dependency.
+        /// Contraction coefficients. Construct via
+        /// `helfem::Vector::Map(data, n)` from any double* range.
         helfem::Vector            contraction;
       };
 
@@ -160,9 +159,7 @@ namespace helfem {
             /*zero_func_right*/true, /*zero_deriv_right*/false);
         atomic::basis::FEMRadialBasis radial(fem, 5 * poly->get_nbf());
         const helfem::Matrix S = radial.overlap();
-        // Quadrature points + weights for the projection integrals. Go
-        // straight to lib1dfem's Eigen-typed templated chebyshev to skip
-        // libhelfem's legacy arma-shim.
+        // Quadrature points + weights for the projection integrals.
         helfem::Vector xq, wq;
         helfem::lib1dfem::chebyshev::chebyshev<double>(
             5 * poly->get_nbf(), xq, wq);


### PR DESCRIPTION
## Summary

Task #17 housekeeping. The full arma → Eigen migration is essentially complete for the public headers; the accumulated *'Phase 5.x: was arma::mat'*, *'to_eigen(to_arma(...)) round-trip the helpers used to do'*, and *'legacy arma-shim'* comments were useful during the migration but are archaeology now.

## Removed

**\`lib1dfem/include/lib1dfem/types.h\`**
- *'Phase 5.x of the arma → Eigen migration'* paragraph on the Vec/Mat aliases
- *'wherever the arma::uvec lived in the v1 code'* note on IVec

**\`lib1dfem/include/lib1dfem/chebyshev.h\`**
- *'Phase 5.1: lib1dfem primitives migrated arma → Eigen'* block replaced with a compact statement about the double-only shim

**\`lib1dfem/include/lib1dfem/PolynomialBasis.h\`**
- *'Phase 5.2: lib1dfem migrated arma → Eigen'* parenthetical

**\`libhelfem/include/GTO.h\` + \`STO.h\`**
- *'Phase 5.27: Eigen at the consumer boundary'* preamble on the contraction field, replaced with a plain construction note
- *'Go straight to lib1dfem's Eigen-typed templated chebyshev to skip libhelfem's legacy arma-shim'* comment on the chebyshev call site; the code speaks for itself

**\`libhelfem/include/NAORadialBasis.h\`**
- *'Phase 5.28: Eigen-typed storage; every matrix element flows through helfem::Matrix from the underlying basis to the downstream Fock builder without an arma round-trip'* block on \`C_\`, replaced with the plain *'Orbital coefficient matrix, shape (Nbf_underlying x Nbf_NAO)'* one-liner

**\`libhelfem/include/CoulombExchangeFE.h\`**
- *'Phase 2c wrap-up'* explanations on \`utils::exchange_tei\`'s Eigen overload — replaced with a plain *'Arma-typed for the diatomic prim_ktei build path'* note on the arma overload and *'Eigen overload of the same permutation'* on the Eigen one
- *'no arma round-trip'* comment in the inline prim_ktei loop (self-evident from the code)
- *'Phase 2c: assemble helpers migrated to Eigen internals'* block on \`assemble_J_FE_one_multipole_cached\`; the docstring above the declarations already explains what it does

## Remaining arma in libhelfem/include (all intentional)

- \`CoulombExchangeFE.h:20\` \`#include <armadillo>\`
- \`CoulombExchangeFE.h:31\` \`arma::mat exchange_tei(const arma::mat &, ...)\` — diatomic-only helper; kept for the diatomic prim_ktei path
- \`ArmaEigen.h\`, \`Matrix.h\` — bridge layer, arma by design
- \`chebyshev.h:27\` — one accurate reference to the \`arma::vec\` output of the libhelfem double-only shim

## Validation

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)
- Be atomic HF: **−14.5728772811245939** (bit-identical baseline)

## Test plan (verified)

- [x] Full build clean
- [x] eigen_foundation_test passes
- [x] Regression baselines unchanged