### PR TITLE
src/atomic/dftgrid: Eigen-typed DFTGrid::eval_Fxc public boundary

### DIFF
--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -20,6 +20,7 @@
 #include <xc.h>
 
 #include "dftgrid.h"
+#include <ArmaEigen.h>
 #include "../general/dftfuncs.h"
 // Angular quadrature
 #include "../general/angular.h"
@@ -564,7 +565,12 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & P, arma::mat & H, double & Exc, double & Nel, double & Ekin, double thr) {
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
+        // Eigen public boundary; bridge to the arma-native interior once.
+        const arma::vec x_pars(helfem::to_arma(x_pars_e));
+        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+        const arma::mat P(helfem::to_arma(P_e));
+        arma::mat H;
         H.zeros(P.n_rows,P.n_rows);
 
         double exc=0.0;
@@ -622,11 +628,18 @@ namespace helfem {
         Exc=exc;
         Ekin=ekin;
         Nel=nel;
+        H_e=helfem::to_eigen(H);
 
         printf("Integral over laplacian %e\n",lapl);
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & Pa, const arma::mat & Pb, arma::mat & Ha, arma::mat & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
+        // Eigen public boundary; bridge to the arma-native interior once.
+        const arma::vec x_pars(helfem::to_arma(x_pars_e));
+        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+        const arma::mat Pa(helfem::to_arma(Pa_e));
+        const arma::mat Pb(helfem::to_arma(Pb_e));
+        arma::mat Ha, Hb;
         Ha.zeros(Pa.n_rows,Pa.n_rows);
         Hb.zeros(Pb.n_rows,Pb.n_rows);
 
@@ -682,6 +695,8 @@ namespace helfem {
         Exc=exc;
         Ekin=ekin;
         Nel=nel;
+        Ha_e=helfem::to_eigen(Ha);
+        Hb_e=helfem::to_eigen(Hb);
       }
 
     }

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -126,10 +126,14 @@ namespace helfem {
         /// Destructor
         ~DFTGrid();
 
-        /// Compute Fock matrix, exchange-correlation energy and integrated electron density, restricted case
-        void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & P, arma::mat & H, double & Exc, double & Nel, double & Ekin, double thr);
-        /// Compute Fock matrix, exchange-correlation energy and integrated electron density, unrestricted case
-        void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & Pa, const arma::mat & Pb, arma::mat & Ha, arma::mat & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr);
+        /// Compute Fock matrix, exchange-correlation energy and integrated
+        /// electron density, restricted case. Eigen-typed public boundary
+        /// (functional parameters, density, and Fock matrix); the quadrature
+        /// interior stays arma-native with a single bridge at entry/exit.
+        void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P, helfem::Matrix & H, double & Exc, double & Nel, double & Ekin, double thr);
+        /// Compute Fock matrix, exchange-correlation energy and integrated
+        /// electron density, unrestricted case. Eigen-typed public boundary.
+        void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa, const helfem::Matrix & Pb, helfem::Matrix & Ha, helfem::Matrix & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr);
 
       };
 

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -184,9 +184,9 @@ int main(int argc, char **argv) {
     symm_eff = 1;
   }
 
-  arma::vec x_pars, c_pars;
-  if (xparf.size()) x_pars = helfem::to_arma(scf::parse_xc_params(xparf));
-  if (cparf.size()) c_pars = helfem::to_arma(scf::parse_xc_params(cparf));
+  helfem::Vector x_pars, c_pars;
+  if (xparf.size()) x_pars = scf::parse_xc_params(xparf);
+  if (cparf.size()) c_pars = scf::parse_xc_params(cparf);
 
   int x_func, c_func;
   ::parse_xc_func(x_func, c_func, method);
@@ -362,11 +362,17 @@ int main(int argc, char **argv) {
     double nelnum = 0.0, ekin_grid = 0.0;
     arma::mat XCa, XCb;
 
+    // grid.eval_Fxc takes/returns Eigen at its public boundary; bridge the
+    // arma-native driver density into it and the XC potential back out.
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
-      if (have_xc)
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+      if (have_xc) {
+        helfem::Matrix XCa_e;
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(P), XCa_e,
+                       Exc, nelnum, ekin_grid, dftthr);
+        XCa = helfem::to_arma(XCa_e);
+      }
       if (have_exx) Pa = 0.5 * P;
     } else {
       Pa.zeros(Nbf, Nbf);
@@ -376,9 +382,13 @@ int main(int argc, char **argv) {
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
-      if (have_xc)
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
-                       Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+      if (have_xc) {
+        helfem::Matrix XCa_e, XCb_e;
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(Pa), helfem::to_eigen(Pb),
+                       XCa_e, XCb_e, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+        XCa = helfem::to_arma(XCa_e);
+        XCb = helfem::to_arma(XCb_e);
+      }
     }
 
     const double Ekin = arma::trace(P * T);


### PR DESCRIPTION
## Summary

Migrates the atomic \`DFTGrid::eval_Fxc\` public API (both restricted
and unrestricted overloads) from arma to helfem types: functional
parameters (\`helfem::Vector\`), input density, and output Fock matrix
(\`helfem::Matrix\`). The quadrature interior and the shared
\`DFTGridWorkerBase\` stay arma-native -- a single bridge at
entry/exit.

This takes arma out of the last public interface of the atomic
\`DFTGrid\` class. On the driver side \`x_pars\` / \`c_pars\` now stay
Eigen straight from \`scf::parse_xc_params\` (dropping two \`to_arma\`
round-trips); the density / XC-potential are bridged at the call site
since the driver's Fock-assembly working set is still arma.

**Out of scope (deliberately):** the interior migration -- the ~90
arma quadrature refs and the shared \`DFTGridWorkerBase\` buffers.
That is a separate, higher-risk numerical change that would touch all
three geometries' grids at once (they share the base class).

## Test plan

- [x] atomic He LDA -> -2.7236397926 (restricted XC path)
- [x] atomic Li UHF LDA -> -7.1934018521 (unrestricted XC path)
- [x] atomic He PBE (GGA) -> -2.8520375355 (gradient/sigma path)
- [x] atomic He HF -> -2.8616799956 (no-XC path, unaffected)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>