### PR TITLE
libhelfem: utils.{h,cpp} drop dead arma::vec overloads

### DIFF
--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -18,67 +18,18 @@
 #include <Eigen/Eigenvalues>
 #include <Eigen/LU>
 #include <cmath>
-#include <cstring>
 
 namespace helfem {
   namespace utils {
-    // v2 refactor (Phase 1): the pure-math helpers (arcosh, arsinh,
-    // bessel_il, bessel_kl) now live in lib1dfem and are templated on the
-    // scalar type. The functions below are thin double-only compatibility
-    // shims that forward to the templated implementations.
-
+    // Scalar-only wrappers around the templated lib1dfem math helpers.
     double arcosh(double x) {
       return helfem::lib1dfem::math::arcosh<double>(x);
     }
-
-    // Phase 5.1: lib1dfem math helpers are Eigen-typed. The arma::vec
-    // shims convert one direction at the boundary.
-    arma::vec arcosh(const arma::vec & x) {
-      Eigen::Matrix<double, Eigen::Dynamic, 1> xe(x.n_elem);
-      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
-      auto ye = helfem::lib1dfem::math::arcosh<double>(xe);
-      arma::vec y(ye.size());
-      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
-      return y;
-    }
-
-    double arsinh(double x) {
-      return helfem::lib1dfem::math::arsinh<double>(x);
-    }
-
-    arma::vec arsinh(const arma::vec & x) {
-      Eigen::Matrix<double, Eigen::Dynamic, 1> xe(x.n_elem);
-      std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
-      auto ye = helfem::lib1dfem::math::arsinh<double>(xe);
-      arma::vec y(ye.size());
-      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
-      return y;
-    }
-
     double bessel_il(double r, int L) {
       return helfem::lib1dfem::math::bessel_il<double>(r, L);
     }
-
-    arma::vec bessel_il(const arma::vec & r, int L) {
-      Eigen::Matrix<double, Eigen::Dynamic, 1> re(r.n_elem);
-      std::memcpy(re.data(), r.memptr(), sizeof(double) * r.n_elem);
-      auto ye = helfem::lib1dfem::math::bessel_il<double>(re, L);
-      arma::vec y(ye.size());
-      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
-      return y;
-    }
-
     double bessel_kl(double r, int L) {
       return helfem::lib1dfem::math::bessel_kl<double>(r, L);
-    }
-
-    arma::vec bessel_kl(const arma::vec & r, int L) {
-      Eigen::Matrix<double, Eigen::Dynamic, 1> re(r.n_elem);
-      std::memcpy(re.data(), r.memptr(), sizeof(double) * r.n_elem);
-      auto ye = helfem::lib1dfem::math::bessel_kl<double>(re, L);
-      arma::vec y(ye.size());
-      std::memcpy(y.memptr(), ye.data(), sizeof(double) * (size_t) ye.size());
-      return y;
     }
 
     arma::mat product_tei(const arma::mat & ijint, const arma::mat & klint) {

--- a/libhelfem/src/utils.h
+++ b/libhelfem/src/utils.h
@@ -22,21 +22,11 @@ namespace helfem {
   namespace utils {
     /// inverse cosh
     double arcosh(double x);
-    /// inverse cosh
-    arma::vec arcosh(const arma::vec & x);
-    /// inverse sinh
-    double arsinh(double x);
-    /// inverse sinh
-    arma::vec arsinh(const arma::vec & x);
 
     /// Modified Bessel function
     double bessel_il(double x, int L);
     /// Modified Bessel function
-    arma::vec bessel_il(const arma::vec & x, int L);
-    /// Modified Bessel function
     double bessel_kl(double x, int L);
-    /// Modified Bessel function
-    arma::vec bessel_kl(const arma::vec & x, int L);
 
     /// Form two-electron integrals from product of large-r and small-r radial moment matrices
     arma::mat product_tei(const arma::mat & big, const arma::mat & small);


### PR DESCRIPTION
## Summary

`libhelfem/src/utils.h` declared four `arma::vec` overloads of the lib1dfem-templated math helpers -- `arcosh`, `arsinh`, `bessel_il`, `bessel_kl` -- plus a scalar `arsinh(double)`. All are dead:

- Every remaining caller of `utils::arcosh` (`src/diatomic/{main, ooo, 1e, corebasis, density_line}.cpp`) passes a scalar `double`.
- Every remaining caller of `utils::bessel_il` / `bessel_kl` (libhelfem's own `quadrature.cpp` and `RadialBasis.cpp`) also passes a scalar (`r * lambda` from inside a `std::function<double(double)>`).
- `utils::arsinh` has *zero* production callers in either shape.

Delete the four `arma::vec` overloads and the dead scalar `arsinh` from `utils.h` + `utils.cpp` (-60 lines). What survives is a three-function shim table (scalar `arcosh` / `bessel_il` / `bessel_kl`) that forwards to lib1dfem's templated helpers; no arma types cross this boundary.

`utils.h` / `utils.cpp` still `#include <armadillo>` for the remaining `product_tei` / `check_tei_symmetry` / `exchange_tei` declarations -- those have live `src/diatomic/basis.cpp` callers and need the full `src/` sweep.

## Test plan

- [x] Full build clean on Fedora 44 + Eigen 5.0.1.
- [x] H atom SCF (`--Z=1 --nelem=5 --primbas=4 --nnodes=5`) reproduces the total energy `-0.4999825290034230` bit-for-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)