### PR TITLE
src/sadatom: restore SAP effective-potential generator in gensap

### DIFF
--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -19,6 +19,7 @@
 #include "../general/gaunt.h"
 #include "utils.h"
 #include "../general/scf_helpers.h"
+#include "../general/dftfuncs.h"
 #include <sstream>
 
 #ifdef _OPENMP
@@ -448,6 +449,723 @@ namespace helfem {
 
       arma::vec TwoDBasis::get_r(size_t iel) const {
         return helfem::to_arma(radial.get_r(iel));
+      }
+
+      double TwoDBasis::nuclear_density(const arma::mat & P) const {
+        return radial.nuclear_density(helfem::to_eigen(P))/(4.0*M_PI);
+      }
+      double TwoDBasis::nuclear_density_gradient(const arma::mat & P) const {
+        return radial.nuclear_density_gradient(helfem::to_eigen(P))/(4.0*M_PI);
+      }
+
+      arma::vec TwoDBasis::quadrature_weights() const {
+        std::vector<arma::vec> w(radial.Nel());
+        size_t ntot=1;
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          w[iel]=helfem::to_arma(radial.get_wrad(iel));
+          ntot+=w[iel].n_elem;
+        }
+        arma::vec wt(ntot);
+        wt.zeros();
+        size_t Npts(w[0].n_elem);
+        for(size_t iel=0;iel<radial.Nel();iel++)
+          wt.subvec(1+iel*Npts,(iel+1)*Npts)=w[iel];
+
+        return wt;
+      }
+
+      arma::vec TwoDBasis::coulomb_screening(const arma::mat & Prad) const {
+        std::vector<arma::vec> r(radial.Nel());
+        std::vector<arma::vec> V(radial.Nel());
+
+        // Calculate potential due to charge outside the element
+        arma::vec zero(radial.Nel());
+        arma::vec minusone(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Radial functions in element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+          // Density matrix
+          arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
+          arma::mat zm(helfem::to_arma(radial.radial_integral(0,iel)));
+          arma::mat mo(helfem::to_arma(radial.radial_integral(-1,iel)));
+          zero(iel)=arma::trace(Psub*zm);
+          minusone(iel)=arma::trace(Psub*mo);
+        }
+        // Sum zero potentials together
+        for(size_t iel=1;iel<radial.Nel();iel++)
+          zero(iel)+=zero(iel-1);
+        // Sum minus one potentials together
+        for(size_t iel=radial.Nel()-2;iel<radial.Nel();iel--)
+          minusone(iel)+=minusone(iel+1);
+
+        // Form potential
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Initialize potential
+          r[iel]=helfem::to_arma(radial.get_r(iel));
+          V[iel].zeros(r[iel].n_elem);
+
+          // Get the density in the element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+          arma::vec Pv(arma::vectorise(Prad.submat(ifirst,ifirst,ilast,ilast)));
+
+          // Calculate the in-element potential
+          arma::mat pot(helfem::to_arma(radial.spherical_potential(iel)));
+          V[iel] += pot*Pv;
+
+          // Add in the contributions from the other elements
+          if(iel>0)
+            for(size_t ip=0;ip<r[iel].n_elem;ip++)
+              V[iel](ip) += zero(iel-1)/r[iel](ip);
+          if(iel != radial.Nel()-1)
+            V[iel] += minusone(iel+1)*arma::ones<arma::vec>(V[iel].n_elem);
+
+          // Multiply by r to convert this into an effective charge
+          for(size_t ip=0;ip<r[iel].n_elem;ip++)
+            V[iel](ip)*=r[iel](ip);
+        }
+
+        // Assemble all of this into an array
+        size_t Npts=r[0].n_elem;
+        arma::vec Veff(radial.Nel()*Npts+1);
+        Veff.zeros();
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          Veff.subvec(1+iel*Npts,(iel+1)*Npts)=V[iel];
+        }
+
+        return Veff;
+      }
+
+      arma::vec TwoDBasis::radii() const {
+        std::vector<arma::vec> r(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          r[iel]=helfem::to_arma(radial.get_r(iel));
+        }
+
+        size_t Npts=r[0].n_elem;
+        arma::vec rad(radial.Nel()*Npts+1);
+        rad.zeros();
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          rad.subvec(1+iel*Npts,(iel+1)*Npts)=r[iel];
+        }
+
+        return rad;
+      }
+
+      double TwoDBasis::slater_F(int k, const arma::vec & c) const {
+        // Bare radial Slater-Condon F^k integral for orbital `c` in the
+        // u = r * R basis. Defined as
+        //     F^k(c, c) = sum_{ab,cd} P_ab P_cd R^k_FE(ab, cd)
+        // with P = c * c.t() and R^k_FE the bare per-multipole 2e integral
+        // from CoulombExchangeFE.h (no 4*pi/(2k+1) factor).
+        //
+        // F^k = trace(P * J^k(P)) where J^k = assemble_J_FE_one_multipole.
+        if (c.n_elem != radial.Nbf()) {
+          std::ostringstream oss;
+          oss << "TwoDBasis::slater_F: orbital length " << c.n_elem
+              << " != Nrad " << radial.Nbf() << ".\n";
+          throw std::logic_error(oss.str());
+        }
+        const arma::mat P = c * c.t();
+        const arma::mat Jk = helfem::to_arma(
+            atomic::basis::assemble_J_FE_one_multipole(radial, k, helfem::to_eigen(P)));
+        return arma::trace(P * Jk);
+      }
+
+      arma::mat TwoDBasis::orbitals(const arma::mat & C) const {
+        std::vector<arma::mat> c(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Radial functions in element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+          // Density matrix
+          arma::mat Csub(C.rows(ifirst,ilast));
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
+
+          c[iel]=bf*Csub;
+        }
+        size_t Npts=c[0].n_rows;
+
+        arma::mat Cv(radial.Nel()*Npts+1,C.n_cols);
+        Cv.zeros();
+        // Values at the nucleus
+        {
+          {
+            const Eigen::RowVectorXd nrow = radial.nuclear_orbital(helfem::to_eigen(C));
+            for (Eigen::Index j = 0; j < nrow.size(); ++j)
+              Cv(0, j) = nrow(j);
+          }
+        }
+        // Other points
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          Cv.rows(1+iel*Npts,(iel+1)*Npts)=c[iel];
+        }
+
+        return Cv;
+      }
+
+      arma::mat TwoDBasis::orbitals_derivative(const arma::mat & C) const {
+        std::vector<arma::mat> c(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Radial functions in element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+          // Density matrix
+          arma::mat Csub(C.rows(ifirst,ilast));
+          arma::mat bf(helfem::to_arma(radial.get_df(iel)));
+
+          c[iel]=bf*Csub;
+        }
+        size_t Npts=c[0].n_rows;
+
+        arma::mat Cv(radial.Nel()*Npts+1,C.n_cols);
+        Cv.zeros();
+        // Values at the nucleus
+        {
+	  // tbd
+        }
+        // Other points
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          Cv.rows(1+iel*Npts,(iel+1)*Npts)=c[iel];
+        }
+
+        return Cv;
+      }
+
+      arma::mat TwoDBasis::orbitals_second_derivative(const arma::mat & C) const {
+        std::vector<arma::mat> c(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Radial functions in element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+          // Density matrix
+          arma::mat Csub(C.rows(ifirst,ilast));
+          arma::mat bf(helfem::to_arma(radial.get_lf(iel)));
+
+          c[iel]=bf*Csub;
+        }
+        size_t Npts=c[0].n_rows;
+
+        arma::mat Cv(radial.Nel()*Npts+1,C.n_cols);
+        Cv.zeros();
+        // Values at the nucleus
+        {
+	  // tbd
+        }
+        // Other points
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          Cv.rows(1+iel*Npts,(iel+1)*Npts)=c[iel];
+        }
+
+        return Cv;
+      }
+
+      arma::vec TwoDBasis::electron_density(const arma::vec & x, size_t iel, const arma::mat & Prad, bool rsqweight) const {
+        // Radial functions in element
+        size_t ifirst, ilast;
+        radial.get_idx(iel,ifirst,ilast);
+        // Density matrix
+        arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
+        // Phase 5.24/5.25: radial.get_bf / get_r per-x-point overloads
+        // take Eigen vectors; bridge once at the call boundary.
+        const helfem::Vector xe = helfem::to_eigen(x);
+        arma::mat bf(helfem::to_arma(radial.get_bf(xe, iel)));
+
+        arma::vec density = arma::diagvec(bf*Psub*bf.t());
+        if(rsqweight)
+          density %= arma::square(helfem::to_arma(radial.get_r(xe, iel)));
+        return density;
+      }
+
+      arma::vec TwoDBasis::electron_density(size_t iel, const arma::mat & Prad, bool rsqweight) const {
+        return electron_density(helfem::to_arma(radial.get_xq()), iel, Prad, rsqweight);
+      }
+
+      arma::vec TwoDBasis::electron_density(const arma::mat & Prad, bool rsqweight) const {
+        std::vector<arma::vec> d(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          d[iel]=electron_density(iel, Prad, rsqweight);
+        }
+        size_t Npts=d[0].n_elem;
+
+        arma::vec n(radial.Nel()*Npts+1);
+        n.zeros();
+        n(0)=4.0*M_PI*nuclear_density(Prad);
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          n.subvec(1+iel*Npts,(iel+1)*Npts)=d[iel];
+        }
+
+        return n;
+      }
+
+      double TwoDBasis::electron_density_maximum_radius(const arma::mat & Prad, bool rsqweight, double eps) const {
+        // Evaluate the density in each quadrature point and take
+        // their maximum
+        arma::vec den(radial.Nel());
+
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          den(iel)=arma::max(electron_density(iel, Prad, rsqweight));
+        }
+
+        // Quadrature points
+        arma::vec xq = helfem::to_arma(radial.get_xq());
+
+        // Find the element with the maximum density
+        arma::uword iel;
+        den.max(iel);
+
+        // Evaluate the density in that element
+        arma::vec del = electron_density(xq, iel, Prad, rsqweight);
+
+        // Find the maximum value
+        arma::uword imax;
+        del.max(imax);
+
+        // Refine the location of the maximum in the element
+        double rmax=0.0;
+        {
+          // Primitive coordinates
+          arma::vec a(1), b(1);
+
+          if(imax == 0) {
+            a(0) = -1.0;
+            b(0) = xq(imax+1);
+          } else if(imax == xq.n_elem-1) {
+            a(0) = xq(imax-1);
+            b(0) = 1.0;
+          } else {
+            a(0) = xq(imax-1);
+            b(0) = xq(imax+1);
+          }
+
+          // Golden ratio search
+          double golden_ratio = 0.5*(sqrt(5.0)+1.0);
+          while(arma::norm(a-b,"inf")>=eps) {
+            arma::vec c = b - (b-a)/golden_ratio;
+            arma::vec d = a + (b-a)/golden_ratio;
+            double density_c = arma::as_scalar(electron_density(c, iel, Prad, rsqweight));
+            double density_d = arma::as_scalar(electron_density(d, iel, Prad, rsqweight));
+            if(density_c > density_d) {
+              b = d;
+            } else {
+              a = c;
+            }
+          }
+          arma::vec cen=((a+b)/2);
+          double dmax = arma::as_scalar(electron_density(cen, iel, Prad, rsqweight));
+          if(dmax < del(imax)) {
+            std::ostringstream oss;
+            oss << "Density maximization failed! Quadrature max " << del(imax) << " optimized max " << dmax << " difference " << dmax-del(imax) << "!\n";
+            throw std::logic_error(oss.str());
+          }
+          // Position of maximum is
+          rmax = radial.get_r(helfem::to_eigen(arma::vec((a+b)/2)), iel)(0);
+        }
+
+        return rmax;
+      }
+
+      double TwoDBasis::vdw_radius(const arma::mat & Prad, double vdw_threshold, double eps) const {
+        // Need to multiply output of electron_density by this factor to get the point-wise density
+        double angfac=1.0/(4.0*M_PI);
+	bool rsqweight=false;
+
+        // Evaluate the density in each quadrature point and take
+        // their maximum
+        size_t iel;
+        for(iel=radial.Nel()-1;iel<radial.Nel();iel--) {
+          arma::vec den(angfac*electron_density(iel, Prad, rsqweight));
+          if(arma::max(den)>vdw_threshold) {
+            // We found the element
+            break;
+          }
+        }
+        if(iel>radial.Nel()) {
+          // No point of density is above threshold!
+          return 0.0;
+        }
+
+        // Now find the position in the element where the density is = vdw_threshold.
+        // Evaluate the difference in density from the threshold value.
+        // Quadrature points
+        arma::vec xq = helfem::to_arma(radial.get_xq());
+        arma::vec diff = angfac*electron_density(xq, iel, Prad, rsqweight);
+        diff-=vdw_threshold*arma::ones<arma::vec>(diff.n_elem);
+        diff=arma::abs(diff);
+
+        // Find the smallest value
+        arma::uword imax;
+        diff.min(imax);
+
+        // Refine the position.
+
+        double rvdw=0.0;
+        {
+          // Primitive coordinates
+          arma::vec a(1), b(1);
+
+          if(imax == 0) {
+            a(0) = -1.0;
+            b(0) = xq(imax+1);
+          } else if(imax == xq.n_elem-1) {
+            a(0) = xq(imax-1);
+            b(0) = 1.0;
+          } else {
+            a(0) = xq(imax-1);
+            b(0) = xq(imax+1);
+          }
+
+          // Bisection
+          size_t ibisect=0;
+          while(arma::norm(a-b,"inf")>=eps) {
+            arma::vec m = a + (b-a)/2.0;
+            double density_m = angfac*arma::as_scalar(electron_density(m, iel, Prad, rsqweight));
+
+            if(density_m < eps) {
+              b = m;
+            } else if(density_m > eps) {
+              a = m;
+            } else if(density_m == eps)
+              break;
+
+            ibisect++;
+            if(ibisect==100)
+              throw std::runtime_error("bisection did not converge in 100 iterations\n");
+          }
+          // Coordinate is
+          arma::vec cen=((a+b)/2);
+          // Position of maximum is
+          rvdw = radial.get_r(helfem::to_eigen(cen), iel)(0);
+        }
+
+        return rvdw;
+      }
+
+      double TwoDBasis::electron_count_radius(const arma::mat & Prad, const double eps, const double conv_thr) const {
+	// Vector with electron density contributions from each element
+	std::vector<double> densities(radial.Nel());
+	for(size_t iel=0;iel<radial.Nel();iel++) {
+	  // Radial functions in element
+	  size_t ifirst, ilast;
+	  radial.get_idx(iel,ifirst,ilast);
+	  // Density matrix
+	  arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
+	  // Overlap matrix (Phase 2a: overlap(iel) returns helfem::Matrix).
+	  arma::mat S(helfem::to_arma(radial.overlap(iel)));
+	  densities[iel]=arma::trace(Psub*S);
+	}
+
+	// Search for the correct element
+	double s_left=eps;
+	size_t ielement;
+	for(ielement=radial.Nel()-1;ielement<radial.Nel();ielement--) {
+	  if(s_left>densities[ielement])
+	    s_left-=densities[ielement];
+	  else
+	    break;
+	}
+
+	// Radial functions in element
+	size_t ifirst, ilast;
+	radial.get_idx(ielement,ifirst,ilast);
+	// Density matrix within the element
+	arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
+
+	// Search for the radius within element
+	double result;
+	// Element limits
+	double a=-1.0, b=1.0;
+	double m=a+(b-a)/2.0;
+	while(b-a>=conv_thr) {
+	  m=a+(b-a)/2.0;
+	  result=arma::trace(Psub*helfem::to_arma(radial.radial_integral(0,ielement,m,1.0)));
+	  if(result<s_left)
+	    b=m;
+	  else if(result>s_left)
+	    a=m;
+	  else
+	    break;
+	}
+
+	return radial.get_r(m, ielement);
+      }
+
+      arma::vec TwoDBasis::electron_density_gradient(const arma::mat & Prad) const {
+        std::vector<arma::vec> d(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Radial functions in element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+          // Density matrix
+          arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
+          arma::mat df(helfem::to_arma(radial.get_df(iel)));
+
+          d[iel]=2.0*arma::diagvec(bf*Psub*df.t());
+        }
+
+        size_t Npts=d[0].n_elem;
+        arma::vec n(radial.Nel()*Npts+1);
+        n.zeros();
+
+        // TODO: implement gradient at the nucleus. This requires
+        // third derivatives of the basis functions...
+
+        // The other points
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          n.subvec(1+iel*Npts,(iel+1)*Npts)=d[iel];
+        }
+
+        return n;
+      }
+
+      arma::vec TwoDBasis::electron_density_laplacian(const arma::mat & Prad) const {
+        std::vector<arma::vec> l(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Radial functions in element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+          // Density matrix
+          arma::mat Psub(Prad.submat(ifirst,ifirst,ilast,ilast));
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
+          arma::mat df(helfem::to_arma(radial.get_df(iel)));
+          arma::mat lf(helfem::to_arma(radial.get_lf(iel)));
+          arma::vec r(helfem::to_arma(radial.get_r(iel)));
+
+          // Laplacian is df^2/dr^2 + 2/r df/dr
+          l[iel]=2.0*(arma::diagvec(df*Psub*df.t()) + arma::diagvec(bf*Psub*lf.t())) + 4.0*arma::diagvec(bf*Psub*df.t())/r;
+        }
+
+        size_t Npts=l[0].n_elem;
+        arma::vec n(radial.Nel()*Npts+1);
+        n.zeros();
+
+        // Skip the laplacian at the nucleus at least for now...
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          n.subvec(1+iel*Npts,(iel+1)*Npts)=l[iel];
+        }
+
+        return n;
+      }
+
+      arma::vec TwoDBasis::kinetic_energy_density(const arma::cube & Pl0) const {
+        // Radial density matrices
+        arma::mat P(Pl0.n_rows, Pl0.n_cols, arma::fill::zeros);
+        arma::mat Pl(Pl0.n_rows, Pl0.n_cols, arma::fill::zeros);
+        for(size_t l=0; l<Pl0.n_slices; l++) {
+          P += Pl0.slice(l);
+          Pl += l*(l+1)*Pl0.slice(l);
+        }
+
+        std::vector<arma::vec> t(radial.Nel());
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          // Radial functions in element
+          size_t ifirst, ilast;
+          radial.get_idx(iel,ifirst,ilast);
+
+          // Radii
+          arma::vec r(helfem::to_arma(radial.get_r(iel)));
+
+          // Density matrix
+          arma::mat Psub(P.submat(ifirst,ifirst,ilast,ilast));
+          arma::mat Psubl(Pl.submat(ifirst,ifirst,ilast,ilast));
+
+          // Basis function
+          arma::mat bf(helfem::to_arma(radial.get_bf(iel)));
+          // Basis function derivative
+          arma::mat bf_rho(helfem::to_arma(radial.get_df(iel)));
+
+          arma::vec term1(arma::diagvec(bf_rho * Psub * bf_rho.t()));
+          arma::vec term2(arma::diagvec(bf * Psubl * bf.t())/arma::square(r));
+          // The second term is tricky near the nucleus since only s
+          // orbitals can contribute to the electron density but their
+          // contribution is killed off by the l(l+1) factor
+          term2(arma::find(term2<0.0)).zeros();
+          t[iel] = 0.5*(term1+term2);
+        }
+
+        size_t Npts=t[0].n_elem;
+        arma::vec tn(radial.Nel()*Npts+1);
+        tn.zeros();
+
+        // Skip the value at the nucleus at least for now...
+        for(size_t iel=0;iel<radial.Nel();iel++) {
+          tn.subvec(1+iel*Npts,(iel+1)*Npts)=t[iel];
+        }
+
+        return tn;
+      }
+
+
+      arma::vec TwoDBasis::xc_screening(const arma::mat & Prad, int x_func, int c_func) const {
+        arma::mat v(xc_screening(Prad/2,Prad/2,x_func,c_func));
+        return 0.5*(v.col(0)+v.col(1));
+      }
+
+      arma::mat TwoDBasis::xc_screening(const arma::mat & Parad, const arma::mat & Pbrad, int x_func, int c_func) const {
+        const double angfac=4.0*M_PI;
+        // Get the electron density
+        arma::vec rhoa(electron_density(Parad)/angfac);
+        arma::vec rhob(electron_density(Pbrad)/angfac);
+        // and the density gradient
+        arma::vec grada(electron_density_gradient(Parad)/angfac);
+        arma::vec gradb(electron_density_gradient(Pbrad)/angfac);
+        // and the density Laplacian
+        arma::vec lapla(electron_density_laplacian(Parad)/angfac);
+        arma::vec laplb(electron_density_laplacian(Pbrad)/angfac);
+        // Radial coordinates
+        arma::vec r(radii());
+        size_t Npoints(r.n_elem);
+
+        // and pack it for libxc
+        arma::mat rho_libxc(Npoints,2);
+        rho_libxc.col(0)=rhoa;
+        rho_libxc.col(1)=rhob;
+        // Take transpose so that order is (na0, nb0, na1, nb1, ...)
+        rho_libxc=rho_libxc.t();
+
+        // Reduced gradient
+        arma::mat sigma_libxc(Npoints,3);
+        sigma_libxc.col(0)=grada%grada;
+        sigma_libxc.col(1)=grada%gradb;
+        sigma_libxc.col(2)=gradb%gradb;
+        // Take transpose to get correct order
+        sigma_libxc=sigma_libxc.t();
+
+        // Potential
+        arma::mat vxc(2,Npoints);
+        vxc.zeros();
+        arma::mat vsigma(3,Npoints);
+        vsigma.zeros();
+
+        // For GGA we also need the second derivative to calculate the
+        // correction to the potential
+        arma::mat v2rhosigma(6,Npoints);
+        v2rhosigma.zeros();
+        arma::mat v2sigma2(6,Npoints);
+        v2sigma2.zeros();
+
+        // Helper arrays
+        arma::mat vxc_wrk(2,Npoints);
+        arma::mat vsigma_wrk(3,Npoints);
+        arma::mat v2rho2_wrk(3,Npoints);
+        arma::mat v2rhosigma_wrk(6,Npoints);
+        arma::mat v2sigma2_wrk(6,Npoints);
+
+        bool do_gga=false;
+
+        if(x_func>0) {
+          vxc_wrk.zeros();
+          vsigma_wrk.zeros();
+          v2rhosigma_wrk.zeros();
+          v2sigma2_wrk.zeros();
+
+          bool gga, mggat, mggal;
+          ::is_gga_mgga(x_func, gga, mggat, mggal);
+          if(mggat || mggal)
+            throw std::logic_error("Mggas not supported!\n");
+
+          xc_func_type func;
+          if(xc_func_init(&func, x_func, XC_POLARIZED) != 0) {
+            throw std::logic_error("Error initializing exchange functional!\n");
+          }
+          if(gga) {
+            xc_gga_vxc(&func, rhoa.n_elem, rho_libxc.memptr(), sigma_libxc.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr());
+            xc_gga_fxc(&func, rhoa.n_elem, rho_libxc.memptr(), sigma_libxc.memptr(), v2rho2_wrk.memptr(), v2rhosigma_wrk.memptr(), v2sigma2_wrk.memptr());
+            do_gga=true;
+            vsigma+=vsigma_wrk;
+            v2rhosigma+=v2rhosigma_wrk;
+            v2sigma2+=v2sigma2_wrk;
+          } else {
+            xc_lda_vxc(&func, rhoa.n_elem, rho_libxc.memptr(), vxc_wrk.memptr());
+          }
+          xc_func_end(&func);
+
+          vxc+=vxc_wrk;
+        }
+        if(c_func>0) {
+          vxc_wrk.zeros();
+          vsigma_wrk.zeros();
+          v2rhosigma_wrk.zeros();
+          v2sigma2_wrk.zeros();
+
+          bool gga, mggat, mggal;
+          ::is_gga_mgga(c_func, gga, mggat, mggal);
+          if(mggat || mggal)
+            throw std::logic_error("Mggas not supported!\n");
+
+          xc_func_type func;
+          if(xc_func_init(&func, c_func, XC_POLARIZED) != 0) {
+            throw std::logic_error("Error initializing correlation functional!\n");
+          }
+          if(gga) {
+            xc_gga_vxc(&func, rhoa.n_elem, rho_libxc.memptr(), sigma_libxc.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr());
+            xc_gga_fxc(&func, rhoa.n_elem, rho_libxc.memptr(), sigma_libxc.memptr(), v2rho2_wrk.memptr(), v2rhosigma_wrk.memptr(), v2sigma2_wrk.memptr());
+            do_gga=true;
+            vsigma+=vsigma_wrk;
+            v2rhosigma+=v2rhosigma_wrk;
+            v2sigma2+=v2sigma2_wrk;
+          } else {
+            xc_lda_vxc(&func, rhoa.n_elem, rho_libxc.memptr(), vxc_wrk.memptr());
+          }
+
+          vxc+=vxc_wrk;
+        }
+
+        // Add GGA correction to xc potential.
+        if(do_gga) {
+          arma::mat corr(2,vxc.n_cols);
+          corr.zeros();
+
+          // Loop over points: skip nucleus since there's no laplacian there for now
+          for(size_t ip=1;ip<Npoints;ip++) {
+            // First term: g(t) ( d^2 E / d n(t) d sigma(ss') ) g(s')
+
+            // (a, aa) + (b, aa)
+            corr(0,ip) += 2.0*(grada(ip)*v2rhosigma(0,ip) + gradb(ip)*v2rhosigma(3,ip))*grada(ip);
+            // (a, ab) + (b, ab)
+            corr(0,ip) += (grada(ip)*v2rhosigma(1,ip) + gradb(ip)*v2rhosigma(4,ip))*gradb(ip);
+
+            // (b, bb) + (a, bb)
+            corr(1,ip) += 2.0*(gradb(ip)*v2rhosigma(5,ip) + grada(ip)*v2rhosigma(2,ip))*gradb(ip);
+            // (a, ab) + (b, ab)
+            corr(1,ip) += (grada(ip)*v2rhosigma(1,ip) + gradb(ip)*v2rhosigma(4,ip))*grada(ip);
+          }
+
+          for(size_t ip=1;ip<Npoints;ip++) {
+            // Second term: (l(t)g(t') + g(t)l(t')) (d^2 E / d sigma(tt') d sigma(ss')) g(s'). Contract t and t' first, put in factor two later
+            double d2Edsaa = lapla(ip)*grada(ip)*v2sigma2(0,ip) + (lapla(ip)*gradb(ip) + grada(ip)*laplb(ip))*v2sigma2(1,ip) + laplb(ip)*gradb(ip)*v2sigma2(2,ip);
+            double d2Edsab = lapla(ip)*grada(ip)*v2sigma2(1,ip) + (lapla(ip)*gradb(ip) + grada(ip)*laplb(ip))*v2sigma2(3,ip) + laplb(ip)*gradb(ip)*v2sigma2(4,ip);
+            double d2Edsbb = lapla(ip)*grada(ip)*v2sigma2(2,ip) + (lapla(ip)*gradb(ip) + grada(ip)*laplb(ip))*v2sigma2(4,ip) + laplb(ip)*gradb(ip)*v2sigma2(5,ip);
+            // and now we can contract this with the gradient
+            corr(0,ip) += 4.0*d2Edsaa*grada(ip) + 2.0*d2Edsab*gradb(ip);
+            corr(1,ip) += 4.0*d2Edsbb*gradb(ip) + 2.0*d2Edsab*grada(ip);
+          }
+
+          for(size_t ip=1;ip<Npoints;ip++) {
+            // Third term: dE/dsigma(ss') l(s')
+            corr(0,ip) += 2.0*vsigma(0,ip)*lapla(ip) + vsigma(1,ip)*laplb(ip);
+            corr(1,ip) += vsigma(1,ip)*lapla(ip) + 2.0*vsigma(2,ip)*laplb(ip);
+          }
+
+          for(size_t ip=1;ip<Npoints;ip++) {
+            // Second term in the divergence: div A = dA/dr + 2 r A
+            corr(0,ip) += 2.0/r(ip)*(2.0*vsigma(0,ip)*grada(ip) + vsigma(1,ip)*gradb(ip));
+            corr(1,ip) += 2.0/r(ip)*(vsigma(1,ip)*grada(ip) + 2.0*vsigma(2,ip)*gradb(ip));
+          }
+
+          // Perform the correction
+          vxc -= corr;
+        }
+
+        // Transpose
+        vxc = vxc.t();
+        // Convert to radial potential (this is how it matches with GPAW)
+        for(size_t ic=0;ic<vxc.n_cols;ic++)
+          vxc.col(ic)%=r;
+
+        return vxc;
       }
 
 

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -119,6 +119,54 @@ namespace helfem {
         /// Get r values
         arma::vec get_r(size_t iel) const;
 
+        /// Electron density at nucleus
+        double nuclear_density(const arma::mat & P) const;
+        /// Electron density gradient at nucleus
+        double nuclear_density_gradient(const arma::mat & P) const;
+
+        /// Get quadrature weights
+        arma::vec quadrature_weights() const;
+        /// Compute the Coulomb screening of the nucleus
+        arma::vec coulomb_screening(const arma::mat & Prad) const;
+
+        /// Radii
+        arma::vec radii() const;
+        /// Compute the radial Slater-Condon integral F^k for an orbital
+        /// specified by its coefficient vector c (length Nrad) in the
+        /// u = r * R basis.
+        double slater_F(int k, const arma::vec & c) const;
+        /// Compute radial orbitals
+        arma::mat orbitals(const arma::mat & C) const;
+        /// Compute radial orbitals' first derivative
+        arma::mat orbitals_derivative(const arma::mat & C) const;
+        /// Compute radial orbitals' second derivative
+        arma::mat orbitals_second_derivative(const arma::mat & C) const;
+
+        /// Compute the electron density in given element at wanted points
+        arma::vec electron_density(const arma::vec & x, size_t iel, const arma::mat & Prad, bool rsqweight = false) const;
+        /// Compute the electron density in given element at default quadrature points
+        arma::vec electron_density(size_t iel, const arma::mat & Prad, bool rsqweight = false) const;
+        /// Compute the position of the electron density maximum
+        double electron_density_maximum_radius(const arma::mat & Prad, bool rsqweight = true, double conv_thr=1e-10) const;
+        /// Compute the van der Waals radius, see doi:10.1002/chem.201602949
+        double vdw_radius(const arma::mat & Prad, double eps=0.001, double conv_thr=1e-10) const;
+        /// Compute the atomic radius by electron density inclusion
+        double electron_count_radius(const arma::mat & Prad, const double eps=0.001, const double conv_thr=1e-10) const;
+
+        /// Compute the electron density
+        arma::vec electron_density(const arma::mat & Prad, bool rsqweight = false) const;
+        /// Compute the electron density gradient
+        arma::vec electron_density_gradient(const arma::mat & Prad) const;
+        /// Compute the electron density laplacian
+        arma::vec electron_density_laplacian(const arma::mat & Prad) const;
+        /// Compute the kinetic energy density
+        arma::vec kinetic_energy_density(const arma::cube & Pl0) const;
+
+        /// Compute the exchange-correlation screening
+        arma::vec xc_screening(const arma::mat & Prad, int x_func, int c_func) const;
+        /// Compute the exchange-correlation screening
+        arma::mat xc_screening(const arma::mat & Parad, const arma::mat & Pbrad, int x_func, int c_func) const;
+
         /// Read-only access to the underlying radial basis. Useful for
         /// callers that want to build an NAORadialBasis on top of a
         /// converged sadatom SCF (see extract_naos_per_l below).

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -29,8 +29,67 @@
 #include "scf.h"
 #include <ArmaEigen.h>
 #include <iostream>
+#include <sstream>
 
 using namespace helfem;
+
+// Assemble the radial effective-potential table for the converged
+// density in `res`, using exchange/correlation ids (xp_func, cp_func)
+// for the xc screening. Mirrors the bespoke SCFSolver::{Restricted,
+// Unrestricted}Potential. Columns:
+//   0 r   1 rho   2 grad(rho)   3 lapl(rho)   4 tau
+//   5 v_coul(screening)   6 v_xc(screening)   7 quad weight
+//   8 Zeff = charge - (v_coul + v_xc)   <-- the SAP effective charge
+static arma::mat effective_potential_table(
+    const helfem::sadatom::basis::TwoDBasis & basis,
+    const helfem::sadatom::scf::AtomicSCFResult & res,
+    bool restricted, int xp_func, int cp_func) {
+
+  const arma::mat P = helfem::to_arma(res.Prad);
+  // Total per-l density cube (for tau). Restricted: Pl_a already holds
+  // the full per-l density; unrestricted: sum alpha + beta.
+  arma::cube Pl = res.Pl_a;
+  if (!restricted)
+    Pl += res.Pl_b;
+
+  const arma::vec r    = basis.radii();
+  const arma::vec wt   = basis.quadrature_weights();
+  const arma::vec vcoul = basis.coulomb_screening(P);
+
+  arma::vec vxc;
+  if (restricted) {
+    vxc = basis.xc_screening(P, xp_func, cp_func);
+  } else {
+    // Averaged spin-unrestricted xc screening.
+    arma::mat Pa = arma::zeros(P.n_rows, P.n_cols);
+    arma::mat Pb = arma::zeros(P.n_rows, P.n_cols);
+    for (arma::uword l = 0; l < res.Pl_a.n_slices; ++l) Pa += res.Pl_a.slice(l);
+    for (arma::uword l = 0; l < res.Pl_b.n_slices; ++l) Pb += res.Pl_b.slice(l);
+    vxc = arma::mean(basis.xc_screening(Pa, Pb, xp_func, cp_func), 1);
+  }
+
+  const arma::vec Zeff = vcoul + vxc;
+  const arma::vec rho  = basis.electron_density(P);
+  const arma::vec grho = basis.electron_density_gradient(P);
+  const arma::vec lrho = basis.electron_density_laplacian(P);
+  const arma::vec tau  = basis.kinetic_energy_density(Pl);
+
+  arma::mat result(r.n_elem, 9);
+  result.col(0) = r;
+  result.col(1) = rho;
+  result.col(2) = grho;
+  result.col(3) = lrho;
+  result.col(4) = tau;
+  result.col(5) = vcoul;
+  result.col(6) = vxc;
+  result.col(7) = wt;
+  result.col(8) = basis.charge() * arma::ones<arma::vec>(Zeff.n_elem) - Zeff;
+
+  printf("Electron density by quadrature: %.10e\n", arma::sum(wt % rho % r % r));
+  printf("Quadrature of tabulated Coulomb potential yields Coulomb energy %.10e\n",
+         arma::sum(0.5 * r % rho % wt % vcoul));
+  return result;
+}
 
 int main(int argc, char **argv) {
   cmdline::parser parser;
@@ -64,6 +123,14 @@ int main(int argc, char **argv) {
 
   parser.add<std::string>("load", 0, "load orbital guess from checkpoint file", false, "");
   parser.add<std::string>("save", 0, "save results to checkpoint file",       false, "");
+
+  // SAP / effective-potential generation (parity with bespoke gensap).
+  // With a functional active, gensap tabulates the radial effective
+  // charge Zeff(r) = Z - r*(V_Hartree + V_xc) to result_<El>.dat -- the
+  // data used to build the SAP guess (see src/general/sap.cpp).
+  parser.add<std::string>("pot", 0, "functional for the effective/SAP potential (empty = use --method)", false, "");
+  parser.add<bool>("savepot", 0, "also save the xc screening potential to xcpot.dat?", false, false);
+  parser.add<bool>("saveing", 0, "also save the density ingredients to xcing.dat?", false, false);
 
   parser.parse_check(argc, argv);
 
@@ -159,6 +226,72 @@ int main(int argc, char **argv) {
   opts.load_file    = parser.get<std::string>("load");
   opts.save_file    = parser.get<std::string>("save");
 
-  sadatom::scf::run_atomic_scf(opts);
+  sadatom::scf::AtomicSCFResult result = sadatom::scf::run_atomic_scf(opts);
+
+  // Effective-potential / SAP-table output. The potential functional is
+  // --pot if given, otherwise the SCF --method. As in the bespoke
+  // driver, the table is written whenever a functional is active.
+  const std::string potmethod = parser.get<std::string>("pot");
+  const bool savepot = parser.get<bool>("savepot");
+  const bool saveing = parser.get<bool>("saveing");
+
+  int xp_func = x_func, cp_func = c_func;
+  if (potmethod.size()) {
+    ::parse_xc_func(xp_func, cp_func, potmethod);
+    ::print_info(xp_func, cp_func);
+  }
+  // Meta-GGA / range-separated potentials are not implemented in the
+  // spherically symmetric screening path (matches the old driver).
+  {
+    bool gga, mgga_t, mgga_l;
+    if (xp_func > 0) {
+      ::is_gga_mgga(xp_func, gga, mgga_t, mgga_l);
+      if (mgga_t || mgga_l)
+        throw std::logic_error("Meta-GGA potentials are not supported in the spherically symmetric program.\n");
+    }
+    if (cp_func > 0) {
+      ::is_gga_mgga(cp_func, gga, mgga_t, mgga_l);
+      if (mgga_t || mgga_l)
+        throw std::logic_error("Meta-GGA potentials are not supported in the spherically symmetric program.\n");
+    }
+    if (xp_func > 0) {
+      double o, a, b;
+      ::range_separation(xp_func, o, a, b);
+      if (o != 0.0 || a != 0.0 || b != 0.0)
+        throw std::logic_error("Optimized effective potential is not implemented in the spherically symmetric program.\n");
+    }
+  }
+
+  if (xp_func > 0 || cp_func > 0) {
+    const arma::mat pot = effective_potential_table(
+        result.basis, result, restricted, xp_func, cp_func);
+    std::ostringstream oss;
+    oss << "result_" << element_symbols[Z] << ".dat";
+    pot.save(oss.str(), arma::raw_ascii);
+    printf("Saved effective potential (SAP table) to %s\n", oss.str().c_str());
+
+    if (savepot) {
+      // xc screening potential: [r, v_xc]
+      arma::mat xcpot(pot.n_rows, 2);
+      xcpot.col(0) = pot.col(0);
+      xcpot.col(1) = pot.col(6);
+      xcpot.save("xcpot.dat", arma::raw_ascii);
+      printf("Saved xc screening potential to xcpot.dat\n");
+    }
+    if (saveing) {
+      // density ingredients: [r, rho, grad, lapl, tau]
+      arma::mat ing(pot.n_rows, 5);
+      ing.col(0) = pot.col(0);
+      ing.col(1) = pot.col(1);
+      ing.col(2) = pot.col(2);
+      ing.col(3) = pot.col(3);
+      ing.col(4) = pot.col(4);
+      ing.save("xcing.dat", arma::raw_ascii);
+      printf("Saved density ingredients to xcing.dat\n");
+    }
+  } else if (savepot || saveing) {
+    printf("No functional active (HF) -- no xc potential/ingredients to save.\n");
+  }
+
   return 0;
 }

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -410,6 +410,48 @@ namespace helfem {
         if (!restricted)
           extract_channel(1, result.orbs_b, result.occs_b);
 
+        // Rebuild the converged per-l radial density cube(s) from the
+        // final orbitals + integer per-l occupations (Aufbau filling,
+        // consistent with the converged ground state and with the
+        // checkpoint written below). Used both for --save and for the
+        // gensap effective-potential / SAP-table output in main.cpp.
+        auto build_cube = [&](const arma::cube & orbs_ao, const arma::ivec & occs_per_l,
+                               arma::cube & Pcube_out) {
+          Pcube_out.zeros(Nrad, Nrad, nblock);
+          for (size_t l = 0; l < nblock; ++l) {
+            if (occs_per_l(l) <= 0) continue;
+            // For an integer per-l total N in a manifold of capacity
+            // 2*(2l+1) restricted or (2l+1) unrestricted, split
+            // evenly across the N/max_orb lowest orbitals.
+            const arma::mat orb_l = arma::mat(orbs_ao.slice(l));
+            const int norb = orb_l.n_cols;
+            const double per_orb = (restricted ? 2.0 * (2 * l + 1) : 2.0 * l + 1);
+            // AO density with occupations set: pick occs from OOO
+            // internal (they are what's converged). For simplicity
+            // fall back to a diagonal-per-orbital occupation of
+            // occs_per_l(l) / norb capped at per_orb.
+            arma::vec occ_vec(norb, arma::fill::zeros);
+            double remaining = static_cast<double>(occs_per_l(l));
+            for (int i = 0; i < norb && remaining > 0; ++i) {
+              const double take = std::min<double>(per_orb, remaining);
+              occ_vec(i) = take;
+              remaining -= take;
+            }
+            Pcube_out.slice(l) = orb_l * arma::diagmat(occ_vec) * arma::trans(orb_l);
+          }
+        };
+
+        build_cube(result.orbs_a, result.occs_a, result.Pl_a);
+        arma::mat Prad_arma = arma::zeros(Nrad, Nrad);
+        for (size_t l = 0; l < nblock; ++l)
+          Prad_arma += result.Pl_a.slice(l);
+        if (!restricted) {
+          build_cube(result.orbs_b, result.occs_b, result.Pl_b);
+          for (size_t l = 0; l < nblock; ++l)
+            Prad_arma += result.Pl_b.slice(l);
+        }
+        result.Prad = helfem::to_eigen(Prad_arma);
+
         // --save path: write basis-defining params + per-l AO density
         // cube(s) + per-l electron counts. Rebuilding a matching basis
         // needs (Z, lmax, bval); the density cube is used by --load.
@@ -426,34 +468,7 @@ namespace helfem {
             savechk.write("sadatom_bval", bval_col);
           }
 
-          auto build_cube = [&](const arma::cube & orbs_ao, const arma::ivec & occs_per_l,
-                                 arma::cube & Pcube_out) {
-            Pcube_out.zeros(Nrad, Nrad, nblock);
-            for (size_t l = 0; l < nblock; ++l) {
-              if (occs_per_l(l) <= 0) continue;
-              // For an integer per-l total N in a manifold of capacity
-              // 2*(2l+1) restricted or (2l+1) unrestricted, split
-              // evenly across the N/max_orb lowest orbitals.
-              const arma::mat orb_l = arma::mat(orbs_ao.slice(l));
-              const int norb = orb_l.n_cols;
-              const double per_orb = (restricted ? 2.0 * (2 * l + 1) : 2.0 * l + 1);
-              // AO density with occupations set: pick occs from OOO
-              // internal (they are what's converged). For simplicity
-              // fall back to a diagonal-per-orbital occupation of
-              // occs_per_l(l) / norb capped at per_orb.
-              arma::vec occ_vec(norb, arma::fill::zeros);
-              double remaining = static_cast<double>(occs_per_l(l));
-              for (int i = 0; i < norb && remaining > 0; ++i) {
-                const double take = std::min<double>(per_orb, remaining);
-                occ_vec(i) = take;
-                remaining -= take;
-              }
-              Pcube_out.slice(l) = orb_l * arma::diagmat(occ_vec) * arma::trans(orb_l);
-            }
-          };
-
-          arma::cube Pal_out;
-          build_cube(result.orbs_a, result.occs_a, Pal_out);
+          const arma::cube & Pal_out = result.Pl_a;
           for (size_t l = 0; l < nblock; ++l)
             savechk.write(std::string("sadatom_Pal_") + std::to_string(l),
                           arma::mat(Pal_out.slice(l)));
@@ -463,8 +478,7 @@ namespace helfem {
             savechk.write("sadatom_occs_a", oa);
           }
           if (!restricted) {
-            arma::cube Pbl_out;
-            build_cube(result.orbs_b, result.occs_b, Pbl_out);
+            const arma::cube & Pbl_out = result.Pl_b;
             for (size_t l = 0; l < nblock; ++l)
               savechk.write(std::string("sadatom_Pbl_") + std::to_string(l),
                             arma::mat(Pbl_out.slice(l)));

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -86,6 +86,18 @@ namespace helfem {
         /// Beta channel (empty for restricted).
         arma::cube orbs_b;
         arma::ivec occs_b;
+        /// Converged total radial density matrix (alpha+beta),
+        /// Nrad x Nrad. Consumed by the gensap effective-potential /
+        /// SAP-table output path (basis::coulomb_screening /
+        /// xc_screening / electron_density).
+        helfem::Matrix Prad;
+        /// Per-l radial density cubes. Pl_a.slice(l) is the l-channel
+        /// density; for restricted it holds the full per-l density
+        /// (alpha+beta), for unrestricted it is the alpha channel and
+        /// Pl_b the beta channel (empty for restricted). Used for the
+        /// kinetic-energy-density (tau) column of the SAP table.
+        arma::cube Pl_a;
+        arma::cube Pl_b;
       };
 
       /// Run an OOO-based sadatom SCF. Replaces the bespoke SCFSolver


### PR DESCRIPTION
## What

Restores `gensap`'s namesake capability — generating the radial **SAP effective-charge table** `Zeff(r) = Z − r·(V_Hartree + V_xc)` that `src/general/sap.cpp` is built from. This is the functionality flagged in the driver audit: the OOO `gensap` could run the SCF but no longer emit the SAP data.

## Why it was lost

- The old driver produced `result_<El>.dat` via `SCFSolver::{Restricted,Unrestricted}Potential`, in `solver.cpp` — deleted with the bespoke solver at `a1a43c2`.
- The radial screening/density surface those relied on (`coulomb_screening`, `xc_screening`, `electron_density{,_gradient,_laplacian}`, `kinetic_energy_density`, `radii`, `quadrature_weights`, …) was deleted from `basis.cpp` at `5e0e3c9`, plus `nuclear_density` at `e27a2aa`.

With all of it gone, the `--pot`/`--savepot`/`--saveorb`/`--saveing` flags and the SAP-table output were absent.

## How

- **`basis.cpp/h`** — un-delete the radial analysis/screening surface (the `5e0e3c9` block + `nuclear_density{,_gradient}`) against the current Eigen-typed radial API. Only new include is `dftfuncs.h` (`is_gga_mgga`); the `FEMRadialBasis` primitives it rests on are unchanged.
- **`scf.h/cpp`** — expose the converged density on `AtomicSCFResult` (total `Prad` + per-l cubes `Pl_a`/`Pl_b`) by lifting the existing `build_cube` reconstruction out of the `--save` block so it always runs. Checkpoint output reuses it, unchanged.
- **`main.cpp`** — `--pot` / `--savepot` / `--saveing` flags + the effective-potential assembler. With a functional active it writes the 9-column `result_<El>.dat` (`r, rho, grad, lapl, tau, v_coul, v_xc, wt, Zeff`), matching the bespoke driver. MGGA / range-separated potentials throw, as before.

## Validation — regenerated tables reproduce `sap_effective_charge` in `sap.cpp`

Both LDA exchange-only (the level `sap.cpp` was generated at):

| Atom | Energy | N (quadrature) | Zeff check |
|---|---|---|---|
| He (restricted) | −2.7236397926 | 2.0 | r≈0.5: **1.1315** vs tab **1.1300**; r≈4: **0.1174** vs **0.1187** |
| Li (unrestricted) | −7.1934018521 | 3.0 | r≈1.0: **1.1463** vs tab **1.1456** |

Both: `Zeff(0)=Z`, tail → 0 (neutral atom fully screened). Residuals are the nearest-r interpolation offset.

Part of the driver functionality audit (task #24). Companion to #214 (diatomic finite nucleus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)