### PR TITLE
src/{atomic,diatomic,sadatom}: delete dead basis methods

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -278,40 +278,18 @@ namespace helfem {
         return M.submat(iang*radial.Nbf(),jang*radial.Nbf(),(iang+1)*radial.Nbf()-1,(jang+1)*radial.Nbf()-1);
       }
 
-      helfem::Matrix TwoDBasis::radial_integral(int Rexp) const {
-        // Build radial elements
+      helfem::Matrix TwoDBasis::overlap() const {
+        // Full overlap matrix built by scattering the radial R=0 integrals
+        // along the angular diagonal.
         arma::mat Orad = helfem::to_arma(helfem::assemble_radial_diagonal(radial,
-            [&](size_t iel) { return radial.radial_integral(Rexp, iel); }));
+            [&](size_t iel) { return radial.radial_integral(0, iel); }));
 
-        // Full overlap matrix
         arma::mat O(Ndummy(),Ndummy());
         O.zeros();
-        // Fill elements
         for(size_t iang=0;iang<lval.n_elem;iang++)
           set_sub(O,iang,iang,Orad);
 
         return helfem::to_eigen(remove_boundaries(O));
-      }
-
-      helfem::Matrix TwoDBasis::overlap() const {
-        // radial_integral now returns helfem::Matrix directly.
-        return radial_integral(0);
-      }
-
-      arma::mat TwoDBasis::overlap(const TwoDBasis & rh) const {
-        // Full overlap matrix
-        arma::mat S(Ndummy(),rh.Ndummy());
-        S.zeros();
-        // Form radial overlap
-        arma::mat Srad(helfem::to_arma(radial.overlap(rh.radial)));
-
-        // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++)
-          for(size_t jang=0;jang<rh.lval.n_elem;jang++)
-            if(lval(iang) == rh.lval(jang) && mval(iang) == rh.mval(jang))
-              S.submat(iang*radial.Nbf(),jang*rh.radial.Nbf(),(iang+1)*radial.Nbf()-1,(jang+1)*rh.radial.Nbf()-1)=Srad;
-
-        return S;
       }
 
       helfem::Matrix TwoDBasis::kinetic() const {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -156,9 +156,6 @@ namespace helfem {
         helfem::Matrix Shalf(bool chol, int sym) const;
         /// Form half-inverse overlap matrix (Phase 5.19: Eigen-typed).
         helfem::Matrix Sinvh(bool chol, int sym) const;
-        /// Form radial integral (Phase 5.19: Eigen-typed).
-        helfem::Matrix radial_integral(int n) const;
-        // Phase 3: SCF surface migrated to Eigen.
         /// Form overlap matrix
         helfem::Matrix overlap() const;
         /// Form kinetic energy matrix
@@ -174,14 +171,8 @@ namespace helfem {
         /// Form quadrupole coupling matrix
         helfem::Matrix quadrupole_zz() const;
 
-        /// Compute overlap matrix
-        arma::mat overlap(const TwoDBasis & rh) const;
-
         /// Coupling to magnetic field in z direction
         helfem::Matrix Bz_field(double B) const;
-
-        /// Form density matrix
-        arma::mat form_density(const arma::mat & C, size_t nocc) const;
 
         /// Form Coulomb matrix
         helfem::Matrix coulomb(const helfem::Matrix & P) const;

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -124,95 +124,6 @@ namespace helfem {
         return eigen_mat_to_arma(fem.matrix_element(false, false, arma_to_eigen_vec(xq), arma_to_eigen_vec(wq), chsh));
       }
 
-      arma::mat RadialBasis::overlap(const RadialBasis & rh, int n) const {
-	// Use the larger number of quadrature points to assure
-	// projection is computed ok
-	size_t n_quad(std::max(xq.n_elem,rh.xq.n_elem));
-
-	arma::vec xproj, wproj;
-	chebyshev::chebyshev(n_quad,xproj,wproj);
-
-        // Form list of overlapping elements
-        std::vector< std::vector<size_t> > overlap(fem.get_nelem());
-        for(size_t iel=0;iel<fem.get_nelem();iel++) {
-          // Range of element i
-          double istart(fem.element_begin(iel));
-          double iend(fem.element_end(iel));
-
-          for(size_t jel=0;jel<rh.fem.get_nelem();jel++) {
-            // Range of element j
-            double jstart(rh.fem.element_begin(jel));
-            double jend(rh.fem.element_end(jel));
-
-            // Is there overlap?
-            if((jstart >= istart && jstart<iend) || (istart >= jstart && istart < jend)) {
-              overlap[iel].push_back(jel);
-	      //printf("New element %i overlaps with old element %i\n",iel,jel);
-	    }
-          }
-        }
-
-        // Form overlap matrix
-        arma::mat S(Nbf(),rh.Nbf());
-        S.zeros();
-        for(size_t iel=0;iel<fem.get_nelem();iel++) {
-          // Loop over overlapping elements
-          for(size_t jj=0;jj<overlap[iel].size();jj++) {
-            // Index of element is
-            size_t jel=overlap[iel][jj];
-
-	    // Because the functions are only defined within a single
-	    // element, the product can be very raggedy. However,
-	    // since we *know* where the overlap is non-zero, we can
-	    // restrict the quadrature to just that zone.
-
-	    // Limits
-	    double imin(fem.element_begin(iel));
-	    double imax(fem.element_end(iel));
-            // Range of element
-            double jmin(rh.fem.element_begin(jel));
-            double jmax(rh.fem.element_end(jel));
-
-	    // Range of integral is thus
-	    double intstart(std::max(imin,jmin));
-	    double intend(std::min(imax,jmax));
-	    // Inteval mid-point is at
-            double intmid(0.5*(intend+intstart));
-            double intlen(0.5*(intend-intstart));
-
-	    // mu values we're going to use are then
-	    arma::vec mu(intmid*arma::ones<arma::vec>(xproj.n_elem)+intlen*xproj);
-
-            // Calculate x values the polynomials should be evaluated at
-            arma::vec xi(eigen_vec_to_arma(fem.eval_prim(arma_to_eigen_vec(mu), iel)));
-	    arma::vec xj(eigen_vec_to_arma(rh.fem.eval_prim(arma_to_eigen_vec(mu), jel)));
-
-	    // Where are we in the matrix?
-	    size_t ifirst, ilast;
-	    get_idx(iel,ifirst,ilast);
-            size_t jfirst, jlast;
-            rh.get_idx(jel,jfirst,jlast);
-
-	    // Calculate total weight per point
-	    arma::vec wtot(wproj*intlen);
-	    wtot%=arma::sinh(mu);
-	    if(n!=0)
-	      wtot%=arma::pow(arma::cosh(mu),n);
-	    // Put in weight
-	    arma::mat ibf(eigen_mat_to_arma(fem.eval_f(arma_to_eigen_vec(xi), iel)));
-	    arma::mat jbf(eigen_mat_to_arma(rh.fem.eval_f(arma_to_eigen_vec(xj), jel)));
-
-	    // Perform quadrature
-            arma::mat s(arma::trans(ibf)*arma::diagmat(wtot)*jbf);
-
-            // Increment overlap matrix
-            S.submat(ifirst,jfirst,ilast,jlast) += s;
-          }
-        }
-
-        return S;
-      }
-
       arma::mat RadialBasis::Plm_integral(int k, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const {
         std::function<double(double)> Plm;
         if(k!=0) {
@@ -660,17 +571,6 @@ namespace helfem {
         return M.submat(iang*radial.Nbf(),jang*radial.Nbf(),(iang+1)*radial.Nbf()-1,(jang+1)*radial.Nbf()-1);
       }
 
-      helfem::Matrix TwoDBasis::radial_integral(int Rexp) const {
-        // Full overlap matrix
-        arma::mat O(Ndummy(),Ndummy());
-        O.zeros();
-
-        (void) Rexp;
-        throw std::logic_error("not implemented.!\n");
-
-        return helfem::to_eigen(remove_boundaries(O));
-      }
-
       helfem::Matrix TwoDBasis::overlap() const {
         // Build radial matrix elements
         arma::mat I10(radial.radial_integral(1,0));
@@ -705,45 +605,6 @@ namespace helfem {
         S*=std::pow(Rhalf,3);
 
         return helfem::to_eigen(remove_boundaries(S));
-      }
-
-      arma::mat TwoDBasis::overlap(const TwoDBasis & rh) const {
-        // Build radial matrix elements
-        arma::mat I10(radial.overlap(rh.radial,0));
-        arma::mat I12(radial.overlap(rh.radial,2));
-
-        // Full overlap matrix
-        arma::mat S(Ndummy(),rh.Ndummy());
-        S.zeros();
-        // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
-          int li(lval(iang));
-          int mi(mval(iang));
-
-          for(size_t jang=0;jang<rh.lval.n_elem;jang++) {
-            int lj(rh.lval(jang));
-            int mj(rh.mval(jang));
-
-            // Calculate coupling
-            if(mi==mj) {
-              if(li==lj)
-                S.submat(iang*radial.Nbf(),jang*rh.radial.Nbf(),(iang+1)*radial.Nbf()-1,(jang+1)*rh.radial.Nbf()-1)=I12;
-
-              // We can also couple through the cos^2 term
-              double cpl(gaunt.cosine2_coupling(lj,mj,li,mi));
-              if(cpl!=0.0)
-                S.submat(iang*radial.Nbf(),jang*rh.radial.Nbf(),(iang+1)*radial.Nbf()-1,(jang+1)*rh.radial.Nbf()-1)-=I10*cpl;
-            }
-          }
-        }
-
-        // Plug in prefactor
-        S*=std::pow(Rhalf,3);
-
-        // Matrix with the boundary conditions removed
-        S=S(pure_indices(),rh.pure_indices());
-
-        return S;
       }
 
       helfem::Matrix TwoDBasis::kinetic() const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -63,18 +63,12 @@ namespace helfem {
         /// Get function indices
         void get_idx(size_t iel, size_t & ifirst, size_t & ilast) const;
 
-        /// Form density matrix
-        arma::mat form_density(const arma::mat & Cl, const arma::mat & Cr, size_t nocc) const;
-
         /// Compute radial matrix elements
         arma::mat radial_integral(int m, int n) const;
         /// Compute primitive kinetic energy matrix in element (excluding l and m parts)
         arma::mat kinetic(size_t iel) const;
         /// Compute primitive kinetic energy matrix
         arma::mat kinetic() const;
-
-        /// Form overlap matrix
-        arma::mat overlap(const RadialBasis & rh, int n) const;
 
         /// Compute Plm integral
         arma::mat Plm_integral(int beta, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const;
@@ -225,8 +219,6 @@ namespace helfem {
         helfem::Matrix Shalf(bool chol, int sym) const;
         /// Form half-inverse overlap matrix
         helfem::Matrix Sinvh(bool chol, int sym) const;
-        /// Form radial integral
-        helfem::Matrix radial_integral(int n) const;
         /// Form overlap matrix
         helfem::Matrix overlap() const;
         /// Form kinetic energy matrix
@@ -238,17 +230,11 @@ namespace helfem {
         /// Form dipole coupling matrix
         helfem::Matrix quadrupole_zz() const;
 
-        /// Form overlap matrix
-        arma::mat overlap(const TwoDBasis & rh) const;
-
         /// Coupling to magnetic field in z direction
         helfem::Matrix Bz_field(double B) const;
 
         /// <r^2> matrix
         arma::mat radial_moments(const arma::mat & P) const;
-
-        /// Form density matrix
-        arma::mat form_density(const arma::mat & C, size_t nocc) const;
 
         /// Form Coulomb matrix
         arma::mat coulomb(const arma::mat & P) const;

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -70,11 +70,6 @@ namespace helfem {
         return scf::form_Sinvh(overlap(), /*chol=*/false);
       }
 
-      helfem::Matrix TwoDBasis::radial_integral(int Rexp) const {
-        return helfem::assemble_radial_diagonal(radial,
-            [&](size_t iel) { return radial.radial_integral(Rexp, iel); });
-      }
-
       helfem::Matrix TwoDBasis::overlap() const {
         return helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(0, iel); });
@@ -1012,15 +1007,6 @@ namespace helfem {
         return tn;
       }
 
-      std::vector< std::pair<int, arma::mat> > TwoDBasis::Rmatrices() const {
-        std::vector< std::pair<int, arma::mat> > rmat;
-        for(int i=-2;i<=3;i++) {
-          if(i==0) continue;
-          std::pair<int, arma::mat> p(i, helfem::to_arma(radial_integral(i)));
-          rmat.push_back(p);
-        }
-        return rmat;
-      }
 
       arma::vec TwoDBasis::xc_screening(const arma::mat & Prad, int x_func, int c_func) const {
         arma::mat v(xc_screening(Prad/2,Prad/2,x_func,c_func));

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -75,8 +75,6 @@ namespace helfem {
 
         /// Form half-inverse overlap matrix
         helfem::Matrix Sinvh() const;
-        /// Form radial integral
-        helfem::Matrix radial_integral(int n) const;
         // Phase 3: SCF surface migrated to Eigen.
         /// Form overlap matrix
         helfem::Matrix overlap() const;
@@ -133,9 +131,6 @@ namespace helfem {
         arma::vec quadrature_weights() const;
         /// Compute the Coulomb screening of the nucleus
         arma::vec coulomb_screening(const arma::mat & Prad) const;
-
-        /// Get the radial matrices
-        std::vector< std::pair<int, arma::mat> > Rmatrices() const;
 
         /// Radii
         arma::vec radii() const;


### PR DESCRIPTION
## Summary

Prune methods declared on the atom / molecule bases that never had external callers (verified by grep across `src/` minus their own `.cpp` bodies). Obviously-dead API surface, no behaviour change.

### Atomic `TwoDBasis`
- `overlap(const TwoDBasis & rh)` — cross-basis overlap
- `form_density(const arma::mat &, size_t)` — decl only, no impl
- `radial_integral(int)` — the only internal caller was `overlap()`, which now inlines the same body directly

### Diatomic `RadialBasis`
- `overlap(const RadialBasis &, int)` — cross-basis overlap
- `form_density(const arma::mat &, const arma::mat &, size_t)` — decl only

### Diatomic `TwoDBasis`
- `overlap(const TwoDBasis & rh)` — cross-basis overlap (the only caller was the deleted `RadialBasis::overlap`)
- `form_density(const arma::mat &, size_t)` — decl only
- `radial_integral(int)` — was a throwing stub

### Sadatom `TwoDBasis`
- `Rmatrices()` — no external callers
- `radial_integral(int)` — the only internal caller was `Rmatrices()`

**−207 / +4 lines.**

## Test plan

- [x] Full clean build.
- [x] H atom LDA: `-0.4570630955`.
- [x] H2 LDA (`lmax=mmax=1`, `nelem=3`, `nnodes=8`, `symmetry=1`): `-1.0161182665`.
- [x] gensap H atom LDA (`nnodes=15`): `-0.4570785099`.

All bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)