### PR TITLE
src/general/scf_driver_common: consolidate fock_builder final assembly

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -460,32 +460,10 @@ int main(int argc, char **argv) {
       if (maverage)
         F = helfem::to_arma(scf::fock_symmetry_average(helfem::to_eigen(F), l_idx));
     };
-    if (restricted) {
-      arma::mat F_ao = H1 + J;
-      if (have_xc)  F_ao += XCa;
-      if (have_exx) F_ao += Ka;
-      apply_mavg(F_ao);
-      for (size_t k = 0; k < nsym; ++k)
-        orthonormalize_block(fock, k, F_ao, k);
-    } else {
-      arma::mat Fa_ao = H1 + J;
-      arma::mat Fb_ao = H1 + J;
-      if (have_xc)  { Fa_ao += XCa; Fb_ao += XCb; }
-      if (have_exx) { Fa_ao += Ka;  Fb_ao += Kb;  }
-      // Spin-Zeeman splitting: alpha <- -Bz/2 * S, beta <- +Bz/2 * S.
-      // Only matters in unrestricted mode -- in restricted the two
-      // channels are equal by construction.
-      if (have_bfield) {
-        Fa_ao -= 0.5 * Bz * S;
-        Fb_ao += 0.5 * Bz * S;
-      }
-      apply_mavg(Fa_ao);
-      apply_mavg(Fb_ao);
-      for (size_t k = 0; k < nsym; ++k) {
-        orthonormalize_block(fock, k,        Fa_ao, k);
-        orthonormalize_block(fock, nsym + k, Fb_ao, k);
-      }
-    }
+    helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
+        fock, H1, J, XCa, XCb, Ka, Kb, S,
+        nsym, restricted, have_xc, have_exx, have_bfield, Bz,
+        apply_mavg, orthonormalize_block);
     return std::make_pair(Etot, fock);
   };
 

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -400,31 +400,10 @@ int main(int argc, char **argv) {
       if (maverage)
         F = helfem::to_arma(scf::fock_symmetry_average(helfem::to_eigen(F), mavg_idx));
     };
-    if (restricted) {
-      arma::mat F_ao = H1 + J;
-      if (have_xc)  F_ao += XCa;
-      if (have_exx) F_ao += Ka;
-      apply_mavg(F_ao);
-      for (size_t k = 0; k < nsym; ++k)
-        orthonormalize_block(fock, k, F_ao, k);
-    } else {
-      arma::mat Fa_ao = H1 + J;
-      arma::mat Fb_ao = H1 + J;
-      if (have_xc)  { Fa_ao += XCa; Fb_ao += XCb; }
-      if (have_exx) { Fa_ao += Ka;  Fb_ao += Kb;  }
-      // Spin-Zeeman splitting Fa -= Bz/2 * S, Fb += Bz/2 * S. In
-      // restricted mode alpha == beta so no split is applied.
-      if (have_bfield) {
-        Fa_ao -= 0.5 * Bz * S;
-        Fb_ao += 0.5 * Bz * S;
-      }
-      apply_mavg(Fa_ao);
-      apply_mavg(Fb_ao);
-      for (size_t k = 0; k < nsym; ++k) {
-        orthonormalize_block(fock, k,        Fa_ao, k);
-        orthonormalize_block(fock, nsym + k, Fb_ao, k);
-      }
-    }
+    helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
+        fock, H1, J, XCa, XCb, Ka, Kb, S,
+        nsym, restricted, have_xc, have_exx, have_bfield, Bz,
+        apply_mavg, orthonormalize_block);
     return std::make_pair(Etot, fock);
   };
 

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -192,6 +192,55 @@ namespace helfem {
       fock[b] = helfem::to_eigen(F_orth);
     }
 
+    /// Fock-builder helper: assemble the per-block orthonormal Fock
+    /// matrices from the AO ingredients. Both drivers' fock_builder
+    /// lambdas end with a byte-identical restricted / unrestricted
+    /// branch that
+    ///   * adds up H1 + J (+ XC + K) per spin channel,
+    ///   * applies the spin-Zeeman +/- Bz/2 * S split (unrestricted
+    ///     only),
+    ///   * runs the driver-supplied apply_mavg / orthonormalize_block
+    ///     callables to symmetrise and orthonormalise per block.
+    /// XCa / XCb, Ka / Kb are assumed pre-zeroed (their addends only
+    /// fire under the corresponding have_* flag), matching the
+    /// convention the driver bodies keep for the XC and HF-exchange
+    /// pieces.
+    template <typename Real, typename ApplyMAvg, typename OrthoBlock>
+    inline void assemble_fock_blocks(
+        OpenOrbitalOptimizer::FockMatrix<Real> & fock,
+        const arma::mat & H1, const arma::mat & J,
+        const arma::mat & XCa, const arma::mat & XCb,
+        const arma::mat & Ka,  const arma::mat & Kb,
+        const arma::mat & S,
+        size_t nsym, bool restricted,
+        bool have_xc, bool have_exx, bool have_bfield, double Bz,
+        ApplyMAvg apply_mavg, OrthoBlock orthonormalize_block) {
+      if (restricted) {
+        arma::mat F_ao = H1 + J;
+        if (have_xc)  F_ao += XCa;
+        if (have_exx) F_ao += Ka;
+        apply_mavg(F_ao);
+        for (size_t k = 0; k < nsym; ++k)
+          orthonormalize_block(fock, k, F_ao, k);
+      } else {
+        arma::mat Fa_ao = H1 + J;
+        arma::mat Fb_ao = H1 + J;
+        if (have_xc)  { Fa_ao += XCa; Fb_ao += XCb; }
+        if (have_exx) { Fa_ao += Ka;  Fb_ao += Kb;  }
+        // Spin-Zeeman: alpha <- -Bz/2 * S, beta <- +Bz/2 * S.
+        if (have_bfield) {
+          Fa_ao -= 0.5 * Bz * S;
+          Fb_ao += 0.5 * Bz * S;
+        }
+        apply_mavg(Fa_ao);
+        apply_mavg(Fb_ao);
+        for (size_t k = 0; k < nsym; ++k) {
+          orthonormalize_block(fock, k,        Fa_ao, k);
+          orthonormalize_block(fock, nsym + k, Fb_ao, k);
+        }
+      }
+    }
+
   } // namespace scf_driver
 } // namespace helfem
 


### PR DESCRIPTION
## Summary

Both drivers' \`fock_builder\` lambdas ended with a byte-identical
restricted / unrestricted branch:

* sum up \`H1 + J\` (+ XC + K) per spin channel
* apply the \`+/- 0.5 * Bz * S\` spin-Zeeman split (unrestricted only)
* run the driver-supplied \`apply_mavg\` and \`orthonormalize_block\`
  closures to symmetrise + orthonormalise per block

Extracts the whole branch into a
\`scf_driver::assemble_fock_blocks\` template. Callers pass the two
closures as \`ApplyMAvg\` / \`OrthoBlock\` type parameters so each
driver's mavg-index set (\`l_idx\` on atomic, \`mavg_idx\` on
diatomic) stays local to its main.cpp.

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] atomic Li UHF LDA -> -7.1934018521 (exercises the unrestricted branch)
- [x] gensap H LDA -> -0.4570785099 (unchanged)
- [x] diatomic H2 LDA -> -1.0436644869 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>