### PR TITLE
src/harmonic: migrate main.cpp + softcoulomb.cpp to native Eigen

### DIFF
--- a/src/harmonic/main.cpp
+++ b/src/harmonic/main.cpp
@@ -15,150 +15,123 @@
 
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
-#include "chebyshev.h"
-#include <ArmaEigen.h>
-#include <cstring>
+#include "Matrix.h"
+#include <lib1dfem/chebyshev.h>
+#include <Eigen/Eigenvalues>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <memory>
 
 using namespace helfem;
 
 namespace {
-  inline helfem::Vector to_e(const arma::vec & v) {
-    helfem::Vector e(v.n_elem);
-    std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
-    return e;
+  helfem::Matrix overlap(const polynomial_basis::FiniteElementBasis & fem,
+                         const helfem::Vector & x, const helfem::Vector & wx) {
+    return fem.matrix_element(false, false, x, wx, nullptr);
   }
-  inline arma::mat to_a(const helfem::Matrix & m) {
-    arma::mat out(m.rows(), m.cols());
-    std::memcpy(out.memptr(), m.data(), sizeof(double) * (size_t) m.size());
-    return out;
+
+  double square_potential(double r) { return r * r; }
+
+  helfem::Matrix potential(const polynomial_basis::FiniteElementBasis & fem,
+                           const helfem::Vector & x, const helfem::Vector & wx) {
+    return fem.matrix_element(false, false, x, wx, square_potential);
   }
-} // namespace
 
-arma::mat overlap(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), nullptr));
-}
+  helfem::Matrix kinetic(const polynomial_basis::FiniteElementBasis & fem,
+                         const helfem::Vector & x, const helfem::Vector & wx) {
+    return fem.matrix_element(true, true, x, wx, nullptr);
+  }
 
-double square_potential(double r) {
-  return r*r;
-}
-
-arma::mat potential(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), square_potential));
-}
-
-arma::mat kinetic(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return to_a(fem.matrix_element(true, true, to_e(x), to_e(wx), nullptr));
+  void write_raw_ascii(const std::string & path, const helfem::Vector & v) {
+    std::ofstream out(path);
+    for (Eigen::Index i = 0; i < v.size(); ++i)
+      out << v(i) << "\n";
+  }
+  void write_raw_ascii(const std::string & path, const helfem::Matrix & m) {
+    std::ofstream out(path);
+    for (Eigen::Index i = 0; i < m.rows(); ++i) {
+      for (Eigen::Index j = 0; j < m.cols(); ++j) {
+        if (j) out << " ";
+        out << m(i, j);
+      }
+      out << "\n";
+    }
+  }
 }
 
 int main(int argc, char **argv) {
-  if(argc!=6) {
-    printf("Usage: %s xmax Nel Nnode primbas Nquad\n",argv[0]);
+  if (argc != 6) {
+    printf("Usage: %s xmax Nel Nnode primbas Nquad\n", argv[0]);
     return 1;
   }
 
-  // Maximum R
-  double xmax=atof(argv[1]);
-  // Number of elements
-  int Nelem=atoi(argv[2]);
+  const double xmax   = std::atof(argv[1]);
+  const int    Nelem  = std::atoi(argv[2]);
+  const int    Nnodes = std::atoi(argv[3]);
+  const int    primbas = std::atoi(argv[4]);
+  const int    Nquad  = std::atoi(argv[5]);
 
-  // Number of nodes
-  int Nnodes=atoi(argv[3]);
-  // Derivative order
-  int primbas=atoi(argv[4]);
-  // Order of quadrature rule
-  int Nquad=atoi(argv[5]);
+  printf("Running calculation with xmax=%e and %i elements.\n", xmax, Nelem);
+  printf("Using %i point quadrature rule.\n", Nquad);
 
-  printf("Running calculation with xmax=%e and %i elements.\n",xmax,Nelem);
-  printf("Using %i point quadrature rule.\n",Nquad);
+  auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
+      polynomial_basis::get_basis(primbas, Nnodes));
 
-  // Get polynomial basis
-  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(primbas, Nnodes)));
+  // Radial grid: linspace(-xmax, xmax, Nelem+1) on helfem::Vector.
+  const helfem::Vector r = helfem::Vector::LinSpaced(Nelem + 1, -xmax, xmax);
 
-  // Radial grid
-  arma::vec r(arma::linspace<arma::vec>(-xmax,xmax,Nelem+1));
+  polynomial_basis::FiniteElementBasis fem(poly, r,
+      /*zero_func_left=*/true,  /*zero_deriv_left=*/true,
+      /*zero_func_right=*/true, /*zero_deriv_right=*/true);
 
-  // Finite element basis
-  bool zero_func_left=true;
-  bool zero_deriv_left=true;
-  bool zero_func_right=true;
-  bool zero_deriv_right=true;
-  helfem::polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(r), zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
+  helfem::Vector xq, wq;
+  helfem::lib1dfem::chebyshev::chebyshev<double>(Nquad, xq, wq);
 
-  // Quadrature rule
-  arma::vec xq, wq;
-  chebyshev::chebyshev(Nquad,xq,wq);
+  helfem::Matrix bf, dbf;
+  poly->eval_dnf(xq, bf,  0, 1.0);
+  poly->eval_dnf(xq, dbf, 1, 1.0);
 
-  // Evaluate polynomials at quadrature points (Phase 5.2: bridge to
-  // lib1dfem Eigen API).
-  arma::mat bf, dbf;
-  {
-    helfem::lib1dfem::Vec<double> xe(xq.n_elem);
-    std::memcpy(xe.data(), xq.memptr(), sizeof(double) * xq.n_elem);
-    helfem::lib1dfem::Mat<double> bfe, dbfe;
-    poly->eval_dnf(xe, bfe,  0, 1.0);
-    poly->eval_dnf(xe, dbfe, 1, 1.0);
-    bf.set_size(bfe.rows(), bfe.cols());
-    dbf.set_size(dbfe.rows(), dbfe.cols());
-    std::memcpy(bf.memptr(), bfe.data(),
-                sizeof(double) * static_cast<size_t>(bfe.size()));
-    std::memcpy(dbf.memptr(), dbfe.data(),
-                sizeof(double) * static_cast<size_t>(dbfe.size()));
-  }
+  write_raw_ascii("x.dat",  xq);
+  write_raw_ascii("bf.dat", bf);
+  write_raw_ascii("dbf.dat", dbf);
 
-  xq.save("x.dat",arma::raw_ascii);
-  bf.save("bf.dat",arma::raw_ascii);
-  dbf.save("dbf.dat",arma::raw_ascii);
+  const size_t Nbf = fem.get_nbf();
+  printf("Basis set contains %i functions\n", (int) Nbf);
 
-  size_t Nbf(fem.get_nbf());
-  printf("Basis set contains %i functions\n",(int) Nbf);
+  const helfem::Matrix S = overlap  (fem, xq, wq);
+  const helfem::Matrix V = potential(fem, xq, wq);
+  const helfem::Matrix T = kinetic  (fem, xq, wq);
+  const helfem::Matrix H = T + V;
 
-  // Form overlap matrix
-  arma::mat S(overlap(fem, xq, wq));
-  // Form potential matrix
-  arma::mat V(potential(fem, xq, wq));
-  // Form kinetic energy matrix
-  arma::mat T(kinetic(fem, xq, wq));
+  // Symmetric orthonormalisation: Sinvh = Svec * diag(Sval^{-1/2}) * Svec^T.
+  Eigen::SelfAdjointEigenSolver<helfem::Matrix> Ses(S);
+  const helfem::Vector Sval = Ses.eigenvalues();
+  const helfem::Matrix Svec = Ses.eigenvectors();
+  printf("Smallest value of overlap matrix is % e, condition number is %e\n",
+         Sval(0), Sval(Sval.size() - 1) / Sval(0));
+  const helfem::Vector Sdiag = S.diagonal().cwiseAbs();
+  printf("Smallest and largest bf norms are %e and %e\n",
+         Sdiag.minCoeff(), Sdiag.maxCoeff());
 
-  // Form Hamiltonian
-  arma::mat H(T+V);
+  const helfem::Matrix Sinvh =
+      Svec * Sval.array().pow(-0.5).matrix().asDiagonal() * Svec.transpose();
 
-  //S.print("Overlap");
-  //T.print("Kinetic");
-  //V.print("Potential");
-  //H.print("Hamiltonian");
+  const helfem::Matrix Horth = Sinvh.transpose() * H * Sinvh;
 
-  // Form orthonormal basis
-  arma::vec Sval;
-  arma::mat Svec;
-  arma::eig_sym(Sval,Svec,S);
-
-  //Sval.print("S eigenvalues");
-  printf("Smallest value of overlap matrix is % e, condition number is %e\n",Sval(0),Sval(Sval.n_elem-1)/Sval(0));
-  printf("Smallest and largest bf norms are %e and %e\n",arma::min(arma::abs(arma::diagvec(S))),arma::max(arma::abs(arma::diagvec(S))));
-
-  // Form half-inverse
-  arma::mat Sinvh(Svec * arma::diagmat(arma::pow(Sval, -0.5)) * arma::trans(Svec));
-
-  // Form orthonormal Hamiltonian
-  arma::mat Horth(arma::trans(Sinvh)*H*Sinvh);
-
-  // Diagonalize Hamiltonian
-  arma::vec E;
-  arma::mat C;
-  arma::eig_sym(E,C,Horth);
-
-  // Go back to non-orthonormal basis
-  C=Sinvh*C;
+  Eigen::SelfAdjointEigenSolver<helfem::Matrix> Hes(Horth);
+  const helfem::Vector E = Hes.eigenvalues();
+  helfem::Matrix C = Sinvh * Hes.eigenvectors();
 
   printf("Eigenvalues\n");
-  size_t neig=std::min(E.n_elem,(arma::uword) 8);
-  for(size_t i=0;i<neig;i++)
-    printf("%i % 10.6f % 10.6f\n",(int) i, E(i),E(i)-(2*i+1));
+  const Eigen::Index neig = std::min<Eigen::Index>(E.size(), 8);
+  for (Eigen::Index i = 0; i < neig; ++i)
+    printf("%i % 10.6f % 10.6f\n", (int) i, E(i), E(i) - (2 * i + 1));
 
-  // Test orthonormality
-  arma::mat Smo(C.t()*S*C);
-  Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
-  printf("Orbital orthonormality devation is %e\n",arma::norm(Smo,"fro"));
+  helfem::Matrix Smo = C.transpose() * S * C;
+  Smo -= helfem::Matrix::Identity(Smo.rows(), Smo.cols());
+  printf("Orbital orthonormality devation is %e\n", Smo.norm());
 
   return 0;
 }

--- a/src/harmonic/softcoulomb.cpp
+++ b/src/harmonic/softcoulomb.cpp
@@ -1,4 +1,3 @@
-#include <ArmaEigen.h>
 /*
  *                This source code is part of
  *
@@ -18,174 +17,141 @@
 #include "../general/checkpoint.h"
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
-#include "chebyshev.h"
-#include <cstring>
+#include "Matrix.h"
+#include "ArmaEigen.h"
+#include <lib1dfem/chebyshev.h>
+#include <Eigen/Eigenvalues>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <functional>
+#include <memory>
 
 using namespace helfem;
 
 namespace {
-  // Phase 5.4 bridge.
-  inline helfem::Vector to_e(const arma::vec & v) {
-    helfem::Vector e(v.n_elem);
-    std::memcpy(e.data(), v.memptr(), sizeof(double) * v.n_elem);
-    return e;
+  helfem::Matrix overlap(const polynomial_basis::FiniteElementBasis & fem,
+                         const helfem::Vector & x, const helfem::Vector & wx) {
+    return fem.matrix_element(false, false, x, wx, nullptr);
   }
-  inline arma::mat to_a(const helfem::Matrix & m) {
-    arma::mat out(m.rows(), m.cols());
-    std::memcpy(out.memptr(), m.data(), sizeof(double) * (size_t) m.size());
-    return out;
+
+  helfem::Matrix potential(const polynomial_basis::FiniteElementBasis & fem,
+                           const helfem::Vector & x, const helfem::Vector & wx,
+                           double z, double x0, double alpha, bool abs) {
+    std::function<double(double)> soft_coulomb;
+    if (abs)
+      soft_coulomb = [z, x0, alpha](double x) { return -z / (std::abs(x - x0) + alpha); };
+    else
+      soft_coulomb = [z, x0, alpha](double x) {
+        return -z / std::sqrt((x - x0) * (x - x0) + alpha * alpha);
+      };
+    return fem.matrix_element(false, false, x, wx, soft_coulomb);
   }
-} // namespace
 
-arma::mat overlap(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), nullptr));
-}
-
-arma::mat potential(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx, double z, double x0, double alpha, bool abs) {
-  std::function<double(double)> soft_coulomb;
-  if(abs) {
-    soft_coulomb = [z, x0, alpha](double x) {
-      return -z/(std::abs(x-x0)+alpha);
-    };
-  } else {
-    soft_coulomb = [z, x0, alpha](double x) {
-      return -z/sqrt((x-x0)*(x-x0)+alpha*alpha);
-    };
+  helfem::Matrix kinetic(const polynomial_basis::FiniteElementBasis & fem,
+                         const helfem::Vector & x, const helfem::Vector & wx) {
+    return 0.5 * fem.matrix_element(true, true, x, wx, nullptr);
   }
-  return to_a(fem.matrix_element(false, false, to_e(x), to_e(wx), soft_coulomb));
-}
-
-arma::mat kinetic(const helfem::polynomial_basis::FiniteElementBasis & fem, const arma::vec & x, const arma::vec & wx) {
-  return 0.5*to_a(fem.matrix_element(true, true, to_e(x), to_e(wx), nullptr));
 }
 
 int main(int argc, char **argv) {
   cmdline::parser parser;
 
-  // full option name, no short option, description, argument required
-  parser.add<double>("xmax", 0, "practical infinity in au", false, 40.0);
-  parser.add<int>("nelem", 0, "number of elements", false, 5);
-  parser.add<int>("nnodes", 0, "number of elements", false, 15);
-  parser.add<int>("primbas", 0, "primitive basis", false, 4);
-  parser.add<int>("nquad", 0, "primitive basis", false, -1);
-  parser.add<int>("Z1", 0, "primitive basis", true);
-  parser.add<int>("Z2", 0, "primitive basis", true);
-  parser.add<double>("R", 0, "Bond length", true);
-  parser.add<double>("alpha", 0, "Coulomb regularization parameter", true);
-  parser.add<bool>("abs", 0, "Use 1/(|x-x0|+alpha) instead of 1/sqrt( (x-x0)^2 + alpha^2 ) as potential", false, 0);
+  parser.add<double>("xmax",   0, "practical infinity in au",   false, 40.0);
+  parser.add<int>("nelem",     0, "number of elements",         false, 5);
+  parser.add<int>("nnodes",    0, "number of elements",         false, 15);
+  parser.add<int>("primbas",   0, "primitive basis",            false, 4);
+  parser.add<int>("nquad",     0, "primitive basis",            false, -1);
+  parser.add<int>("Z1",        0, "primitive basis",            true);
+  parser.add<int>("Z2",        0, "primitive basis",            true);
+  parser.add<double>("R",      0, "Bond length",                true);
+  parser.add<double>("alpha",  0, "Coulomb regularization parameter", true);
+  parser.add<bool>("abs",      0, "Use 1/(|x-x0|+alpha) instead of 1/sqrt( (x-x0)^2 + alpha^2 ) as potential", false, 0);
   parser.add<std::string>("save", 0, "Checkpoint to save results to", false, "softcoulomb.chk");
 
   parser.parse_check(argc, argv);
-  double xmax = parser.get<double>("xmax");
-  int Nelem = parser.get<int>("nelem");
-  int Nnodes = parser.get<int>("nnodes");
-  int primbas = parser.get<int>("primbas");
-  int Nquad = parser.get<int>("nquad");
-  int Z1 = parser.get<int>("Z1");
-  int Z2 = parser.get<int>("Z2");
-  double R = parser.get<double>("R");
-  double alpha = parser.get<double>("alpha");
-  bool abs = parser.get<bool>("abs");
-  std::string save = parser.get<std::string>("save");
+  const double xmax   = parser.get<double>("xmax");
+  const int    Nelem  = parser.get<int>("nelem");
+  const int    Nnodes = parser.get<int>("nnodes");
+  const int    primbas = parser.get<int>("primbas");
+        int    Nquad  = parser.get<int>("nquad");
+  const int    Z1     = parser.get<int>("Z1");
+  const int    Z2     = parser.get<int>("Z2");
+  const double R      = parser.get<double>("R");
+  const double alpha  = parser.get<double>("alpha");
+  const bool   abs    = parser.get<bool>("abs");
+  const std::string save = parser.get<std::string>("save");
 
-  if(abs)
+  if (abs)
     printf("Using potential V(x) = -Z / ( |x-x0| + alpha )\n");
   else
     printf("Using potential V(x) = -Z / sqrt( (x-x0)^2 + alpha^2 )\n");
 
-  // Get polynomial basis
-  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(primbas, Nnodes)));
-  if(Nquad<0)
-    Nquad=5*poly->get_nbf();
+  auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
+      polynomial_basis::get_basis(primbas, Nnodes));
+  if (Nquad < 0) Nquad = 5 * poly->get_nbf();
 
-  // Radial grid
-  arma::vec x(arma::linspace<arma::vec>(-xmax,xmax,Nelem+1));
+  const helfem::Vector x = helfem::Vector::LinSpaced(Nelem + 1, -xmax, xmax);
 
-  // Finite element basis
-  bool zero_func_left=true;
-  bool zero_deriv_left=true;
-  bool zero_func_right=true;
-  bool zero_deriv_right=true;
-  helfem::polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(x), zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
+  polynomial_basis::FiniteElementBasis fem(poly, x,
+      /*zero_func_left=*/true,  /*zero_deriv_left=*/true,
+      /*zero_func_right=*/true, /*zero_deriv_right=*/true);
 
-  // Quadrature rule
-  arma::vec xq, wq;
-  chebyshev::chebyshev(Nquad,xq,wq);
+  helfem::Vector xq, wq;
+  helfem::lib1dfem::chebyshev::chebyshev<double>(Nquad, xq, wq);
 
-  size_t Nbf(fem.get_nbf());
-  printf("Basis set contains %i functions\n",(int) Nbf);
+  const size_t Nbf = fem.get_nbf();
+  printf("Basis set contains %i functions\n", (int) Nbf);
 
-  // Form overlap matrix
-  arma::mat S(overlap(fem, xq, wq));
-  // Form potential matrix
-  arma::mat V(potential(fem, xq, wq, Z1, -0.5*R, alpha, abs)+potential(fem, xq, wq, Z2, 0.5*R, alpha, abs));
-  // Form kinetic energy matrix
-  arma::mat T(kinetic(fem, xq, wq));
+  const helfem::Matrix S = overlap(fem, xq, wq);
+  const helfem::Matrix V = potential(fem, xq, wq, Z1, -0.5 * R, alpha, abs)
+                         + potential(fem, xq, wq, Z2,  0.5 * R, alpha, abs);
+  const helfem::Matrix T = kinetic(fem, xq, wq);
+  const helfem::Matrix H = T + V;
 
-  // Form Hamiltonian
-  arma::mat H(T+V);
+  Eigen::SelfAdjointEigenSolver<helfem::Matrix> Ses(S);
+  const helfem::Vector Sval = Ses.eigenvalues();
+  const helfem::Matrix Svec = Ses.eigenvectors();
+  printf("Smallest value of overlap matrix is % e, condition number is %e\n",
+         Sval(0), Sval(Sval.size() - 1) / Sval(0));
+  const helfem::Vector Sdiag = S.diagonal().cwiseAbs();
+  printf("Smallest and largest bf norms are %e and %e\n",
+         Sdiag.minCoeff(), Sdiag.maxCoeff());
 
-  //S.print("Overlap");
-  //T.print("Kinetic");
-  //V.print("Potential");
-  //H.print("Hamiltonian");
+  const helfem::Matrix Sinvh =
+      Svec * Sval.array().pow(-0.5).matrix().asDiagonal() * Svec.transpose();
 
-  // Form orthonormal basis
-  arma::vec Sval;
-  arma::mat Svec;
-  arma::eig_sym(Sval,Svec,S);
+  const helfem::Matrix Horth = Sinvh.transpose() * H * Sinvh;
 
-  //Sval.print("S eigenvalues");
-  printf("Smallest value of overlap matrix is % e, condition number is %e\n",Sval(0),Sval(Sval.n_elem-1)/Sval(0));
-  printf("Smallest and largest bf norms are %e and %e\n",arma::min(arma::abs(arma::diagvec(S))),arma::max(arma::abs(arma::diagvec(S))));
+  Eigen::SelfAdjointEigenSolver<helfem::Matrix> Hes(Horth);
+  const helfem::Vector E = Hes.eigenvalues();
+  helfem::Matrix C = Sinvh * Hes.eigenvectors();
 
-  // Form half-inverse
-  arma::mat Sinvh(Svec * arma::diagmat(arma::pow(Sval, -0.5)) * arma::trans(Svec));
+  for (int i = 0; i < 10 && i < E.size(); ++i)
+    printf("E[%i] = % .15e\n", i, E(i));
 
-  // Form orthonormal Hamiltonian
-  arma::mat Horth(arma::trans(Sinvh)*H*Sinvh);
+  helfem::Matrix Smo = C.transpose() * S * C;
+  Smo -= helfem::Matrix::Identity(Smo.rows(), Smo.cols());
+  printf("Orbital orthonormality devation is %e\n", Smo.norm());
 
-  // Diagonalize Hamiltonian
-  arma::vec E;
-  arma::mat C;
-  arma::eig_sym(E,C,Horth);
+  // Evaluate the basis set: 0th derivative -- native Eigen through the
+  // FE interface.
+  const helfem::Matrix bfval = fem.eval_dnf(xq, 0);
+  const helfem::Matrix phival = bfval * C;
+  const helfem::Vector coords = fem.eval_coord(xq);
+  const helfem::Vector weights = fem.eval_weights(wq);
 
-  // Go back to non-orthonormal basis
-  C=Sinvh*C;
+  helfem::Matrix Sgrid = phival.transpose() * weights.asDiagonal() * phival;
+  Sgrid -= helfem::Matrix::Identity(Sgrid.rows(), Sgrid.cols());
+  printf("Orbital orthonormality devation on grid is %e\n", Sgrid.norm());
 
-  for(size_t i=0;i<10;i++)
-    printf("E[%i] = % .15e\n",(int) i, E[i]);
-
-  // Test orthonormality
-  arma::mat Smo(C.t()*S*C);
-  Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
-  printf("Orbital orthonormality devation is %e\n",arma::norm(Smo,"fro"));
-
-  // Evaluate the basis set: 0th derivative (Phase 5.3 bridge).
-  helfem::Vector xq_e(xq.n_elem);
-  std::memcpy(xq_e.data(), xq.memptr(), sizeof(double) * xq.n_elem);
-  helfem::Matrix bfval_e = fem.eval_dnf(xq_e, 0);
-  arma::mat bfval(bfval_e.rows(), bfval_e.cols());
-  std::memcpy(bfval.memptr(), bfval_e.data(), sizeof(double) * (size_t) bfval_e.size());
-  arma::mat phival(bfval*C);
-  helfem::Vector coords_e = fem.eval_coord(xq_e);
-  arma::vec coords(coords_e.size());
-  std::memcpy(coords.memptr(), coords_e.data(), sizeof(double) * coords_e.size());
-  helfem::Vector weights_e(fem.eval_weights(to_e(wq)));
-  arma::vec weights(weights_e.size());
-  std::memcpy(weights.memptr(), weights_e.data(), sizeof(double) * weights_e.size());
-
-  // Test orbitals are still orthonormal
-  arma::mat Sgrid(phival.t()*arma::diagmat(weights)*phival);
-  Sgrid-=arma::eye<arma::mat>(Sgrid.n_rows,Sgrid.n_cols);
-  printf("Orbital orthonormality devation on grid is %e\n",arma::norm(Sgrid,"fro"));
-
+  // Checkpoint I/O is still arma-typed; bridge at the write boundary.
   Checkpoint chkpt(save, true);
-  chkpt.write("bf",bfval);
-  chkpt.write("C",C);
-  chkpt.write("phi",phival);
-  chkpt.write("coords",coords);
-  chkpt.write("weights",weights);
+  chkpt.write("bf",     helfem::to_arma(bfval));
+  chkpt.write("C",      helfem::to_arma(C));
+  chkpt.write("phi",    helfem::to_arma(phival));
+  chkpt.write("coords", helfem::to_arma(coords));
+  chkpt.write("weights", helfem::to_arma(weights));
 
   return 0;
 }


### PR DESCRIPTION
## Summary

First slice of the `src/` arma sweep. The harmonic-oscillator and soft-Coulomb toy drivers use only FE-basis matrix elements and a symmetric eigenproblem, both of which have been Eigen-typed since Phase 5. Rewrite both TUs in native `helfem::Matrix` / `Vector`:

- `overlap` / `potential` / `kinetic` helpers now take `helfem::Vector` quadrature nodes/weights directly and return `helfem::Matrix`.
- Gauss-Chebyshev quadrature comes straight from `helfem::lib1dfem::chebyshev::chebyshev<double>`, skipping the local arma-typed shim in `src/general/chebyshev.h`.
- Grid built via `helfem::Vector::LinSpaced` instead of `arma::linspace`.
- `arma::eig_sym` on `S` and `Horth` becomes `Eigen::SelfAdjointEigenSolver<helfem::Matrix>`; `Sinvh` built as `Svec * Sval.array().pow(-0.5).matrix().asDiagonal() * Svec.T`.
- `harmonic/main.cpp` keeps its raw-ASCII `x.dat` / `bf.dat` / `dbf.dat` dumps (used by the plotting scripts). Reimplement via a local `write_raw_ascii(std::ofstream)` helper on `helfem::Vector` / `Matrix`, dropping the `arma::mat::save` calls.
- `softcoulomb.cpp` writes an HDF5 checkpoint. `Checkpoint::write` is still arma-typed; keep it that way and bridge with `helfem::to_arma` at the five `write()` call sites (one-line copy per matrix, cost is negligible at post-SCF write time).

Both TUs are now arma-free (`grep -c 'arma::\|<armadillo>' src/harmonic/*.cpp` → 0).

## Test plan

- [x] Full build clean.
- [x] `./src/harmonic 5 4 5 4 20` (H_1D on `(-5, 5)` with 4 elements, primbas=4) — first 8 eigenvalues bit-identical pre/post migration.
- [x] `./src/softcoulomb --xmax=20 --nelem=5 --nnodes=8 --primbas=4 --Z1=1 --Z2=1 --R=2 --alpha=0.5 --save=/tmp/soft.chk` writes a valid checkpoint at the same file size; orthonormality deviations `1e-14` as before.

## Follow-up

Next slices in the `src/` arma sweep (in decreasing size of arma footprint):
- `diatomic/basis.cpp` (256 refs) + `basis.h` (70) — biggest single chunk; TwoDBasis public API is arma-native.
- `sadatom/basis.cpp` (182) + `basis.h` (39).
- `atomic/TwoDBasis.cpp` (149) + `.h` (34) + `dftgrid.cpp` (105) + `.h` (37).
- `sadatom/dftgrid.cpp` (93) + `.h` (35); `diatomic/dftgrid.cpp` (95) + `.h` (34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)