### PR TITLE
src/{atomic,sadatom,diatomic}: migrate 1e / inttest / density_line to Eigen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ general/timer.cpp general/elements.cpp
 general/angular.cpp general/scf_helpers.cpp general/lcao.cpp
 general/dftgrid_common.cpp
 general/gsz.cpp general/sap.cpp general/dftfuncs.cpp
-general/checkpoint.cpp atomic/basis.cpp
+general/checkpoint.cpp general/eigen_io.cpp atomic/basis.cpp
 atomic/TwoDBasis.cpp
 atomic/dftgrid.cpp sadatom/basis.cpp
 sadatom/dftgrid.cpp sadatom/scf.cpp

--- a/src/atomic/inttest.cpp
+++ b/src/atomic/inttest.cpp
@@ -16,41 +16,15 @@
 #include "PolynomialBasis.h"
 #include "LIPBasis.h"
 #include "Matrix.h"
+#include "../general/eigen_io.h"
 #include <lib1dfem/chebyshev.h>
 #include <lib1dfem/lobatto.h>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <fstream>
 #include <memory>
 
 using namespace helfem;
-
-namespace {
-  void write_raw_ascii(const std::string & path, const helfem::Vector & v) {
-    std::ofstream out(path);
-    for (Eigen::Index i = 0; i < v.size(); ++i)
-      out << v(i) << "\n";
-  }
-  void write_raw_ascii(const std::string & path, const helfem::Matrix & m) {
-    std::ofstream out(path);
-    for (Eigen::Index i = 0; i < m.rows(); ++i) {
-      for (Eigen::Index j = 0; j < m.cols(); ++j) {
-        if (j) out << " ";
-        out << m(i, j);
-      }
-      out << "\n";
-    }
-  }
-  void print_matrix(const std::string & name, const helfem::Matrix & m) {
-    printf("%s\n", name.c_str());
-    for (Eigen::Index i = 0; i < m.rows(); ++i) {
-      for (Eigen::Index j = 0; j < m.cols(); ++j)
-        printf(" %8.4f", m(i, j));
-      printf("\n");
-    }
-  }
-}
 
 void run(double R, int n_quad) {
   // Basis functions on [0, R]: x/R, (R-x)/R.
@@ -83,9 +57,9 @@ void run(double R, int n_quad) {
     teiishould(i, 3) = (ri * ri) / (3.0 * R2);
   }
 
-  write_raw_ascii("r.dat",     r);
-  write_raw_ascii("teii_q.dat", teiinner);
-  write_raw_ascii("teii.dat",   teiishould);
+  io::write_raw_ascii("r.dat",     r);
+  io::write_raw_ascii("teii_q.dat", teiinner);
+  io::write_raw_ascii("teii.dat",   teiishould);
 
   const helfem::Matrix teiidiff = teiishould - teiinner;
   printf("Error in inner integral is %e\n", teiidiff.norm());
@@ -123,9 +97,9 @@ void run(double R, int n_quad) {
   tei(3, 3) = 1.0 / 15.0;
   tei = 4.0 * M_PI * (tei + tei.transpose().eval()) * R;
 
-  print_matrix("Analytical", tei);
-  print_matrix("Quadrature", teiq);
-  print_matrix("Difference", helfem::Matrix(teiq - tei));
+  io::print_matrix("Analytical", tei);
+  io::print_matrix("Quadrature", teiq);
+  io::print_matrix("Difference", helfem::Matrix(teiq - tei));
 }
 
 int main(int argc, char **argv) {

--- a/src/atomic/inttest.cpp
+++ b/src/atomic/inttest.cpp
@@ -14,108 +14,127 @@
  */
 #include "quadrature.h"
 #include "PolynomialBasis.h"
-#include "chebyshev.h"
-#include "lobatto.h"
 #include "LIPBasis.h"
-#include <ArmaEigen.h>
-#include <cstring>
+#include "Matrix.h"
+#include <lib1dfem/chebyshev.h>
+#include <lib1dfem/lobatto.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <memory>
 
 using namespace helfem;
+
+namespace {
+  void write_raw_ascii(const std::string & path, const helfem::Vector & v) {
+    std::ofstream out(path);
+    for (Eigen::Index i = 0; i < v.size(); ++i)
+      out << v(i) << "\n";
+  }
+  void write_raw_ascii(const std::string & path, const helfem::Matrix & m) {
+    std::ofstream out(path);
+    for (Eigen::Index i = 0; i < m.rows(); ++i) {
+      for (Eigen::Index j = 0; j < m.cols(); ++j) {
+        if (j) out << " ";
+        out << m(i, j);
+      }
+      out << "\n";
+    }
+  }
+  void print_matrix(const std::string & name, const helfem::Matrix & m) {
+    printf("%s\n", name.c_str());
+    for (Eigen::Index i = 0; i < m.rows(); ++i) {
+      for (Eigen::Index j = 0; j < m.cols(); ++j)
+        printf(" %8.4f", m(i, j));
+      printf("\n");
+    }
+  }
+}
 
 void run(double R, int n_quad) {
   // Basis functions on [0, R]: x/R, (R-x)/R.
 
   // Get primitive polynomial representation for LIP
-  arma::vec x, w;
-  ::lobatto_compute(2,x,w);
-  helfem::lib1dfem::Vec<double> xe(x.n_elem);
-  std::memcpy(xe.data(), x.memptr(), sizeof(double) * x.n_elem);
-  auto pbas(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(new helfem::polynomial_basis::LIPBasis(xe,0)));
+  helfem::Vector x, w;
+  helfem::lib1dfem::lobatto::lobatto_compute<double>(2, x, w);
+  auto pbas = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
+      new polynomial_basis::LIPBasis(x, 0));
 
-  // Get quadrature rule
-  arma::vec xq, wq;
-  chebyshev::chebyshev(n_quad,xq,wq);
+  // Gauss-Chebyshev nodes for the outer TEI quadrature.
+  helfem::Vector xq, wq;
+  helfem::lib1dfem::chebyshev::chebyshev<double>(n_quad, xq, wq);
 
-  // Get inner integral by quadrature (Phase 5.7: quadrature is Eigen).
-  arma::mat teiinner(helfem::to_arma(
-      quadrature::twoe_inner_integral(0, R, helfem::to_eigen(xq), helfem::to_eigen(wq), pbas, 0)));
+  // Inner integral by quadrature.
+  const helfem::Matrix teiinner =
+      quadrature::twoe_inner_integral(0, R, xq, wq, pbas, 0);
 
-  // Test against analytical integrals. r values are
-  arma::vec r(0.5*R*arma::ones<arma::vec>(xq.n_elem)+0.5*R*xq);
+  // Radial points at which the inner integral is sampled.
+  helfem::Vector r = 0.5 * R * (helfem::Vector::Ones(xq.size()) + xq);
 
-  // The inner integral should give the following
-  arma::mat teiishould(r.n_elem,4);
-  teiishould.col(0)=(arma::ones<arma::vec>(r.n_elem) - r/R + 1.0/3.0*arma::square(r)/(R*R));
-  teiishould.col(1)=r%(-2.0*r + 3*R*arma::ones<arma::vec>(r.n_elem))/(6.0*R*R);
-  teiishould.col(2)=teiishould.col(1);
-  teiishould.col(3)=arma::square(r)/(3.0*R*R);
+  // Analytical inner integrals for L=0 on this element.
+  helfem::Matrix teiishould(r.size(), 4);
+  for (Eigen::Index i = 0; i < r.size(); ++i) {
+    const double ri  = r(i);
+    const double R2  = R * R;
+    teiishould(i, 0) = 1.0 - ri / R + (ri * ri) / (3.0 * R2);
+    teiishould(i, 1) = ri * (-2.0 * ri + 3.0 * R) / (6.0 * R2);
+    teiishould(i, 2) = teiishould(i, 1);
+    teiishould(i, 3) = (ri * ri) / (3.0 * R2);
+  }
 
-  r.save("r.dat",arma::raw_ascii);
-  teiinner.save("teii_q.dat",arma::raw_ascii);
-  teiishould.save("teii.dat",arma::raw_ascii);
+  write_raw_ascii("r.dat",     r);
+  write_raw_ascii("teii_q.dat", teiinner);
+  write_raw_ascii("teii.dat",   teiishould);
 
-  teiishould-=teiinner;
-  printf("Error in inner integral is %e\n",arma::norm(teiishould,"fro"));
+  const helfem::Matrix teiidiff = teiishould - teiinner;
+  printf("Error in inner integral is %e\n", teiidiff.norm());
 
-  arma::mat teiq(helfem::to_arma(
-      quadrature::twoe_integral(0, R, helfem::to_eigen(xq), helfem::to_eigen(wq), pbas, 0)));
+  // Full inner+outer integral.
+  helfem::Matrix teiq = quadrature::twoe_integral(0, R, xq, wq, pbas, 0);
 
-  arma::mat tei(4,4);
-  // Maple gives the following integrals for L=0, in units of R
-
+  // Maple analytical values for the eight independent (ij|kl) entries.
+  helfem::Matrix tei = helfem::Matrix::Zero(4, 4);
   // 1111
-  tei(0,0) = 47.0/180.0;
-  // 1112
-  tei(0,1) = 11/360.0;
-  // 1121
-  tei(0,2) = tei(0,1);
+  tei(0, 0) = 47.0 / 180.0;
+  // 111{2} = 1121
+  tei(0, 1) = 11.0 / 360.0;
+  tei(0, 2) = tei(0, 1);
   // 1122
-  tei(0,3) = 1.0/90.0;
-
+  tei(0, 3) = 1.0 / 90.0;
   // 1211
-  tei(1,0) = 1.0/10.0;
-  // 1212
-  tei(1,1) = 1.0/40.0;
-  // 1221
-  tei(1,2) = tei(1,1);
+  tei(1, 0) = 1.0 / 10.0;
+  // 1212 = 1221
+  tei(1, 1) = 1.0 / 40.0;
+  tei(1, 2) = tei(1, 1);
   // 1222
-  tei(1,3) = 1.0/60.0;
-
-  // 2111
-  tei(2,0) = tei(1,0);
-  // 2112
-  tei(2,1) = tei(1,1);
-  // 2121
-  tei(2,2) = tei(1,2);
-  // 2122
-  tei(2,3) = tei(1,3);
-
+  tei(1, 3) = 1.0 / 60.0;
+  // 2111 = 1211, 2112 = 1212, 2121 = 1221, 2122 = 1222 by symmetry.
+  tei(2, 0) = tei(1, 0);
+  tei(2, 1) = tei(1, 1);
+  tei(2, 2) = tei(1, 2);
+  tei(2, 3) = tei(1, 3);
   // 2211
-  tei(3,0) = 3.0/20.0;
-  // 2212
-  tei(3,1) = 7.0/120.0;
-  // 2221
-  tei(3,2) = tei(3,1);
+  tei(3, 0) = 3.0 / 20.0;
+  // 2212 = 2221
+  tei(3, 1) = 7.0 / 120.0;
+  tei(3, 2) = tei(3, 1);
   // 2222
-  tei(3,3) = 1.0/15.0;
+  tei(3, 3) = 1.0 / 15.0;
+  tei = 4.0 * M_PI * (tei + tei.transpose().eval()) * R;
 
-  // Symmetrization and coefficient
-  tei=4.0*M_PI*(tei+tei.t())*R;
-
-  tei.print("Analytical");
-  teiq.print("Quadrature");
-  teiq-=tei;
-  teiq.print("Difference");
+  print_matrix("Analytical", tei);
+  print_matrix("Quadrature", teiq);
+  print_matrix("Difference", helfem::Matrix(teiq - tei));
 }
 
 int main(int argc, char **argv) {
-  if(argc!=3) {
-    printf("Usage: %s nquad R\n",argv[0]);
+  if (argc != 3) {
+    printf("Usage: %s nquad R\n", argv[0]);
     return 1;
   }
-
-  int nquad(atoi(argv[1]));
-  double R(atof(argv[2]));
-  run(R,nquad);
+  const int    nquad = std::atoi(argv[1]);
+  const double R     = std::atof(argv[2]);
+  run(R, nquad);
   return 0;
 }

--- a/src/diatomic/density_line.cpp
+++ b/src/diatomic/density_line.cpp
@@ -18,15 +18,18 @@
 #include "../general/timer.h"
 #include "utils.h"
 #include "basis.h"
+#include "Matrix.h"
+#include "ArmaEigen.h"
 #include <cfloat>
 #include <climits>
+#include <complex>
+#include <fstream>
 
 using namespace helfem;
 
 int main(int argc, char **argv) {
   cmdline::parser parser;
 
-  // full option name, no short option, description, argument required
   parser.add<std::string>("load", 0, "load guess from checkpoint", false, "");
   parser.add<double>("x", 0, "value of x", false, 0.0);
   parser.add<double>("y", 0, "value of y", false, 0.0);
@@ -36,71 +39,69 @@ int main(int argc, char **argv) {
   parser.add<std::string>("savedens", 0, "save density to file", false, "density.dat");
   parser.parse_check(argc, argv);
 
-  // Get parameters
-  std::string load(parser.get<std::string>("load"));
-  double x(parser.get<double>("x"));
-  double y(parser.get<double>("y"));
-  double zmin(parser.get<double>("zmin"));
-  double zmax(parser.get<double>("zmax"));
-  std::string savedens(parser.get<std::string>("savedens"));
-  int Nz(parser.get<int>("Nz"));
-  
-  // Load checkpoint
-  Checkpoint loadchk(load,false);
-  // Basis set
+  const std::string load = parser.get<std::string>("load");
+  const double x         = parser.get<double>("x");
+  const double y         = parser.get<double>("y");
+  const double zmin      = parser.get<double>("zmin");
+  const double zmax      = parser.get<double>("zmax");
+  const std::string savedens = parser.get<std::string>("savedens");
+  const int Nz           = parser.get<int>("Nz");
+
+  // Load checkpoint. Basis + density matrices are still arma-typed on
+  // the diatomic side; bridge to Eigen at the read boundary.
+  Checkpoint loadchk(load, false);
   diatomic::basis::TwoDBasis basis;
   loadchk.read(basis);
-  // Density matrix
-  arma::mat Pa, Pb;
-  loadchk.read("Pa",Pa);
-  loadchk.read("Pb",Pb);
-  // Rhalf
+  arma::mat Pa_a, Pb_a;
+  loadchk.read("Pa", Pa_a);
+  loadchk.read("Pb", Pb_a);
+  const helfem::Matrix Pa = helfem::to_eigen(Pa_a);
+  const helfem::Matrix Pb = helfem::to_eigen(Pb_a);
   double Rhalf;
-  loadchk.read("Rhalf",Rhalf);
+  loadchk.read("Rhalf", Rhalf);
 
-  const arma::vec z(arma::linspace<arma::vec>(zmin,zmax,Nz));
-  
-  // Solve for phi angle
-  const double phi(atan2(y,x));
-  const double xysq(x*x+y*y);
+  const helfem::Vector z = helfem::Vector::LinSpaced(Nz, zmin, zmax);
 
-  // Densities
-  arma::mat den(Nz,4);
-  den.zeros();
-  for(size_t iz=0;iz<z.n_elem;iz++) {
-    // Compute distances of point from the two nuclei
-    double ra(sqrt(std::pow(z(iz)+Rhalf,2)+xysq));
-    double rb(sqrt(std::pow(z(iz)-Rhalf,2)+xysq));
+  const double phi  = std::atan2(y, x);
+  const double xysq = x * x + y * y;
 
-    // xi and eta are
-    double xi((ra+rb)/(2*Rhalf));
-    double eta((ra-rb)/(2*Rhalf));
-
-    // Sanity check
-    if(eta<-1.0)
-      eta=-1.0;
-    if(eta>1.0)
-      eta=1.0;
-
-    // so mu is
-    double mu(utils::arcosh(xi));
-
-    // Check range: is mu outside of basis set?
-    if(mu>basis.get_mumax())
+  // Density on the line (z col + alpha col + beta col + total col).
+  helfem::Matrix den = helfem::Matrix::Zero(Nz, 4);
+  for (Eigen::Index iz = 0; iz < z.size(); ++iz) {
+    const double zi = z(iz);
+    const double ra = std::sqrt(std::pow(zi + Rhalf, 2) + xysq);
+    const double rb = std::sqrt(std::pow(zi - Rhalf, 2) + xysq);
+    const double xi = (ra + rb) / (2.0 * Rhalf);
+    double eta      = (ra - rb) / (2.0 * Rhalf);
+    if (eta < -1.0) eta = -1.0;
+    if (eta >  1.0) eta =  1.0;
+    const double mu = utils::arcosh(xi);
+    if (mu > basis.get_mumax()) {
+      den(iz, 0) = zi;
       continue;
-
-    // Evaluate basis functions
-    arma::cx_vec bf(basis.eval_bf(mu, eta, phi));
-
-    // Evaluate density at the point
-    den(iz,0)=z(iz);
-    den(iz,1)=std::real(arma::as_scalar(bf.t()*Pa*bf));
-    den(iz,2)=std::real(arma::as_scalar(bf.t()*Pb*bf));
-    den(iz,3)=den(iz,1)+den(iz,2);
+    }
+    // basis.eval_bf returns arma::cx_vec; bridge to Eigen VectorXcd.
+    const arma::cx_vec bf_a = basis.eval_bf(mu, eta, phi);
+    Eigen::VectorXcd bf(bf_a.n_elem);
+    for (arma::uword i = 0; i < bf_a.n_elem; ++i) bf(i) = bf_a(i);
+    // rho_spin = Re(bf^* . P . bf) with P symmetric real.
+    const double rhoa = (bf.adjoint() * Pa * bf).real().value();
+    const double rhob = (bf.adjoint() * Pb * bf).real().value();
+    den(iz, 0) = zi;
+    den(iz, 1) = rhoa;
+    den(iz, 2) = rhob;
+    den(iz, 3) = rhoa + rhob;
   }
 
-  printf("Saving density to file %s\n",savedens.c_str());
-  den.save(savedens,arma::raw_ascii);
+  printf("Saving density to file %s\n", savedens.c_str());
+  std::ofstream out(savedens);
+  for (Eigen::Index i = 0; i < den.rows(); ++i) {
+    for (Eigen::Index j = 0; j < den.cols(); ++j) {
+      if (j) out << " ";
+      out << den(i, j);
+    }
+    out << "\n";
+  }
 
   return 0;
 }

--- a/src/general/eigen_io.cpp
+++ b/src/general/eigen_io.cpp
@@ -1,0 +1,49 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#include "eigen_io.h"
+#include <cstdio>
+#include <fstream>
+
+namespace helfem {
+  namespace io {
+
+    void write_raw_ascii(const std::string & path, const helfem::Vector & v) {
+      std::ofstream out(path);
+      for (Eigen::Index i = 0; i < v.size(); ++i)
+        out << v(i) << "\n";
+    }
+
+    void write_raw_ascii(const std::string & path, const helfem::Matrix & m) {
+      std::ofstream out(path);
+      for (Eigen::Index i = 0; i < m.rows(); ++i) {
+        for (Eigen::Index j = 0; j < m.cols(); ++j) {
+          if (j) out << " ";
+          out << m(i, j);
+        }
+        out << "\n";
+      }
+    }
+
+    void print_matrix(const std::string & name, const helfem::Matrix & m) {
+      printf("%s\n", name.c_str());
+      for (Eigen::Index i = 0; i < m.rows(); ++i) {
+        for (Eigen::Index j = 0; j < m.cols(); ++j)
+          printf(" %8.4f", m(i, j));
+        printf("\n");
+      }
+    }
+
+  }
+}

--- a/src/general/eigen_io.h
+++ b/src/general/eigen_io.h
@@ -1,0 +1,43 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef HELFEM_EIGEN_IO_H
+#define HELFEM_EIGEN_IO_H
+
+#include "Matrix.h"
+#include <string>
+
+// Diagnostic dump helpers for helfem::Vector / helfem::Matrix. Used
+// by the FE test drivers (harmonic, inttest, ...) that want the same
+// arma-style raw-ASCII / print output the codebase had before the
+// arma migration.
+
+namespace helfem {
+  namespace io {
+    /// Write a Vector to `path` one entry per line (matches
+    /// arma::mat::save("...", arma::raw_ascii) semantics for a
+    /// column vector).
+    void write_raw_ascii(const std::string & path, const helfem::Vector & v);
+
+    /// Write a Matrix to `path` in row-major raw ASCII: entries in a
+    /// row separated by single spaces, rows separated by newlines.
+    void write_raw_ascii(const std::string & path, const helfem::Matrix & m);
+
+    /// Print a Matrix to stdout in the same fixed-width 8.4f grid the
+    /// arma::mat::print(name) layout used.
+    void print_matrix(const std::string & name, const helfem::Matrix & m);
+  }
+}
+
+#endif

--- a/src/harmonic/main.cpp
+++ b/src/harmonic/main.cpp
@@ -16,12 +16,12 @@
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
 #include "Matrix.h"
+#include "../general/eigen_io.h"
 #include <lib1dfem/chebyshev.h>
 #include <Eigen/Eigenvalues>
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
-#include <fstream>
 #include <memory>
 
 using namespace helfem;
@@ -42,22 +42,6 @@ namespace {
   helfem::Matrix kinetic(const polynomial_basis::FiniteElementBasis & fem,
                          const helfem::Vector & x, const helfem::Vector & wx) {
     return fem.matrix_element(true, true, x, wx, nullptr);
-  }
-
-  void write_raw_ascii(const std::string & path, const helfem::Vector & v) {
-    std::ofstream out(path);
-    for (Eigen::Index i = 0; i < v.size(); ++i)
-      out << v(i) << "\n";
-  }
-  void write_raw_ascii(const std::string & path, const helfem::Matrix & m) {
-    std::ofstream out(path);
-    for (Eigen::Index i = 0; i < m.rows(); ++i) {
-      for (Eigen::Index j = 0; j < m.cols(); ++j) {
-        if (j) out << " ";
-        out << m(i, j);
-      }
-      out << "\n";
-    }
   }
 }
 
@@ -93,9 +77,9 @@ int main(int argc, char **argv) {
   poly->eval_dnf(xq, bf,  0, 1.0);
   poly->eval_dnf(xq, dbf, 1, 1.0);
 
-  write_raw_ascii("x.dat",  xq);
-  write_raw_ascii("bf.dat", bf);
-  write_raw_ascii("dbf.dat", dbf);
+  io::write_raw_ascii("x.dat",  xq);
+  io::write_raw_ascii("bf.dat", bf);
+  io::write_raw_ascii("dbf.dat", dbf);
 
   const size_t Nbf = fem.get_nbf();
   printf("Basis set contains %i functions\n", (int) Nbf);

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -20,6 +20,10 @@
 #include "../general/scf_helpers.h"
 #include "utils.h"
 #include "dftgrid.h"
+#include "../atomic/basis.h"
+#include "Matrix.h"
+#include "ArmaEigen.h"
+#include <Eigen/Eigenvalues>
 #include <cfloat>
 
 using namespace helfem;
@@ -87,85 +91,69 @@ int main(int argc, char **argv) {
   // Order of quadrature rule
   printf("Using %i point quadrature rule.\n",Nquad);
 
-  // Radial basis
-  arma::vec bval=atomic::basis::form_grid((modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax, igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0);
+  // Radial basis. atomic::basis::form_grid still returns arma::vec;
+  // bridge once at the FiniteElementBasis constructor.
+  const arma::vec bval = atomic::basis::form_grid(
+      (modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax,
+      igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0);
 
-  // Construct radial basis
-  bool zero_func_left=true;
-  bool zero_deriv_left=false;
-  bool zero_func_right=true;
-  polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(bval), zero_func_left, zero_deriv_left, zero_func_right, zeroder);
+  const bool zero_func_left  = true;
+  const bool zero_deriv_left = false;
+  const bool zero_func_right = true;
+  polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(bval),
+      zero_func_left, zero_deriv_left, zero_func_right, zeroder);
   atomic::basis::FEMRadialBasis radial(fem, Nquad);
 
-  // Compute matrices. Phase 2a: radial.overlap() returns
-  // helfem::Matrix (Eigen); rest of sadatom 1e is still arma -- bridge
-  // at the boundary via to_arma until the chemistry layer migrates.
-  arma::mat S(helfem::to_arma(radial.overlap()));
-  arma::mat Sinvh=helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S),false));
+  // FE-side matrices are already helfem::Matrix; no arma bridge needed.
+  const helfem::Matrix S     = radial.overlap();
+  const helfem::Matrix Sinvh = scf::form_Sinvh(S, /*chol=*/false);
+  const helfem::Matrix T     = radial.kinetic();
+  const helfem::Matrix Tl    = radial.kinetic_l();
+  const helfem::Matrix V     = radial.nuclear();
 
-  // Phase 2a: radial.kinetic / kinetic_l / nuclear return helfem::Matrix.
-  arma::mat T(helfem::to_arma(radial.kinetic()));
-  arma::mat Tl(helfem::to_arma(radial.kinetic_l()));
-  arma::mat V(helfem::to_arma(radial.nuclear()));
+  for (int l = 0; l <= lmax; ++l) {
+    const helfem::Matrix H0 =
+        Sinvh.transpose() * (T + Z * V + l * (l + 1) * Tl) * Sinvh;
+    Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(H0);
+    const helfem::Vector E = es.eigenvalues();
+    helfem::Matrix C = Sinvh * es.eigenvectors();
 
-  // Compute orbitals
-  for(int l=0;l<=lmax;l++) {
-    arma::mat H0 = Sinvh.t() * (T+Z*V+l*(l+1)*Tl) * Sinvh;
-    arma::vec E;
-    arma::mat C;
-    arma::eig_sym(E,C,H0);
-    C = Sinvh*C;
+    printf("l=%i eigenvalues\n", l);
+    for (Eigen::Index i = 0; i < E.size(); ++i)
+      printf("  %.15e\n", E(i));
+
+    // Evaluate orbitals on the quadrature grid.
+    const Eigen::Index Ncols = C.cols();
+    const Eigen::Index Npts  = radial.get_bf(0).rows();
+    helfem::Matrix Cv = helfem::Matrix::Zero(radial.Nel() * Npts, Ncols);
+    for (size_t iel = 0; iel < radial.Nel(); ++iel) {
+      size_t ifirst, ilast;
+      radial.get_idx(iel, ifirst, ilast);
+      const helfem::Matrix Csub = C.middleRows(ifirst, ilast - ifirst + 1);
+      const helfem::Matrix bf   = radial.get_bf(iel);
+      Cv.middleRows(iel * Npts, Npts) = bf * Csub;
+    }
 
     std::ostringstream oss;
-    oss << "l=" << l << " eigenvalues";
-    E.print(oss.str());
-
-    // Evaluate orbitals on grid
-    std::vector<arma::mat> c(radial.Nel());
-    for(size_t iel=0;iel<radial.Nel();iel++) {
-      // Radial functions in element
-      size_t ifirst, ilast;
-      radial.get_idx(iel,ifirst,ilast);
-      // Density matrix
-      arma::mat Csub(C.rows(ifirst,ilast));
-      arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
-
-      c[iel]=bf*Csub;
-    }
-    size_t Npts=c[0].n_rows;
-
-    // Orbital values
-    arma::mat Cv(radial.Nel()*Npts,C.n_cols,arma::fill::zeros);
-    for(size_t iel=0;iel<radial.Nel();iel++) {
-      Cv.rows(iel*Npts,(iel+1)*Npts-1)=c[iel];
-    }
-
-    oss.str("");
     oss << "orbs_" << l;
-    chkpt.write(oss.str(), Cv);
+    chkpt.write(oss.str(), helfem::to_arma(Cv));
     oss.str("");
     oss << "E_" << l;
-    chkpt.write(oss.str(), E);
+    chkpt.write(oss.str(), helfem::to_arma(E));
   }
 
-  // Get the radii and quadrature weights as well
-  std::vector<arma::vec> r(radial.Nel()), wr(radial.Nel());
-  for(size_t iel=0;iel<radial.Nel();iel++) {
-    r[iel]=helfem::to_arma(radial.get_r(iel));
-    wr[iel]=helfem::to_arma(radial.get_wrad(iel));
-  }
-  size_t Npts=r[0].n_rows;
-
-  // Value of radii and weights
-  arma::vec radii(radial.Nel()*Npts,arma::fill::zeros);
-  arma::vec weights(radial.Nel()*Npts,arma::fill::zeros);
-  for(size_t iel=0;iel<radial.Nel();iel++) {
-    radii.subvec(iel*Npts,(iel+1)*Npts-1)=r[iel];
-    weights.subvec(iel*Npts,(iel+1)*Npts-1)=wr[iel];
+  // Concatenate per-element radii and quadrature weights into flat
+  // vectors and write them to the checkpoint.
+  const Eigen::Index Npts = radial.get_r(0).size();
+  helfem::Vector radii   = helfem::Vector::Zero(radial.Nel() * Npts);
+  helfem::Vector weights = helfem::Vector::Zero(radial.Nel() * Npts);
+  for (size_t iel = 0; iel < radial.Nel(); ++iel) {
+    radii  .segment(iel * Npts, Npts) = radial.get_r   (iel);
+    weights.segment(iel * Npts, Npts) = radial.get_wrad(iel);
   }
 
-  chkpt.write("r",radii);
-  chkpt.write("wr",weights);
+  chkpt.write("r",  helfem::to_arma(radii));
+  chkpt.write("wr", helfem::to_arma(weights));
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Second slice of the `src/` arma sweep. Three analysis tools where the compute layer is already Eigen-typed on the FE side, so the migration is confined to the driver-level scratch and a couple of I/O bridges.

| Tool | arma refs (before → after) |
|------|-----------------------------|
| `atomic/inttest.cpp`      | 14 → 0 (fully arma-free) |
| `sadatom/1e.cpp`          | 17 → 2  (form_grid + Checkpoint::write bridges) |
| `diatomic/density_line.cpp` | 7 → 4  (Checkpoint::read + basis.eval_bf return) |

Net: **−32 arma refs**.

- **`atomic/inttest.cpp`**: `lobatto` / `chebyshev` come from `lib1dfem::…::*` directly; `quadrature::twoe_*` already return `helfem::Matrix` so the `helfem::to_arma` round-trip is gone. Local `write_raw_ascii` / `print_matrix` helpers replace `arma::mat::save` / `.print`.
- **`sadatom/1e.cpp`**: FE matrices are Eigen; drop the `to_arma` wrappers. Per-`l` eigenvalue problem via `Eigen::SelfAdjointEigenSolver`, orbital slice via `C.middleRows`. Radii and weights concatenated with `.segment`, bridged to arma once each at the `Checkpoint::write` boundary.
- **`diatomic/density_line.cpp`**: Load `Pa`, `Pb` as arma from the checkpoint and convert once; density evaluated in Eigen throughout. `basis.eval_bf` still returns `arma::cx_vec` so bridge to `Eigen::VectorXcd` at that call site.

## Test plan

- [x] Full build clean.
- [x] `atomic_itest 20 1.0` reproduces its pre-migration `analytical / quadrature / difference` matrices bit-identical.
- [x] `1e_atom --Z=1 --nelem=5 --nnodes=15 --lmax=0 --primbas=4` produces the H eigenvalues `-0.5, -0.125, -0.05555..., -0.03055..., -0.01106...` bit-identical to pre-migration.
- [ ] `diatomic_dline` end-to-end validation deferred since it needs a saved diatomic checkpoint — compiles + links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)