### PR TITLE
src/general/scf_driver_common: consolidate atomic + diatomic OOO driver duplication

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -35,6 +35,7 @@
 #include "../general/dftfuncs.h"
 #include "../general/elements.h"
 #include "../general/scf_helpers.h"
+#include "../general/scf_driver_common.h"
 #include "../general/checkpoint.h"
 
 #include "openorbitaloptimizer/scfsolver.hpp"
@@ -310,13 +311,9 @@ int main(int argc, char **argv) {
   }
   const size_t nsym = dsym.size();
 
-  // --- Per-block Sinvh_k = symmetric orthonormalization of S(dsym[k], dsym[k]).
-  std::vector<arma::mat> Sinvh_arma(nsym);
-  for (size_t k = 0; k < nsym; ++k) {
-    if (!dsym[k].n_elem) continue;
-    const arma::mat Sk = S(dsym[k], dsym[k]);
-    Sinvh_arma[k] = helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(Sk), /*chol*/false));
-  }
+  // Per-block Sinvh_k = symmetric orthonormalization of S(dsym[k], dsym[k]).
+  const std::vector<arma::mat> Sinvh_arma =
+      helfem::scf_driver::build_per_block_Sinvh(S, dsym);
 
   const int ldft = ldft_arg > 0 ? ldft_arg : 4 * lmax + 12;
   const int mdft = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
@@ -538,23 +535,9 @@ int main(int argc, char **argv) {
     delete model;
   }
   const arma::mat H0 = T + Vguess + Vel + Vmag + Vconf;
-  OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(nsym * nparttype);
-  for (size_t t = 0; t < nparttype; ++t) {
-    for (size_t k = 0; k < nsym; ++k) {
-      if (!dsym[k].n_elem) {
-        CoreH[t * nsym + k] = helfem::Matrix::Zero(0, 0);
-        continue;
-      }
-      arma::mat H_sub = H0(dsym[k], dsym[k]);
-      // Same spin-Zeeman split as in the Fock builder (only meaningful
-      // in unrestricted mode; harmless in restricted since we hit both
-      // channels equally).
-      if (have_bfield && nparttype == 2)
-        H_sub += (t == 0 ? -0.5 : 0.5) * Bz * arma::mat(S(dsym[k], dsym[k]));
-      const arma::mat H_orth = Sinvh_arma[k].t() * H_sub * Sinvh_arma[k];
-      CoreH[t * nsym + k] = helfem::to_eigen(H_orth);
-    }
-  }
+  const OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH =
+      helfem::scf_driver::build_coreH_from_H0<OOO_Real>(
+          H0, S, dsym, Sinvh_arma, nparttype, have_bfield, Bz);
 
   OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
       number_of_blocks_per_particle_type, maximum_occupation,
@@ -669,38 +652,18 @@ int main(int argc, char **argv) {
     OpenOrbitalOptimizer::OrbitalOccupations<OOO_Real>  loaded_occs(nsym * nparttype);
     const double max_occ_restr = 2.0;
     const double max_occ_open  = 1.0;
-    auto fill_block = [&](size_t base, size_t k, const arma::mat & Pspin,
-                           double max_occ) {
-      if (!dsym[k].n_elem) {
-        loaded_orbs[base + k] = helfem::Matrix::Zero(0, 0);
-        loaded_occs[base + k] = helfem::Vector::Zero(0);
-        return;
-      }
-      const arma::mat Pblk  = Pspin(dsym[k], dsym[k]);
-      const arma::mat Porth = arma::trans(Sinvh_arma[k]) * Pblk * Sinvh_arma[k];
-      arma::vec occ_eigs;
-      arma::mat vec_eigs;
-      if (!arma::eig_sym(occ_eigs, vec_eigs, Porth))
-        throw std::logic_error("--load: eigendecomposition of projected block density failed");
-      // Ascending -> descending so highest-occupation orbitals come first.
-      const arma::uword n = vec_eigs.n_cols;
-      arma::mat V(vec_eigs.n_rows, n);
-      arma::vec w(n);
-      for (arma::uword i = 0; i < n; ++i) {
-        V.col(i) = vec_eigs.col(n - 1 - i);
-        w(i)     = std::min(std::max(occ_eigs(n - 1 - i), 0.0), max_occ);
-      }
-      loaded_orbs[base + k] = helfem::to_eigen(V);
-      loaded_occs[base + k] = helfem::to_eigen(w);
-    };
     if (restricted) {
       // Single channel: eigenvalues of total P should be in [0, 2].
       const arma::mat P_total = Pa_new + Pb_new;
-      for (size_t k = 0; k < nsym; ++k) fill_block(0, k, P_total, max_occ_restr);
+      for (size_t k = 0; k < nsym; ++k)
+        helfem::scf_driver::fill_block_from_density(
+            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh_arma[k], max_occ_restr);
     } else {
       for (size_t k = 0; k < nsym; ++k) {
-        fill_block(0,    k, Pa_new, max_occ_open);
-        fill_block(nsym, k, Pb_new, max_occ_open);
+        helfem::scf_driver::fill_block_from_density(
+            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh_arma[k], max_occ_open);
+        helfem::scf_driver::fill_block_from_density(
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh_arma[k], max_occ_open);
       }
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);
@@ -719,30 +682,9 @@ int main(int argc, char **argv) {
     savechk.write(basis);
     const auto final_orbs = scfsolver.get_orbitals();
     const auto final_occs = scfsolver.get_orbital_occupations();
-
-    arma::mat Pa_final(Nbf, Nbf, arma::fill::zeros);
-    arma::mat Pb_final(Nbf, Nbf, arma::fill::zeros);
-    for (size_t k = 0; k < nsym; ++k) {
-      if (!dsym[k].n_elem) continue;
-      const arma::mat orb_a_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[k]);
-      const arma::vec occ_a    = helfem::to_arma(final_occs[k]);
-      if (restricted) {
-        // orbitals[k] carries the closed-shell total density (max occ 2);
-        // split evenly between alpha and beta on disk.
-        const arma::mat P_block = 0.5 * (orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao));
-        arma::mat Pa_tmp = Pa_final; Pa_tmp(dsym[k], dsym[k]) += P_block; Pa_final = Pa_tmp;
-        arma::mat Pb_tmp = Pb_final; Pb_tmp(dsym[k], dsym[k]) += P_block; Pb_final = Pb_tmp;
-      } else {
-        const arma::mat orb_b_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[nsym + k]);
-        const arma::vec occ_b    = helfem::to_arma(final_occs[nsym + k]);
-        arma::mat Pa_tmp = Pa_final;
-        Pa_tmp(dsym[k], dsym[k]) += orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao);
-        Pa_final = Pa_tmp;
-        arma::mat Pb_tmp = Pb_final;
-        Pb_tmp(dsym[k], dsym[k]) += orb_b_ao * arma::diagmat(occ_b) * arma::trans(orb_b_ao);
-        Pb_final = Pb_tmp;
-      }
-    }
+    arma::mat Pa_final, Pb_final;
+    std::tie(Pa_final, Pb_final) = helfem::scf_driver::assemble_final_density<OOO_Real>(
+        Nbf, restricted, dsym, Sinvh_arma, final_orbs, final_occs);
     savechk.write("Pa", Pa_final);
     savechk.write("Pb", Pb_final);
     savechk.write("nela", nela);

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -34,6 +34,7 @@
 #include "../general/dftfuncs.h"
 #include "../general/elements.h"
 #include "../general/scf_helpers.h"
+#include "../general/scf_driver_common.h"
 #include "../general/timer.h"
 #include "../general/checkpoint.h"
 
@@ -274,12 +275,8 @@ int main(int argc, char **argv) {
   const size_t nsym = dsym.size();
 
   // Per-block Sinvh_k.
-  std::vector<arma::mat> Sinvh_arma(nsym);
-  for (size_t k = 0; k < nsym; ++k) {
-    if (!dsym[k].n_elem) continue;
-    const arma::mat Sk = S(dsym[k], dsym[k]);
-    Sinvh_arma[k] = helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(Sk), /*chol*/false));
-  }
+  const std::vector<arma::mat> Sinvh_arma =
+      helfem::scf_driver::build_per_block_Sinvh(S, dsym);
 
   const int lang = ldft_arg > 0 ? ldft_arg : 4 * arma::max(lval) + 12;
   const int mang = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
@@ -482,20 +479,9 @@ int main(int argc, char **argv) {
     delete p2;
   }
   const arma::mat H0 = T + Vguess + Vel + Vmag;
-  OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(nsym * nparttype);
-  for (size_t t = 0; t < nparttype; ++t) {
-    for (size_t k = 0; k < nsym; ++k) {
-      if (!dsym[k].n_elem) {
-        CoreH[t * nsym + k] = helfem::Matrix::Zero(0, 0);
-        continue;
-      }
-      arma::mat H_sub = H0(dsym[k], dsym[k]);
-      if (have_bfield && nparttype == 2)
-        H_sub += (t == 0 ? -0.5 : 0.5) * Bz * arma::mat(S(dsym[k], dsym[k]));
-      const arma::mat H_orth = Sinvh_arma[k].t() * H_sub * Sinvh_arma[k];
-      CoreH[t * nsym + k] = helfem::to_eigen(H_orth);
-    }
-  }
+  const OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH =
+      helfem::scf_driver::build_coreH_from_H0<OOO_Real>(
+          H0, S, dsym, Sinvh_arma, nparttype, have_bfield, Bz);
 
   OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
       number_of_blocks_per_particle_type, maximum_occupation,
@@ -592,36 +578,17 @@ int main(int argc, char **argv) {
     OpenOrbitalOptimizer::OrbitalOccupations<OOO_Real>  loaded_occs(nsym * nparttype);
     const double max_occ_restr = 2.0;
     const double max_occ_open  = 1.0;
-    auto fill_block = [&](size_t base, size_t k, const arma::mat & Pspin,
-                           double max_occ) {
-      if (!dsym[k].n_elem) {
-        loaded_orbs[base + k] = helfem::Matrix::Zero(0, 0);
-        loaded_occs[base + k] = helfem::Vector::Zero(0);
-        return;
-      }
-      const arma::mat Pblk  = Pspin(dsym[k], dsym[k]);
-      const arma::mat Porth = arma::trans(Sinvh_arma[k]) * Pblk * Sinvh_arma[k];
-      arma::vec occ_eigs;
-      arma::mat vec_eigs;
-      if (!arma::eig_sym(occ_eigs, vec_eigs, Porth))
-        throw std::logic_error("--load: eigendecomposition of projected block density failed");
-      const arma::uword n = vec_eigs.n_cols;
-      arma::mat V(vec_eigs.n_rows, n);
-      arma::vec w(n);
-      for (arma::uword i = 0; i < n; ++i) {
-        V.col(i) = vec_eigs.col(n - 1 - i);
-        w(i)     = std::min(std::max(occ_eigs(n - 1 - i), 0.0), max_occ);
-      }
-      loaded_orbs[base + k] = helfem::to_eigen(V);
-      loaded_occs[base + k] = helfem::to_eigen(w);
-    };
     if (restricted) {
       const arma::mat P_total = Pa_new + Pb_new;
-      for (size_t k = 0; k < nsym; ++k) fill_block(0, k, P_total, max_occ_restr);
+      for (size_t k = 0; k < nsym; ++k)
+        helfem::scf_driver::fill_block_from_density(
+            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh_arma[k], max_occ_restr);
     } else {
       for (size_t k = 0; k < nsym; ++k) {
-        fill_block(0,    k, Pa_new, max_occ_open);
-        fill_block(nsym, k, Pb_new, max_occ_open);
+        helfem::scf_driver::fill_block_from_density(
+            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh_arma[k], max_occ_open);
+        helfem::scf_driver::fill_block_from_density(
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh_arma[k], max_occ_open);
       }
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);
@@ -636,28 +603,9 @@ int main(int argc, char **argv) {
     savechk.write(basis);
     const auto final_orbs = scfsolver.get_orbitals();
     const auto final_occs = scfsolver.get_orbital_occupations();
-
-    arma::mat Pa_final(Nbf, Nbf, arma::fill::zeros);
-    arma::mat Pb_final(Nbf, Nbf, arma::fill::zeros);
-    for (size_t k = 0; k < nsym; ++k) {
-      if (!dsym[k].n_elem) continue;
-      const arma::mat orb_a_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[k]);
-      const arma::vec occ_a    = helfem::to_arma(final_occs[k]);
-      if (restricted) {
-        const arma::mat P_block = 0.5 * (orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao));
-        arma::mat Pa_tmp = Pa_final; Pa_tmp(dsym[k], dsym[k]) += P_block; Pa_final = Pa_tmp;
-        arma::mat Pb_tmp = Pb_final; Pb_tmp(dsym[k], dsym[k]) += P_block; Pb_final = Pb_tmp;
-      } else {
-        const arma::mat orb_b_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[nsym + k]);
-        const arma::vec occ_b    = helfem::to_arma(final_occs[nsym + k]);
-        arma::mat Pa_tmp = Pa_final;
-        Pa_tmp(dsym[k], dsym[k]) += orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao);
-        Pa_final = Pa_tmp;
-        arma::mat Pb_tmp = Pb_final;
-        Pb_tmp(dsym[k], dsym[k]) += orb_b_ao * arma::diagmat(occ_b) * arma::trans(orb_b_ao);
-        Pb_final = Pb_tmp;
-      }
-    }
+    arma::mat Pa_final, Pb_final;
+    std::tie(Pa_final, Pb_final) = helfem::scf_driver::assemble_final_density<OOO_Real>(
+        Nbf, restricted, dsym, Sinvh_arma, final_orbs, final_occs);
     savechk.write("Pa", Pa_final);
     savechk.write("Pb", Pb_final);
     savechk.write("nela", nela);

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -15,90 +15,143 @@
 #ifndef HELFEM_SCF_DRIVER_COMMON_H
 #define HELFEM_SCF_DRIVER_COMMON_H
 
-// Shared building blocks for the atomic and diatomic SCF drivers.
-// Extracted from src/atomic/main.cpp and src/diatomic/main.cpp
-// (both files kept byte-identical copies of these).
+// Shared building blocks for the atomic and diatomic OOO SCF
+// drivers. Both driver bodies used to keep byte-identical copies of
+// these routines; extracted here so bug fixes only need to happen in
+// one place.
 
 #include <armadillo>
 #include <cstdio>
 #include <stdexcept>
-#include <string>
+#include <utility>
 #include <vector>
-#include "checkpoint.h"
 #include "scf_helpers.h"
 #include <ArmaEigen.h>
+#include "openorbitaloptimizer/scfsolver.hpp"
 
 namespace helfem {
   namespace scf_driver {
-    /// In-place symmetric scaling M(i, j) *= norm(i) * norm(j),
-    /// used by both drivers to renormalise Fock / density blocks.
-    inline void normalize_matrix(arma::mat & M, const arma::vec & norm) {
-      if (M.n_rows != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
-      if (M.n_cols != norm.n_elem) throw std::logic_error("Incompatible dimensions!\n");
-      for (size_t i = 0; i < M.n_rows; ++i)
-        for (size_t j = 0; j < M.n_cols; ++j)
-          M(i, j) *= norm(i) * norm(j);
-    }
 
-    /// Gram-Schmidt reorthonormalise the first nocc columns of C
-    /// against the overlap S. Used after re-loading orbitals from a
-    /// checkpoint or projecting between bases so subsequent SCF
-    /// iterations start from a strictly orthonormal set.
-    inline void gram_schmidt(arma::mat & C, const arma::mat & S, int nocc) {
-      for (int i = 0; i < nocc; ++i) {
-        for (int j = 0; j < i; ++j)
-          C.col(i) -= C.col(j) * (arma::trans(C.col(j)) * S * C.col(i));
-        C.col(i) /= std::sqrt(arma::as_scalar(arma::trans(C.col(i)) * S * C.col(i)));
+    /// Per-block symmetric orthonormalisation of the AO overlap S
+    /// restricted to each symmetry index set. Both drivers build this
+    /// once and reuse it in the CoreH construction, the --load block
+    /// projection, and the --save density reconstruction.
+    inline std::vector<arma::mat> build_per_block_Sinvh(
+        const arma::mat & S, const std::vector<arma::uvec> & dsym) {
+      const size_t nsym = dsym.size();
+      std::vector<arma::mat> out(nsym);
+      for (size_t k = 0; k < nsym; ++k) {
+        if (!dsym[k].n_elem) continue;
+        const arma::mat Sk = S(dsym[k], dsym[k]);
+        out[k] = helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(Sk), /*chol=*/false));
       }
+      return out;
     }
 
-    /// Report orbital-orthonormality deviation ||Sinvh^T S Sinvh - I||_F.
-    /// Both drivers print this immediately after Sinvh is formed.
-    inline void report_ortho_deviation(const arma::mat & S, const arma::mat & Sinvh) {
-      arma::mat Smo(Sinvh.t() * S * Sinvh);
-      Smo -= arma::eye<arma::mat>(Smo.n_rows, Smo.n_cols);
-      printf("Orbital orthonormality deviation is %e\n", arma::norm(Smo, "fro"));
+    /// Build OOO's per-(spin, block) initial Fock matrix in the
+    /// orthonormal basis from a global AO Hamiltonian H0. For
+    /// unrestricted magnetic-field runs each spin channel gets its
+    /// own +/- 0.5 * Bz * S Zeeman split, matching the split the
+    /// steady-state Fock builder applies.
+    template <typename Real>
+    inline OpenOrbitalOptimizer::FockMatrix<Real> build_coreH_from_H0(
+        const arma::mat & H0, const arma::mat & S,
+        const std::vector<arma::uvec> & dsym,
+        const std::vector<arma::mat> & Sinvh_arma,
+        size_t nparttype, bool have_bfield, double Bz) {
+      const size_t nsym = dsym.size();
+      OpenOrbitalOptimizer::FockMatrix<Real> CoreH(nsym * nparttype);
+      for (size_t t = 0; t < nparttype; ++t) {
+        for (size_t k = 0; k < nsym; ++k) {
+          if (!dsym[k].n_elem) {
+            CoreH[t * nsym + k] = helfem::Matrix::Zero(0, 0);
+            continue;
+          }
+          arma::mat H_sub = H0(dsym[k], dsym[k]);
+          if (have_bfield && nparttype == 2)
+            H_sub += (t == 0 ? -0.5 : 0.5) * Bz * arma::mat(S(dsym[k], dsym[k]));
+          const arma::mat H_orth = Sinvh_arma[k].t() * H_sub * Sinvh_arma[k];
+          CoreH[t * nsym + k] = helfem::to_eigen(H_orth);
+        }
+      }
+      return CoreH;
     }
 
-    /// Report half-overlap consistency ||Sh^T Sinvh - I||_F. Both
-    /// drivers print this immediately after Sh is formed.
-    inline void report_halfoverlap_error(const arma::mat & Sh, const arma::mat & Sinvh) {
-      arma::mat Smo(Sh.t() * Sinvh);
-      Smo -= arma::eye<arma::mat>(Smo.n_rows, Smo.n_cols);
-      printf("Half-overlap error is %e\n", arma::norm(Smo, "fro"));
-    }
-
-    /// Load a Fock matrix by key, project it through the checkpoint's
-    /// (old) orthonormal basis into the current (new) orthonormal
-    /// basis, transform back to the AO basis, and diagonalise into
-    /// (E, C). Both drivers use this pattern once per spin channel
-    /// when restarting from a checkpoint via Fock projection.
+    /// Load-path helper: take a saved AO density Pspin projected into
+    /// the current basis, diagonalise it inside symmetry block k in
+    /// the block's orthonormal basis, and hand OOO the resulting
+    /// orbitals + occupations (largest occupation first). Empty
+    /// blocks become 0x0 placeholders. Called per spin channel and
+    /// per block from the driver's --load path.
     ///
-    ///   F <- oldSinvh^T F oldSinvh                       (to old orthonormal)
-    ///   F <- S12 F S12^T                                  (project to new orthonormal)
-    ///   F <- SSinvh F SSinvh^T                            (back to AO)
-    ///   (E, C) <- symm ? eig_gsym_sub(F, Sinvh, dsym) : eig_gsym(F, Sinvh).
-    inline void project_and_diagonalize(
-        Checkpoint & loadchk, const std::string & fock_key,
-        const arma::mat & oldSinvh, const arma::mat & S12,
-        const arma::mat & SSinvh,   const arma::mat & Sinvh,
-        bool symm, const std::vector<arma::uvec> & dsym,
-        arma::vec & E, arma::mat & C) {
-      arma::mat F;
-      loadchk.read(fock_key, F);
-      F = arma::trans(oldSinvh) * F * oldSinvh;
-      F = S12 * F * arma::trans(S12);
-      F = SSinvh * F * arma::trans(SSinvh);
-
-      helfem::Vector E_e;
-      helfem::Matrix C_e;
-      if (symm)
-        helfem::scf::eig_gsym_sub(E_e, C_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh), dsym);
-      else
-        helfem::scf::eig_gsym    (E_e, C_e, helfem::to_eigen(F), helfem::to_eigen(Sinvh));
-      E = helfem::to_arma(E_e);
-      C = helfem::to_arma(C_e);
+    ///   P_orth = Sinvh_k^T . Pspin(dsym[k], dsym[k]) . Sinvh_k
+    ///          -> V, w  (descending); w clamped to [0, max_occ]
+    template <typename Real>
+    inline void fill_block_from_density(
+        size_t out_index,
+        OpenOrbitalOptimizer::Orbitals<Real> & orbs,
+        OpenOrbitalOptimizer::OrbitalOccupations<Real> & occs,
+        const arma::mat & Pspin, const arma::uvec & idx,
+        const arma::mat & Sinvh_block, double max_occ) {
+      if (!idx.n_elem) {
+        orbs[out_index] = helfem::Matrix::Zero(0, 0);
+        occs[out_index] = helfem::Vector::Zero(0);
+        return;
+      }
+      const arma::mat Pblk  = Pspin(idx, idx);
+      const arma::mat Porth = arma::trans(Sinvh_block) * Pblk * Sinvh_block;
+      arma::vec occ_eigs;
+      arma::mat vec_eigs;
+      if (!arma::eig_sym(occ_eigs, vec_eigs, Porth))
+        throw std::logic_error("--load: eigendecomposition of projected block density failed");
+      const arma::uword n = vec_eigs.n_cols;
+      arma::mat V(vec_eigs.n_rows, n);
+      arma::vec w(n);
+      for (arma::uword i = 0; i < n; ++i) {
+        V.col(i) = vec_eigs.col(n - 1 - i);
+        w(i)     = std::min(std::max(occ_eigs(n - 1 - i), 0.0), max_occ);
+      }
+      orbs[out_index] = helfem::to_eigen(V);
+      occs[out_index] = helfem::to_eigen(w);
     }
+
+    /// Save-path helper: reconstruct the full AO alpha / beta density
+    /// matrices from OOO's converged per-block orbitals + occupations.
+    /// Restricted case: orbs[k] carries the closed-shell density
+    /// (max occ 2); alpha and beta both get half of it. Unrestricted:
+    /// alpha in indices [0, nsym), beta in [nsym, 2*nsym).
+    template <typename Real>
+    inline std::pair<arma::mat, arma::mat> assemble_final_density(
+        size_t Nbf, bool restricted,
+        const std::vector<arma::uvec> & dsym,
+        const std::vector<arma::mat> & Sinvh_arma,
+        const OpenOrbitalOptimizer::Orbitals<Real> & final_orbs,
+        const OpenOrbitalOptimizer::OrbitalOccupations<Real> & final_occs) {
+      const size_t nsym = dsym.size();
+      arma::mat Pa_final(Nbf, Nbf, arma::fill::zeros);
+      arma::mat Pb_final(Nbf, Nbf, arma::fill::zeros);
+      for (size_t k = 0; k < nsym; ++k) {
+        if (!dsym[k].n_elem) continue;
+        const arma::mat orb_a_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[k]);
+        const arma::vec occ_a    = helfem::to_arma(final_occs[k]);
+        if (restricted) {
+          const arma::mat P_block = 0.5 * (orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao));
+          arma::mat Pa_tmp = Pa_final; Pa_tmp(dsym[k], dsym[k]) += P_block; Pa_final = Pa_tmp;
+          arma::mat Pb_tmp = Pb_final; Pb_tmp(dsym[k], dsym[k]) += P_block; Pb_final = Pb_tmp;
+        } else {
+          const arma::mat orb_b_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[nsym + k]);
+          const arma::vec occ_b    = helfem::to_arma(final_occs[nsym + k]);
+          arma::mat Pa_tmp = Pa_final;
+          Pa_tmp(dsym[k], dsym[k]) += orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao);
+          Pa_final = Pa_tmp;
+          arma::mat Pb_tmp = Pb_final;
+          Pb_tmp(dsym[k], dsym[k]) += orb_b_ao * arma::diagmat(occ_b) * arma::trans(orb_b_ao);
+          Pb_final = Pb_tmp;
+        }
+      }
+      return {Pa_final, Pb_final};
+    }
+
   } // namespace scf_driver
 } // namespace helfem
 

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -238,31 +238,7 @@ namespace helfem {
         return nel;
       }
 
-      double DFTGridWorker::compute_tau() const {
-        double t=0.0;
-        if(!polarized) {
-          for(size_t ip=0;ip<tau.n_cols;ip++)
-            t+=wtot(ip)*tau(0,ip);
-        } else {
-          for(size_t ip=0;ip<tau.n_cols;ip++)
-            t+=wtot(ip)*(tau(0,ip)+tau(1,ip));
-        }
 
-        return t;
-      }
-
-      double DFTGridWorker::compute_lapl() const {
-        double l=0.0;
-        if(!polarized) {
-          for(size_t ip=0;ip<lapl.n_cols;ip++)
-            l+=wtot(ip)*lapl(0,ip);
-        } else {
-          for(size_t ip=0;ip<lapl.n_cols;ip++)
-            l+=wtot(ip)*(lapl(0,ip)+lapl(1,ip));
-        }
-
-        return l;
-      }
 
       // init_xc, zero_Exc: inherited from
       // helfem::dftgrid_common::DFTGridWorkerBase.
@@ -454,110 +430,7 @@ namespace helfem {
       }
 #endif
 
-      void DFTGridWorker::get_pot(arma::mat & pot) const {
-        double vrhoa=0.0, vrhob=0.0, vsigmaaa=0.0, vsigmaab=0.0, vsigmabb=0.0, vlapla=0.0, vlaplb=0.0, vtaua=0.0, vtaub=0.0;
 
-        pot.zeros(11,wtot.n_elem);
-        for(size_t i=0; i<wtot.n_elem; i++) {
-          if(polarized) {
-            vrhoa = vxc(0,i);
-            vrhob = vxc(1,i);
-            if(do_gga) {
-              vsigmaaa = vsigma(0,i);
-              vsigmaab = vsigma(1,i);
-              vsigmabb = vsigma(2,i);
-            }
-            if(do_mgga_l) {
-              vlapla = vlapl(0,i);
-              vlaplb = vlapl(1,i);
-            }
-            if(do_mgga_t) {
-              vtaua = vtau(0,i);
-              vtaub = vtau(1,i);
-            }
-          } else {
-            vrhoa = vxc(i,0);
-            vrhob = vxc(i,0);
-            if(do_gga) {
-              vsigmaaa = vsigma(i,0);
-              vsigmaab = vsigma(i,0);
-              vsigmabb = vsigma(i,0);
-            }
-            if(do_mgga_l) {
-              vlapla = vlapl(i,0);
-              vlaplb = vlapl(i,0);
-            }
-            if(do_mgga_t) {
-              vtaua = vtau(i,0);
-              vtaub = vtau(i,0);
-            }
-          }
-
-          pot(0,i) = r(i);
-          pot(1,i) = exc[i];
-          pot(2,i) = vrhoa;
-          pot(3,i) = vrhob;
-          pot(4,i) = vsigmaaa;
-          pot(5,i) = vsigmaab;
-          pot(6,i) = vsigmabb;
-          pot(7,i) = vlapla;
-          pot(8,i) = vlaplb;
-          pot(9,i) = vtaua;
-          pot(10,i) = vtaub;
-        }
-      }
-
-      void DFTGridWorker::get_ingredients(arma::mat & ing) const {
-        double rhoa=0.0, rhob=0.0, sigmaaa=0.0, sigmaab=0.0, sigmabb=0.0, lapla=0.0, laplb=0.0, taua=0.0, taub=0.0;
-
-        ing.zeros(10,wtot.n_elem);
-        for(size_t i=0; i<wtot.n_elem; i++) {
-          if(polarized) {
-            rhoa = rho(0,i);
-            rhob = rho(1,i);
-            if(do_gga) {
-              sigmaaa = sigma(0,i);
-              sigmaab = sigma(1,i);
-              sigmabb = sigma(2,i);
-            }
-            if(do_mgga_l) {
-              lapla = lapl(0,i);
-              laplb = lapl(1,i);
-            }
-            if(do_mgga_t) {
-              taua = tau(0,i);
-              taub = tau(1,i);
-            }
-          } else {
-            rhoa = 0.5*rho(i,0);
-            rhob = 0.5*rho(i,0);
-            if(do_gga) {
-              sigmaaa = 0.25*sigma(i,0);
-              sigmaab = 0.25*sigma(i,0);
-              sigmabb = 0.25*sigma(i,0);
-            }
-            if(do_mgga_l) {
-              lapla = 0.5*lapl(i,0);
-              laplb = 0.5*lapl(i,0);
-            }
-            if(do_mgga_t) {
-              taua = 0.5*tau(i,0);
-              taub = 0.5*tau(i,0);
-            }
-          }
-
-          ing(0,i) = r(i);
-          ing(1,i) = rhoa;
-          ing(2,i) = rhob;
-          ing(3,i) = sigmaaa;
-          ing(4,i) = sigmaab;
-          ing(5,i) = sigmabb;
-          ing(6,i) = lapla;
-          ing(7,i) = laplb;
-          ing(8,i) = taua;
-          ing(9,i) = taub;
-        }
-      }
 
       // eval_Exc: inherited from DFTGridWorkerBase.
 
@@ -807,11 +680,9 @@ namespace helfem {
 
         double exc=0.0;
         double nel=0.0;
-        double tau=0.0;
-        double lapl=0.0;
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:exc,nel,tau,lapl)
+#pragma omp parallel reduction(+:exc,nel)
 #endif
         {
           DFTGridWorker grid(basp);
@@ -824,8 +695,6 @@ namespace helfem {
             grid.compute_bf(iel);
             grid.update_density(P);
             nel+=grid.compute_Nel();
-            tau+=grid.compute_tau();
-            lapl+=grid.compute_lapl();
 
             grid.init_xc();
             if(x_func>0)
@@ -843,8 +712,6 @@ namespace helfem {
             grid.compute_bf(iel);
             grid.update_density(P);
             nel+=grid.compute_Nel();
-            tau+=grid.compute_tau();
-            lapl+=grid.compute_lapl();
 
             grid.init_xc();
             if(x_func>0)
@@ -860,13 +727,6 @@ namespace helfem {
         // Save outputs
         Exc=exc;
         Nel=nel;
-
-#if 0
-        if(tau!=0.0)
-          printf("Tau integral %.10e\n",tau);
-        if(lapl!=0.0)
-          printf("Laplacian integral %.10e\n",lapl);
-#endif
       }
 
       void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr) {
@@ -923,155 +783,9 @@ namespace helfem {
         Nel=nel;
       }
 
-      void DFTGrid::eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & pot, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // exc vxca vxcb vsigmaaa vsigmaab vsigmabb vlapla vlaplb vtaua vtaub
-        pot.zeros(11, Nquad*Nelem);
 
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
 
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(P);
 
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store the potential
-            arma::mat subpot;
-            grid.get_pot(subpot);
-            pot.cols(iel*Nquad, (iel+1)*Nquad-1)=subpot;
-          }
-        }
-        // Swap rows and columns
-        pot = pot.t();
-      }
-
-      void DFTGrid::eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars,  const arma::cube & Pa, const arma::cube & Pb, arma::mat & pot, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // exc vxca vxcb vsigmaaa vsigmaab vsigmabb vlapla vlaplb vtaua vtaub
-        pot.zeros(11, Nquad*Nelem);
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(Pa,Pb);
-
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store the potential
-            arma::mat subpot;
-            grid.get_pot(subpot);
-            pot.cols(iel*Nquad, (iel+1)*Nquad-1)=subpot;
-          }
-        }
-        // Swap rows and columns
-        pot = pot.t();
-      }
-
-      void DFTGrid::eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & ing, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // rhoa rhob sigmaaa sigmaab sigmabb lapla laplb taua taub
-        ing.zeros(10, Nquad*Nelem);
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(P);
-
-            // We need to evaluate the xc functional to initialize the variables
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store
-            arma::mat subing;
-            grid.get_ingredients(subing);
-            ing.cols(iel*Nquad, (iel+1)*Nquad-1)=subing;
-          }
-        }
-        // Swap rows and columns
-        ing = ing.t();
-      }
-
-      void DFTGrid::eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars,  const arma::cube & Pa, const arma::cube & Pb, arma::mat & ing, double thr) {
-        // Compute number of quadrature points
-        size_t Nquad=basp->get_r(0).n_elem;
-        size_t Nelem=basp->get_rad_Nel();
-        // rhoa rhob sigmaaa sigmaab sigmabb lapla laplb taua taub
-        ing.zeros(10, Nquad*Nelem);
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        {
-          DFTGridWorker grid(basp);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
-#ifdef _OPENMP
-#pragma omp for
-#endif
-          for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            grid.compute_bf(iel);
-            grid.update_density(Pa,Pb);
-
-            // We need to evaluate the xc functional to initialize the variables
-            grid.init_xc();
-            if(x_func>0)
-              grid.compute_xc(x_func,x_pars,thr);
-            if(c_func>0)
-              grid.compute_xc(c_func,c_pars,thr);
-
-            // Store
-            arma::mat subing;
-            grid.get_ingredients(subing);
-            ing.cols(iel*Nquad, (iel+1)*Nquad-1)=subing;
-          }
-        }
-        // Swap rows and columns
-        ing = ing.t();
-      }
     }
   }
 }

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -81,10 +81,6 @@ namespace helfem {
 
         /// Compute number of electrons
         double compute_Nel() const;
-        /// Compute kinetic energy density
-        double compute_tau() const;
-        /// Compute laplacian
-        double compute_lapl() const;
 
         // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
         // from DFTGridWorkerBase.
@@ -96,11 +92,6 @@ namespace helfem {
         void eval_Fxc(arma::cube & H) const;
         /// Evaluate Fock matrix, unrestricted calculation
         void eval_Fxc(arma::cube & Ha, arma::cube & Hb, bool beta=true) const;
-
-        /// Get the potential
-        void get_pot(arma::mat & pot) const;
-        /// Get the ingredients
-        void get_ingredients(arma::mat & ing) const;
       };
 
       /// Wrapper routine
@@ -121,16 +112,6 @@ namespace helfem {
         void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr);
         /// Compute Fock matrix, exchange-correlation energy and integrated electron density, unrestricted case
         void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr);
-
-        /// Evaluate the potential
-        void eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & pot, double thr);
-        /// Compute the potential
-        void eval_pot(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::mat & pot, double thr);
-
-        /// Evaluate the ingredients
-        void eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::mat & ing, double thr);
-        /// Compute the ingredients
-        void eval_ing(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::mat & ing, double thr);
 
       };
 


### PR DESCRIPTION
## Summary

The atomic + diatomic OOO SCF drivers carried byte-identical copies
of four boilerplate sections. Extracts them into
\`scf_driver_common.h\` so bug fixes only need to happen in one place:

| Helper | What it does | Sites collapsed |
|---|---|---|
| \`build_per_block_Sinvh\` | Per-block symmetric orthonormalisation of S | 2 |
| \`build_coreH_from_H0\` | Guess Fock in the orthonormal basis, w/ spin-Zeeman split | 2 |
| \`fill_block_from_density\` | \`--load\` block density → OOO (orbitals, occupations) | 2 |
| \`assemble_final_density\` | \`--save\` reconstruction of Pa/Pb from OOO's final orbs+occs | 2 |

Diff: **+151 / −208** across the two drivers and the helper header.

The header's previous helpers (\`normalize_matrix\`, \`gram_schmidt\`,
\`report_ortho_deviation\`, \`report_halfoverlap_error\`,
\`project_and_diagonalize\`) were bespoke-era leftovers with zero
in-tree callers — those go too.

## Test plan

- [x] atomic He LDA → -2.7236397926 (unchanged)
- [x] gensap H LDA → -0.4570785099 (unchanged)
- [x] diatomic H2 LDA → -1.0436644869 (unchanged)
- [x] atomic He --save (coarse) → --load (fine) recovers the fresh
  fine-basis energy exactly (-2.7236397926)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>