### PR TITLE
libhelfem: CoulombExchangeFE.h drop the retained arma exchange_tei decl

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -16,8 +16,6 @@
 #define ATOMIC_BASIS_COULOMB_EXCHANGE_FE_H
 
 #include "RadialBasis.h"
-#include "ArmaEigen.h"
-#include <armadillo>
 #include <functional>
 
 namespace helfem {
@@ -26,12 +24,9 @@ namespace helfem {
   // public include path; the symbol is resolved at link time -- callers
   // of these helpers link against libhelfem anyway).
   namespace utils {
-    /// Arma-typed (ij|kl) -> (jk|il) permutation. Used by the diatomic
-    /// prim_ktei build path.
-    arma::mat exchange_tei(const arma::mat & tei, size_t Ni, size_t Nj,
-                            size_t Nk, size_t Nl);
-    /// Eigen overload of the same permutation for helfem::Matrix-typed
-    /// in-element TEIs.
+    /// (ij|kl) -> (jk|il) permutation on the helfem::Matrix-typed
+    /// in-element TEI. Used internally by the assemble_K_FE_one_multipole
+    /// helpers below.
     helfem::Matrix exchange_tei(const helfem::Matrix & tei, size_t Ni, size_t Nj,
                                  size_t Nk, size_t Nl);
   }


### PR DESCRIPTION
## Summary

`libhelfem/include/CoulombExchangeFE.h` -- an *installed* public header -- forward-declared an arma-typed `utils::exchange_tei(arma::mat, ...)` overload, and included both `<armadillo>` and `ArmaEigen.h` purely to support that one declaration.

Two facts make this decl unnecessary:

1. The lone remaining external caller of the arma exchange_tei -- `src/diatomic/basis.cpp` -- already `#include "utils.h"` directly for `product_tei` / `check_tei_symmetry` / `exchange_tei` (`utils.h` lives in `libhelfem/src/`, on the in-tree include path).
2. Inside CoulombExchangeFE.h itself, all four internal uses of `utils::exchange_tei` are on `helfem::Matrix` (from `radial.erfc_integral` and `detail_fe_2e::in_element_tei`) -- so the arma overload is genuinely unused.

Delete the arma exchange_tei forward-decl and both arma includes. `libhelfem/include/CoulombExchangeFE.h` is now arma-free. The arma-typed `exchange_tei` / `product_tei` / `check_tei_symmetry` still live in `libhelfem/src/utils.{h,cpp}` for the diatomic caller (blocked by that TU's full arma-typed J/K storage), but `utils.h` is not on the install list.

Also tighten the surviving `helfem::Matrix` decl's docstring.

## Test plan

- [x] Full build clean.
- [x] H atom SCF (`--Z=1 --nelem=5 --primbas=4 --nnodes=5`) reproduces its total energy.
- [x] H2 diatomic SCF (`--Z1=1 --Z2=1 --Rbond=1.4 --nela=1 --nelb=1 --lmax=0 --mmax=0 --nelem=5 --nnodes=5 --primbas=4`) converges to `-1.10909...` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)