### PR TITLE
src/general/scf_driver_common: consolidate nela/nelb/restricted derivation

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -165,19 +165,10 @@ int main(int argc, char **argv) {
 
   // Derive nela/nelb from Q, M -- same convention as the bespoke atomic
   // driver, so --M is the natural way to specify open-shell states.
-  // parse_nela_nelb(nela, nelb, Q, M, Ztot) fills in nela/nelb when
-  // both are zero on entry (using Q and M); if nela/nelb are given,
-  // it recomputes Q from them.
-  scf::parse_nela_nelb(nela, nelb, Q, M, Z);
-  if (restr == -1) {
-    // Auto: closed shell -> restricted, else unrestricted.
-    restr = (nela == nelb) ? 1 : 0;
-  }
-  const bool restricted = (restr != 0);
-  const int Ntot = nela + nelb;
-  if (restricted && nela != nelb)
-    throw std::logic_error("Restricted mode requires nela == nelb (closed shell). "
-                            "Use --restricted=0 (or leave -1 for auto) for open-shell.");
+  bool restricted;
+  int Ntot;
+  helfem::scf_driver::derive_nela_nelb_restricted(
+      nela, nelb, restr, Q, M, Z, restricted, Ntot);
 
   // symm=2 (per-(l,m)) breaks in the presence of an external electric or
   // magnetic field -- the field mixes l or m sectors respectively, so the

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -144,13 +144,10 @@ int main(int argc, char **argv) {
 
   // Derive nela/nelb from Q, M -- same convention as the bespoke diatomic
   // driver. Total nuclear charge is Z1 + Z2.
-  scf::parse_nela_nelb(nela, nelb, Q, M, Z1 + Z2);
-  if (restr == -1) restr = (nela == nelb) ? 1 : 0;
-  const bool restricted = (restr != 0);
-  if (restricted && nela != nelb)
-    throw std::logic_error("Restricted mode requires nela == nelb (closed shell). "
-                            "Use --restricted=0 (or leave -1 for auto) for open-shell.");
-  const int Ntot = nela + nelb;
+  bool restricted;
+  int Ntot;
+  helfem::scf_driver::derive_nela_nelb_restricted(
+      nela, nelb, restr, Q, M, Z1 + Z2, restricted, Ntot);
 
   arma::vec x_pars, c_pars;
   if (xparf.size()) x_pars = helfem::to_arma(scf::parse_xc_params(xparf));

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -152,6 +152,26 @@ namespace helfem {
       return {Pa_final, Pb_final};
     }
 
+    /// CLI-input normalisation shared by both drivers:
+    /// * scf::parse_nela_nelb fills in nela/nelb from --Q and --M
+    ///   when both are zero on entry;
+    /// * restr = -1 means "auto": closed shell -> 1 restricted,
+    ///   otherwise 0 unrestricted;
+    /// * restricted mode requires nela == nelb, else throws.
+    /// Returns the derived (restricted, Ntot = nela + nelb) pair via
+    /// out-refs so both drivers can use them directly below.
+    inline void derive_nela_nelb_restricted(
+        int & nela, int & nelb, int & restr, int Q, int M, int Ztotal,
+        bool & restricted, int & Ntot) {
+      scf::parse_nela_nelb(nela, nelb, Q, M, Ztotal);
+      if (restr == -1) restr = (nela == nelb) ? 1 : 0;
+      restricted = (restr != 0);
+      if (restricted && nela != nelb)
+        throw std::logic_error("Restricted mode requires nela == nelb (closed shell). "
+                                "Use --restricted=0 (or leave -1 for auto) for open-shell.");
+      Ntot = nela + nelb;
+    }
+
     /// OOO block wiring. Fills the four IndexVector / Eigen /
     /// std::vector holders that the OOO SCFSolver constructor takes:
     ///   number_of_blocks_per_particle_type (size = nparttype)

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -24,6 +24,7 @@
 #include "../general/dftfuncs.h"
 #include "../general/elements.h"
 #include "../general/scf_helpers.h"
+#include "../general/scf_driver_common.h"
 #include "../atomic/basis.h"
 #include "scf.h"
 #include <ArmaEigen.h>
@@ -91,12 +92,11 @@ int main(int argc, char **argv) {
   const double shift_conf   = parser.get<double>("shift_conf");
   const bool   add_conf     = parser.get<bool>("add_conf");
 
-  scf::parse_nela_nelb(nela, nelb, Q, M, Z);
-  if (restr == -1) restr = (nela == nelb) ? 1 : 0;
-  const bool restricted = (restr != 0);
-  if (restricted && nela != nelb)
-    throw std::logic_error("Restricted mode requires nela == nelb (closed shell). "
-                            "Use --restricted=0 (or leave -1 for auto) for open-shell.");
+  bool restricted;
+  int Ntot;
+  helfem::scf_driver::derive_nela_nelb_restricted(
+      nela, nelb, restr, Q, M, Z, restricted, Ntot);
+  (void) Ntot;  // sadatom SCF driver does its own per-l particle counting.
 
   arma::vec x_pars, c_pars;
   if (xparf.size()) {


### PR DESCRIPTION
## Summary

All three drivers (atomic, diatomic, sadatom) share a near-identical
CLI-input normalisation:

\`\`\`cpp
scf::parse_nela_nelb(nela, nelb, Q, M, Ztot);
if (restr == -1) restr = (nela == nelb) ? 1 : 0;
const bool restricted = (restr != 0);
if (restricted && nela != nelb) throw ...;
const int Ntot = nela + nelb;
\`\`\`

Extracts it into a \`scf_driver::derive_nela_nelb_restricted\`
helper. Sadatom doesn't consume \`Ntot\` (its solver counts
particles per angular block) so it drops the output with a
\`(void) Ntot\` cast.

## Test plan

- [x] atomic He LDA -> -2.7236397926 (unchanged)
- [x] atomic Li UHF LDA -> -7.1934018521 (unchanged)
- [x] gensap H LDA -> -0.4570785099 (unchanged)
- [x] diatomic H2 LDA -> -1.0436644869 (unchanged)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>