### PR TITLE
src/sadatom/dftgrid: delete unused DFTGrid::eval_{pot,ing} + DFTGridWorker leaves

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -100,6 +100,12 @@ int main(int argc, char **argv) {
   // Fock builds only).
   parser.add<bool>("readocc", 0, "read frozen per-block occupations from occs.dat", false, false);
 
+  // Initial guess model potential. Bespoke atomic defaulted to iguess=2
+  // (SAP); we keep that here since SAP typically converges materially
+  // faster than the bare core-Hamiltonian guess. Ignored when --load
+  // supplies orbitals from a checkpoint.
+  parser.add<int>("iguess", 0, "initial guess: 0 core Hamiltonian, 1 GSZ, 2 SAP, 3 Thomas-Fermi", false, 2);
+
   // Load orbital guess from a checkpoint written by an earlier run.
   // The old basis + AO densities Pa, Pb are read; densities are
   // projected into the current basis via P_new = P_proj * P_old *
@@ -152,6 +158,7 @@ int main(int argc, char **argv) {
   const bool   add_conf     = parser.get<bool>("add_conf");
   const bool   maverage     = parser.get<bool>("maverage");
   const bool   readocc      = parser.get<bool>("readocc");
+  const int    iguess       = parser.get<int>("iguess");
   const std::string loadfile = parser.get<std::string>("load");
   const std::string savefile = parser.get<std::string>("save");
 
@@ -497,10 +504,40 @@ int main(int argc, char **argv) {
     return std::make_pair(Etot, fock);
   };
 
-  // Core-Hamiltonian guess per block per particle type. Include the
+  // Initial-guess Hamiltonian per block per particle type. Include the
   // external-field 1e matrices so the guess feels the perturbing
-  // potential from the start.
-  const arma::mat H0 = T + Vnuc + Vel + Vmag + Vconf;
+  // potential from the start. iguess selects the electron-nuclear
+  // channel:
+  //   0 core Hamiltonian: bare Vnuc
+  //   1..3 model potential (GSZ / SAP / Thomas-Fermi) instead of Vnuc.
+  //     Restores the bespoke-atomic guess menu; SAP is the default
+  //     because it typically converges materially faster than core-H.
+  arma::mat Vguess;
+  if (iguess == 0) {
+    printf("Guess orbitals from core Hamiltonian\n");
+    Vguess = Vnuc;
+  } else {
+    modelpotential::ModelPotential * model = nullptr;
+    switch (iguess) {
+    case 1:
+      printf("Guess orbitals from GSZ screened nucleus\n");
+      model = new modelpotential::GSZAtom(Z);
+      break;
+    case 2:
+      printf("Guess orbitals from SAP screened nucleus\n");
+      model = new modelpotential::SAPAtom(Z);
+      break;
+    case 3:
+      printf("Guess orbitals from Thomas-Fermi screened nucleus\n");
+      model = new modelpotential::TFAtom(Z);
+      break;
+    default:
+      throw std::logic_error("Unsupported iguess value (expected 0..3).\n");
+    }
+    Vguess = helfem::to_arma(basis.model_potential(model));
+    delete model;
+  }
+  const arma::mat H0 = T + Vguess + Vel + Vmag + Vconf;
   OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(nsym * nparttype);
   for (size_t t = 0; t < nparttype; ++t) {
     for (size_t k = 0; k < nsym; ++k) {

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -93,6 +93,12 @@ int main(int argc, char **argv) {
   // occupations apply for the whole SCF, not just N Fock builds).
   parser.add<bool>("readocc", 0, "read frozen per-block occupations from occs.dat", false, false);
 
+  // Initial guess model potential (parity with bespoke diatomic). SAP
+  // is the default because it typically converges materially faster
+  // than the bare core-Hamiltonian guess. Ignored when --load supplies
+  // orbitals from a checkpoint.
+  parser.add<int>("iguess", 0, "initial guess: 0 core Hamiltonian, 1 GSZ, 2 SAP, 3 Thomas-Fermi", false, 2);
+
   // Load orbital guess from a checkpoint written by an earlier run.
   parser.add<std::string>("load", 0, "load orbital guess from checkpoint file", false, "");
   // Save basis + AO densities + Rhalf/Z1/Z2/electron counts to a
@@ -131,6 +137,7 @@ int main(int argc, char **argv) {
   const double Bz     = parser.get<double>("Bz");
   const bool   maverage = parser.get<bool>("maverage");
   const bool   readocc  = parser.get<bool>("readocc");
+  const int    iguess       = parser.get<int>("iguess");
   const std::string loadfile = parser.get<std::string>("load");
   const std::string savefile = parser.get<std::string>("save");
 
@@ -435,9 +442,46 @@ int main(int argc, char **argv) {
     return std::make_pair(Etot, fock);
   };
 
-  // Core-H guess per block per particle type. Fold in the external-field
-  // 1e matrices so the very first Fock reflects the perturbing potential.
-  const arma::mat H0 = T + Vnuc + Vel + Vmag;
+  // Initial-guess Hamiltonian per block per particle type. Fold in the
+  // external-field 1e matrices so the very first Fock reflects the
+  // perturbing potential. iguess selects the electron-nuclear channel:
+  //   0 core Hamiltonian: bare Vnuc
+  //   1..3 model potential (GSZ / SAP / Thomas-Fermi) on each centre
+  //     instead of Vnuc. Matches the bespoke-diatomic guess menu; SAP
+  //     is the default because it typically converges materially
+  //     faster than core-H.
+  arma::mat Vguess;
+  if (iguess == 0) {
+    printf("Guess orbitals from core Hamiltonian\n");
+    Vguess = Vnuc;
+  } else {
+    modelpotential::ModelPotential *p1 = nullptr, *p2 = nullptr;
+    switch (iguess) {
+    case 1:
+      printf("Guess orbitals from GSZ screened nuclei\n");
+      p1 = new modelpotential::GSZAtom(Z1);
+      p2 = new modelpotential::GSZAtom(Z2);
+      break;
+    case 2:
+      printf("Guess orbitals from SAP screened nuclei\n");
+      p1 = new modelpotential::SAPAtom(Z1);
+      p2 = new modelpotential::SAPAtom(Z2);
+      break;
+    case 3:
+      printf("Guess orbitals from Thomas-Fermi screened nuclei\n");
+      p1 = new modelpotential::TFAtom(Z1);
+      p2 = new modelpotential::TFAtom(Z2);
+      break;
+    default:
+      throw std::logic_error("Unsupported iguess value (expected 0..3).\n");
+    }
+    const int lquad = 4 * arma::max(lmmax) + 12;
+    helfem::diatomic::twodquad::TwoDGrid qgrid(&basis, lquad);
+    Vguess = qgrid.model_potential(p1, p2);
+    delete p1;
+    delete p2;
+  }
+  const arma::mat H0 = T + Vguess + Vel + Vmag;
   OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(nsym * nparttype);
   for (size_t t = 0; t < nparttype; ++t) {
     for (size_t k = 0; k < nsym; ++k) {

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -238,31 +238,7 @@ namespace helfem {
         return nel;
       }
 
-      double DFTGridWorker::compute_tau() const {
-        double t=0.0;
-        if(!polarized) {
-          for(size_t ip=0;ip<tau.n_cols;ip++)
-            t+=wtot(ip)*tau(0,ip);
-        } else {
-          for(size_t ip=0;ip<tau.n_cols;ip++)
-            t+=wtot(ip)*(tau(0,ip)+tau(1,ip));
-        }
 
-        return t;
-      }
-
-      double DFTGridWorker::compute_lapl() const {
-        double l=0.0;
-        if(!polarized) {
-          for(size_t ip=0;ip<lapl.n_cols;ip++)
-            l+=wtot(ip)*lapl(0,ip);
-        } else {
-          for(size_t ip=0;ip<lapl.n_cols;ip++)
-            l+=wtot(ip)*(lapl(0,ip)+lapl(1,ip));
-        }
-
-        return l;
-      }
 
       // init_xc, zero_Exc: inherited from
       // helfem::dftgrid_common::DFTGridWorkerBase.
@@ -454,110 +430,7 @@ namespace helfem {
       }
 #endif
 
-      void DFTGridWorker::get_pot(arma::mat & pot) const {
-        double vrhoa=0.0, vrhob=0.0, vsigmaaa=0.0, vsigmaab=0.0, vsigmabb=0.0, vlapla=0.0, vlaplb=0.0, vtaua=0.0, vtaub=0.0;
 
-        pot.zeros(11,wtot.n_elem);
-        for(size_t i=0; i<wtot.n_elem; i++) {
-          if(polarized) {
-            vrhoa = vxc(0,i);
-            vrhob = vxc(1,i);
-            if(do_gga) {
-              vsigmaaa = vsigma(0,i);
-              vsigmaab = vsigma(1,i);
-              vsigmabb = vsigma(2,i);
-            }
-            if(do_mgga_l) {
-              vlapla = vlapl(0,i);
-              vlaplb = vlapl(1,i);
-            }
-            if(do_mgga_t) {
-              vtaua = vtau(0,i);
-              vtaub = vtau(1,i);
-            }
-          } else {
-            vrhoa = vxc(i,0);
-            vrhob = vxc(i,0);
-            if(do_gga) {
-              vsigmaaa = vsigma(i,0);
-              vsigmaab = vsigma(i,0);
-              vsigmabb = vsigma(i,0);
-            }
-            if(do_mgga_l) {
-              vlapla = vlapl(i,0);
-              vlaplb = vlapl(i,0);
-            }
-            if(do_mgga_t) {
-              vtaua = vtau(i,0);
-              vtaub = vtau(i,0);
-            }
-          }
-
-          pot(0,i) = r(i);
-          pot(1,i) = exc[i];
-          pot(2,i) = vrhoa;
-          pot(3,i) = vrhob;
-          pot(4,i) = vsigmaaa;
-          pot(5,i) = vsigmaab;
-          pot(6,i) = vsigmabb;
-          pot(7,i) = vlapla;
-          pot(8,i) = vlaplb;
-          pot(9,i) = vtaua;
-          pot(10,i) = vtaub;
-        }
-      }
-
-      void DFTGridWorker::get_ingredients(arma::mat & ing) const {
-        double rhoa=0.0, rhob=0.0, sigmaaa=0.0, sigmaab=0.0, sigmabb=0.0, lapla=0.0, laplb=0.0, taua=0.0, taub=0.0;
-
-        ing.zeros(10,wtot.n_elem);
-        for(size_t i=0; i<wtot.n_elem; i++) {
-          if(polarized) {
-            rhoa = rho(0,i);
-            rhob = rho(1,i);
-            if(do_gga) {
-              sigmaaa = sigma(0,i);
-              sigmaab = sigma(1,i);
-              sigmabb = sigma(2,i);
-            }
-            if(do_mgga_l) {
-              lapla = lapl(0,i);
-              laplb = lapl(1,i);
-            }
-            if(do_mgga_t) {
-              taua = tau(0,i);
-              taub = tau(1,i);
-            }
-          } else {
-            rhoa = 0.5*rho(i,0);
-            rhob = 0.5*rho(i,0);
-            if(do_gga) {
-              sigmaaa = 0.25*sigma(i,0);
-              sigmaab = 0.25*sigma(i,0);
-              sigmabb = 0.25*sigma(i,0);
-            }
-            if(do_mgga_l) {
-              lapla = 0.5*lapl(i,0);
-              laplb = 0.5*lapl(i,0);
-            }
-            if(do_mgga_t) {
-              taua = 0.5*tau(i,0);
-              taub = 0.5*tau(i,0);
-            }
-          }
-
-          ing(0,i) = r(i);
-          ing(1,i) = rhoa;
-          ing(2,i) = rhob;
-          ing(3,i) = sigmaaa;
-          ing(4,i) = sigmaab;
-          ing(5,i) = sigmabb;
-          ing(6,i) = lapla;
-          ing(7,i) = laplb;
-          ing(8,i) = taua;
-          ing(9,i) = taub;
-        }
-      }
 
       // eval_Exc: inherited from DFTGridWorkerBase.
 
@@ -807,11 +680,9 @@ namespace helfem {
 
         double exc=0.0;
         double nel=0.0;
-        double tau=0.0;
-        double lapl=0.0;
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:exc,nel,tau,lapl)
+#pragma omp parallel reduction(+:exc,nel)
 #endif
         {
           DFTGridWorker grid(basp);
@@ -824,8 +695,6 @@ namespace helfem {
             grid.compute_bf(iel);
             grid.update_density(P);
             nel+=grid.compute_Nel();
-            tau+=grid.compute_tau();
-            lapl+=grid.compute_lapl();
 
             grid.init_xc();
             if(x_func>0)
@@ -843,8 +712,6 @@ namespace helfem {
             grid.compute_bf(iel);
             grid.update_density(P);
             nel+=grid.compute_Nel();
-            tau+=grid.compute_tau();
-            lapl+=grid.compute_lapl();
 
             grid.init_xc();
             if(x_func>0)
@@ -860,13 +727,6 @@ namespace helfem {
         // Save outputs
         Exc=exc;
         Nel=nel;
-
-#if 0
-        if(tau!=0.0)
-          printf("Tau integral %.10e\n",tau);
-        if(lapl!=0.0)
-          printf("Laplacian integral %.10e\n",lapl);
-#endif
       }
 
       void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr) {
@@ -923,155 +783,9 @@ namespace helfem {
         Nel=nel;
       }
 
-      void DFTGrid::eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & pot, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // exc vxca vxcb vsigmaaa vsigmaab vsigmabb vlapla vlaplb vtaua vtaub
-        pot.zeros(11, Nquad*Nelem);
 
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
 
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(P);
 
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store the potential
-            arma::mat subpot;
-            grid.get_pot(subpot);
-            pot.cols(iel*Nquad, (iel+1)*Nquad-1)=subpot;
-          }
-        }
-        // Swap rows and columns
-        pot = pot.t();
-      }
-
-      void DFTGrid::eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars,  const arma::cube & Pa, const arma::cube & Pb, arma::mat & pot, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // exc vxca vxcb vsigmaaa vsigmaab vsigmabb vlapla vlaplb vtaua vtaub
-        pot.zeros(11, Nquad*Nelem);
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(Pa,Pb);
-
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store the potential
-            arma::mat subpot;
-            grid.get_pot(subpot);
-            pot.cols(iel*Nquad, (iel+1)*Nquad-1)=subpot;
-          }
-        }
-        // Swap rows and columns
-        pot = pot.t();
-      }
-
-      void DFTGrid::eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & ing, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // rhoa rhob sigmaaa sigmaab sigmabb lapla laplb taua taub
-        ing.zeros(10, Nquad*Nelem);
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(P);
-
-            // We need to evaluate the xc functional to initialize the variables
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store
-            arma::mat subing;
-            grid.get_ingredients(subing);
-            ing.cols(iel*Nquad, (iel+1)*Nquad-1)=subing;
-          }
-        }
-        // Swap rows and columns
-        ing = ing.t();
-      }
-
-      void DFTGrid::eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars,  const arma::cube & Pa, const arma::cube & Pb, arma::mat & ing, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // rhoa rhob sigmaaa sigmaab sigmabb lapla laplb taua taub
-        ing.zeros(10, Nquad*Nelem);
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(Pa,Pb);
-
-            // We need to evaluate the xc functional to initialize the variables
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store
-            arma::mat subing;
-            grid.get_ingredients(subing);
-            ing.cols(iel*Nquad, (iel+1)*Nquad-1)=subing;
-          }
-        }
-        // Swap rows and columns
-        ing = ing.t();
-      }
     }
   }
 }

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -81,10 +81,6 @@ namespace helfem {
 
         /// Compute number of electrons
         double compute_Nel() const;
-        /// Compute kinetic energy density
-        double compute_tau() const;
-        /// Compute laplacian
-        double compute_lapl() const;
 
         // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
         // from DFTGridWorkerBase.
@@ -96,11 +92,6 @@ namespace helfem {
         void eval_Fxc(arma::cube & H) const;
         /// Evaluate Fock matrix, unrestricted calculation
         void eval_Fxc(arma::cube & Ha, arma::cube & Hb, bool beta=true) const;
-
-        /// Get the potential
-        void get_pot(arma::mat & pot) const;
-        /// Get the ingredients
-        void get_ingredients(arma::mat & ing) const;
       };
 
       /// Wrapper routine
@@ -121,16 +112,6 @@ namespace helfem {
         void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr);
         /// Compute Fock matrix, exchange-correlation energy and integrated electron density, unrestricted case
         void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr);
-
-        /// Evaluate the potential
-        void eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & pot, double thr);
-        /// Compute the potential
-        void eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::mat & pot, double thr);
-
-        /// Evaluate the ingredients
-        void eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & ing, double thr);
-        /// Compute the ingredients
-        void eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::mat & ing, double thr);
 
       };
 


### PR DESCRIPTION
## Summary

Retires a cluster of sadatom DFT-grid methods with no remaining
callers — all orphaned by the bespoke-driver retirement:

* \`DFTGrid::eval_pot\` (restricted + unrestricted overloads) —
  bespoke's \"print v_xc on the grid\" analysis path
* \`DFTGrid::eval_ing\` (restricted + unrestricted overloads) —
  bespoke's density-ingredients grid dump
* \`DFTGridWorker::get_pot\`, \`get_ingredients\` — per-element workers
  for the above
* \`DFTGridWorker::compute_tau\`, \`compute_lapl\` — fed a debug
  integral in \`eval_Fxc\` that was already gated under \`#if 0\`

Also removes the stray \`tau\` / \`lapl\` accumulator + the \`#if 0\`
print block from \`DFTGrid::eval_Fxc\`.

## Test plan

- [x] H gensap LDA converges to -0.4570785099 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>