### PR TITLE
src/dftgrid: dedup compute_Nel + increment_lda across geometries

### DIFF
--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -231,19 +231,6 @@ namespace helfem {
         }
       }
 
-      double DFTGridWorker::compute_Nel() const {
-        double nel=0.0;
-        if(!polarized) {
-          for(size_t ip=0;ip<wtot.n_elem;ip++)
-            nel+=wtot(ip)*rho(0,ip);
-        } else {
-          for(size_t ip=0;ip<wtot.n_elem;ip++)
-            nel+=wtot(ip)*(rho(0,ip)+rho(1,ip));
-        }
-
-        return nel;
-      }
-
       double DFTGridWorker::compute_laplsum() const {
         double sum=0.0;
         if(lapl.n_cols == wtot.n_elem) {

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -92,8 +92,7 @@ namespace helfem {
         /// Update values of density, unrestricted calculation
         void update_density(const arma::mat & Pa, const arma::mat & Pb);
 
-        /// Compute number of electrons
-        double compute_Nel() const;
+        // compute_Nel() is inherited from DFTGridWorkerBase.
         /// Compute integral over density laplacian
         double compute_laplsum() const;
         /// Compute kinetic energy
@@ -137,26 +136,8 @@ namespace helfem {
 
       };
 
-      /// BLAS routine for LDA-type quadrature
-      template<typename T> void increment_lda(arma::mat & H, const arma::rowvec & vxc, const arma::Mat<T> & f) {
-        if(f.n_cols != vxc.n_elem) {
-          std::ostringstream oss;
-          oss << "Number of functions " << f.n_cols << " and potential values " << vxc.n_elem << " do not match!\n";
-          throw std::runtime_error(oss.str());
-        }
-        if(H.n_rows != f.n_rows || H.n_cols != f.n_rows) {
-          std::ostringstream oss;
-          oss << "Size of basis function (" << f.n_rows << "," << f.n_cols << ") and Fock matrix (" << H.n_rows << "," << H.n_cols << ") doesn't match!\n";
-          throw std::runtime_error(oss.str());
-        }
-
-        // Form helper matrix
-        arma::Mat<T> fhlp(f);
-        for(size_t i=0;i<fhlp.n_rows;i++)
-          for(size_t j=0;j<fhlp.n_cols;j++)
-            fhlp(i,j)*=vxc(j);
-        H+=arma::real(fhlp*arma::trans(f));
-      }
+      /// LDA quadrature accumulation is shared across geometries.
+      using helfem::dftgrid_common::increment_lda;
 
       /// BLAS routine for GGA-type quadrature
       template<typename T> void increment_gga(arma::mat & H, const arma::mat & gn, const arma::Mat<T> & f, arma::Mat<T> f_x, arma::Mat<T> f_y, arma::Mat<T> f_z) {

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -211,18 +211,6 @@ namespace helfem {
         }
       }
 
-      double DFTGridWorker::compute_Nel() const {
-        double nel=0.0;
-        if(!polarized) {
-          for(size_t ip=0;ip<wtot.n_elem;ip++)
-            nel+=wtot(ip)*rho(0,ip);
-        } else {
-          for(size_t ip=0;ip<wtot.n_elem;ip++)
-            nel+=wtot(ip)*(rho(0,ip)+rho(1,ip));
-        }
-
-        return nel;
-      }
 
       double DFTGridWorker::compute_Ekin() const {
         double ekin=0.0;

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -86,8 +86,7 @@ namespace helfem {
         /// Update values of density, unrestricted calculation
         void update_density(const arma::mat & Pa, const arma::mat & Pb);
 
-        /// Compute number of electrons
-        double compute_Nel() const;
+        // compute_Nel() is inherited from DFTGridWorkerBase.
         /// Compute kinetic energy
         double compute_Ekin() const;
 
@@ -127,26 +126,8 @@ namespace helfem {
 
       };
 
-      /// BLAS routine for LDA-type quadrature
-      template<typename T> void increment_lda(arma::mat & H, const arma::rowvec & vxc, const arma::Mat<T> & f) {
-        if(f.n_cols != vxc.n_elem) {
-          std::ostringstream oss;
-          oss << "Number of functions " << f.n_cols << " and potential values " << vxc.n_elem << " do not match!\n";
-          throw std::runtime_error(oss.str());
-        }
-        if(H.n_rows != f.n_rows || H.n_cols != f.n_rows) {
-          std::ostringstream oss;
-          oss << "Size of basis function (" << f.n_rows << "," << f.n_cols << ") and Fock matrix (" << H.n_rows << "," << H.n_cols << ") doesn't match!\n";
-          throw std::runtime_error(oss.str());
-        }
-
-        // Form helper matrix
-        arma::Mat<T> fhlp(f);
-        for(size_t i=0;i<fhlp.n_rows;i++)
-          for(size_t j=0;j<fhlp.n_cols;j++)
-            fhlp(i,j)*=vxc(j);
-        H+=arma::real(fhlp*arma::trans(f));
-      }
+      /// LDA quadrature accumulation is shared across geometries.
+      using helfem::dftgrid_common::increment_lda;
 
       /// BLAS routine for GGA-type quadrature
       template<typename T> void increment_gga(arma::mat & H, const arma::mat & gn, const arma::Mat<T> & f, arma::Mat<T> f_x, arma::Mat<T> f_y, arma::Mat<T> f_z) {

--- a/src/general/dftgrid_common.cpp
+++ b/src/general/dftgrid_common.cpp
@@ -82,6 +82,19 @@ namespace helfem {
       return arma::sum(wtot % exc % dens);
     }
 
+    double DFTGridWorkerBase::compute_Nel() const {
+      double nel=0.0;
+      if(!polarized) {
+        for(size_t ip=0;ip<wtot.n_elem;ip++)
+          nel+=wtot(ip)*rho(0,ip);
+      } else {
+        for(size_t ip=0;ip<wtot.n_elem;ip++)
+          nel+=wtot(ip)*(rho(0,ip)+rho(1,ip));
+      }
+
+      return nel;
+    }
+
     void DFTGridWorkerBase::compute_xc(int func_id, const helfem::Vector & p, double thr, bool pot) {
       bool gga, mgga_t, mgga_l;
       is_gga_mgga(func_id, gga, mgga_t, mgga_l);

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -24,6 +24,8 @@
 
 #include <armadillo>
 #include <Matrix.h>
+#include <sstream>
+#include <stdexcept>
 
 namespace helfem {
   namespace dftgrid_common {
@@ -93,10 +95,41 @@ namespace helfem {
       /// Evaluate int wtot * exc * rho_total
       double eval_Exc() const;
 
+      /// Integrate the (total) electron density over the current
+      /// element grid: int wtot * rho. Geometry-independent -- reads
+      /// only the shared wtot / rho / polarized state.
+      double compute_Nel() const;
+
       /// Compute libxc functional contribution and add to exc / vxc /
       /// vsigma / vtau / vlapl. pot=true also computes potentials.
       void compute_xc(int func_id, const helfem::Vector & params, double thr, bool pot = true);
     };
+
+    /// BLAS routine for LDA-type quadrature: accumulate
+    /// H += Re( (f .* vxc) * f^T ), i.e. the weighted outer product of
+    /// the basis-function values f (Nbf x Npts) against themselves with
+    /// per-point potential weights vxc (1 x Npts). Geometry-independent
+    /// -- shared verbatim by all three DFTGridWorker variants (real f
+    /// for sadatom, complex f for atomic/diatomic).
+    template<typename T> void increment_lda(arma::mat & H, const arma::rowvec & vxc, const arma::Mat<T> & f) {
+      if(f.n_cols != vxc.n_elem) {
+        std::ostringstream oss;
+        oss << "Number of functions " << f.n_cols << " and potential values " << vxc.n_elem << " do not match!\n";
+        throw std::runtime_error(oss.str());
+      }
+      if(H.n_rows != f.n_rows || H.n_cols != f.n_rows) {
+        std::ostringstream oss;
+        oss << "Size of basis function (" << f.n_rows << "," << f.n_cols << ") and Fock matrix (" << H.n_rows << "," << H.n_cols << ") doesn't match!\n";
+        throw std::runtime_error(oss.str());
+      }
+
+      // Form helper matrix
+      arma::Mat<T> fhlp(f);
+      for(size_t i=0;i<fhlp.n_rows;i++)
+        for(size_t j=0;j<fhlp.n_cols;j++)
+          fhlp(i,j)*=vxc(j);
+      H+=arma::real(fhlp*arma::trans(f));
+    }
   }
 }
 

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -226,19 +226,6 @@ namespace helfem {
         }
       }
 
-      double DFTGridWorker::compute_Nel() const {
-        double nel=0.0;
-        if(!polarized) {
-          for(size_t ip=0;ip<wtot.n_elem;ip++)
-            nel+=wtot(ip)*rho(0,ip);
-        } else {
-          for(size_t ip=0;ip<wtot.n_elem;ip++)
-            nel+=wtot(ip)*(rho(0,ip)+rho(1,ip));
-        }
-
-        return nel;
-      }
-
 
 
       // init_xc, zero_Exc: inherited from

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -77,8 +77,7 @@ namespace helfem {
         /// Update values of density, unrestricted calculation
         void update_density(const arma::cube & Pa, const arma::cube & Pb);
 
-        /// Compute number of electrons
-        double compute_Nel() const;
+        // compute_Nel() is inherited from DFTGridWorkerBase.
 
         // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
         // from DFTGridWorkerBase.
@@ -115,26 +114,8 @@ namespace helfem {
 
       };
 
-      /// BLAS routine for LDA-type quadrature
-      template<typename T> void increment_lda(arma::mat & H, const arma::rowvec & vxc, const arma::Mat<T> & f) {
-        if(f.n_cols != vxc.n_elem) {
-          std::ostringstream oss;
-          oss << "Number of functions " << f.n_cols << " and potential values " << vxc.n_elem << " do not match!\n";
-          throw std::runtime_error(oss.str());
-        }
-        if(H.n_rows != f.n_rows || H.n_cols != f.n_rows) {
-          std::ostringstream oss;
-          oss << "Size of basis function (" << f.n_rows << "," << f.n_cols << ") and Fock matrix (" << H.n_rows << "," << H.n_cols << ") doesn't match!\n";
-          throw std::runtime_error(oss.str());
-        }
-
-        // Form helper matrix
-        arma::Mat<T> fhlp(f);
-        for(size_t i=0;i<fhlp.n_rows;i++)
-          for(size_t j=0;j<fhlp.n_cols;j++)
-            fhlp(i,j)*=vxc(j);
-        H+=arma::real(fhlp*arma::trans(f));
-      }
+      /// LDA quadrature accumulation is shared across geometries.
+      using helfem::dftgrid_common::increment_lda;
 
       /// BLAS routine for GGA-type quadrature
       template<typename T> void increment_gga(arma::mat & H, const arma::mat & gn, const arma::Mat<T> & f, arma::Mat<T> f_x) {


### PR DESCRIPTION
## Summary

Follows up the "is the DFT quadrature code de-duplicated?" audit. The
atomic, diatomic and sadatom `DFTGridWorker`s each carried a
byte-identical copy of two geometry-independent helpers:

| Helper | Was | Now |
|---|---|---|
| `compute_Nel()` | member in all 3 workers | inherited from `DFTGridWorkerBase` (reads only shared `wtot`/`rho`/`polarized`) |
| `increment_lda<T>()` | free template in all 3 headers | one copy in `helfem::dftgrid_common`, each geometry keeps a one-line `using` so the ~34 call sites stay unqualified |

`increment_lda` works for both complex `f` (atomic/diatomic) and real
`f` (sadatom).

**Deliberately still separate** — the remaining per-geometry worker
code (`update_density`, `compute_bf`, `eval_Fxc`,
`increment_gga`/`increment_mgga_lapl`) is genuinely
coordinate-system-specific (spherical vs prolate-spheroidal vs
radial; different gradient-component counts).

Net **-49 lines**, no behavioural change.

## Test plan

- [x] atomic He LDA -> -2.7236397926, Li UHF PBE -> -7.4113849032
- [x] gensap C PBE -> -37.6477217328 (real-f increment_lda)
- [x] diatomic H2 LDA -> -1.0436644869, PBE -> -1.1240728083 (complex-f)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>