### PR TITLE
src/general/dftgrid_common: Eigen-typed functional params on compute_xc

### DIFF
--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -565,10 +565,9 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
-        // Eigen public boundary; bridge to the arma-native interior once.
-        const arma::vec x_pars(helfem::to_arma(x_pars_e));
-        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
+        // Eigen public boundary; bridge the density to the arma interior once
+        // (functional parameters flow straight through to compute_xc).
         const arma::mat P(helfem::to_arma(P_e));
         arma::mat H;
         H.zeros(P.n_rows,P.n_rows);
@@ -633,10 +632,9 @@ namespace helfem {
         printf("Integral over laplacian %e\n",lapl);
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
-        // Eigen public boundary; bridge to the arma-native interior once.
-        const arma::vec x_pars(helfem::to_arma(x_pars_e));
-        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
+        // Eigen public boundary; bridge the density to the arma interior once
+        // (functional parameters flow straight through to compute_xc).
         const arma::mat Pa(helfem::to_arma(Pa_e));
         const arma::mat Pb(helfem::to_arma(Pb_e));
         arma::mat Ha, Hb;

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -512,10 +512,9 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
-        // Eigen public boundary; bridge to the arma-native interior once.
-        const arma::vec x_pars(helfem::to_arma(x_pars_e));
-        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
+        // Eigen public boundary; bridge the density to the arma interior once
+        // (functional parameters flow straight through to compute_xc).
         const arma::mat P(helfem::to_arma(P_e));
         arma::mat H;
         H.zeros(basp->Ndummy(),basp->Ndummy());
@@ -554,10 +553,9 @@ namespace helfem {
         H_e=helfem::to_eigen(basp->remove_boundaries(H));
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
-        // Eigen public boundary; bridge to the arma-native interior once.
-        const arma::vec x_pars(helfem::to_arma(x_pars_e));
-        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
+        // Eigen public boundary; bridge the density to the arma interior once
+        // (functional parameters flow straight through to compute_xc).
         const arma::mat Pa(helfem::to_arma(Pa_e));
         const arma::mat Pb(helfem::to_arma(Pb_e));
         arma::mat Ha, Hb;

--- a/src/general/dftgrid_common.cpp
+++ b/src/general/dftgrid_common.cpp
@@ -82,7 +82,7 @@ namespace helfem {
       return arma::sum(wtot % exc % dens);
     }
 
-    void DFTGridWorkerBase::compute_xc(int func_id, const arma::vec & p, double thr, bool pot) {
+    void DFTGridWorkerBase::compute_xc(int func_id, const helfem::Vector & p, double thr, bool pot) {
       bool gga, mgga_t, mgga_l;
       is_gga_mgga(func_id, gga, mgga_t, mgga_l);
 
@@ -117,11 +117,11 @@ namespace helfem {
       }
       xc_func_set_dens_threshold(&func, thr);
 
-      if (p.n_elem) {
-        if (p.n_elem != (arma::uword) xc_func_info_get_n_ext_params((xc_func_info_type *) func.info))
+      if (p.size()) {
+        if (p.size() != (Eigen::Index) xc_func_info_get_n_ext_params((xc_func_info_type *) func.info))
           throw std::logic_error("Incompatible number of parameters!\n");
-        arma::vec phlp(p);
-        xc_func_set_ext_params(&func, phlp.memptr());
+        helfem::Vector phlp(p);
+        xc_func_set_ext_params(&func, phlp.data());
       }
 
       if (has_exc(func_id)) {

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -23,6 +23,7 @@
 // compute_Nel, etc.) stay in the derived classes.
 
 #include <armadillo>
+#include <Matrix.h>
 
 namespace helfem {
   namespace dftgrid_common {
@@ -94,7 +95,7 @@ namespace helfem {
 
       /// Compute libxc functional contribution and add to exc / vxc /
       /// vsigma / vtau / vlapl. pot=true also computes potentials.
-      void compute_xc(int func_id, const arma::vec & params, double thr, bool pot = true);
+      void compute_xc(int func_id, const helfem::Vector & params, double thr, bool pot = true);
     };
   }
 }

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -667,10 +667,7 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr) {
-        // Functional parameters are Eigen at the boundary; bridge once.
-        const arma::vec x_pars(helfem::to_arma(x_pars_e));
-        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const arma::cube & P, arma::cube & H, double & Exc, double & Nel, double thr) {
         H.zeros(P.n_rows,P.n_rows,P.n_slices);
 
         double exc=0.0;
@@ -724,10 +721,7 @@ namespace helfem {
         Nel=nel;
       }
 
-      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars_e, int c_func, const helfem::Vector & c_pars_e, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr) {
-        // Functional parameters are Eigen at the boundary; bridge once.
-        const arma::vec x_pars(helfem::to_arma(x_pars_e));
-        const arma::vec c_pars(helfem::to_arma(c_pars_e));
+      void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const arma::cube & Pa, const arma::cube & Pb, arma::cube & Ha, arma::cube & Hb, double & Exc, double & Nel, bool beta, double thr) {
         Ha.zeros(Pa.n_rows,Pa.n_rows,Pa.n_slices);
         Hb.zeros(Pb.n_rows,Pb.n_rows,Pb.n_slices);
 


### PR DESCRIPTION
## Summary

`DFTGridWorkerBase::compute_xc`'s `params` argument goes from
`arma::vec` to `helfem::Vector`, so the geometry `DFTGrid::eval_Fxc`
methods hand the Eigen `x_pars` / `c_pars` straight through instead of
bridging to arma first. Removes the three per-geometry `x_pars` /
`c_pars` `to_arma` bridge locals that #205–#207 had introduced.

Inside `compute_xc` only the parameter handling touches arma
(`p.n_elem` -> `p.size()`, ext-params `memptr()` -> `data()`); the XC
buffers (`rho`/`sigma`/`vxc`/...) stay arma -- that shared-interior
migration is the separate, larger follow-up.

Net **-9 lines**.

## Test plan

- [x] atomic He LDA -> -2.7236397926
- [x] atomic He PBE -> -2.8520375355
- [x] gensap C PBE -> -37.6477217328 (unrestricted GGA)
- [x] diatomic H2 PBE -> -1.1240728083
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>