### PR TITLE
src/{atomic,diatomic,sadatom}: delete more dead worker surface

### DIFF
--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -86,8 +86,6 @@ namespace helfem {
 
         /// Compute basis functions on grid points
         void compute_bf(size_t iel);
-        /// Free memory
-        void free();
 
         /// Update values of density, restricted calculation
         void update_density(const arma::mat & P);

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -80,8 +80,6 @@ namespace helfem {
 
         /// Compute basis functions on grid points
         void compute_bf(size_t iel, size_t irad);
-        /// Free memory
-        void free();
 
         /// Update values of density, restricted calculation
         void update_density(const arma::mat & P);

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -229,10 +229,6 @@ namespace helfem {
           }
       }
 
-      void TwoDGridWorker::unit_pot() {
-        itg.ones(1,wtot.n_elem);
-      }
-
       void TwoDGridWorker::multiply_Plm(int l, int m, probe_t p) {
         arma::vec chmu(arma::cosh(r));
         arma::vec shmu(arma::sinh(r));
@@ -382,32 +378,6 @@ namespace helfem {
         H=basp->remove_boundaries(H);
 
         return H;
-      }
-
-      arma::mat TwoDGrid::overlap() {
-        arma::mat S;
-        S.zeros(basp->Ndummy(),basp->Ndummy());
-
-        // Get unique m values in basis set
-        arma::ivec muni(basp->get_mval());
-        muni=muni(arma::find_unique(muni));
-        {
-          TwoDGridWorker grid(basp,lang);
-
-          for(size_t im=0;im<muni.n_elem;im++) {
-            for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-              for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
-                grid.compute_bf(iel,irad,muni(im));
-                grid.unit_pot();
-                grid.eval_pot(S);
-              }
-            }
-          }
-        }
-
-        S=basp->remove_boundaries(S);
-
-        return S;
       }
 
       arma::mat TwoDGrid::gto_projection(int l, int m, const arma::vec & expn, probe_t p) {

--- a/src/diatomic/twodquadrature.h
+++ b/src/diatomic/twodquadrature.h
@@ -68,13 +68,9 @@ namespace helfem {
 
         /// Compute basis functions on grid points
         void compute_bf(size_t iel, size_t irad, int m);
-        /// Free memory
-        void free();
 
         /// Compute model potential
         void model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2);
-        /// Set unit potential
-        void unit_pot();
 
         /// Compute AO projection
         void ao_projection(const std::function<arma::vec(double r)> & compute_ao, probe_t p);
@@ -119,8 +115,6 @@ namespace helfem {
         /// Compute model potential matrix
         arma::mat model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2);
 
-        /// Compute overlap matrix
-        arma::mat overlap();
         /// Compute GTO projection
         arma::mat gto_projection(int l, int m, const arma::vec & expn, probe_t p);
         /// Compute GTO projection

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -71,8 +71,6 @@ namespace helfem {
 
         /// Compute basis functions on grid points
         void compute_bf(size_t iel);
-        /// Free memory
-        void free();
 
         /// Update values of density, restricted calculation
         void update_density(const arma::cube & P);


### PR DESCRIPTION
## Summary

Three small orphans across the DFT-grid and twodquadrature workers:

* \`void free()\` is declared on all four Worker classes
  (\`atomic\` / \`diatomic\` / \`sadatom\` \`DFTGridWorker\` plus
  \`diatomic::TwoDGridWorker\`) but was never defined — nothing calls
  it, and the linker only tolerates that because nothing tries.
* \`diatomic::TwoDGrid::overlap()\` (~24 lines) computed the
  quadrature overlap via \`TwoDGridWorker::unit_pot\`. No caller
  outside \`twodquadrature.cpp\`; the diatomic driver uses the
  analytic FE overlap from \`TwoDBasis::overlap()\`.
* \`diatomic::TwoDGridWorker::unit_pot()\` — the wrapper above was
  its only caller.

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] gensap H LDA -> -0.4570785099 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>