### PR TITLE
src/{atomic,diatomic,sadatom}/dftgrid: delete unused DFTGridWorker leaves

### DIFF
--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -303,26 +303,6 @@ namespace helfem {
       // compute_xc, eval_Exc: inherited from
       // helfem::dftgrid_common::DFTGridWorkerBase.
 
-      void DFTGridWorker::eval_overlap(arma::mat & So) const {
-        // Calculate in subspace
-        arma::mat S(bf_ind.n_elem,bf_ind.n_elem);
-        S.zeros();
-        increment_lda< std::complex<double> >(S,wtot,bf);
-        // Increment
-        So.submat(bf_ind,bf_ind)+=S;
-      }
-
-      void DFTGridWorker::eval_kinetic(arma::mat & To) const {
-        // Calculate in subspace
-        arma::mat T(bf_ind.n_elem,bf_ind.n_elem);
-        T.zeros();
-        increment_lda< std::complex<double> >(T,wtot % inv_scale_r2,bf_rho);
-        increment_lda< std::complex<double> >(T,wtot % inv_scale_theta2,bf_theta);
-        increment_lda< std::complex<double> >(T,wtot % inv_scale_phi2,bf_phi);
-        // Increment
-        To.submat(bf_ind,bf_ind)+=0.5*T;
-      }
-
       void DFTGridWorker::eval_Fxc(arma::mat & Ho) const {
         if(polarized) {
           throw std::runtime_error("Refusing to compute restricted Fock matrix with unrestricted density.\n");

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -106,11 +106,6 @@ namespace helfem {
 
         /// Numerical clean up of xc
 
-        /// Evaluate overlap matrix
-        void eval_overlap(arma::mat & S) const;
-        /// Evaluate kinetic energy matrix
-        void eval_kinetic(arma::mat & T) const;
-
         /// Evaluate Fock matrix, restricted calculation
         void eval_Fxc(arma::mat & H) const;
         /// Evaluate Fock matrix, unrestricted calculation

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -267,38 +267,7 @@ namespace helfem {
 
       // compute_xc: inherited from DFTGridWorkerBase.
 
-      void DFTGridWorker::save(const std::string & info) const {
-        rho.save("rho"+info+".dat",arma::raw_ascii);
-        sigma.save("sigma"+info+".dat",arma::raw_ascii);
-        tau.save("tau"+info+".dat",arma::raw_ascii);
-
-        vxc.save("vxc"+info+".dat",arma::raw_ascii);
-        vsigma.save("vsigma"+info+".dat",arma::raw_ascii);
-        vtau.save("vtau"+info+".dat",arma::raw_ascii);
-        exc.save("exc"+info+".dat",arma::raw_ascii);
-      }
-
       // eval_Exc: inherited from DFTGridWorkerBase.
-
-      void DFTGridWorker::eval_overlap(arma::mat & So) const {
-        // Calculate in subspace
-        arma::mat S(bf_ind.n_elem,bf_ind.n_elem);
-        S.zeros();
-        increment_lda< std::complex<double> >(S,wtot,bf);
-        // Increment
-        So.submat(bf_ind,bf_ind)+=S;
-      }
-
-      void DFTGridWorker::eval_kinetic(arma::mat & To) const {
-        // Calculate in subspace
-        arma::mat T(bf_ind.n_elem,bf_ind.n_elem);
-        T.zeros();
-        increment_lda< std::complex<double> >(T,wtot/(scale_r%scale_r),bf_rho);
-        increment_lda< std::complex<double> >(T,wtot/(scale_theta%scale_theta),bf_theta);
-        increment_lda< std::complex<double> >(T,wtot/(scale_phi%scale_phi),bf_phi);
-        // Increment
-        To.submat(bf_ind,bf_ind)+=0.5*T;
-      }
 
       void DFTGridWorker::eval_Fxc(arma::mat & Ho) const {
         if(polarized) {
@@ -567,12 +536,6 @@ namespace helfem {
 
               exc+=grid.eval_Exc();
               grid.eval_Fxc(H);
-
-#if 0
-              std::ostringstream oss;
-              oss << "_" << iel << "_" << irad;
-              grid.save(oss.str());
-#endif
             }
           }
         }
@@ -611,12 +574,6 @@ namespace helfem {
 
               exc+=grid.eval_Exc();
               grid.eval_Fxc(Ha,Hb,beta);
-
-#if 0
-              std::ostringstream oss;
-              oss << "_" << iel << "_" << irad;
-              grid.save(oss.str());
-#endif
             }
           }
         }

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -82,8 +82,6 @@ namespace helfem {
         void compute_bf(size_t iel, size_t irad);
         /// Free memory
         void free();
-        /// Save data
-        void save(const std::string & info) const;
 
         /// Update values of density, restricted calculation
         void update_density(const arma::mat & P);
@@ -97,13 +95,6 @@ namespace helfem {
 
         // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
         // from DFTGridWorkerBase.
-
-        /// Numerical clean up of xc
-
-        /// Evaluate overlap matrix
-        void eval_overlap(arma::mat & S) const;
-        /// Evaluate kinetic energy matrix
-        void eval_kinetic(arma::mat & T) const;
 
         /// Evaluate Fock matrix, restricted calculation
         void eval_Fxc(arma::mat & H) const;

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -434,15 +434,6 @@ namespace helfem {
 
       // eval_Exc: inherited from DFTGridWorkerBase.
 
-      void DFTGridWorker::eval_overlap(arma::mat & So) const {
-        // Calculate in subspace
-        arma::mat S(bf_ind.n_elem,bf_ind.n_elem);
-        S.zeros();
-        increment_lda<double>(S,wtot,bf);
-        // Increment
-        So.submat(bf_ind,bf_ind)+=S;
-      }
-
       void DFTGridWorker::eval_Fxc(arma::cube & Ho) const {
         if(polarized) {
           throw std::runtime_error("Refusing to compute restricted Fock matrix with unrestricted density.\n");

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -85,8 +85,6 @@ namespace helfem {
         // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
         // from DFTGridWorkerBase.
 
-        /// Evaluate overlap matrix
-        void eval_overlap(arma::mat & S) const;
 
         /// Evaluate Fock matrix, restricted calculation
         void eval_Fxc(arma::cube & H) const;


### PR DESCRIPTION
## Summary

Follow-on to commit de06a34 (which retired the
\`DFTGrid::eval_{overlap,kinetic}\` wrappers): the per-element
\`DFTGridWorker\` routines they called are now themselves orphaned.

Deleted across the three geometries:

* \`atomic::DFTGridWorker::eval_overlap\`, \`::eval_kinetic\`
* \`diatomic::DFTGridWorker::eval_overlap\`, \`::eval_kinetic\`
* \`sadatom::DFTGridWorker::eval_overlap\`

Plus \`diatomic::DFTGridWorker::save\` (per-element rho / sigma / tau
/ vxc dat-file dump) and the two \`#if 0\` scaffolds in
\`diatomic::DFTGrid::eval_Fxc\` that were its only callers.

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] gensap H LDA -> -0.4570785099 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>