### PR TITLE
src/diatomic/dftgrid: Eigen-typed DFTGrid::eval_Fxc public boundary

### DIFF
--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -20,6 +20,7 @@
 #include <xc.h>
 
 #include "dftgrid.h"
+#include <ArmaEigen.h>
 #include "../general/dftfuncs.h"
 // Angular quadrature
 #include "../general/angular.h"
@@ -511,7 +512,12 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & P, arma::mat & H, double & Exc, double & Nel, double & Ekin, double thr) {
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
+        // Eigen public boundary; bridge to the arma-native interior once.
+        const arma::vec x_pars(helfem::to_arma(x_pars_e));
+        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+        const arma::mat P(helfem::to_arma(P_e));
+        arma::mat H;
         H.zeros(basp->Ndummy(),basp->Ndummy());
 
         double exc=0.0;
@@ -545,10 +551,16 @@ namespace helfem {
         Ekin=ekin;
         Nel=nel;
 
-        H=basp->remove_boundaries(H);
+        H_e=helfem::to_eigen(basp->remove_boundaries(H));
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & Pa, const arma::mat & Pb, arma::mat & Ha, arma::mat & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
+        // Eigen public boundary; bridge to the arma-native interior once.
+        const arma::vec x_pars(helfem::to_arma(x_pars_e));
+        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+        const arma::mat Pa(helfem::to_arma(Pa_e));
+        const arma::mat Pb(helfem::to_arma(Pb_e));
+        arma::mat Ha, Hb;
         Ha.zeros(basp->Ndummy(),basp->Ndummy());
         Hb.zeros(basp->Ndummy(),basp->Ndummy());
 
@@ -584,8 +596,8 @@ namespace helfem {
         Nel=nel;
 
         // Clean up matrices
-        Ha=basp->remove_boundaries(Ha);
-        Hb=basp->remove_boundaries(Hb);
+        Ha_e=helfem::to_eigen(basp->remove_boundaries(Ha));
+        Hb_e=helfem::to_eigen(basp->remove_boundaries(Hb));
       }
 
     }

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -116,10 +116,14 @@ namespace helfem {
         /// Destructor
         ~DFTGrid();
 
-        /// Compute Fock matrix, exchange-correlation energy and integrated electron density, restricted case
-        void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & P, arma::mat & H, double & Exc, double & Nel, double & Ekin, double thr);
-        /// Compute Fock matrix, exchange-correlation energy and integrated electron density, unrestricted case
-        void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::mat & Pa, const arma::mat & Pb, arma::mat & Ha, arma::mat & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr);
+        /// Compute Fock matrix, exchange-correlation energy and integrated
+        /// electron density, restricted case. Eigen-typed public boundary
+        /// (functional parameters, density, and Fock matrix); the quadrature
+        /// interior stays arma-native with a single bridge at entry/exit.
+        void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P, helfem::Matrix & H, double & Exc, double & Nel, double & Ekin, double thr);
+        /// Compute Fock matrix, exchange-correlation energy and integrated
+        /// electron density, unrestricted case. Eigen-typed public boundary.
+        void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa, const helfem::Matrix & Pb, helfem::Matrix & Ha, helfem::Matrix & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr);
 
       };
 

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -149,9 +149,9 @@ int main(int argc, char **argv) {
   helfem::scf_driver::derive_nela_nelb_restricted(
       nela, nelb, restr, Q, M, Z1 + Z2, restricted, Ntot);
 
-  arma::vec x_pars, c_pars;
-  if (xparf.size()) x_pars = helfem::to_arma(scf::parse_xc_params(xparf));
-  if (cparf.size()) c_pars = helfem::to_arma(scf::parse_xc_params(cparf));
+  helfem::Vector x_pars, c_pars;
+  if (xparf.size()) x_pars = scf::parse_xc_params(xparf);
+  if (cparf.size()) c_pars = scf::parse_xc_params(cparf);
 
   int x_func, c_func;
   ::parse_xc_func(x_func, c_func, method);
@@ -324,11 +324,17 @@ int main(int argc, char **argv) {
     double nelnum = 0.0, ekin_grid = 0.0;
     arma::mat XCa, XCb;
 
+    // grid.eval_Fxc takes/returns Eigen at its public boundary; bridge the
+    // arma-native driver density into it and the XC potential back out.
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
-      if (have_xc)
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa, Exc, nelnum, ekin_grid, dftthr);
+      if (have_xc) {
+        helfem::Matrix XCa_e;
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(P), XCa_e,
+                       Exc, nelnum, ekin_grid, dftthr);
+        XCa = helfem::to_arma(XCa_e);
+      }
       if (have_exx) Pa = 0.5 * P;
     } else {
       Pa.zeros(Nbf, Nbf);
@@ -338,9 +344,13 @@ int main(int argc, char **argv) {
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
-      if (have_xc)
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb, XCa, XCb,
-                       Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+      if (have_xc) {
+        helfem::Matrix XCa_e, XCb_e;
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(Pa), helfem::to_eigen(Pb),
+                       XCa_e, XCb_e, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+        XCa = helfem::to_arma(XCa_e);
+        XCb = helfem::to_arma(XCb_e);
+      }
     }
 
     const double Ekin = arma::trace(P * T);


### PR DESCRIPTION
## Summary

Second in the DFTGrid → Eigen series (follows #205 for atomic).
Migrates the diatomic \`DFTGrid::eval_Fxc\` public API (both
overloads) from arma to helfem types: functional parameters
(\`helfem::Vector\`), input density, and output Fock matrix
(\`helfem::Matrix\`). Interior + shared \`DFTGridWorkerBase\` stay
arma-native, single bridge at entry/exit; the diatomic-specific
\`remove_boundaries\` step folds into the exit bridge.

Driver side: \`x_pars\` / \`c_pars\` stay Eigen straight from
\`scf::parse_xc_params\` (drops two \`to_arma\` round-trips); the
density / XC-potential are bridged at the call site.

## Test plan

- [x] H2 LDA -> -1.0436644869 (restricted XC path)
- [x] H2 PBE (GGA) -> -1.1240728083 (gradient/sigma path)
- [x] H2 HF -> -1.1336051414 (no-XC path, unaffected)
- [x] Li2 LDA -> -10.1953246143 (heavier case)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>