### PR TITLE
src/general/scf_driver_common: consolidate HF-exchange assembly

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -418,25 +418,19 @@ int main(int argc, char **argv) {
     //     sign matches the bespoke atomic driver's line 754.
     //     For RS hybrids, rs_exchange uses the erfc or Yukawa kernel
     //     precomputed above.
+    // Atomic exchange kernel: kfrac * K + kshort * K_rs. Empty
+    // branches contribute zero, so RS hybrids and plain hybrids all
+    // flow through the same builder.
+    auto exchange_fn = [&](const arma::mat & P) {
+      arma::mat K(Nbf, Nbf, arma::fill::zeros);
+      if (kfrac  != 0.0) K += kfrac  * helfem::to_arma(basis.exchange(helfem::to_eigen(P)));
+      if (kshort != 0.0) K += kshort * helfem::to_arma(basis.rs_exchange(helfem::to_eigen(P)));
+      return K;
+    };
     arma::mat Ka, Kb;
     double Exx = 0.0;
-    if (have_exx) {
-      Ka.zeros(Nbf, Nbf);
-      if (kfrac  != 0.0) Ka += kfrac  * helfem::to_arma(basis.exchange(helfem::to_eigen(Pa)));
-      if (kshort != 0.0) Ka += kshort * helfem::to_arma(basis.rs_exchange(helfem::to_eigen(Pa)));
-      Exx = 0.5 * arma::trace(Pa * Ka);
-      if (!restricted) {
-        Kb.zeros(Nbf, Nbf);
-        if (kfrac  != 0.0) Kb += kfrac  * helfem::to_arma(basis.exchange(helfem::to_eigen(Pb)));
-        if (kshort != 0.0) Kb += kshort * helfem::to_arma(basis.rs_exchange(helfem::to_eigen(Pb)));
-        Exx += 0.5 * arma::trace(Pb * Kb);
-      } else {
-        // In restricted mode alpha == beta density, and we only assemble
-        // one Fock. Skipping the K(Pb) call saves one exchange build;
-        // the beta contribution equals the alpha one so double it.
-        Exx *= 2.0;
-      }
-    }
+    helfem::scf_driver::assemble_hf_exchange(
+        Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
 
     const double Etot = Ekin + Enuc + Eefield + Emfield + Econf
                        + Ecoul + Exc + Exx;

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -364,21 +364,14 @@ int main(int argc, char **argv) {
     const arma::mat J = helfem::to_arma(basis.coulomb(helfem::to_eigen(P)));
     const double Ecoul = 0.5 * arma::trace(P * J);
 
-    // HF exchange. See sign-convention note in atomic/ooo.cpp: basis.exchange
-    // returns a matrix that gets ADDED to the Fock and the energy
-    // contribution is +0.5*trace(Pspin*Kspin) per channel.
+    // Diatomic exchange kernel: pure Coulomb K (no RS split yet).
+    auto exchange_fn = [&](const arma::mat & P) {
+      return arma::mat(kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(P))));
+    };
     arma::mat Ka, Kb;
     double Exx = 0.0;
-    if (have_exx) {
-      Ka = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pa)));
-      Exx = 0.5 * arma::trace(Pa * Ka);
-      if (!restricted) {
-        Kb = kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(Pb)));
-        Exx += 0.5 * arma::trace(Pb * Kb);
-      } else {
-        Exx *= 2.0;
-      }
-    }
+    helfem::scf_driver::assemble_hf_exchange(
+        Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
 
     const double Etot = Ekin + Enuc + Eefield + Emfield
                        + Ecoul + Exc + Exx + Enucr;

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -192,6 +192,35 @@ namespace helfem {
       fock[b] = helfem::to_eigen(F_orth);
     }
 
+    /// Fock-builder helper: assemble the alpha/beta HF exchange
+    /// matrices and their energy contribution from a per-driver
+    /// exchange_fn callable. exchange_fn(P) returns the AO K matrix
+    /// for a spin-density P, folding in whichever coefficient set
+    /// the driver supports (kfrac * K + kshort * K_rs for atomic,
+    /// kfrac * K for diatomic). Restricted mode skips the K(Pb)
+    /// build; alpha == beta by construction so the beta contribution
+    /// is just 2 * the alpha one.
+    ///
+    /// Ka and Kb are the AO exchange buffers the caller then folds
+    /// into the Fock matrix downstream. Exx is the energy
+    /// contribution.
+    template <typename ExchangeFn>
+    inline void assemble_hf_exchange(
+        arma::mat & Ka, arma::mat & Kb, double & Exx,
+        const arma::mat & Pa, const arma::mat & Pb,
+        bool restricted, bool have_exx, ExchangeFn exchange_fn) {
+      Exx = 0.0;
+      if (!have_exx) return;
+      Ka = exchange_fn(Pa);
+      Exx = 0.5 * arma::trace(Pa * Ka);
+      if (!restricted) {
+        Kb = exchange_fn(Pb);
+        Exx += 0.5 * arma::trace(Pb * Kb);
+      } else {
+        Exx *= 2.0;
+      }
+    }
+
     /// Fock-builder helper: assemble the per-block orthonormal Fock
     /// matrices from the AO ingredients. Both drivers' fock_builder
     /// lambdas end with a byte-identical restricted / unrestricted


### PR DESCRIPTION
## Summary

Both drivers' \`fock_builder\` lambdas had a nearly-identical HF
exchange block:

* \`kfrac * exchange(P)\` (+ \`kshort * rs_exchange(P)\` on atomic)
* \`Exx = 0.5 * trace(P_spin * K_spin)\` per channel
* restricted mode skips \`K(Pb)\` and doubles \`Exx\`

Extracts the outer loop structure into a
\`scf_driver::assemble_hf_exchange\` template that takes an
\`exchange_fn\` callable. Each driver defines its own kernel:

| Driver | Kernel |
|---|---|
| atomic | \`kfrac * K + kshort * K_rs\` (RS hybrids supported) |
| diatomic | \`kfrac * K\` (RS not supported here) |

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] atomic Li UHF LDA -> -7.1934018521 (unrestricted branch)
- [x] atomic He HF -> -2.8616799956 (exercises have_exx)
- [x] diatomic H2 LDA -> -1.0436644869 (unchanged)
- [x] diatomic H2 HF -> -1.1336051414 (also have_exx)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>