### PR TITLE
src/sadatom/dftgrid: Eigen-typed functional parameters on eval_Fxc

### DIFF
--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -20,6 +20,7 @@
 #include <xc.h>
 
 #include "dftgrid.h"
+#include <ArmaEigen.h>
 #include "../general/dftfuncs.h"
 
 // OpenMP parallellization for XC calculations
@@ -666,7 +667,10 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr) {
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr) {
+        // Functional parameters are Eigen at the boundary; bridge once.
+        const arma::vec x_pars(helfem::to_arma(x_pars_e));
+        const arma::vec c_pars(helfem::to_arma(c_pars_e));
         H.zeros(P.n_rows,P.n_rows,P.n_slices);
 
         double exc=0.0;
@@ -720,7 +724,10 @@ namespace helfem {
         Nel=nel;
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr) {
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr) {
+        // Functional parameters are Eigen at the boundary; bridge once.
+        const arma::vec x_pars(helfem::to_arma(x_pars_e));
+        const arma::vec c_pars(helfem::to_arma(c_pars_e));
         Ha.zeros(Pa.n_rows,Pa.n_rows,Pa.n_slices);
         Hb.zeros(Pb.n_rows,Pb.n_rows,Pb.n_slices);
 

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -104,10 +104,14 @@ namespace helfem {
         /// Destructor
         ~DFTGrid();
 
-        /// Compute Fock matrix, exchange-correlation energy and integrated electron density, restricted case
-        void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr);
-        /// Compute Fock matrix, exchange-correlation energy and integrated electron density, unrestricted case
-        void eval_Fxc(int x_func, const arma::vec & x_pars, int c_func, const arma::vec & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr);
+        /// Compute Fock matrix, exchange-correlation energy and integrated
+        /// electron density, restricted case. Functional parameters are
+        /// Eigen-typed (helfem::Vector), matching the atomic/diatomic grids;
+        /// the per-l density/Fock stay arma::cube (no helfem cube type).
+        void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr);
+        /// Compute Fock matrix, exchange-correlation energy and integrated
+        /// electron density, unrestricted case.
+        void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr);
 
       };
 

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -28,6 +28,7 @@
 #include "../atomic/basis.h"
 #include "scf.h"
 #include <ArmaEigen.h>
+#include <iostream>
 
 using namespace helfem;
 
@@ -98,14 +99,14 @@ int main(int argc, char **argv) {
       nela, nelb, restr, Q, M, Z, restricted, Ntot);
   (void) Ntot;  // sadatom SCF driver does its own per-l particle counting.
 
-  arma::vec x_pars, c_pars;
+  helfem::Vector x_pars, c_pars;
   if (xparf.size()) {
-    x_pars = helfem::to_arma(scf::parse_xc_params(xparf));
-    x_pars.t().print("Exchange functional parameters");
+    x_pars = scf::parse_xc_params(xparf);
+    std::cout << "Exchange functional parameters\n" << x_pars.transpose() << std::endl;
   }
   if (cparf.size()) {
-    c_pars = helfem::to_arma(scf::parse_xc_params(cparf));
-    c_pars.t().print("Correlation functional parameters");
+    c_pars = scf::parse_xc_params(cparf);
+    std::cout << "Correlation functional parameters\n" << c_pars.transpose() << std::endl;
   }
 
   printf("Running %s %s calculation with Rmax=%e and %i elements.\n",

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -38,8 +38,8 @@ namespace helfem {
         bool   restricted = true;
         int    x_func     = 0;
         int    c_func     = 0;
-        arma::vec x_pars;
-        arma::vec c_pars;
+        helfem::Vector x_pars;
+        helfem::Vector c_pars;
         double dftthr     = 1e-12;
         modelpotential::nuclear_model_t finitenuc = modelpotential::POINT_NUCLEUS;
         double Rrms       = 0.0;


### PR DESCRIPTION
## Summary

Completes the DFTGrid `eval_Fxc` functional-parameter interface
across all three geometries (follows #205 atomic, #206 diatomic):
`x_pars` / `c_pars` are now `helfem::Vector` at the sadatom DFTGrid
boundary and in `AtomicSCFOptions`, dropping the `to_arma`
round-trip in the gensap driver.

**Why the density/Fock stay arma here:** unlike the atomic/diatomic
grids, the sadatom density and Fock are `arma::cube` — per-l
(`slice(l)` is the l-channel block) — and helfem has no cube type, so
arma is the natural representation. The interior stays arma-native
with a single functional-parameter bridge at entry.

## Test plan

- [x] gensap H LDA -> -0.4570785099 (unrestricted)
- [x] gensap He LDA -> -2.7236397926 (restricted)
- [x] gensap C PBE (GGA) -> -37.6477217328 (gradient path)
- [x] diatomic LiH via SAP guess -> -6.5452166425 (exercises the
      sadatom sub-SCF with default empty params)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>