### PR TITLE
src/general/dftgrid_common: inline zero_Exc into init_xc

### DIFF
--- a/src/general/dftgrid_common.cpp
+++ b/src/general/dftgrid_common.cpp
@@ -57,13 +57,9 @@ namespace helfem {
       do_lapl = lap_;
     }
 
-    void DFTGridWorkerBase::zero_Exc() {
-      exc.zeros(wtot.n_elem);
-    }
-
     void DFTGridWorkerBase::init_xc() {
       const size_t N = wtot.n_elem;
-      zero_Exc();
+      exc.zeros(N);
       if (!polarized) {
         vxc.zeros(1, N);
         if (do_grad) vsigma.zeros(1, N);

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -82,12 +82,8 @@ namespace helfem {
       /// Check necessity of computing gradient / tau / laplacian for the
       /// given exchange + correlation functional ids.
       void check_grad_tau_lapl(int x_func, int c_func);
-      /// Query the do_grad / do_tau / do_lapl flags
       /// Explicit override of the do_grad / do_tau / do_lapl flags
       void set_grad_tau_lapl(bool grad, bool tau, bool lapl);
-
-      /// Zero the exchange-correlation energy density buffer
-      void zero_Exc();
 
       /// Initialise vxc / vsigma / vtau / vlapl buffers with the
       /// correct shape and zero exc.


### PR DESCRIPTION
## Summary

\`DFTGridWorkerBase::zero_Exc\` had exactly one caller (\`init_xc\`)
and zero external users. Inlines the one-liner
(\`exc.zeros(wtot.n_elem)\`) into \`init_xc\` and drops the method +
its (now dead) public declaration.

Also removes a stray "Query the do_grad / do_tau / do_lapl flags"
comment above \`set_grad_tau_lapl\` — it referred to a
\`get_grad_tau_lapl\` getter deleted a few PRs back.

## Test plan

- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>