### PR TITLE
src/{sadatom,diatomic}: Sinvh / Shalf / radial_integral return helfem::Matrix

### DIFF
--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
   timer.set();
   bool diag=true;
   bool symm=false;
-  arma::mat Sinvh(basis.Sinvh(!diag,symm));
+  arma::mat Sinvh(helfem::to_arma(basis.Sinvh(!diag,symm)));
   chkpt.write("Sinvh",Sinvh);
   printf("Half-inverse formed in %.6f\n",timer.get());
   {

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -579,7 +579,7 @@ namespace helfem {
         return idx;
       }
 
-      arma::mat TwoDBasis::Shalf(bool chol, int sym) const {
+      helfem::Matrix TwoDBasis::Shalf(bool chol, int sym) const {
         // Form overlap matrix
         arma::mat S(helfem::to_arma(overlap()));
 
@@ -592,7 +592,7 @@ namespace helfem {
 
         if(chol && sym==0) {
           // Half-inverse is
-          return arma::diagmat(bfinvnormlz) * arma::chol(S);
+          return helfem::to_eigen(arma::mat(arma::diagmat(bfinvnormlz) * arma::chol(S)));
 
         } else {
           arma::vec Sval;
@@ -617,17 +617,17 @@ namespace helfem {
           arma::mat Shalf(Svec*arma::diagmat(arma::pow(Sval,0.5))*arma::trans(Svec));
           Shalf=arma::diagmat(bfinvnormlz)*Shalf;
 
-          return Shalf;
+          return helfem::to_eigen(Shalf);
         }
       }
 
-      arma::mat TwoDBasis::Sinvh(bool chol, int sym) const {
+      helfem::Matrix TwoDBasis::Sinvh(bool chol, int sym) const {
         // Form overlap matrix
         arma::mat S(helfem::to_arma(overlap()));
 
         // Half-inverse is
         if(sym==0) {
-          return helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S), chol));
+          return scf::form_Sinvh(helfem::to_eigen(S), chol);
         } else {
           // Get basis function indices
           std::vector<arma::uvec> midx(get_sym_idx(sym));
@@ -644,7 +644,7 @@ namespace helfem {
             // Increment offset
             ioff += midx[i].n_elem;
           }
-          return Sinvh;
+          return helfem::to_eigen(Sinvh);
         }
       }
 

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -222,9 +222,9 @@ namespace helfem {
         size_t Nang() const;
 
         /// Form half-overlap matrix
-        arma::mat Shalf(bool chol, int sym) const;
+        helfem::Matrix Shalf(bool chol, int sym) const;
         /// Form half-inverse overlap matrix
-        arma::mat Sinvh(bool chol, int sym) const;
+        helfem::Matrix Sinvh(bool chol, int sym) const;
         /// Form radial integral
         helfem::Matrix radial_integral(int n) const;
         /// Form overlap matrix

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -48,7 +48,7 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   // Form kinetic energy matrix
   arma::mat T(helfem::to_arma(basis.kinetic()));
   // Get half-inverse
-  arma::mat Sinvh(basis.Sinvh(!diag,symm));
+  arma::mat Sinvh(helfem::to_arma(basis.Sinvh(!diag,symm)));
   // Form nuclear attraction energy matrix
   arma::mat Vnuc;
 

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -66,15 +66,13 @@ namespace helfem {
         return Z;
       }
 
-      arma::mat TwoDBasis::Sinvh() const {
-        arma::mat S(helfem::to_arma(overlap()));
-        return helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(S), false));
+      helfem::Matrix TwoDBasis::Sinvh() const {
+        return scf::form_Sinvh(overlap(), /*chol=*/false);
       }
 
-      arma::mat TwoDBasis::radial_integral(int Rexp) const {
-        // Bridge to arma at the public API boundary.
-        return helfem::to_arma(helfem::assemble_radial_diagonal(radial,
-            [&](size_t iel) { return radial.radial_integral(Rexp, iel); }));
+      helfem::Matrix TwoDBasis::radial_integral(int Rexp) const {
+        return helfem::assemble_radial_diagonal(radial,
+            [&](size_t iel) { return radial.radial_integral(Rexp, iel); });
       }
 
       helfem::Matrix TwoDBasis::overlap() const {
@@ -1018,7 +1016,7 @@ namespace helfem {
         std::vector< std::pair<int, arma::mat> > rmat;
         for(int i=-2;i<=3;i++) {
           if(i==0) continue;
-          std::pair<int, arma::mat> p(i, radial_integral(i));
+          std::pair<int, arma::mat> p(i, helfem::to_arma(radial_integral(i)));
           rmat.push_back(p);
         }
         return rmat;

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -74,9 +74,9 @@ namespace helfem {
         int charge() const;
 
         /// Form half-inverse overlap matrix
-        arma::mat Sinvh() const;
+        helfem::Matrix Sinvh() const;
         /// Form radial integral
-        arma::mat radial_integral(int n) const;
+        helfem::Matrix radial_integral(int n) const;
         // Phase 3: SCF surface migrated to Eigen.
         /// Form overlap matrix
         helfem::Matrix overlap() const;

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -51,7 +51,7 @@ namespace helfem {
                                          opts.bval, lmax);
 
         const helfem::Matrix S    = basis.overlap();
-        const helfem::Matrix Sinvh = helfem::to_eigen(basis.Sinvh());
+        const helfem::Matrix Sinvh = basis.Sinvh();
         const helfem::Matrix T    = basis.kinetic();
         const helfem::Matrix Tl   = basis.kinetic_l();
         const helfem::Matrix Vnuc = basis.nuclear();


### PR DESCRIPTION
## Summary

Migrate the sadatom and diatomic basis symmetric-orthonormalisation and per-order radial-integral matrix returns from `arma::mat` to `helfem::Matrix`, matching the atomic basis convention.

### Sadatom

- `TwoDBasis::Sinvh()` and `radial_integral(int)` both change return type. `Sinvh`'s body drops to a one-liner `scf::form_Sinvh(overlap(), false)` since `overlap()` is already `helfem::Matrix` and `form_Sinvh` is Eigen-typed.
- `Rmatrices()` (returns `std::vector<std::pair<int, arma::mat>>`) picks up a `helfem::to_arma` bridge at the per-row `radial_integral(i)` call site; its return type is unchanged.

### Diatomic

- `TwoDBasis::Shalf(bool, int)` and `Sinvh(bool, int)` change return type. Implementations still build in arma via `arma::chol` / `arma::eig_sym` / midx-based subblock stitching; wrap the arma output in `helfem::to_eigen` at each return path.

### Callers updated

- `src/sadatom/scf.cpp`: drop the `helfem::to_eigen` wrapper around `basis.Sinvh()`.
- `src/diatomic/1e.cpp` and `src/diatomic/corebasis.cpp`: add `helfem::to_arma` bridges at the `arma::mat Sinvh = ...` sites.

## Test plan

- [x] Full clean build.
- [x] H2 LDA (`--Rbond=1.4 --lmax=1 --mmax=1 --nelem=3 --nnodes=8`) converges to `-1.0161182665` bit-identical.
- [x] gensap H atom LDA (`--nelem=5 --nnodes=15`) converges to `-0.4570785099` bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)