### PR TITLE
build: accept Eigen 5.x -- version range + placeholder shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,11 @@ endif()
 # converters in libhelfem/include without yet replacing Armadillo
 # anywhere. Subsequent phases migrate libhelfem and src/ leaf-by-leaf.
 # Prefer a system-installed Eigen3 >= 3.4, otherwise fetch v3.4.0.
-find_package(Eigen3 3.4 QUIET NO_MODULE)
+# Use the CMake range form `3.4...99` so that any 3.4-or-newer install
+# is accepted. A bare `3.4` request is treated by Eigen's stock
+# Eigen3ConfigVersion.cmake as the exclusive range [3.4, 3.5) and
+# rejects e.g. Fedora's Eigen 5.0.1.
+find_package(Eigen3 3.4...99 QUIET NO_MODULE)
 if(NOT Eigen3_FOUND)
     message(STATUS "Eigen3 >= 3.4 not found via find_package; fetching v3.4.0")
     include(FetchContent)

--- a/cmake/helfemConfig.cmake.in
+++ b/cmake/helfemConfig.cmake.in
@@ -16,7 +16,10 @@ include(CMakeFindDependencyMacro)
 # Transitive deps -- these must be resolvable by the consumer's
 # find_package chain so the IMPORTED targets in helfemTargets.cmake
 # find their linkage.
-find_dependency(Eigen3 3.4 CONFIG)
+# Range form `3.4...99` so any Eigen >= 3.4 is accepted. A bare `3.4`
+# is treated by Eigen's ConfigVersion.cmake as the exclusive range
+# [3.4, 3.5) and rejects e.g. Fedora's Eigen 5.0.1.
+find_dependency(Eigen3 3.4...99 CONFIG)
 find_dependency(wignernj 0.5.0)
 # OpenMP is included in helfem-common's INTERFACE_LINK_LIBRARIES so
 # consumers inherit -fopenmp / libgomp automatically. We must be able

--- a/lib1dfem/include/lib1dfem/types.h
+++ b/lib1dfem/include/lib1dfem/types.h
@@ -17,6 +17,18 @@
 
 #include <Eigen/Core>
 
+// Eigen 5 moved the indexing placeholders `all`, `last`, `lastp1`
+// from namespace `Eigen` into `Eigen::placeholders`. Everything in
+// HelFEM was written against the 3.x location, so re-expose them at
+// the old spelling for any Eigen >= 4.9 (i.e. 5.x prereleases and up).
+#if EIGEN_VERSION_AT_LEAST(4, 90, 0)
+namespace Eigen {
+  using placeholders::all;
+  using placeholders::last;
+  using placeholders::lastp1;
+}
+#endif
+
 // Shorthand aliases for the dynamic-size Eigen types used throughout
 // lib1dfem (and re-exported by libhelfem). The full
 // `Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>` spelling is

--- a/libhelfem/include/Matrix.h
+++ b/libhelfem/include/Matrix.h
@@ -16,6 +16,18 @@
 #include <Eigen/Core>
 #include <vector>
 
+// Eigen 5 moved the indexing placeholders `all`, `last`, `lastp1`
+// from namespace `Eigen` into `Eigen::placeholders`. HelFEM code was
+// written against the 3.x location; re-expose them at the old
+// spelling for any Eigen >= 4.9 (5.x prereleases and up).
+#if EIGEN_VERSION_AT_LEAST(4, 90, 0)
+namespace Eigen {
+  using placeholders::all;
+  using placeholders::last;
+  using placeholders::lastp1;
+}
+#endif
+
 namespace helfem {
 
   // Phase 4 of the Eigen migration arc.


### PR DESCRIPTION
## Summary

- The top-level `find_package(Eigen3 3.4 ...)` requests version *3.4* as a single component. Eigen's stock `Eigen3ConfigVersion.cmake` treats a single-component request as the exclusive range `[3.4, 3.5)`, so a Fedora system Eigen (currently `eigen3-devel 5.0.1`) is rejected as "incompatible" and CMake silently falls back to fetching Eigen 3.4.0 from GitLab.
- Fix: switch both the top-level `find_package` and the exported `helfemConfig.cmake.in`'s `find_dependency` to the CMake **range form** `3.4...99`, so any Eigen `>=3.4` is accepted.
- The next thing that breaks against Eigen 5 is the indexing placeholders: `Eigen::all` / `Eigen::last` / `Eigen::lastp1` were moved into `Eigen::placeholders::`. Our lib1dfem `PolynomialBasis::eval_dnf` and atomic `scf_helpers` were written against the 3.x location. Add a small compatibility shim (guarded by `EIGEN_VERSION_AT_LEAST(4, 90, 0)`) at the two type-header entry points — `libhelfem/include/Matrix.h` and `lib1dfem/include/lib1dfem/types.h` — that re-exposes the placeholders at the old spelling, so all call sites compile against both 3.4 and 5.x without further edits.

## Test plan

- [x] `mkdir objdir && cd objdir && cmake .. && make -j` on Fedora 44 with `eigen3-devel 5.0.1` — reports `Using system Eigen3 (5.0.1)` and builds all binaries clean.
- [x] `./src/atomic_itest 15 1.0`, `./src/legendre_test` run to completion.
- [ ] Re-verify with an Eigen 3.4 install (should be unchanged; the shim is a no-op when `EIGEN_VERSION_AT_LEAST(4, 90, 0)` is false, and the range `3.4...99` still admits 3.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)