### PR TITLE
src/diatomic: restore --angstrom (input Rbond in angstrom)

### DIFF
--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -59,6 +59,7 @@ int main(int argc, char **argv) {
   parser.add<std::string>("Z1", 0, "first nuclear charge", true);
   parser.add<std::string>("Z2", 0, "second nuclear charge", true);
   parser.add<double>("Rbond", 0, "internuclear distance", true);
+  parser.add<bool>("angstrom", 0, "input Rbond in angstrom instead of bohr", false, false);
   parser.add<int>("Q", 0, "charge state", false, 0);
   parser.add<int>("M", 0, "spin multiplicity (2S+1); mutually exclusive with nela/nelb", false, 0);
   parser.add<int>("nela", 0, "number of alpha electrons (leave 0 to derive from Q/M)", false, 0);
@@ -114,7 +115,11 @@ int main(int argc, char **argv) {
 
   const int Z1        = get_Z(parser.get<std::string>("Z1"));
   const int Z2        = get_Z(parser.get<std::string>("Z2"));
-  const double Rbond  = parser.get<double>("Rbond");
+        double Rbond  = parser.get<double>("Rbond");
+  if (parser.get<bool>("angstrom")) {
+    printf("Converting Rbond from %g angstrom to %g bohr.\n", Rbond, Rbond * ANGSTROMINBOHR);
+    Rbond *= ANGSTROMINBOHR;
+  }
         int Q         = parser.get<int>("Q");
         int M         = parser.get<int>("M");
         int nela      = parser.get<int>("nela");


### PR DESCRIPTION
## What

Restores `--angstrom` to the `diatomic` driver — bond length input in ångström instead of bohr. When set, `Rbond` is multiplied by `ANGSTROMINBOHR` before use (conversion echoed to stdout).

## Scope

Only diatomic. The bespoke **atomic** `--angstrom` converted the off-centre `Rmid`/`Rhalf`, which the OOO atomic driver no longer exposes (`Zl=Zr=0` hardcoded, no physical geometry input) — so there is nothing there for it to act on.

## Validation (H₂, lda_x)

`--Rbond=0.740882 --angstrom=1` → converts to 1.40006 bohr → **−1.0161283716**, matching `--Rbond=1.4` bohr (**−1.0161291084**) to the 6×10⁻⁵ bohr geometry difference.

Bucket 4 of the driver audit. Follows #214–#217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)