### PR TITLE
libhelfem: PolynomialBasis.cpp arma-free

### DIFF
--- a/libhelfem/src/PolynomialBasis.cpp
+++ b/libhelfem/src/PolynomialBasis.cpp
@@ -19,25 +19,14 @@
 // constructs the concrete libhelfem-side polynomial bases by primitive ID.
 
 #include "PolynomialBasis.h"
-#include "lobatto.h"
 #include "LIPBasis.h"
 #include "HIPBasis.h"
 #include "LegendreBasis.h"
 #include <lib1dfem/HIP2Basis.h>  // analytic HIP order 2 (primbas=8 since v2)
 #include <lib1dfem/HIP3Basis.h>  // analytic HIP order 3 (primbas=9 since v2)
-#include <ArmaEigen.h>
-#include <cstring>
+#include <lib1dfem/lobatto.h>
+#include <cmath>
 
-namespace {
-  // Phase 5.2: lib1dfem PolynomialBasis subclasses now take Vec<T>
-  // (Eigen) constructors. This helper bridges from arma::vec at the
-  // libhelfem factory boundary; copy cost is one-time at basis setup.
-  inline helfem::lib1dfem::Vec<double> arma_to_eigen_vec(const arma::vec & v) {
-    helfem::lib1dfem::Vec<double> e(v.n_elem);
-    std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
-    return e;
-  }
-} // namespace
 // (GeneralHIPBasis was removed when its callers were either rerouted to
 // analytic HIP2/HIP3 (primbas=8, 9) or deprecated (primbas=6, 7, 10, 11).)
 
@@ -63,40 +52,38 @@ namespace helfem {
 
       case(4):
         {
-          arma::vec x, w;
-          ::lobatto_compute(Nnodes,x,w);
-          poly=new polynomial_basis::LIPBasis(arma_to_eigen_vec(x),primbas);
+          helfem::lib1dfem::Vec<double> x, w;
+          helfem::lib1dfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
+          poly=new polynomial_basis::LIPBasis(x, primbas);
           printf("Basis set composed of %i-node LIPs with Gauss-Lobatto nodes.\n",Nnodes);
           break;
         }
 
       case(5):
         {
-          arma::vec x, w;
-          ::lobatto_compute(Nnodes,x,w);
-          poly=new polynomial_basis::HIPBasis(arma_to_eigen_vec(x),primbas);
+          helfem::lib1dfem::Vec<double> x, w;
+          helfem::lib1dfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
+          poly=new polynomial_basis::HIPBasis(x, primbas);
           printf("Basis set composed of %i-node HIPs with Gauss-Lobatto nodes.\n",Nnodes);
           break;
         }
 
       case(100):
         {
-          arma::vec ang(Nnodes);
+          helfem::lib1dfem::Vec<double> x(Nnodes);
           for(int i=0;i<Nnodes;i++)
-            ang(i) = M_PI*(Nnodes-1-i)/(Nnodes-1);
-          arma::vec x=arma::cos(ang);
-          poly=new polynomial_basis::LIPBasis(arma_to_eigen_vec(x),4);
+            x(i) = std::cos(M_PI*(Nnodes-1-i)/(Nnodes-1));
+          poly=new polynomial_basis::LIPBasis(x, 4);
           printf("Basis set composed of %i-node LIPs with Chebyshev nodes.\n",Nnodes);
           break;
         }
 
       case(101):
         {
-          arma::vec ang(Nnodes);
+          helfem::lib1dfem::Vec<double> x(Nnodes);
           for(int i=0;i<Nnodes;i++)
-            ang(i) = M_PI*(Nnodes-1-i)/(Nnodes-1);
-          arma::vec x=arma::cos(ang);
-          poly=new polynomial_basis::HIPBasis(arma_to_eigen_vec(x),5);
+            x(i) = std::cos(M_PI*(Nnodes-1-i)/(Nnodes-1));
+          poly=new polynomial_basis::HIPBasis(x, 5);
           printf("Basis set composed of %i-node HIPs with Chebyshev nodes.\n",Nnodes);
           break;
         }
@@ -105,9 +92,9 @@ namespace helfem {
         {
           // Analytic HIP2 (closed-form Hermite, second-order). Replaces the
           // runtime-inverted GeneralHIPBasis(nder=2) path.
-          arma::vec x, w;
-          ::lobatto_compute(Nnodes, x, w);
-          poly = new lib1dfem::polynomial_basis::HIP2Basis<double>(arma_to_eigen_vec(x), primbas);
+          helfem::lib1dfem::Vec<double> x, w;
+          helfem::lib1dfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
+          poly = new lib1dfem::polynomial_basis::HIP2Basis<double>(x, primbas);
           printf("Basis set composed of %i-node 2nd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
           break;
         }
@@ -116,9 +103,9 @@ namespace helfem {
         {
           // Analytic HIP3 (closed-form Hermite, third-order). Replaces the
           // runtime-inverted GeneralHIPBasis(nder=3) path.
-          arma::vec x, w;
-          ::lobatto_compute(Nnodes, x, w);
-          poly = new lib1dfem::polynomial_basis::HIP3Basis<double>(arma_to_eigen_vec(x), primbas);
+          helfem::lib1dfem::Vec<double> x, w;
+          helfem::lib1dfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
+          poly = new lib1dfem::polynomial_basis::HIP3Basis<double>(x, primbas);
           printf("Basis set composed of %i-node 3rd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
           break;
         }


### PR DESCRIPTION
## Summary

`get_basis(primbas, Nnodes)` was the only remaining arma consumer inside `libhelfem/src/PolynomialBasis.cpp`. It buffered the node grid in `arma::vec` before feeding it, via a one-liner `arma_to_eigen_vec` bridge, into each concrete `lib1dfem::polynomial_basis::*` subclass whose constructors have accepted `helfem::lib1dfem::Vec<double>` since Phase 5.2.

Skip the detour:

- Request the Gauss-Lobatto nodes straight from lib1dfem's Eigen-typed `helfem::lib1dfem::lobatto::lobatto_compute<double>` (primbas = 4, 5, 8, 9).
- Build the Chebyshev-node grid on a `Vec<double>` in one loop (primbas = 100, 101).
- Pass the resulting `Vec<double>` directly to `LIPBasis` / `HIPBasis` / `HIP2Basis<double>` / `HIP3Basis<double>`.

Drops the anonymous-namespace `arma_to_eigen_vec` helper, `#include "lobatto.h"` (the libhelfem arma shim), and `#include <ArmaEigen.h>`. Adds `#include <lib1dfem/lobatto.h>` and `#include <cmath>`.

## Test plan

- [x] Full build clean on Fedora 44 + Eigen 5.0.1.
- [x] `./src/atomic --Z=1 --lmax=0 --mmax=0 --nelem=5 --nela=1 --nelb=0 --primbas=4 --nnodes=5` and `--primbas=5 --nnodes=5` both construct their bases (`Basis set composed of 5-node LIPs / HIPs with Gauss-Lobatto nodes.`) and pass the continuity check (`max discontinuity 0.000000e+00`).

The buffered node grid is a `Vec<double>` of exactly `Nnodes` doubles copied from the same underlying lib1dfem routine, so the produced LIP / HIP / HIP2 / HIP3 bases are bit-identical to the arma path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)