### PR TITLE
src/general/scf_driver_common: extract fock-builder lambda helpers

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -350,27 +350,15 @@ int main(int argc, char **argv) {
   auto accumulate_density = [&](arma::mat & P_full, size_t k,
                                  const helfem::Matrix & orb_e,
                                  const helfem::Vector & occ_e) {
-    if (!dsym[k].n_elem) return;
-    const arma::mat orb  = helfem::to_arma(orb_e);
-    const arma::vec occ  = helfem::to_arma(occ_e);
-    const arma::mat C_k  = Sinvh_arma[k] * orb;
-    const arma::mat P_k  = C_k * arma::diagmat(occ) * C_k.t();
-    P_full(dsym[k], dsym[k]) += P_k;
+    helfem::scf_driver::accumulate_density_block<OOO_Real>(
+        P_full, dsym, k, Sinvh_arma, orb_e, occ_e);
   };
 
-  // Extract F_full(dsym[k], dsym[k]), transform to the block's
-  // orthonormal basis via Sinvh_k^T . F_k . Sinvh_k, and stash into
-  // fock[b] as helfem::Matrix.
   auto orthonormalize_block =
       [&](OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock, size_t b,
           const arma::mat & F_full, size_t k) {
-    if (!dsym[k].n_elem) {
-      fock[b] = helfem::Matrix::Zero(0, 0);
-      return;
-    }
-    const arma::mat Fk_sub = F_full(dsym[k], dsym[k]);
-    const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
-    fock[b] = helfem::to_eigen(F_orth);
+    helfem::scf_driver::orthonormalize_fock_block<OOO_Real>(
+        fock, b, dsym, k, Sinvh_arma, F_full);
   };
 
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -308,26 +308,15 @@ int main(int argc, char **argv) {
   auto accumulate_density = [&](arma::mat & P_full, size_t k,
                                  const helfem::Matrix & orb_e,
                                  const helfem::Vector & occ_e) {
-    if (!dsym[k].n_elem) return;
-    const arma::mat orb  = helfem::to_arma(orb_e);
-    const arma::vec occ  = helfem::to_arma(occ_e);
-    const arma::mat C_k  = Sinvh_arma[k] * orb;
-    const arma::mat P_k  = C_k * arma::diagmat(occ) * C_k.t();
-    P_full(dsym[k], dsym[k]) += P_k;
+    helfem::scf_driver::accumulate_density_block<OOO_Real>(
+        P_full, dsym, k, Sinvh_arma, orb_e, occ_e);
   };
 
-  // Extract F_full(dsym[k], dsym[k]), transform to the block's
-  // orthonormal basis via Sinvh_k^T . F_k . Sinvh_k, stash into fock[b].
   auto orthonormalize_block =
       [&](OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock, size_t b,
           const arma::mat & F_full, size_t k) {
-    if (!dsym[k].n_elem) {
-      fock[b] = helfem::Matrix::Zero(0, 0);
-      return;
-    }
-    const arma::mat Fk_sub = F_full(dsym[k], dsym[k]);
-    const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
-    fock[b] = helfem::to_eigen(F_orth);
+    helfem::scf_driver::orthonormalize_fock_block<OOO_Real>(
+        fock, b, dsym, k, Sinvh_arma, F_full);
   };
 
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -152,6 +152,46 @@ namespace helfem {
       return {Pa_final, Pb_final};
     }
 
+    /// Fock-builder helper: accumulate one block of the AO density
+    /// matrix P_full from OOO's per-block (orbitals, occupations)
+    /// pair. Called per symmetry block per spin channel from both
+    /// drivers' fock_builder lambdas. Empty blocks are no-ops.
+    ///
+    ///   C_k     = Sinvh_k . orb_e
+    ///   P_full(dsym[k], dsym[k]) += C_k . diag(occ_e) . C_k^T
+    template <typename Real>
+    inline void accumulate_density_block(
+        arma::mat & P_full, const std::vector<arma::uvec> & dsym, size_t k,
+        const std::vector<arma::mat> & Sinvh_arma,
+        const helfem::Matrix & orb_e, const helfem::Vector & occ_e) {
+      if (!dsym[k].n_elem) return;
+      const arma::mat orb  = helfem::to_arma(orb_e);
+      const arma::vec occ  = helfem::to_arma(occ_e);
+      const arma::mat C_k  = Sinvh_arma[k] * orb;
+      const arma::mat P_k  = C_k * arma::diagmat(occ) * C_k.t();
+      P_full(dsym[k], dsym[k]) += P_k;
+    }
+
+    /// Fock-builder helper: extract block k of a full AO Fock matrix,
+    /// transform to that block's orthonormal basis via
+    /// Sinvh_k^T . F_k . Sinvh_k, and stash it into the OOO
+    /// FockMatrix at index b (as helfem::Matrix). Empty blocks
+    /// become 0x0 placeholders.
+    template <typename Real>
+    inline void orthonormalize_fock_block(
+        OpenOrbitalOptimizer::FockMatrix<Real> & fock, size_t b,
+        const std::vector<arma::uvec> & dsym, size_t k,
+        const std::vector<arma::mat> & Sinvh_arma,
+        const arma::mat & F_full) {
+      if (!dsym[k].n_elem) {
+        fock[b] = helfem::Matrix::Zero(0, 0);
+        return;
+      }
+      const arma::mat Fk_sub = F_full(dsym[k], dsym[k]);
+      const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
+      fock[b] = helfem::to_eigen(F_orth);
+    }
+
   } // namespace scf_driver
 } // namespace helfem
 


### PR DESCRIPTION
## Summary

Both atomic and diatomic OOO \`fock_builder\` lambdas open with two
byte-identical helper lambdas:

* \`accumulate_density\` — build one AO density block from OOO's
  \`(orbitals, occupations)\` pair for a symmetry index set.
* \`orthonormalize_block\` — extract \`F_full(dsym[k], dsym[k])\`,
  transform to the block's orthonormal basis via
  \`Sinvh_k^T . F_k . Sinvh_k\`, stash into \`fock[b]\`.

Extracts both into \`scf_driver_common.h\` as templates
\`accumulate_density_block\` and \`orthonormalize_fock_block\`. The
driver-side lambdas stay as thin closure wrappers — one per driver
each — but the actual arithmetic is single-sourced.

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] gensap H LDA -> -0.4570785099 (unchanged)
- [x] diatomic H2 LDA -> -1.0436644869 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>