### PR TITLE
src/{atomic,diatomic,sadatom}: basis field methods return helfem::Matrix

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -417,13 +417,13 @@ namespace helfem {
         return remove_boundaries(V);
       }
 
-      arma::mat TwoDBasis::confinement(const int N, double r_0, const int iconf, const double V, const double shift_pot) const {
+      helfem::Matrix TwoDBasis::confinement(const int N, double r_0, const int iconf, const double V, const double shift_pot) const {
         // Full matrix
         arma::mat O(Ndummy(),Ndummy());
         O.zeros();
 
 	if(iconf==0)
-	  return remove_boundaries(O);
+	  return helfem::to_eigen(remove_boundaries(O));
 
         arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) {
@@ -434,10 +434,10 @@ namespace helfem {
         for(size_t iang=0;iang<lval.n_elem;iang++)
           set_sub(O,iang,iang,Orad);
 
-        return remove_boundaries(O);
+        return helfem::to_eigen(remove_boundaries(O));
       }
 
-      arma::mat TwoDBasis::dipole_z() const {
+      helfem::Matrix TwoDBasis::dipole_z() const {
         // Build radial elements
         arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(1, iel); }));
@@ -465,10 +465,10 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(V);
+        return helfem::to_eigen(remove_boundaries(V));
       }
 
-      arma::mat TwoDBasis::quadrupole_zz() const {
+      helfem::Matrix TwoDBasis::quadrupole_zz() const {
         // Build radial elements
         arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(2, iel); }));
@@ -502,10 +502,10 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(V);
+        return helfem::to_eigen(remove_boundaries(V));
       }
 
-      arma::mat TwoDBasis::Bz_field(double B) const {
+      helfem::Matrix TwoDBasis::Bz_field(double B) const {
         // Build radial elements
         arma::mat O0rad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(0, iel); }));
@@ -540,7 +540,7 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(V);
+        return helfem::to_eigen(remove_boundaries(V));
       }
 
       size_t TwoDBasis::mem_1el() const {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -166,19 +166,19 @@ namespace helfem {
         /// Form nuclear attraction matrix
         helfem::Matrix nuclear() const;
 	/// Form confinement potential matrix
-	arma::mat confinement(const int N, const double r_0, const int iconf, const double V, const double shift_pot) const;
+	helfem::Matrix confinement(const int N, const double r_0, const int iconf, const double V, const double shift_pot) const;
 	/// Form model potential matrix
 	arma::mat model_potential(const modelpotential::ModelPotential * model) const;
         /// Form dipole coupling matrix
-        arma::mat dipole_z() const;
+        helfem::Matrix dipole_z() const;
         /// Form quadrupole coupling matrix
-        arma::mat quadrupole_zz() const;
+        helfem::Matrix quadrupole_zz() const;
 
         /// Compute overlap matrix
         arma::mat overlap(const TwoDBasis & rh) const;
 
         /// Coupling to magnetic field in z direction
-        arma::mat Bz_field(double B) const;
+        helfem::Matrix Bz_field(double B) const;
 
         /// Form density matrix
         arma::mat form_density(const arma::mat & C, size_t nocc) const;

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -241,12 +241,12 @@ int main(int argc, char **argv) {
   arma::mat Vconf(Nbf, Nbf, arma::fill::zeros);
   if (iconf) {
     printf("Computing confinement potential\n");
-    Vconf = basis.confinement(conf_N, conf_R, iconf, conf_barrier, shift_conf);
+    Vconf = helfem::to_arma(basis.confinement(conf_N, conf_R, iconf, conf_barrier, shift_conf));
   }
-  const arma::mat dip  = basis.dipole_z();
-  const arma::mat quad = basis.quadrupole_zz();
+  const arma::mat dip  = helfem::to_arma(basis.dipole_z());
+  const arma::mat quad = helfem::to_arma(basis.quadrupole_zz());
   const arma::mat Vel  = Ez * dip + Qzz * quad / 3.0;
-  const arma::mat Vmag = basis.Bz_field(Bz);
+  const arma::mat Vmag = helfem::to_arma(basis.Bz_field(Bz));
   const bool have_efield = (Ez != 0.0 || Qzz != 0.0);
   const bool have_bfield = (Bz != 0.0);
   const bool have_conf   = (iconf != 0);

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -813,7 +813,7 @@ namespace helfem {
         return remove_boundaries(V);
       }
 
-      arma::mat TwoDBasis::dipole_z() const {
+      helfem::Matrix TwoDBasis::dipole_z() const {
         // Full electric couplings
         arma::mat V(Ndummy(),Ndummy());
         V.zeros();
@@ -849,10 +849,10 @@ namespace helfem {
         // Plug in prefactors
         V*=std::pow(Rhalf,4);
 
-        return remove_boundaries(V);
+        return helfem::to_eigen(remove_boundaries(V));
       }
 
-      arma::mat TwoDBasis::quadrupole_zz() const {
+      helfem::Matrix TwoDBasis::quadrupole_zz() const {
         // Full electric couplings
         arma::mat V(Ndummy(),Ndummy());
         V.zeros();
@@ -893,10 +893,10 @@ namespace helfem {
         // Plug in prefactors
         V*=std::pow(Rhalf,5)/2;
 
-        return remove_boundaries(V);
+        return helfem::to_eigen(remove_boundaries(V));
       }
 
-      arma::mat TwoDBasis::Bz_field(double B) const {
+      helfem::Matrix TwoDBasis::Bz_field(double B) const {
         // Full couplings
         arma::mat V(Ndummy(),Ndummy());
         V.zeros();
@@ -946,7 +946,7 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(V);
+        return helfem::to_eigen(remove_boundaries(V));
       }
 
       arma::mat TwoDBasis::radial_moments(const arma::mat & P0) const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -234,15 +234,15 @@ namespace helfem {
         /// Form nuclear attraction matrix
         arma::mat nuclear() const;
         /// Form dipole coupling matrix
-        arma::mat dipole_z() const;
+        helfem::Matrix dipole_z() const;
         /// Form dipole coupling matrix
-        arma::mat quadrupole_zz() const;
+        helfem::Matrix quadrupole_zz() const;
 
         /// Form overlap matrix
         arma::mat overlap(const TwoDBasis & rh) const;
 
         /// Coupling to magnetic field in z direction
-        arma::mat Bz_field(double B) const;
+        helfem::Matrix Bz_field(double B) const;
 
         /// <r^2> matrix
         arma::mat radial_moments(const arma::mat & P) const;

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -87,14 +87,14 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   // Form Hamiltonian
   arma::mat H0(T+Vnuc);
   if(Ez!=0.0)
-    H0+=Ez*basis.dipole_z();
+    H0+=Ez*helfem::to_arma(basis.dipole_z());
   // Quadrupole coupling
   if(Qzz!=0.0)
-    H0+=Qzz*basis.quadrupole_zz()/3.0;
+    H0+=Qzz*helfem::to_arma(basis.quadrupole_zz())/3.0;
   // Magnetic field coupling
   if(Bz!=0.0) {
     printf("Bz=%e\n",Bz);
-    H0+=basis.Bz_field(Bz)-Bz*S/2.0;
+    H0+=helfem::to_arma(basis.Bz_field(Bz))-Bz*S/2.0;
   }
   // Use core guess
   arma::vec Ev;

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -219,10 +219,10 @@ int main(int argc, char **argv) {
   //   nucquad = (Z1 + Z2) * Rhalf^2
   //   Enucfield = -Ez * nucdip - Qzz * nucquad / 3
   // Vel/Vmag are the electron-side matrix contributions folded into H0.
-  const arma::mat dip  = basis.dipole_z();
-  const arma::mat quad = basis.quadrupole_zz();
+  const arma::mat dip  = helfem::to_arma(basis.dipole_z());
+  const arma::mat quad = helfem::to_arma(basis.quadrupole_zz());
   const arma::mat Vel  = Ez * dip + Qzz * quad / 3.0;
-  const arma::mat Vmag = basis.Bz_field(Bz);
+  const arma::mat Vmag = helfem::to_arma(basis.Bz_field(Bz));
   const double nucdip  = (Z2 - Z1) * Rhalf;
   const double nucquad = (Z1 + Z2) * Rhalf * Rhalf;
   const double Enucfield = -Ez * nucdip - Qzz * nucquad / 3.0;

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -103,15 +103,15 @@ namespace helfem {
             [&](size_t iel) { return radial.radial_integral(-1, iel); });
       }
 
-      arma::mat TwoDBasis::confinement(int N, double r_0, int iconf, double V, double shift_pot) const {
+      helfem::Matrix TwoDBasis::confinement(int N, double r_0, int iconf, double V, double shift_pot) const {
         if (!iconf) {
-          const size_t Nrad = radial.Nbf();
-          return arma::zeros<arma::mat>(Nrad, Nrad);
+          const Eigen::Index Nrad = static_cast<Eigen::Index>(radial.Nbf());
+          return helfem::Matrix::Zero(Nrad, Nrad);
         }
-        return helfem::to_arma(helfem::assemble_radial_diagonal(radial,
+        return helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) {
               return radial.confinement_potential(iel, N, r_0, iconf, V, shift_pot);
-            }));
+            });
       }
 
       arma::mat TwoDBasis::model_potential(const modelpotential::ModelPotential * pot) const {

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -87,7 +87,7 @@ namespace helfem {
         /// Form nuclear attraction matrix
         helfem::Matrix nuclear() const;
 	/// Form confinement potential matrix
-	arma::mat confinement(int N, double r_0, int iconf, double V, double shift_pot) const;
+	helfem::Matrix confinement(int N, double r_0, int iconf, double V, double shift_pot) const;
         /// Form model potential matrix
 	arma::mat model_potential(const modelpotential::ModelPotential * model) const;
         /// Form Coulomb matrix

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -58,9 +58,8 @@ namespace helfem {
 
         helfem::Matrix Vconf = helfem::Matrix::Zero(basis.Nbf(), basis.Nbf());
         if (opts.iconf) {
-          Vconf = helfem::to_eigen(basis.confinement(
-              opts.conf_N, opts.conf_R, opts.iconf,
-              opts.conf_barrier, opts.shift_conf));
+          Vconf = basis.confinement(opts.conf_N, opts.conf_R, opts.iconf,
+                                     opts.conf_barrier, opts.shift_conf);
         }
         const bool have_conf = (opts.iconf != 0);
 


### PR DESCRIPTION
## Summary

Migrate the return type of the four one-shot field/perturbation matrices on the three atom/molecule bases from `arma::mat` to `helfem::Matrix`:

- `atomic::basis::TwoDBasis`:  `confinement`, `dipole_z`, `quadrupole_zz`, `Bz_field`
- `diatomic::basis::TwoDBasis`: `dipole_z`, `quadrupole_zz`, `Bz_field` (no confinement)
- `sadatom::basis::TwoDBasis`:  `confinement`

The internal implementations still build in arma via `set_sub` / `add_sub` / `remove_boundaries`; wrap the final return in `helfem::to_eigen` for the atomic and diatomic bases and rewrite sadatom's confinement in native `helfem::assemble_radial_diagonal` so it never touches arma at all.

## Callers updated

- `src/atomic/main.cpp`: four `helfem::to_arma` bridges at the CLI-driven field-matrix assignments (`Vconf`, `dip`, `quad`, `Vmag`).
- `src/diatomic/main.cpp`: three bridges.
- `src/diatomic/corebasis.cpp`: three bridges (Ez/Qzz/Bz additions to H0).
- `src/sadatom/scf.cpp`: drops the `to_eigen` wrapper that was there to bridge the old arma-typed confinement return.

The atomic-driver-side `to_arma` bridges are intermediate — when the drivers migrate their internal Fock scratch to `helfem::Matrix` (dsym indexing switch is the gating change), the bridges disappear.

## Test plan

- [x] Full clean build.
- [x] H atom LDA lmax=0 no field: `-0.4570630955` (unchanged).
- [x] H atom LDA lmax=1 Ez=0.01: `-0.4574012192`, `Eefield -6.47e-4` (physical Ez polarization).
- [x] H2 LDA lmax=1 Ez=0.01 Bz=0.05: `-1.0153512934` (unchanged from PR #179).
- [x] gensap H atom confinement (`iconf=1 conf_R=5 conf_N=4 conf_barrier=0.1`): `-0.4274862525` (unchanged from PR #178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)