### PR TITLE
libhelfem: install NAORadialBasis / GTO / STO / CoulombExchangeFE headers

### DIFF
--- a/libhelfem/CMakeLists.txt
+++ b/libhelfem/CMakeLists.txt
@@ -17,7 +17,6 @@ list(APPEND LIBHELFEM_PUBLIC_HEADERS
     "ModelPotential.h"
     "GaussianNucleus.h"
     "HollowNucleus.h"
-    "ModelPotential.h"
     "PointNucleus.h"
     "PolynomialBasis.h"
     "FiniteElementBasis.h"
@@ -26,6 +25,16 @@ list(APPEND LIBHELFEM_PUBLIC_HEADERS
     "RegularizedNucleus.h"
     "Matrix.h"
     "ArmaEigen.h"
+    # NAO surface -- installed for libatomscf-style consumers that
+    # build atom-centred numerical-orbital bases in their own SCF
+    # driver, using libhelfem's FE-projection factories:
+    "NAORadialBasis.h"
+    "GTO.h"
+    "STO.h"
+    # One-multipole J/K assembly helpers used by the NAO two-electron
+    # methods and by any consumer driving its own Fock build over an
+    # FE-backed atomic basis.
+    "CoulombExchangeFE.h"
 )
 foreach(header IN LISTS LIBHELFEM_PUBLIC_HEADERS)
     configure_file("include/${header}" "include/${header}" COPYONLY)


### PR DESCRIPTION
## Summary

Task #17 wrap-up. The four consumer-facing headers migrated in the recent arma-to-Eigen sweep

- \`libhelfem/include/NAORadialBasis.h\` (PR #164)
- \`libhelfem/include/GTO.h\` + \`STO.h\` (PR #163)
- \`libhelfem/include/CoulombExchangeFE.h\` (PR #165)

are now added to \`LIBHELFEM_PUBLIC_HEADERS\` so a downstream consumer doing \`find_package(helfem)\` can \`#include\` them directly. Previously they were compiled and Eigen-native but not on the install list — libatomscf-style consumers had to reach into the source tree by hand.

Also drops one duplicate \`ModelPotential.h\` entry that was in the whitelist twice; net addition is **+4 headers**.

## Validation

Fresh install to \`/tmp/install-check/install\`. All four headers land at \`\${PREFIX}/include/\`:

\`\`\`
NAORadialBasis.h
GTO.h
STO.h
CoulombExchangeFE.h
\`\`\`

**Throwaway consumer test** (\`/tmp/nao-consumer\`) with a 3-line CMakeLists.txt:

\`\`\`cmake
cmake_minimum_required(VERSION 3.14)
project(nao_smoke_test CXX)
find_package(helfem CONFIG REQUIRED)
add_executable(nao_smoke_test nao_smoke_test.cpp)
target_link_libraries(nao_smoke_test PRIVATE helfem::helfem)
\`\`\`

Consumer source \`#include\`s NAORadialBasis.h, GTO.h, STO.h, CoulombExchangeFE.h — **zero arma includes on the consumer side**. Builds and runs against the installed package. Output confirms the Eigen-native surface works end-to-end:

\`\`\`
STO basis Nbf = 2
GTO basis Nbf = 1
STO S(0,0)  = 1.000000   (normalized 1s Slater self-overlap)
STO T(0,0)  = 0.500000   (Ekin = zeta^2/2 = 0.5 for zeta=1)
GTO S(0,0)  = 1.000000
STO J^0(D=I)(0,0)  = 1.439815
\`\`\`

## Regression

- \`eigen_foundation_test\`: 13/13 PASS
- He gensap HF: **Etot = −2.861679987** (unchanged)

## Test plan (verified)

- [x] Fresh install completes
- [x] All four new headers land in \`\${PREFIX}/include/\`
- [x] External consumer (3-line CMakeLists, zero arma includes) builds
- [x] External consumer runs to completion with physically-correct values
- [x] Regression baselines unchanged