### PR TITLE
src/sadatom: restore gensap --iguess and --occs

### DIFF
--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -30,6 +30,8 @@
 #include <ArmaEigen.h>
 #include <iostream>
 #include <sstream>
+#include <algorithm>
+#include <vector>
 
 using namespace helfem;
 
@@ -120,6 +122,9 @@ int main(int argc, char **argv) {
   parser.add<double>("conf_barrier", 0, "Confinement barrier height",        false, 0.0);
   parser.add<double>("shift_conf",   0, "Where does confinement start?",     false, 0.0);
   parser.add<bool>  ("add_conf",     0, "Add element boundary at shifted confinement radius?", false, true);
+
+  parser.add<int>("iguess", 0, "initial guess: 0 core Hamiltonian, 1 GSZ, 2 SAP, 3 Thomas-Fermi", false, 2);
+  parser.add<std::string>("occs", 0, "occupations: 'auto' (Aufbau), or space-separated per-l counts (lmax+1 totals; unrestricted also accepts 2*(lmax+1) as alpha then beta)", false, "auto");
 
   parser.add<std::string>("load", 0, "load orbital guess from checkpoint file", false, "");
   parser.add<std::string>("save", 0, "save results to checkpoint file",       false, "");
@@ -223,8 +228,58 @@ int main(int argc, char **argv) {
   opts.conf_barrier = conf_barrier;
   opts.shift_conf   = shift_conf;
   opts.verbosity    = 5;
+  opts.iguess       = parser.get<int>("iguess");
   opts.load_file    = parser.get<std::string>("load");
   opts.save_file    = parser.get<std::string>("save");
+
+  // Explicit occupations. "auto" leaves OOO to fill by Aufbau. Otherwise
+  // parse space-separated per-l integer counts and pin them via the
+  // frozen-occupation API (opts.fixed_per_l_*). Restricted expects
+  // lmax+1 per-l totals; unrestricted accepts lmax+1 totals (Hund
+  // high-spin split into alpha/beta) or 2*(lmax+1) explicit alpha-then-
+  // beta counts.
+  {
+    const std::string occstr = parser.get<std::string>("occs");
+    if (occstr != "auto" && occstr != "AUTO" && occstr != "Auto") {
+      std::istringstream iss(occstr);
+      std::vector<int> vals; int v;
+      while (iss >> v) vals.push_back(v);
+      const int nl = lmax + 1;
+      auto to_ivec = [](const std::vector<int> & x) {
+        arma::ivec o(x.size());
+        for (size_t i = 0; i < x.size(); ++i) o(i) = x[i];
+        return o;
+      };
+      if (restricted) {
+        if ((int) vals.size() != nl)
+          throw std::logic_error("Restricted --occs needs lmax+1 per-l totals.\n");
+        opts.fixed_per_l_a = to_ivec(vals);
+      } else if ((int) vals.size() == nl) {
+        // Hund high-spin split of each per-l total across n-shells: fill
+        // shells of capacity 2*(2l+1), putting up to (2l+1) per shell in
+        // alpha before beta (matches the bespoke driver's hund_rule).
+        arma::ivec a(nl, arma::fill::zeros), b(nl, arma::fill::zeros);
+        for (int l = 0; l < nl; ++l) {
+          int numel = vals[l];
+          while (numel > 0) {
+            const int numsh = std::min(numel, 2 * (2 * l + 1));
+            const int na    = std::min(numsh, 2 * l + 1);
+            a(l) += na;
+            b(l) += numsh - na;
+            numel -= numsh;
+          }
+        }
+        opts.fixed_per_l_a = a;
+        opts.fixed_per_l_b = b;
+      } else if ((int) vals.size() == 2 * nl) {
+        opts.fixed_per_l_a = to_ivec(std::vector<int>(vals.begin(), vals.begin() + nl));
+        opts.fixed_per_l_b = to_ivec(std::vector<int>(vals.begin() + nl, vals.end()));
+      } else {
+        throw std::logic_error("Unrestricted --occs needs lmax+1 totals or 2*(lmax+1) alpha/beta counts.\n");
+      }
+      printf("Using explicit occupations from --occs.\n");
+    }
+  }
 
   sadatom::scf::AtomicSCFResult result = sadatom::scf::run_atomic_scf(opts);
 

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -210,10 +210,29 @@ namespace helfem {
           return std::make_pair(Etot, fock);
         };
 
+        // Initial-guess electron-nuclear potential. iguess 0 uses the
+        // bare nuclear attraction (core-Hamiltonian guess); 1/2/3 use a
+        // GSZ / SAP / Thomas-Fermi screened-nucleus model potential,
+        // which typically converges materially faster. Only the guess
+        // Fock matrix is affected -- the SCF Fock build above always
+        // uses the true Vnuc.
+        helfem::Matrix Vguess = Vnuc;
+        if (opts.iguess != 0) {
+          modelpotential::ModelPotential * model = nullptr;
+          switch (opts.iguess) {
+          case 1: model = new modelpotential::GSZAtom(opts.Z); break;
+          case 2: model = new modelpotential::SAPAtom(opts.Z); break;
+          case 3: model = new modelpotential::TFAtom(opts.Z);  break;
+          default: throw std::logic_error("Unsupported iguess value (expected 0..3).\n");
+          }
+          Vguess = basis.model_potential(model);
+          delete model;
+        }
+
         OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH(nblock * nparttype);
         for (size_t t = 0; t < nparttype; ++t) {
           for (size_t l = 0; l < nblock; ++l) {
-            helfem::Matrix Hl = T + Vnuc;
+            helfem::Matrix Hl = T + Vguess;
             if (have_conf) Hl += Vconf;
             if (l > 0) Hl += l * (l + 1) * Tl;
             CoreH[t * nblock + l] = Sinvh.transpose() * Hl * Sinvh;

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -41,6 +41,12 @@ namespace helfem {
         helfem::Vector x_pars;
         helfem::Vector c_pars;
         double dftthr     = 1e-12;
+        /// Initial-guess electron-nuclear potential: 0 core Hamiltonian
+        /// (bare Vnuc), 1 GSZ, 2 SAP, 3 Thomas-Fermi. Affects only the
+        /// starting Fock matrix; the SCF Fock build always uses the true
+        /// nuclear attraction. Default 0 so the twodquadrature sub-SCF
+        /// keeps its core-Hamiltonian guess; the gensap CLI defaults to 2.
+        int    iguess     = 0;
         modelpotential::nuclear_model_t finitenuc = modelpotential::POINT_NUCLEUS;
         double Rrms       = 0.0;
         bool   zeroder    = false;


### PR DESCRIPTION
## What

Two more bespoke-`gensap` input controls the OOO rewrite dropped (bucket 4 of the driver audit).

### `--iguess` (0 core-H, 1 GSZ, 2 SAP, 3 Thomas-Fermi; CLI default 2, as before)
Selects the initial-guess electron-nuclear potential. Builds a model-potential guess Fock matrix via `basis.model_potential()`; **only the guess is affected** — the SCF Fock build still uses the true `Vnuc`. The `AtomicSCFOptions` struct default stays `0`, so the `twodquadrature` sub-SCF keeps its core-Hamiltonian guess unchanged.

### `--occs` (`auto` = Aufbau, or space-separated per-l counts)
Pins occupations via the existing OOO `fixed_number_of_particles_per_block` path (`opts.fixed_per_l_*`). Restricted takes `lmax+1` per-l totals; unrestricted takes `lmax+1` totals (Hund high-spin split across n-shells, replicating the bespoke `hund_rule`) or `2*(lmax+1)` explicit alpha/beta counts. `hf` (Saito 2009 table) is **not** restored — it needs the deleted `configurations.cpp`.

## Validation (lda_x)

- **iguess invariance**: He converges to −2.7236397926 from both core-H (`0`) and SAP (`2`) guesses.
- **occs restricted**: Be forced 1s²2p² (`--occs "2 2"`) → −13.9694886789 vs the 1s²2s² ground state −14.2232908267.
- **occs unrestricted Hund split**: N (`--occs "4 3"`) reproduces the Aufbau ground state −53.7092762871 exactly (α=(2,3), β=(2,0)) — this caught and fixed an initial wrong split (`min(n,2l+1)`) that ignored multi-shell filling.

Follows #214, #215, #216. Independent of #216 (touches disjoint code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)