### PR TITLE
src/diatomic: coulomb / exchange return helfem::Matrix

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -1081,9 +1081,13 @@ namespace helfem {
         return r;
       }
 
-      arma::mat TwoDBasis::coulomb(const arma::mat & P0) const {
+      helfem::Matrix TwoDBasis::coulomb(const helfem::Matrix & P_in) const {
         if(!prim_tei00.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
+
+        // Public boundary Eigen -> internal arma. One conversion at
+        // entry, one at exit; the interior is arma-native.
+        const arma::mat P0 = helfem::to_arma(P_in);
 
         // Extend to boundaries
         arma::mat P(expand_boundaries(P0));
@@ -1257,12 +1261,16 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(J);
+        return helfem::to_eigen(remove_boundaries(J));
       }
 
-      arma::mat TwoDBasis::exchange(const arma::mat & P0) const {
+      helfem::Matrix TwoDBasis::exchange(const helfem::Matrix & P_in) const {
         if(!prim_ktei00.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
+
+        // Public boundary Eigen -> internal arma. One conversion at
+        // entry, one at exit; the interior is arma-native.
+        const arma::mat P0 = helfem::to_arma(P_in);
 
         // Extend to boundaries
         arma::mat P(expand_boundaries(P0));
@@ -1465,7 +1473,7 @@ namespace helfem {
           }
         }
 
-        return remove_boundaries(K);
+        return helfem::to_eigen(remove_boundaries(K));
       }
 
       arma::mat TwoDBasis::remove_boundaries(const arma::mat & Fnob) const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -231,10 +231,13 @@ namespace helfem {
         /// Coupling to magnetic field in z direction
         helfem::Matrix Bz_field(double B) const;
 
-        /// Form Coulomb matrix
-        arma::mat coulomb(const arma::mat & P) const;
-        /// Form exchange matrix
-        arma::mat exchange(const arma::mat & P) const;
+        /// Form Coulomb matrix (Eigen-typed public boundary; internal
+        /// implementation is arma-native, one to_arma bridge at entry
+        /// and one to_eigen bridge at exit).
+        helfem::Matrix coulomb(const helfem::Matrix & P) const;
+        /// Form exchange matrix (Eigen-typed public boundary; same
+        /// bridging convention as coulomb() above).
+        helfem::Matrix exchange(const helfem::Matrix & P) const;
 
 
         /// Get indices of basis functions with wanted m quantum number

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -361,7 +361,7 @@ int main(int argc, char **argv) {
     const double Emfield = have_bfield
         ? arma::trace(P * Vmag) - 0.5 * Bz * (nela - nelb) : 0.0;
 
-    const arma::mat J = basis.coulomb(P);
+    const arma::mat J = helfem::to_arma(basis.coulomb(helfem::to_eigen(P)));
     const double Ecoul = 0.5 * arma::trace(P * J);
 
     // HF exchange. See sign-convention note in atomic/ooo.cpp: basis.exchange
@@ -370,10 +370,10 @@ int main(int argc, char **argv) {
     arma::mat Ka, Kb;
     double Exx = 0.0;
     if (have_exx) {
-      Ka = kfrac * basis.exchange(Pa);
+      Ka = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pa)));
       Exx = 0.5 * arma::trace(Pa * Ka);
       if (!restricted) {
-        Kb = kfrac * basis.exchange(Pb);
+        Kb = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pb)));
         Exx += 0.5 * arma::trace(Pb * Kb);
       } else {
         Exx *= 2.0;


### PR DESCRIPTION
## Summary

Brings the diatomic \`TwoDBasis\`'s HF SCF surface in line with the
atomic side:

* \`helfem::Matrix coulomb(const helfem::Matrix & P) const\`
* \`helfem::Matrix exchange(const helfem::Matrix & P) const\`

Interior implementation stays arma-native — a single
\`helfem::to_arma\` bridge at entry, \`helfem::to_eigen\` at exit —
matching the atomic \`TwoDBasis\` convention exactly.

Signature parity matters because the atomic and diatomic OOO
drivers share \`fock_builder\` wiring via \`scf_driver_common.h\`.
Keeping the diatomic coulomb / exchange arma-typed forced the
diatomic driver body to differ from the atomic one for no functional
reason; this is preparatory work for consolidating more of the
\`fock_builder\` between the two drivers.

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] gensap H LDA -> -0.4570785099 (unchanged)
- [x] diatomic H2 LDA -> -1.0436644869 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>