### PR TITLE
src/general/checkpoint: Eigen overloads for helfem::Matrix / Vector

### DIFF
--- a/src/diatomic/density_line.cpp
+++ b/src/diatomic/density_line.cpp
@@ -47,16 +47,14 @@ int main(int argc, char **argv) {
   const std::string savedens = parser.get<std::string>("savedens");
   const int Nz           = parser.get<int>("Nz");
 
-  // Load checkpoint. Basis + density matrices are still arma-typed on
-  // the diatomic side; bridge to Eigen at the read boundary.
+  // Basis is still arma-typed internally (its serialised layout);
+  // Pa / Pb read straight into helfem::Matrix via the Eigen overload.
   Checkpoint loadchk(load, false);
   diatomic::basis::TwoDBasis basis;
   loadchk.read(basis);
-  arma::mat Pa_a, Pb_a;
-  loadchk.read("Pa", Pa_a);
-  loadchk.read("Pb", Pb_a);
-  const helfem::Matrix Pa = helfem::to_eigen(Pa_a);
-  const helfem::Matrix Pb = helfem::to_eigen(Pb_a);
+  helfem::Matrix Pa, Pb;
+  loadchk.read("Pa", Pa);
+  loadchk.read("Pb", Pb);
   double Rhalf;
   loadchk.read("Rhalf", Rhalf);
 

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -1063,6 +1063,39 @@ void change_dir(std::string dir, bool create) {
   }
 }
 
+// Eigen overloads: bridge through arma::mat at the HDF5 boundary so
+// on-disk layout is unchanged and checkpoints written by an Eigen-typed
+// caller can be read back by an arma-typed caller (and vice versa).
+void Checkpoint::write(const std::string & name, const helfem::Matrix & mat) {
+  write(name, helfem::to_arma(mat));
+}
+
+void Checkpoint::read(const std::string & name, helfem::Matrix & mat) {
+  arma::mat tmp;
+  read(name, tmp);
+  mat = helfem::to_eigen(tmp);
+}
+
+void Checkpoint::write(const std::string & name, const helfem::Vector & v) {
+  write(name, helfem::to_arma(v));
+}
+
+void Checkpoint::read(const std::string & name, helfem::Vector & v) {
+  arma::vec tmp;
+  {
+    arma::mat m;
+    read(name, m);
+    if (m.n_cols != 1) {
+      std::ostringstream oss;
+      oss << "Cannot read \"" << name << "\" as a helfem::Vector: "
+          << "expected 1 column, got " << m.n_cols << "\n";
+      throw std::runtime_error(oss.str());
+    }
+    tmp = m.col(0);
+  }
+  v = helfem::to_eigen(tmp);
+}
+
 std::string tempname() {
   // Get random file name
   char *tmpname=tempnam("./",".chk");

--- a/src/general/checkpoint.h
+++ b/src/general/checkpoint.h
@@ -19,6 +19,7 @@
 #include <armadillo>
 #include "../atomic/basis.h"
 #include "../diatomic/basis.h"
+#include "Matrix.h"
 
 // Use C routines, since C++ routines don't seem to add any ease of use.
 extern "C" {
@@ -83,6 +84,18 @@ class Checkpoint {
   void write(const std::string & name, const arma::mat & mat);
   /// Read matrix
   void read(const std::string & name, arma::mat & mat);
+
+  /// Eigen overload: writes/reads a helfem::Matrix by bridging through
+  /// arma::mat at the HDF5 boundary. Layout on disk is unchanged so
+  /// checkpoints stay round-trippable between arma-typed and
+  /// Eigen-typed callers.
+  void write(const std::string & name, const helfem::Matrix & mat);
+  void read(const std::string & name, helfem::Matrix & mat);
+
+  /// Eigen overload for helfem::Vector: writes as a single-column
+  /// arma::mat and reads back the first column.
+  void write(const std::string & name, const helfem::Vector & v);
+  void read(const std::string & name, helfem::Vector & v);
 
   /// Save complex matrix
   void cwrite(const std::string & name, const arma::cx_mat & mat);

--- a/src/harmonic/softcoulomb.cpp
+++ b/src/harmonic/softcoulomb.cpp
@@ -18,7 +18,6 @@
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
 #include "Matrix.h"
-#include "ArmaEigen.h"
 #include <lib1dfem/chebyshev.h>
 #include <Eigen/Eigenvalues>
 #include <algorithm>
@@ -145,13 +144,12 @@ int main(int argc, char **argv) {
   Sgrid -= helfem::Matrix::Identity(Sgrid.rows(), Sgrid.cols());
   printf("Orbital orthonormality devation on grid is %e\n", Sgrid.norm());
 
-  // Checkpoint I/O is still arma-typed; bridge at the write boundary.
   Checkpoint chkpt(save, true);
-  chkpt.write("bf",     helfem::to_arma(bfval));
-  chkpt.write("C",      helfem::to_arma(C));
-  chkpt.write("phi",    helfem::to_arma(phival));
-  chkpt.write("coords", helfem::to_arma(coords));
-  chkpt.write("weights", helfem::to_arma(weights));
+  chkpt.write("bf",      bfval);
+  chkpt.write("C",       C);
+  chkpt.write("phi",     phival);
+  chkpt.write("coords",  coords);
+  chkpt.write("weights", weights);
 
   return 0;
 }

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -136,10 +136,10 @@ int main(int argc, char **argv) {
 
     std::ostringstream oss;
     oss << "orbs_" << l;
-    chkpt.write(oss.str(), helfem::to_arma(Cv));
+    chkpt.write(oss.str(), Cv);
     oss.str("");
     oss << "E_" << l;
-    chkpt.write(oss.str(), helfem::to_arma(E));
+    chkpt.write(oss.str(), E);
   }
 
   // Concatenate per-element radii and quadrature weights into flat
@@ -152,8 +152,8 @@ int main(int argc, char **argv) {
     weights.segment(iel * Npts, Npts) = radial.get_wrad(iel);
   }
 
-  chkpt.write("r",  helfem::to_arma(radii));
-  chkpt.write("wr", helfem::to_arma(weights));
+  chkpt.write("r",  radii);
+  chkpt.write("wr", weights);
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Adds `Checkpoint::write` and `Checkpoint::read` overloads that take `helfem::Matrix` / `helfem::Vector` directly. Both bridge through `arma::mat` at the HDF5 boundary via `helfem::to_arma` / `to_eigen` so the on-disk layout is unchanged — checkpoints written by an Eigen-typed caller can still be read by an arma-typed one and vice versa.

The Vector overload is a single-column matrix on disk; the read path rejects any dataset that isn't 1 column with a clear error.

## Drops the manual `helfem::to_arma` bridges

- `src/harmonic/softcoulomb.cpp` (fully arma-free now; also drops the `ArmaEigen.h` include).
- `src/sadatom/1e.cpp` (tidier — the remaining two arma refs are `form_grid`'s `arma::vec` return, bridged once at the `FiniteElementBasis` constructor).
- `src/diatomic/density_line.cpp`: `Pa` / `Pb` read straight into `helfem::Matrix` via the new overloads, dropping the manual `arma::mat` → `helfem::Matrix` conversion.

Any future analysis / driver TU can now write Eigen matrices directly without a per-callsite bridge — enables cleaner migrations in the `src/` arma sweep going forward.

## Test plan

- [x] Full build clean.
- [x] `softcoulomb` writes an identical 132288-byte checkpoint pre/post migration.
- [x] `1e_atom` H eigenvalues (`-0.5, -0.125, -0.0555..., -0.0305..., -0.0110...`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)