### PR TITLE
atomic_ooo, diatomic_ooo: --maverage parity

### DIFF
--- a/src/atomic/ooo.cpp
+++ b/src/atomic/ooo.cpp
@@ -90,6 +90,9 @@ int main(int argc, char **argv) {
   parser.add<double>("shift_conf",   0, "Where does confinement start?",       false, 0.0);
   parser.add<bool>  ("add_conf",     0, "Add element boundary at shifted confinement radius?", false, true);
 
+  // Fock symmetry averaging over m values (parity with bespoke atomic).
+  parser.add<bool>("maverage", 0, "average Fock matrix over m values", false, false);
+
   parser.parse_check(argc, argv);
 
   const int    Z          = get_Z(parser.get<std::string>("Z"));
@@ -130,6 +133,7 @@ int main(int argc, char **argv) {
   const double conf_barrier = parser.get<double>("conf_barrier");
   const double shift_conf   = parser.get<double>("shift_conf");
   const bool   add_conf     = parser.get<bool>("add_conf");
+  const bool   maverage     = parser.get<bool>("maverage");
 
   // Derive nela/nelb from Q, M -- same convention as the bespoke atomic
   // driver, so --M is the natural way to specify open-shell states.
@@ -239,6 +243,33 @@ int main(int argc, char **argv) {
   const bool have_efield = (Ez != 0.0 || Qzz != 0.0);
   const bool have_bfield = (Bz != 0.0);
   const bool have_conf   = (iconf != 0);
+
+  // l_idx groups AO basis-function index sets by (l, m): the l-th outer
+  // entry contains the BF-index arrays for the m values that are
+  // actually present in the basis (|m| <= min(l, mmax)). The Fock
+  // symmetry-average step below averages each l-block's Fock over that
+  // m subset, enforcing degenerate orbital energies for orbitals of the
+  // same l but different m (a physical symmetry of the atomic
+  // Hamiltonian that finite-precision SCF can drift out of).
+  //
+  // Note: the bespoke atomic driver builds an m = -l..+l range
+  // unconditionally, which crashes fock_symmetry_average when the basis
+  // has mmax < lmax (empty index arrays hit a 0x0 = NxN assignment).
+  // Filtering by lm_indices(l, m).n_elem > 0 keeps parity when
+  // mmax == lmax and degrades gracefully when mmax < lmax (partial
+  // m-average over the represented m subset -- a no-op when only m=0
+  // is present, which is what you want).
+  std::vector<std::vector<arma::uvec>> l_idx;
+  if (maverage) {
+    const arma::ivec l_all = basis.get_l();
+    const int lmax_bf = arma::max(l_all);
+    l_idx.assign(lmax_bf + 1, {});
+    for (int l = 0; l <= lmax_bf; ++l)
+      for (int m = -l; m <= l; ++m) {
+        arma::uvec idx = basis.lm_indices(l, m);
+        if (idx.n_elem) l_idx[l].push_back(idx);
+      }
+  }
 
   // --- Symmetry decomposition. symm==0 collapses to one block containing
   //     all basis functions.
@@ -412,10 +443,16 @@ int main(int argc, char **argv) {
     // their coupling is off so this is unchanged from H0 = T + Vnuc in
     // the no-field case.
     const arma::mat H1 = T + Vnuc + Vel + Vmag + Vconf;
+    // Apply the maverage post-processor once per channel; noop otherwise.
+    auto apply_mavg = [&](arma::mat & F) {
+      if (maverage)
+        F = helfem::to_arma(scf::fock_symmetry_average(helfem::to_eigen(F), l_idx));
+    };
     if (restricted) {
       arma::mat F_ao = H1 + J;
       if (have_xc)  F_ao += XCa;
       if (have_exx) F_ao += Ka;
+      apply_mavg(F_ao);
       for (size_t k = 0; k < nsym; ++k)
         orthonormalize_block(fock, k, F_ao, k);
     } else {
@@ -430,6 +467,8 @@ int main(int argc, char **argv) {
         Fa_ao -= 0.5 * Bz * S;
         Fb_ao += 0.5 * Bz * S;
       }
+      apply_mavg(Fa_ao);
+      apply_mavg(Fb_ao);
       for (size_t k = 0; k < nsym; ++k) {
         orthonormalize_block(fock, k,        Fa_ao, k);
         orthonormalize_block(fock, nsym + k, Fb_ao, k);

--- a/src/diatomic/ooo.cpp
+++ b/src/diatomic/ooo.cpp
@@ -84,6 +84,9 @@ int main(int argc, char **argv) {
   parser.add<double>("Qzz", 0, "electric quadrupole field", false, 0.0);
   parser.add<double>("Bz",  0, "magnetic dipole field",     false, 0.0);
 
+  // Fock symmetry averaging over m values (parity with bespoke diatomic).
+  parser.add<bool>("maverage", 0, "average Fock matrix over m values", false, false);
+
   parser.parse_check(argc, argv);
 
   const int Z1        = get_Z(parser.get<std::string>("Z1"));
@@ -113,6 +116,7 @@ int main(int argc, char **argv) {
   const double Ez     = parser.get<double>("Ez");
   const double Qzz    = parser.get<double>("Qzz");
   const double Bz     = parser.get<double>("Bz");
+  const bool   maverage = parser.get<bool>("maverage");
 
   // Derive nela/nelb from Q, M -- same convention as the bespoke diatomic
   // driver. Total nuclear charge is Z1 + Z2.
@@ -218,6 +222,22 @@ int main(int argc, char **argv) {
   const double Enucfield = -Ez * nucdip - Qzz * nucquad / 3.0;
   const bool have_efield = (Ez != 0.0 || Qzz != 0.0);
   const bool have_bfield = (Bz != 0.0);
+
+  // For diatomic m-averaging: each outer entry groups the (+m, -m) pair
+  // of BF-index sets so scf::fock_symmetry_average enforces
+  // f(+m) == f(-m). At m == 0 there is no partner so the group has a
+  // single member and the "average" is a no-op on that block. Matches
+  // src/diatomic/main.cpp lines 318..328.
+  std::vector<std::vector<arma::uvec>> mavg_idx;
+  if (maverage) {
+    const int mmax_bf = arma::max(arma::abs(basis.get_mval()));
+    for (int m = 0; m <= mmax_bf; ++m) {
+      std::vector<arma::uvec> entry;
+      entry.push_back(basis.m_indices(m));
+      if (m > 0) entry.push_back(basis.m_indices(-m));
+      mavg_idx.push_back(entry);
+    }
+  }
 
   // Symmetry decomposition.
   std::vector<arma::uvec> dsym;
@@ -367,10 +387,15 @@ int main(int argc, char **argv) {
     // their coupling is off so this matches T + Vnuc + J exactly in the
     // no-field case.
     const arma::mat H1 = T + Vnuc + Vel + Vmag;
+    auto apply_mavg = [&](arma::mat & F) {
+      if (maverage)
+        F = helfem::to_arma(scf::fock_symmetry_average(helfem::to_eigen(F), mavg_idx));
+    };
     if (restricted) {
       arma::mat F_ao = H1 + J;
       if (have_xc)  F_ao += XCa;
       if (have_exx) F_ao += Ka;
+      apply_mavg(F_ao);
       for (size_t k = 0; k < nsym; ++k)
         orthonormalize_block(fock, k, F_ao, k);
     } else {
@@ -384,6 +409,8 @@ int main(int argc, char **argv) {
         Fa_ao -= 0.5 * Bz * S;
         Fb_ao += 0.5 * Bz * S;
       }
+      apply_mavg(Fa_ao);
+      apply_mavg(Fb_ao);
       for (size_t k = 0; k < nsym; ++k) {
         orthonormalize_block(fock, k,        Fa_ao, k);
         orthonormalize_block(fock, nsym + k, Fb_ao, k);


### PR DESCRIPTION
## Summary

Adds `--maverage` to both `atomic_ooo` and `diatomic_ooo`. The AO Fock is passed through `scf::fock_symmetry_average` right before the per-block orthonormalize step, matching the bespoke drivers' placement (after all 1e + 2e + XC + Bz spin-Zeeman additions).

Averaging groups:

- **atomic**: for each `l`, the `(2l+1)` BF-index sets for `m = -l..+l`. `fock_symmetry_average` enforces `f(l, m) == mean_m' f(l, m')` per `l`, restoring the l-degeneracy that a finite-precision SCF can drift out of.
- **diatomic**: for each `m > 0`, the `(+m, -m)` BF-index pair (`m == 0` is a singleton -> no-op). Enforces `f(+m) == f(-m)`.

## Robustness fix over bespoke

The bespoke atomic driver builds the `m = -l..+l` range unconditionally, which lands *empty* index arrays in the average when the basis has `mmax < lmax` -- `fock_symmetry_average` then crashes on a 0x0 <- NxN assignment (`atomic --Z=4 --lmax=1 --mmax=0 --maverage=1` dumps core). This PR filters by `lm_indices(l, m).n_elem > 0`, so the mmax<lmax case degrades gracefully (partial m-average over the represented m subset) instead of crashing, while staying bit-identical to bespoke when the basis is symmetric.

## Verified against bespoke

| Case | Bespoke | OOO |
|------|---------|-----|
| Be, LDA, lmax=mmax=1, `--maverage=1` | -14.2232908267095617 | -14.2232908267 |
| H2, LDA, lmax=mmax=1, `--maverage=1` | -1.0161182665103179 | -1.0161182665 |
| H2+, LDA, lmax=mmax=1, `--maverage=1` (open shell) | -0.5328509031060205 | -0.5328509031 |
| Be, LDA, lmax=1 mmax=0, `--maverage=1` (bespoke crashes) | dumps core | falls back to no-maverage baseline |
| No-maverage baseline | (unchanged) | bit-identical pre/post |

## Deferred

`readocc` (occupation freezing from a file) for `atomic_ooo` / `diatomic_ooo` -- the last OOO parity slice remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)