### PR TITLE
src/atomic: retire pure_indices / expand_boundaries / remove_boundaries

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -148,10 +148,6 @@ namespace helfem {
         return lval.n_elem;
       }
 
-      arma::uvec TwoDBasis::pure_indices() const {
-        return arma::linspace<arma::uvec>(0,Nbf()-1,Nbf());
-      }
-
       arma::uvec TwoDBasis::m_indices(int m) const {
         return helfem::collect_shell_indices(mval.n_elem,
             [&](size_t)   { return radial.Nbf(); },
@@ -1009,46 +1005,6 @@ namespace helfem {
         }
 
         return K;
-      }
-
-      arma::mat TwoDBasis::remove_boundaries(const arma::mat & Fnob) const {
-        if(Fnob.n_rows != Ndummy() || Fnob.n_cols != Ndummy()) {
-          std::ostringstream oss;
-          oss << "Matrix does not have expected size! Got " << Fnob.n_rows << " x " << Fnob.n_cols << ", expected " << Ndummy() << " x " << Ndummy() << "!\n";
-          throw std::logic_error(oss.str());
-        }
-
-        // Get indices
-        arma::uvec idx(pure_indices());
-
-        // Matrix with the boundary conditions removed
-        arma::mat Fpure(Fnob(idx,idx));
-
-        //Fnob.print("Input: w/o built-in boundaries");
-        //Fpure.print("Output: w built-in boundaries");
-
-        return Fpure;
-      }
-
-      arma::mat TwoDBasis::expand_boundaries(const arma::mat & Ppure) const {
-        if(Ppure.n_rows != Nbf() || Ppure.n_cols != Nbf()) {
-          std::ostringstream oss;
-          oss << "Matrix does not have expected size! Got " << Ppure.n_rows << " x " << Ppure.n_cols << ", expected " << Nbf() << " x " << Nbf() << "!\n";
-          throw std::logic_error(oss.str());
-        }
-
-        // Get indices
-        arma::uvec idx(pure_indices());
-
-        // Matrix with the boundary conditions removed
-        arma::mat Pnob(Ndummy(),Ndummy());
-        Pnob.zeros();
-        Pnob(idx,idx)=Ppure;
-
-        //Ppure.print("Input: w built-in boundaries");
-        //Pnob.print("Output: w/o built-in boundaries");
-
-        return Pnob;
       }
 
       arma::cx_mat TwoDBasis::eval_bf(size_t iel, double cth, double phi) const {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -118,13 +118,6 @@ namespace helfem {
         /// Is derivative zeroed at infinity?
         int get_zeroder() const;
 
-        /// Get indices of real basis functions
-        arma::uvec pure_indices() const;
-        /// Expand boundary conditions
-        arma::mat expand_boundaries(const arma::mat & H) const;
-        /// Remove boundary conditions
-        arma::mat remove_boundaries(const arma::mat & H) const;
-
 
         /// Compute two-electron integrals
         void compute_tei(bool exchange);

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -53,7 +53,9 @@ namespace helfem {
         if(!P0.n_elem) {
           throw std::runtime_error("Error - density matrix is empty!\n");
         }
-        arma::mat P(basp->expand_boundaries(P0)(bf_ind,bf_ind));
+        // The atomic basis has no boundary reduction, so P0 already spans
+        // the full (Ndummy) basis; slice out this element's functions.
+        arma::mat P(P0(bf_ind,bf_ind));
 
         // Non-polarized calculation.
         polarized=false;
@@ -130,9 +132,9 @@ namespace helfem {
         // Polarized calculation.
         polarized=true;
 
-        // Update density vector
-        arma::mat Pa(basp->expand_boundaries(Pa0)(bf_ind,bf_ind));
-        arma::mat Pb(basp->expand_boundaries(Pb0)(bf_ind,bf_ind));
+        // Update density vector (atomic basis has no boundary reduction).
+        arma::mat Pa(Pa0(bf_ind,bf_ind));
+        arma::mat Pb(Pb0(bf_ind,bf_ind));
 
         Pav=Pa*arma::conj(bf);
         Pbv=Pb*arma::conj(bf);


### PR DESCRIPTION
## Summary

The atomic basis has **no** boundary-condition reduction:
`pure_indices()` was always the full identity index set, so
`expand_boundaries` and `remove_boundaries` were both no-ops (a size
assertion + identity slice).

After the field-method (#211) and J/K (#212) migrations, the only
remaining caller was `atomic/dftgrid.cpp`'s `update_density`, which did
`basp->expand_boundaries(P0)(bf_ind, bf_ind)` — i.e. exactly
`P0(bf_ind, bf_ind)`.

This replaces those three DFT-grid slices with the direct
`P0(bf_ind, bf_ind)` form and deletes `pure_indices` /
`expand_boundaries` / `remove_boundaries` from `TwoDBasis` (.cpp + .h).

`arma::` refs in `TwoDBasis.cpp`: 75 → 67.

## Test plan
- [x] He LDA → -2.7236397926 (restricted grid path)
- [x] Li UHF LDA → -7.1934018521 (unrestricted Pa/Pb grid path)
- [x] N UHF PBE → -54.3577852701 (GGA, unrestricted)
- [x] Full build clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>