### PR TITLE
src/general/scf_driver_common: consolidate OOO block-metadata setup

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -328,21 +328,14 @@ int main(int argc, char **argv) {
   // --- OOO block layout.
   using OOO_Real = double;
   const size_t nparttype = restricted ? 1 : 2;
-  OpenOrbitalOptimizer::IndexVector number_of_blocks_per_particle_type(nparttype);
-  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> maximum_occupation(nsym * nparttype);
-  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles(nparttype);
+  OpenOrbitalOptimizer::IndexVector number_of_blocks_per_particle_type;
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> maximum_occupation;
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles;
   std::vector<std::string> block_descriptions;
-  block_descriptions.reserve(nsym * nparttype);
-
-  for (size_t t = 0; t < nparttype; ++t) {
-    number_of_blocks_per_particle_type(t) = static_cast<int>(nsym);
-    number_of_particles(t) = static_cast<OOO_Real>(restricted ? Ntot : (t == 0 ? nela : nelb));
-    for (size_t k = 0; k < nsym; ++k) {
-      maximum_occupation(t * nsym + k) = restricted ? 2.0 : 1.0;
-      block_descriptions.push_back(
-          (nparttype == 1 ? "" : (t == 0 ? "a:" : "b:")) + std::string("sym") + std::to_string(k));
-    }
-  }
+  helfem::scf_driver::build_ooo_block_metadata<OOO_Real>(
+      nsym, nparttype, restricted, Ntot, nela, nelb,
+      number_of_blocks_per_particle_type, maximum_occupation,
+      number_of_particles, block_descriptions);
 
   // Accumulate a per-block density (C_k * diag(occ_k) * C_k^T) into the
   // full-Nbf density matrix P_full through the block's basis-function

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -287,21 +287,14 @@ int main(int argc, char **argv) {
 
   using OOO_Real = double;
   const size_t nparttype = restricted ? 1 : 2;
-  OpenOrbitalOptimizer::IndexVector number_of_blocks_per_particle_type(nparttype);
-  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> maximum_occupation(nsym * nparttype);
-  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles(nparttype);
+  OpenOrbitalOptimizer::IndexVector number_of_blocks_per_particle_type;
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> maximum_occupation;
+  Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles;
   std::vector<std::string> block_descriptions;
-  block_descriptions.reserve(nsym * nparttype);
-
-  for (size_t t = 0; t < nparttype; ++t) {
-    number_of_blocks_per_particle_type(t) = static_cast<int>(nsym);
-    number_of_particles(t) = static_cast<OOO_Real>(restricted ? Ntot : (t == 0 ? nela : nelb));
-    for (size_t k = 0; k < nsym; ++k) {
-      maximum_occupation(t * nsym + k) = restricted ? 2.0 : 1.0;
-      block_descriptions.push_back(
-          (nparttype == 1 ? "" : (t == 0 ? "a:" : "b:")) + std::string("sym") + std::to_string(k));
-    }
-  }
+  helfem::scf_driver::build_ooo_block_metadata<OOO_Real>(
+      nsym, nparttype, restricted, Ntot, nela, nelb,
+      number_of_blocks_per_particle_type, maximum_occupation,
+      number_of_particles, block_descriptions);
 
   // Accumulate a per-block density into the full-Nbf density matrix
   // P_full through the block's basis-function scatter index dsym[k].

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -152,6 +152,43 @@ namespace helfem {
       return {Pa_final, Pb_final};
     }
 
+    /// OOO block wiring. Fills the four IndexVector / Eigen /
+    /// std::vector holders that the OOO SCFSolver constructor takes:
+    ///   number_of_blocks_per_particle_type (size = nparttype)
+    ///   maximum_occupation                 (size = nsym * nparttype)
+    ///   number_of_particles                (size = nparttype)
+    ///   block_descriptions                 (size = nsym * nparttype)
+    ///
+    /// Restricted mode packs everything into a single closed-shell
+    /// particle type with max_occ = 2 per block. Unrestricted splits
+    /// alpha (t=0) and beta (t=1) into two particle types with
+    /// max_occ = 1 per block; block descriptions get an "a:" / "b:"
+    /// prefix per channel.
+    template <typename Real>
+    inline void build_ooo_block_metadata(
+        size_t nsym, size_t nparttype, bool restricted,
+        int Ntot, int nela, int nelb,
+        OpenOrbitalOptimizer::IndexVector & number_of_blocks_per_particle_type,
+        Eigen::Matrix<Real, Eigen::Dynamic, 1> & maximum_occupation,
+        Eigen::Matrix<Real, Eigen::Dynamic, 1> & number_of_particles,
+        std::vector<std::string> & block_descriptions) {
+      number_of_blocks_per_particle_type.resize(nparttype);
+      maximum_occupation.resize(nsym * nparttype);
+      number_of_particles.resize(nparttype);
+      block_descriptions.clear();
+      block_descriptions.reserve(nsym * nparttype);
+      for (size_t t = 0; t < nparttype; ++t) {
+        number_of_blocks_per_particle_type(t) = static_cast<int>(nsym);
+        number_of_particles(t) = static_cast<Real>(restricted ? Ntot : (t == 0 ? nela : nelb));
+        for (size_t k = 0; k < nsym; ++k) {
+          maximum_occupation(t * nsym + k) = restricted ? 2.0 : 1.0;
+          block_descriptions.push_back(
+              (nparttype == 1 ? "" : (t == 0 ? "a:" : "b:"))
+              + std::string("sym") + std::to_string(k));
+        }
+      }
+    }
+
     /// Fock-builder helper: accumulate one block of the AO density
     /// matrix P_full from OOO's per-block (orbitals, occupations)
     /// pair. Called per symmetry block per spin channel from both


### PR DESCRIPTION
## Summary

Both drivers built the four holders that OOO's \`SCFSolver\`
constructor takes -- \`number_of_blocks_per_particle_type\`,
\`maximum_occupation\`, \`number_of_particles\`,
\`block_descriptions\` -- from byte-identical
\`(nsym, nparttype, restricted, Ntot, nela, nelb)\` inputs.

Extracts the 16-line setup into a
\`scf_driver::build_ooo_block_metadata\` template. Callers still
declare the four variables (they need to name them for the
subsequent \`SCFSolver\` call) but the fill code is single-sourced.

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] atomic Li UHF LDA -> -7.1934018521 (unrestricted t = 0/1 branch)
- [x] gensap H LDA -> -0.4570785099 (unchanged)
- [x] diatomic H2 LDA -> -1.0436644869 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>