### PR TITLE
src/diatomic: overlap / kinetic / nuclear / radial_integral return helfem::Matrix

### DIFF
--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -128,10 +128,10 @@ int main(int argc, char **argv) {
   Timer timer;
 
   // Form overlap matrix
-  arma::mat S(basis.overlap());
+  arma::mat S(helfem::to_arma(basis.overlap()));
   chkpt.write("S",S);
   // Form kinetic energy matrix
-  arma::mat T(basis.kinetic());
+  arma::mat T(helfem::to_arma(basis.kinetic()));
   chkpt.write("T",T);
 
   // Get half-inverse
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
 
   // Form nuclear attraction energy matrix
   Timer tnuc;
-  arma::mat Vnuc=basis.nuclear();
+  arma::mat Vnuc=helfem::to_arma(basis.nuclear());
   chkpt.write("Vnuc",Vnuc);
 
   // Form Hamiltonian

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -581,7 +581,7 @@ namespace helfem {
 
       arma::mat TwoDBasis::Shalf(bool chol, int sym) const {
         // Form overlap matrix
-        arma::mat S(overlap());
+        arma::mat S(helfem::to_arma(overlap()));
 
         // Get the basis function norms
         arma::vec bfnormlz(arma::pow(arma::diagvec(S),-0.5));
@@ -623,7 +623,7 @@ namespace helfem {
 
       arma::mat TwoDBasis::Sinvh(bool chol, int sym) const {
         // Form overlap matrix
-        arma::mat S(overlap());
+        arma::mat S(helfem::to_arma(overlap()));
 
         // Half-inverse is
         if(sym==0) {
@@ -660,7 +660,7 @@ namespace helfem {
         return M.submat(iang*radial.Nbf(),jang*radial.Nbf(),(iang+1)*radial.Nbf()-1,(jang+1)*radial.Nbf()-1);
       }
 
-      arma::mat TwoDBasis::radial_integral(int Rexp) const {
+      helfem::Matrix TwoDBasis::radial_integral(int Rexp) const {
         // Full overlap matrix
         arma::mat O(Ndummy(),Ndummy());
         O.zeros();
@@ -668,10 +668,10 @@ namespace helfem {
         (void) Rexp;
         throw std::logic_error("not implemented.!\n");
 
-        return remove_boundaries(O);
+        return helfem::to_eigen(remove_boundaries(O));
       }
 
-      arma::mat TwoDBasis::overlap() const {
+      helfem::Matrix TwoDBasis::overlap() const {
         // Build radial matrix elements
         arma::mat I10(radial.radial_integral(1,0));
         arma::mat I12(radial.radial_integral(1,2));
@@ -704,7 +704,7 @@ namespace helfem {
         // Plug in prefactor
         S*=std::pow(Rhalf,3);
 
-        return remove_boundaries(S);
+        return helfem::to_eigen(remove_boundaries(S));
       }
 
       arma::mat TwoDBasis::overlap(const TwoDBasis & rh) const {
@@ -746,7 +746,7 @@ namespace helfem {
         return S;
       }
 
-      arma::mat TwoDBasis::kinetic() const {
+      helfem::Matrix TwoDBasis::kinetic() const {
         // Build radial kinetic energy matrix
         arma::mat Trad(radial.kinetic());
         arma::mat Ip1(radial.radial_integral(1,0));
@@ -771,10 +771,10 @@ namespace helfem {
         // Plug in prefactor
         T*=Rhalf/2.0;
 
-        return remove_boundaries(T);
+        return helfem::to_eigen(remove_boundaries(T));
       }
 
-      arma::mat TwoDBasis::nuclear() const {
+      helfem::Matrix TwoDBasis::nuclear() const {
         // Build radial matrices
         arma::mat I10(radial.radial_integral(1,0));
         arma::mat I11(radial.radial_integral(1,1));
@@ -810,7 +810,7 @@ namespace helfem {
         // Plug in prefactor
         V*=-std::pow(Rhalf,2);
 
-        return remove_boundaries(V);
+        return helfem::to_eigen(remove_boundaries(V));
       }
 
       helfem::Matrix TwoDBasis::dipole_z() const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -226,13 +226,13 @@ namespace helfem {
         /// Form half-inverse overlap matrix
         arma::mat Sinvh(bool chol, int sym) const;
         /// Form radial integral
-        arma::mat radial_integral(int n) const;
+        helfem::Matrix radial_integral(int n) const;
         /// Form overlap matrix
-        arma::mat overlap() const;
+        helfem::Matrix overlap() const;
         /// Form kinetic energy matrix
-        arma::mat kinetic() const;
+        helfem::Matrix kinetic() const;
         /// Form nuclear attraction matrix
-        arma::mat nuclear() const;
+        helfem::Matrix nuclear() const;
         /// Form dipole coupling matrix
         helfem::Matrix dipole_z() const;
         /// Form dipole coupling matrix

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -44,16 +44,16 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   std::vector<arma::uvec> dsym=basis.get_sym_idx(symm);
 
   // Form overlap matrix
-  arma::mat S(basis.overlap());
+  arma::mat S(helfem::to_arma(basis.overlap()));
   // Form kinetic energy matrix
-  arma::mat T(basis.kinetic());
+  arma::mat T(helfem::to_arma(basis.kinetic()));
   // Get half-inverse
   arma::mat Sinvh(basis.Sinvh(!diag,symm));
   // Form nuclear attraction energy matrix
   arma::mat Vnuc;
 
   if(imodel==0) {
-    Vnuc=basis.nuclear();
+    Vnuc=helfem::to_arma(basis.nuclear());
   } else {
     modelpotential::ModelPotential * p1, * p2;
     if(imodel == 1) {

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -15,6 +15,7 @@
 
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"
+#include <ArmaEigen.h>
 #include "../general/constants.h"
 #include "../general/spherical_harmonics.h"
 #include "../general/timer.h"
@@ -129,7 +130,7 @@ int main(int argc, char **argv) {
   if(nelb>0)
     Sb.zeros(nelb,nelb);
 
-  arma::mat T(basis.kinetic());
+  arma::mat T(helfem::to_arma(basis.kinetic()));
   arma::mat STCa = Sinv*T*Ca;
   arma::mat STCb = Sinv*T*Cb;
 

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -208,9 +208,9 @@ int main(int argc, char **argv) {
           restricted ? "restricted" : "unrestricted", symm, nela, nelb);
 
   // Diatomic chemistry-layer methods are still arma-native.
-  const arma::mat S    = basis.overlap();
-  const arma::mat T    = basis.kinetic();
-  const arma::mat Vnuc = basis.nuclear();
+  const arma::mat S    = helfem::to_arma(basis.overlap());
+  const arma::mat T    = helfem::to_arma(basis.kinetic());
+  const arma::mat Vnuc = helfem::to_arma(basis.nuclear());
 
   // External static-field one-electron matrices. Diatomic has two
   // nuclei at (0, 0, +/- Rhalf); nuclear dipole/quadrupole moments are


### PR DESCRIPTION
## Summary

Migrate the diatomic `TwoDBasis` 1e matrix returns from `arma::mat` to `helfem::Matrix`, matching the atomic `TwoDBasis` convention. Four methods change return type on the diatomic side:

- `TwoDBasis::overlap()`
- `TwoDBasis::kinetic()`
- `TwoDBasis::nuclear()`
- `TwoDBasis::radial_integral(int)`  (no live callers; throws "not implemented" internally)

Internal implementations still build in arma via `set_sub` / `add_sub` / `remove_boundaries`; wrap the final `remove_boundaries(...)` return in `helfem::to_eigen`.

`Shalf()` and `Sinvh()` (still arma-typed for now, their bodies are non-trivially arma-native) pick the arma overlap up via a new `helfem::to_arma` bridge at their internal `arma::mat S(overlap())` site.

## Callers updated

`helfem::to_arma` bridge added at the driver-level assignments:

- `src/diatomic/main.cpp` (S, T, Vnuc setup)
- `src/diatomic/1e.cpp` (three sites)
- `src/diatomic/corebasis.cpp` (S, T, Vnuc)
- `src/diatomic/density_grid.cpp` (T)

The `overlap(const TwoDBasis & rh)` cross-basis form is left arma-typed in this PR — its impl is more entangled; separate slice.

## Test plan

- [x] Full clean build.
- [x] H2 LDA (`--Rbond=1.4 --nela=1 --nelb=1 --lmax=1 --mmax=1 --nelem=3 --nnodes=8`) converges to `-1.0161182665` bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)