### PR TITLE
src/general/scf_driver_common + drivers: migrate SCF-driver glue to Eigen

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -273,25 +273,25 @@ int main(int argc, char **argv) {
   printf("Mode: %s, symmetry=%d, nela=%d nelb=%d\n",
           restricted ? "restricted" : "unrestricted", symm, nela, nelb);
 
-  // --- One-electron + overlap in arma (chemistry-layer buffers stay arma).
-  const arma::mat S    = helfem::to_arma(basis.overlap());
-  const arma::mat T    = helfem::to_arma(basis.kinetic());
-  const arma::mat Vnuc = helfem::to_arma(basis.nuclear());
+  // --- One-electron + overlap (basis returns helfem::Matrix directly).
+  const helfem::Matrix S    = basis.overlap();
+  const helfem::Matrix T    = basis.kinetic();
+  const helfem::Matrix Vnuc = basis.nuclear();
 
   // --- External static-field one-electron matrices. All four are added
   //     into H0 (and hence into every Fock build), and their trace
   //     contribution is broken out in the energy print for parity with
   //     the bespoke atomic driver. Left as zeros when the corresponding
   //     coupling is off, so the additions cost nothing but a trace pass.
-  arma::mat Vconf(Nbf, Nbf, arma::fill::zeros);
+  helfem::Matrix Vconf = helfem::Matrix::Zero(Nbf, Nbf);
   if (iconf) {
     printf("Computing confinement potential\n");
-    Vconf = helfem::to_arma(basis.confinement(conf_N, conf_R, iconf, conf_barrier, shift_conf));
+    Vconf = basis.confinement(conf_N, conf_R, iconf, conf_barrier, shift_conf);
   }
-  const arma::mat dip  = helfem::to_arma(basis.dipole_z());
-  const arma::mat quad = helfem::to_arma(basis.quadrupole_zz());
-  const arma::mat Vel  = Ez * dip + Qzz * quad / 3.0;
-  const arma::mat Vmag = helfem::to_arma(basis.Bz_field(Bz));
+  const helfem::Matrix dip  = basis.dipole_z();
+  const helfem::Matrix quad = basis.quadrupole_zz();
+  const helfem::Matrix Vel  = Ez * dip + Qzz * quad / 3.0;
+  const helfem::Matrix Vmag = basis.Bz_field(Bz);
   const bool have_efield = (Ez != 0.0 || Qzz != 0.0);
   const bool have_bfield = (Bz != 0.0);
   const bool have_conf   = (iconf != 0);
@@ -336,7 +336,7 @@ int main(int argc, char **argv) {
   const size_t nsym = dsym.size();
 
   // Per-block Sinvh_k = symmetric orthonormalization of S(dsym[k], dsym[k]).
-  const std::vector<arma::mat> Sinvh_arma =
+  const std::vector<helfem::Matrix> Sinvh =
       helfem::scf_driver::build_per_block_Sinvh(S, dsym);
 
   const int ldft = ldft_arg > 0 ? ldft_arg : 4 * lmax + 12;
@@ -364,18 +364,18 @@ int main(int argc, char **argv) {
   // Accumulate a per-block density (C_k * diag(occ_k) * C_k^T) into the
   // full-Nbf density matrix P_full through the block's basis-function
   // scatter index dsym[k].
-  auto accumulate_density = [&](arma::mat & P_full, size_t k,
+  auto accumulate_density = [&](helfem::Matrix & P_full, size_t k,
                                  const helfem::Matrix & orb_e,
                                  const helfem::Vector & occ_e) {
     helfem::scf_driver::accumulate_density_block<OOO_Real>(
-        P_full, dsym, k, Sinvh_arma, orb_e, occ_e);
+        P_full, dsym, k, Sinvh, orb_e, occ_e);
   };
 
   auto orthonormalize_block =
       [&](OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock, size_t b,
-          const arma::mat & F_full, size_t k) {
+          const helfem::Matrix & F_full, size_t k) {
     helfem::scf_driver::orthonormalize_fock_block<OOO_Real>(
-        fock, b, dsym, k, Sinvh_arma, F_full);
+        fock, b, dsym, k, Sinvh, F_full);
   };
 
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
@@ -387,56 +387,51 @@ int main(int argc, char **argv) {
     //     channel with max_occ = 2, so P comes straight from the alpha
     //     channel; no Pa/Pb split, no *0.5 double-scatter, no unused Pb.
     OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
-    arma::mat P(Nbf, Nbf, arma::fill::zeros);
+    helfem::Matrix P = helfem::Matrix::Zero(Nbf, Nbf);
     // Spin-density buffers used for both the XC branch and the HF
     // exchange branch; for restricted the alpha density is 0.5 * P.
-    arma::mat Pa, Pb;
+    helfem::Matrix Pa, Pb;
     double Exc = 0.0;
     double nelnum = 0.0, ekin_grid = 0.0;
-    arma::mat XCa, XCb;
+    helfem::Matrix XCa, XCb;
 
-    // grid.eval_Fxc takes/returns Eigen at its public boundary; bridge the
-    // arma-native driver density into it and the XC potential back out.
+    // grid.eval_Fxc takes/returns Eigen at its public boundary; the driver
+    // density is now Eigen-native, so pass it straight through.
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
       if (have_xc) {
-        helfem::Matrix XCa_e;
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(P), XCa_e,
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa,
                        Exc, nelnum, ekin_grid, dftthr);
-        XCa = helfem::to_arma(XCa_e);
       }
       if (have_exx) Pa = 0.5 * P;
     } else {
-      Pa.zeros(Nbf, Nbf);
-      Pb.zeros(Nbf, Nbf);
+      Pa = helfem::Matrix::Zero(Nbf, Nbf);
+      Pb = helfem::Matrix::Zero(Nbf, Nbf);
       for (size_t k = 0; k < nsym; ++k) {
         accumulate_density(Pa, k, orbitals[k],        occupations[k]);
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
       if (have_xc) {
-        helfem::Matrix XCa_e, XCb_e;
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(Pa), helfem::to_eigen(Pb),
-                       XCa_e, XCb_e, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
-        XCa = helfem::to_arma(XCa_e);
-        XCb = helfem::to_arma(XCb_e);
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb,
+                       XCa, XCb, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
       }
     }
 
-    const double Ekin = arma::trace(P * T);
-    const double Enuc = arma::trace(P * Vnuc);
+    const double Ekin = (P * T).trace();
+    const double Enuc = (P * Vnuc).trace();
     // External-field contributions. Vel/Vmag/Vconf are zero matrices when
     // the corresponding coupling is disabled, so the traces cost O(Nbf).
     // The -Bz/2 * (nela-nelb) piece is the Ms.Bz spin-Zeeman term:
     // restricted mode has nela == nelb so it vanishes there.
-    const double Eefield = have_efield ? arma::trace(P * Vel)  : 0.0;
+    const double Eefield = have_efield ? (P * Vel).trace()  : 0.0;
     const double Emfield = have_bfield
-        ? arma::trace(P * Vmag) - 0.5 * Bz * (nela - nelb) : 0.0;
-    const double Econf   = have_conf   ? arma::trace(P * Vconf) : 0.0;
+        ? (P * Vmag).trace() - 0.5 * Bz * (nela - nelb) : 0.0;
+    const double Econf   = have_conf   ? (P * Vconf).trace() : 0.0;
 
-    const arma::mat J = helfem::to_arma(basis.coulomb(helfem::to_eigen(P)));
-    const double Ecoul = 0.5 * arma::trace(P * J);
+    const helfem::Matrix J = basis.coulomb(P);
+    const double Ecoul = 0.5 * (P * J).trace();
 
     // --- HF exchange: K = kfrac * basis.exchange(P) + kshort * basis.rs_exchange(P).
     //     Sign convention is baked into basis.exchange (it returns the
@@ -448,13 +443,13 @@ int main(int argc, char **argv) {
     // Atomic exchange kernel: kfrac * K + kshort * K_rs. Empty
     // branches contribute zero, so RS hybrids and plain hybrids all
     // flow through the same builder.
-    auto exchange_fn = [&](const arma::mat & P) {
-      arma::mat K(Nbf, Nbf, arma::fill::zeros);
-      if (kfrac  != 0.0) K += kfrac  * helfem::to_arma(basis.exchange(helfem::to_eigen(P)));
-      if (kshort != 0.0) K += kshort * helfem::to_arma(basis.rs_exchange(helfem::to_eigen(P)));
+    auto exchange_fn = [&](const helfem::Matrix & P) {
+      helfem::Matrix K = helfem::Matrix::Zero(Nbf, Nbf);
+      if (kfrac  != 0.0) K += kfrac  * basis.exchange(P);
+      if (kshort != 0.0) K += kshort * basis.rs_exchange(P);
       return K;
     };
-    arma::mat Ka, Kb;
+    helfem::Matrix Ka, Kb;
     double Exx = 0.0;
     helfem::scf_driver::assemble_hf_exchange(
         Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
@@ -476,11 +471,11 @@ int main(int argc, char **argv) {
     // Pre-assembled 1-electron core matrix. Vel/Vmag/Vconf are zero when
     // their coupling is off so this is unchanged from H0 = T + Vnuc in
     // the no-field case.
-    const arma::mat H1 = T + Vnuc + Vel + Vmag + Vconf;
+    const helfem::Matrix H1 = T + Vnuc + Vel + Vmag + Vconf;
     // Apply the maverage post-processor once per channel; noop otherwise.
-    auto apply_mavg = [&](arma::mat & F) {
+    auto apply_mavg = [&](helfem::Matrix & F) {
       if (maverage)
-        F = helfem::to_arma(scf::fock_symmetry_average(helfem::to_eigen(F), l_idx));
+        F = scf::fock_symmetry_average(F, l_idx);
     };
     helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
         fock, H1, J, XCa, XCb, Ka, Kb, S,
@@ -497,7 +492,7 @@ int main(int argc, char **argv) {
   //   1..3 model potential (GSZ / SAP / Thomas-Fermi) instead of Vnuc.
   //     Restores the bespoke-atomic guess menu; SAP is the default
   //     because it typically converges materially faster than core-H.
-  arma::mat Vguess;
+  helfem::Matrix Vguess;
   if (iguess == 0) {
     printf("Guess orbitals from core Hamiltonian\n");
     Vguess = Vnuc;
@@ -519,13 +514,13 @@ int main(int argc, char **argv) {
     default:
       throw std::logic_error("Unsupported iguess value (expected 0..3).\n");
     }
-    Vguess = helfem::to_arma(basis.model_potential(model));
+    Vguess = basis.model_potential(model);
     delete model;
   }
-  const arma::mat H0 = T + Vguess + Vel + Vmag + Vconf;
+  const helfem::Matrix H0 = T + Vguess + Vel + Vmag + Vconf;
   const OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH =
       helfem::scf_driver::build_coreH_from_H0<OOO_Real>(
-          H0, S, dsym, Sinvh_arma, nparttype, have_bfield, Bz);
+          H0, S, dsym, Sinvh, nparttype, have_bfield, Bz);
 
   OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
       number_of_blocks_per_particle_type, maximum_occupation,
@@ -612,20 +607,21 @@ int main(int argc, char **argv) {
       throw std::logic_error("--load: checkpoint nela/nelb do not match current run.");
 
     // Cross-basis overlap S12 = <this | oldbasis>, shape (Nbf, Nbf_old).
-    const arma::mat S12         = helfem::to_arma(basis.overlap(oldbasis));
+    const helfem::Matrix S12         = basis.overlap(oldbasis);
     // Full-basis Sinvh (symmetric orthonormalisation, no per-symmetry
     // block). S^-1 = Sinvh * Sinvh^T since Sinvh = S^{-1/2}.
-    const arma::mat Sinvh_full  = helfem::to_arma(basis.Sinvh(/*chol*/false, /*sym*/0));
-    const arma::mat Pproj       = Sinvh_full * arma::trans(Sinvh_full) * S12;
+    const helfem::Matrix Sinvh_full  = basis.Sinvh(/*chol*/false, /*sym*/0);
+    const helfem::Matrix Pproj       = Sinvh_full * Sinvh_full.transpose() * S12;
 
     // Project the old AO densities to the current basis, then rescale
     // so the total trace P*S recovers the exact electron count (the
     // projection itself is not particle-conserving when the two bases
-    // do not span the same subspace).
-    arma::mat Pa_new = Pproj * Pa_old * arma::trans(Pproj);
-    arma::mat Pb_new = Pproj * Pb_old * arma::trans(Pproj);
-    const double na = arma::trace(Pa_new * S);
-    const double nb = arma::trace(Pb_new * S);
+    // do not span the same subspace). Pa_old/Pb_old came in via arma
+    // checkpoint I/O; bridge them into Eigen for the projection.
+    helfem::Matrix Pa_new = Pproj * helfem::to_eigen(Pa_old) * Pproj.transpose();
+    helfem::Matrix Pb_new = Pproj * helfem::to_eigen(Pb_old) * Pproj.transpose();
+    const double na = (Pa_new * S).trace();
+    const double nb = (Pb_new * S).trace();
     if (na > 0 && nela > 0) Pa_new *= static_cast<double>(nela) / na;
     if (nb > 0 && nelb > 0) Pb_new *= static_cast<double>(nelb) / nb;
 
@@ -642,16 +638,16 @@ int main(int argc, char **argv) {
     const double max_occ_open  = 1.0;
     if (restricted) {
       // Single channel: eigenvalues of total P should be in [0, 2].
-      const arma::mat P_total = Pa_new + Pb_new;
+      const helfem::Matrix P_total = Pa_new + Pb_new;
       for (size_t k = 0; k < nsym; ++k)
         helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh_arma[k], max_occ_restr);
+            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh[k], max_occ_restr);
     } else {
       for (size_t k = 0; k < nsym; ++k) {
         helfem::scf_driver::fill_block_from_density(
-            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh_arma[k], max_occ_open);
+            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh[k], max_occ_open);
         helfem::scf_driver::fill_block_from_density(
-            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh_arma[k], max_occ_open);
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh[k], max_occ_open);
       }
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);
@@ -670,11 +666,12 @@ int main(int argc, char **argv) {
     savechk.write(basis);
     const auto final_orbs = scfsolver.get_orbitals();
     const auto final_occs = scfsolver.get_orbital_occupations();
-    arma::mat Pa_final, Pb_final;
+    helfem::Matrix Pa_final, Pb_final;
     std::tie(Pa_final, Pb_final) = helfem::scf_driver::assemble_final_density<OOO_Real>(
-        Nbf, restricted, dsym, Sinvh_arma, final_orbs, final_occs);
-    savechk.write("Pa", Pa_final);
-    savechk.write("Pb", Pb_final);
+        Nbf, restricted, dsym, Sinvh, final_orbs, final_occs);
+    // Checkpoint I/O stays arma; bridge the Eigen densities out.
+    savechk.write("Pa", helfem::to_arma(Pa_final));
+    savechk.write("Pb", helfem::to_arma(Pb_final));
     savechk.write("nela", nela);
     savechk.write("nelb", nelb);
     printf("Saved results to %s\n", savefile.c_str());

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -233,18 +233,18 @@ int main(int argc, char **argv) {
   printf("Mode: %s, symmetry=%d, nela=%d nelb=%d\n",
           restricted ? "restricted" : "unrestricted", symm, nela, nelb);
 
-  // Diatomic chemistry-layer methods are still arma-native.
-  const arma::mat S    = helfem::to_arma(basis.overlap());
-  const arma::mat T    = helfem::to_arma(basis.kinetic());
+  // Diatomic chemistry-layer methods now return Eigen (helfem::Matrix).
+  const helfem::Matrix S    = basis.overlap();
+  const helfem::Matrix T    = basis.kinetic();
   // Nuclear attraction. Point nuclei use the exact analytic
   // prolate-spheroidal matrix; a finite nuclear model is evaluated on
   // the two-dimensional quadrature grid (same path the SAP guess uses),
   // one modelpotential::ModelPotential per nucleus. finitenuc indexes
   // modelpotential::nuclear_model_t directly (0 == point), matching the
   // atomic driver's convention.
-  arma::mat Vnuc;
+  helfem::Matrix Vnuc;
   if (finitenuc == 0) {
-    Vnuc = helfem::to_arma(basis.nuclear());
+    Vnuc = basis.nuclear();
   } else {
     modelpotential::ModelPotential *pot1 =
         modelpotential::get_nuclear_model((modelpotential::nuclear_model_t) finitenuc, Z1, Rrms1);
@@ -252,7 +252,8 @@ int main(int argc, char **argv) {
         modelpotential::get_nuclear_model((modelpotential::nuclear_model_t) finitenuc, Z2, Rrms2);
     const int lquad = 4 * arma::max(lmmax) + 12;
     helfem::diatomic::twodquad::TwoDGrid qgrid(&basis, lquad);
-    Vnuc = qgrid.model_potential(pot1, pot2);
+    // TwoDGrid::model_potential still returns arma::mat -> bridge to Eigen.
+    Vnuc = helfem::to_eigen(qgrid.model_potential(pot1, pot2));
     delete pot1;
     delete pot2;
     printf("Using finite nuclear model %d (Rrms1=%g, Rrms2=%g)\n", finitenuc, Rrms1, Rrms2);
@@ -265,10 +266,10 @@ int main(int argc, char **argv) {
   //   nucquad = (Z1 + Z2) * Rhalf^2
   //   Enucfield = -Ez * nucdip - Qzz * nucquad / 3
   // Vel/Vmag are the electron-side matrix contributions folded into H0.
-  const arma::mat dip  = helfem::to_arma(basis.dipole_z());
-  const arma::mat quad = helfem::to_arma(basis.quadrupole_zz());
-  const arma::mat Vel  = Ez * dip + Qzz * quad / 3.0;
-  const arma::mat Vmag = helfem::to_arma(basis.Bz_field(Bz));
+  const helfem::Matrix dip  = basis.dipole_z();
+  const helfem::Matrix quad = basis.quadrupole_zz();
+  const helfem::Matrix Vel  = Ez * dip + Qzz * quad / 3.0;
+  const helfem::Matrix Vmag = basis.Bz_field(Bz);
   const double nucdip  = (Z2 - Z1) * Rhalf;
   const double nucquad = (Z1 + Z2) * Rhalf * Rhalf;
   const double Enucfield = -Ez * nucdip - Qzz * nucquad / 3.0;
@@ -303,7 +304,7 @@ int main(int argc, char **argv) {
   const size_t nsym = dsym.size();
 
   // Per-block Sinvh_k.
-  const std::vector<arma::mat> Sinvh_arma =
+  const std::vector<helfem::Matrix> Sinvh =
       helfem::scf_driver::build_per_block_Sinvh(S, dsym);
 
   const int lang = ldft_arg > 0 ? ldft_arg : 4 * arma::max(lval) + 12;
@@ -326,18 +327,18 @@ int main(int argc, char **argv) {
 
   // Accumulate a per-block density into the full-Nbf density matrix
   // P_full through the block's basis-function scatter index dsym[k].
-  auto accumulate_density = [&](arma::mat & P_full, size_t k,
+  auto accumulate_density = [&](helfem::Matrix & P_full, size_t k,
                                  const helfem::Matrix & orb_e,
                                  const helfem::Vector & occ_e) {
     helfem::scf_driver::accumulate_density_block<OOO_Real>(
-        P_full, dsym, k, Sinvh_arma, orb_e, occ_e);
+        P_full, dsym, k, Sinvh, orb_e, occ_e);
   };
 
   auto orthonormalize_block =
       [&](OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock, size_t b,
-          const arma::mat & F_full, size_t k) {
+          const helfem::Matrix & F_full, size_t k) {
     helfem::scf_driver::orthonormalize_fock_block<OOO_Real>(
-        fock, b, dsym, k, Sinvh_arma, F_full);
+        fock, b, dsym, k, Sinvh, F_full);
   };
 
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
@@ -349,57 +350,50 @@ int main(int argc, char **argv) {
     // with max_occ = 2, so P comes straight from the alpha channel; no
     // Pa/Pb split, no *0.5 double-scatter.
     OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
-    arma::mat P(Nbf, Nbf, arma::fill::zeros);
-    arma::mat Pa, Pb;
+    helfem::Matrix P = helfem::Matrix::Zero(Nbf, Nbf);
+    helfem::Matrix Pa, Pb;
     double Exc = 0.0;
     double nelnum = 0.0, ekin_grid = 0.0;
-    arma::mat XCa, XCb;
+    helfem::Matrix XCa, XCb;
 
-    // grid.eval_Fxc takes/returns Eigen at its public boundary; bridge the
-    // arma-native driver density into it and the XC potential back out.
+    // grid.eval_Fxc takes/returns Eigen at its public boundary; densities
+    // and XC potentials are Eigen throughout, so no bridging is needed.
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
-      if (have_xc) {
-        helfem::Matrix XCa_e;
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(P), XCa_e,
+      if (have_xc)
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa,
                        Exc, nelnum, ekin_grid, dftthr);
-        XCa = helfem::to_arma(XCa_e);
-      }
       if (have_exx) Pa = 0.5 * P;
     } else {
-      Pa.zeros(Nbf, Nbf);
-      Pb.zeros(Nbf, Nbf);
+      Pa = helfem::Matrix::Zero(Nbf, Nbf);
+      Pb = helfem::Matrix::Zero(Nbf, Nbf);
       for (size_t k = 0; k < nsym; ++k) {
         accumulate_density(Pa, k, orbitals[k],        occupations[k]);
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
-      if (have_xc) {
-        helfem::Matrix XCa_e, XCb_e;
-        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, helfem::to_eigen(Pa), helfem::to_eigen(Pb),
-                       XCa_e, XCb_e, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
-        XCa = helfem::to_arma(XCa_e);
-        XCb = helfem::to_arma(XCb_e);
-      }
+      if (have_xc)
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb,
+                       XCa, XCb, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
     }
 
-    const double Ekin = arma::trace(P * T);
-    const double Enuc = arma::trace(P * Vnuc);
+    const double Ekin = (P * T).trace();
+    const double Enuc = (P * Vnuc).trace();
     // External-field trace contributions. Vel/Vmag are zero when their
     // coupling is off; Enucfield is a scalar independent of the density.
-    const double Eefield = have_efield ? arma::trace(P * Vel) + Enucfield : 0.0;
+    const double Eefield = have_efield ? (P * Vel).trace() + Enucfield : 0.0;
     const double Emfield = have_bfield
-        ? arma::trace(P * Vmag) - 0.5 * Bz * (nela - nelb) : 0.0;
+        ? (P * Vmag).trace() - 0.5 * Bz * (nela - nelb) : 0.0;
 
-    const arma::mat J = helfem::to_arma(basis.coulomb(helfem::to_eigen(P)));
-    const double Ecoul = 0.5 * arma::trace(P * J);
+    const helfem::Matrix J = basis.coulomb(P);
+    const double Ecoul = 0.5 * (P * J).trace();
 
     // Diatomic exchange kernel: pure Coulomb K (no RS split yet).
-    auto exchange_fn = [&](const arma::mat & P) {
-      return arma::mat(kfrac * helfem::to_arma(basis.exchange(helfem::to_eigen(P))));
+    auto exchange_fn = [&](const helfem::Matrix & P) {
+      return helfem::Matrix(kfrac * basis.exchange(P));
     };
-    arma::mat Ka, Kb;
+    helfem::Matrix Ka, Kb;
     double Exx = 0.0;
     helfem::scf_driver::assemble_hf_exchange(
         Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
@@ -419,10 +413,10 @@ int main(int argc, char **argv) {
     // Pre-assembled 1-electron core. Vel/Vmag are zero matrices when
     // their coupling is off so this matches T + Vnuc + J exactly in the
     // no-field case.
-    const arma::mat H1 = T + Vnuc + Vel + Vmag;
-    auto apply_mavg = [&](arma::mat & F) {
+    const helfem::Matrix H1 = T + Vnuc + Vel + Vmag;
+    auto apply_mavg = [&](helfem::Matrix & F) {
       if (maverage)
-        F = helfem::to_arma(scf::fock_symmetry_average(helfem::to_eigen(F), mavg_idx));
+        F = scf::fock_symmetry_average(F, mavg_idx);
     };
     helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
         fock, H1, J, XCa, XCb, Ka, Kb, S,
@@ -439,7 +433,7 @@ int main(int argc, char **argv) {
   //     instead of Vnuc. Matches the bespoke-diatomic guess menu; SAP
   //     is the default because it typically converges materially
   //     faster than core-H.
-  arma::mat Vguess;
+  helfem::Matrix Vguess;
   if (iguess == 0) {
     printf("Guess orbitals from core Hamiltonian\n");
     Vguess = Vnuc;
@@ -466,14 +460,15 @@ int main(int argc, char **argv) {
     }
     const int lquad = 4 * arma::max(lmmax) + 12;
     helfem::diatomic::twodquad::TwoDGrid qgrid(&basis, lquad);
-    Vguess = qgrid.model_potential(p1, p2);
+    // TwoDGrid::model_potential still returns arma::mat -> bridge to Eigen.
+    Vguess = helfem::to_eigen(qgrid.model_potential(p1, p2));
     delete p1;
     delete p2;
   }
-  const arma::mat H0 = T + Vguess + Vel + Vmag;
+  const helfem::Matrix H0 = T + Vguess + Vel + Vmag;
   const OpenOrbitalOptimizer::FockMatrix<OOO_Real> CoreH =
       helfem::scf_driver::build_coreH_from_H0<OOO_Real>(
-          H0, S, dsym, Sinvh_arma, nparttype, have_bfield, Bz);
+          H0, S, dsym, Sinvh, nparttype, have_bfield, Bz);
 
   OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
       number_of_blocks_per_particle_type, maximum_occupation,
@@ -546,23 +541,24 @@ int main(int argc, char **argv) {
     Checkpoint loadchk(loadfile, /*writemode=*/false);
     diatomic::basis::TwoDBasis oldbasis;
     loadchk.read(oldbasis);
-    arma::mat Pa_old, Pb_old;
-    loadchk.read("Pa", Pa_old);
-    loadchk.read("Pb", Pb_old);
+    // Checkpoint I/O is arma-native -> read into arma, bridge to Eigen.
+    arma::mat Pa_old_arma, Pb_old_arma;
+    loadchk.read("Pa", Pa_old_arma);
+    loadchk.read("Pb", Pb_old_arma);
     int nela_old = 0, nelb_old = 0;
     loadchk.read("nela", nela_old);
     loadchk.read("nelb", nelb_old);
     if (nela_old != nela || nelb_old != nelb)
       throw std::logic_error("--load: checkpoint nela/nelb do not match current run.");
 
-    const arma::mat S12         = helfem::to_arma(basis.overlap(oldbasis));
-    const arma::mat Sinvh_full  = helfem::to_arma(basis.Sinvh(/*chol*/false, /*sym*/0));
-    const arma::mat Pproj       = Sinvh_full * arma::trans(Sinvh_full) * S12;
+    const helfem::Matrix S12         = basis.overlap(oldbasis);
+    const helfem::Matrix Sinvh_full  = basis.Sinvh(/*chol*/false, /*sym*/0);
+    const helfem::Matrix Pproj       = Sinvh_full * Sinvh_full.transpose() * S12;
 
-    arma::mat Pa_new = Pproj * Pa_old * arma::trans(Pproj);
-    arma::mat Pb_new = Pproj * Pb_old * arma::trans(Pproj);
-    const double na = arma::trace(Pa_new * S);
-    const double nb = arma::trace(Pb_new * S);
+    helfem::Matrix Pa_new = Pproj * helfem::to_eigen(Pa_old_arma) * Pproj.transpose();
+    helfem::Matrix Pb_new = Pproj * helfem::to_eigen(Pb_old_arma) * Pproj.transpose();
+    const double na = (Pa_new * S).trace();
+    const double nb = (Pb_new * S).trace();
     if (na > 0 && nela > 0) Pa_new *= static_cast<double>(nela) / na;
     if (nb > 0 && nelb > 0) Pb_new *= static_cast<double>(nelb) / nb;
 
@@ -571,16 +567,16 @@ int main(int argc, char **argv) {
     const double max_occ_restr = 2.0;
     const double max_occ_open  = 1.0;
     if (restricted) {
-      const arma::mat P_total = Pa_new + Pb_new;
+      const helfem::Matrix P_total = Pa_new + Pb_new;
       for (size_t k = 0; k < nsym; ++k)
         helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh_arma[k], max_occ_restr);
+            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh[k], max_occ_restr);
     } else {
       for (size_t k = 0; k < nsym; ++k) {
         helfem::scf_driver::fill_block_from_density(
-            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh_arma[k], max_occ_open);
+            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh[k], max_occ_open);
         helfem::scf_driver::fill_block_from_density(
-            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh_arma[k], max_occ_open);
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh[k], max_occ_open);
       }
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);
@@ -595,11 +591,12 @@ int main(int argc, char **argv) {
     savechk.write(basis);
     const auto final_orbs = scfsolver.get_orbitals();
     const auto final_occs = scfsolver.get_orbital_occupations();
-    arma::mat Pa_final, Pb_final;
+    helfem::Matrix Pa_final, Pb_final;
     std::tie(Pa_final, Pb_final) = helfem::scf_driver::assemble_final_density<OOO_Real>(
-        Nbf, restricted, dsym, Sinvh_arma, final_orbs, final_occs);
-    savechk.write("Pa", Pa_final);
-    savechk.write("Pb", Pb_final);
+        Nbf, restricted, dsym, Sinvh, final_orbs, final_occs);
+    // Checkpoint I/O is arma-native -> bridge the Eigen densities back.
+    savechk.write("Pa", helfem::to_arma(Pa_final));
+    savechk.write("Pb", helfem::to_arma(Pb_final));
     savechk.write("nela", nela);
     savechk.write("nelb", nelb);
     // Extra parameters needed by density_line / density_grid / completeness.

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -19,8 +19,18 @@
 // drivers. Both driver bodies used to keep byte-identical copies of
 // these routines; extracted here so bug fixes only need to happen in
 // one place.
+//
+// The linear algebra is Eigen-native (helfem::Matrix / helfem::Vector);
+// the per-symmetry-block gather/scatter uses the arma::uvec index lists
+// the basis get_sym_idx returns, converted to Eigen index vectors once
+// per use. Keeping the working matrices Eigen (rather than arma/LAPACK)
+// is what lets the SCF driver be instantiated at extended precision --
+// Eigen's SelfAdjointEigenSolver is scalar-generic where arma::eig_sym
+// is LAPACK/double-only.
 
 #include <armadillo>
+#include <Eigen/Eigenvalues>
+#include <algorithm>
 #include <cstdio>
 #include <stdexcept>
 #include <utility>
@@ -32,18 +42,28 @@
 namespace helfem {
   namespace scf_driver {
 
+    /// Convert an arma::uvec index list (from basis get_sym_idx) into an
+    /// Eigen index vector usable in Eigen 3.4 indexed views.
+    inline std::vector<Eigen::Index> to_idx(const arma::uvec & u) {
+      std::vector<Eigen::Index> idx(u.n_elem);
+      for (arma::uword i = 0; i < u.n_elem; ++i)
+        idx[i] = static_cast<Eigen::Index>(u(i));
+      return idx;
+    }
+
     /// Per-block symmetric orthonormalisation of the AO overlap S
     /// restricted to each symmetry index set. Both drivers build this
     /// once and reuse it in the CoreH construction, the --load block
     /// projection, and the --save density reconstruction.
-    inline std::vector<arma::mat> build_per_block_Sinvh(
-        const arma::mat & S, const std::vector<arma::uvec> & dsym) {
+    inline std::vector<helfem::Matrix> build_per_block_Sinvh(
+        const helfem::Matrix & S, const std::vector<arma::uvec> & dsym) {
       const size_t nsym = dsym.size();
-      std::vector<arma::mat> out(nsym);
+      std::vector<helfem::Matrix> out(nsym);
       for (size_t k = 0; k < nsym; ++k) {
         if (!dsym[k].n_elem) continue;
-        const arma::mat Sk = S(dsym[k], dsym[k]);
-        out[k] = helfem::to_arma(scf::form_Sinvh(helfem::to_eigen(Sk), /*chol=*/false));
+        const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+        const helfem::Matrix Sk = S(idx, idx);
+        out[k] = scf::form_Sinvh(Sk, /*chol=*/false);
       }
       return out;
     }
@@ -55,9 +75,9 @@ namespace helfem {
     /// steady-state Fock builder applies.
     template <typename Real>
     inline OpenOrbitalOptimizer::FockMatrix<Real> build_coreH_from_H0(
-        const arma::mat & H0, const arma::mat & S,
+        const helfem::Matrix & H0, const helfem::Matrix & S,
         const std::vector<arma::uvec> & dsym,
-        const std::vector<arma::mat> & Sinvh_arma,
+        const std::vector<helfem::Matrix> & Sinvh,
         size_t nparttype, bool have_bfield, double Bz) {
       const size_t nsym = dsym.size();
       OpenOrbitalOptimizer::FockMatrix<Real> CoreH(nsym * nparttype);
@@ -67,11 +87,11 @@ namespace helfem {
             CoreH[t * nsym + k] = helfem::Matrix::Zero(0, 0);
             continue;
           }
-          arma::mat H_sub = H0(dsym[k], dsym[k]);
+          const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+          helfem::Matrix H_sub = H0(idx, idx);
           if (have_bfield && nparttype == 2)
-            H_sub += (t == 0 ? -0.5 : 0.5) * Bz * arma::mat(S(dsym[k], dsym[k]));
-          const arma::mat H_orth = Sinvh_arma[k].t() * H_sub * Sinvh_arma[k];
-          CoreH[t * nsym + k] = helfem::to_eigen(H_orth);
+            H_sub += (t == 0 ? -0.5 : 0.5) * Bz * helfem::Matrix(S(idx, idx));
+          CoreH[t * nsym + k] = Sinvh[k].transpose() * H_sub * Sinvh[k];
         }
       }
       return CoreH;
@@ -91,28 +111,31 @@ namespace helfem {
         size_t out_index,
         OpenOrbitalOptimizer::Orbitals<Real> & orbs,
         OpenOrbitalOptimizer::OrbitalOccupations<Real> & occs,
-        const arma::mat & Pspin, const arma::uvec & idx,
-        const arma::mat & Sinvh_block, double max_occ) {
-      if (!idx.n_elem) {
+        const helfem::Matrix & Pspin, const arma::uvec & idx_u,
+        const helfem::Matrix & Sinvh_block, double max_occ) {
+      if (!idx_u.n_elem) {
         orbs[out_index] = helfem::Matrix::Zero(0, 0);
         occs[out_index] = helfem::Vector::Zero(0);
         return;
       }
-      const arma::mat Pblk  = Pspin(idx, idx);
-      const arma::mat Porth = arma::trans(Sinvh_block) * Pblk * Sinvh_block;
-      arma::vec occ_eigs;
-      arma::mat vec_eigs;
-      if (!arma::eig_sym(occ_eigs, vec_eigs, Porth))
+      const std::vector<Eigen::Index> idx = to_idx(idx_u);
+      const helfem::Matrix Pblk  = Pspin(idx, idx);
+      const helfem::Matrix Porth = Sinvh_block.transpose() * Pblk * Sinvh_block;
+      // SelfAdjointEigenSolver returns eigenvalues in ascending order;
+      // reverse for descending (largest occupation first), matching the
+      // old arma::eig_sym + manual reversal.
+      Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(Porth);
+      if (es.info() != Eigen::Success)
         throw std::logic_error("--load: eigendecomposition of projected block density failed");
-      const arma::uword n = vec_eigs.n_cols;
-      arma::mat V(vec_eigs.n_rows, n);
-      arma::vec w(n);
-      for (arma::uword i = 0; i < n; ++i) {
-        V.col(i) = vec_eigs.col(n - 1 - i);
-        w(i)     = std::min(std::max(occ_eigs(n - 1 - i), 0.0), max_occ);
+      const Eigen::Index n = es.eigenvalues().size();
+      helfem::Matrix V(es.eigenvectors().rows(), n);
+      helfem::Vector w(n);
+      for (Eigen::Index i = 0; i < n; ++i) {
+        V.col(i) = es.eigenvectors().col(n - 1 - i);
+        w(i)     = std::min(std::max(es.eigenvalues()(n - 1 - i), 0.0), max_occ);
       }
-      orbs[out_index] = helfem::to_eigen(V);
-      occs[out_index] = helfem::to_eigen(w);
+      orbs[out_index] = V;
+      occs[out_index] = w;
     }
 
     /// Save-path helper: reconstruct the full AO alpha / beta density
@@ -121,32 +144,30 @@ namespace helfem {
     /// (max occ 2); alpha and beta both get half of it. Unrestricted:
     /// alpha in indices [0, nsym), beta in [nsym, 2*nsym).
     template <typename Real>
-    inline std::pair<arma::mat, arma::mat> assemble_final_density(
+    inline std::pair<helfem::Matrix, helfem::Matrix> assemble_final_density(
         size_t Nbf, bool restricted,
         const std::vector<arma::uvec> & dsym,
-        const std::vector<arma::mat> & Sinvh_arma,
+        const std::vector<helfem::Matrix> & Sinvh,
         const OpenOrbitalOptimizer::Orbitals<Real> & final_orbs,
         const OpenOrbitalOptimizer::OrbitalOccupations<Real> & final_occs) {
       const size_t nsym = dsym.size();
-      arma::mat Pa_final(Nbf, Nbf, arma::fill::zeros);
-      arma::mat Pb_final(Nbf, Nbf, arma::fill::zeros);
+      const Eigen::Index N = static_cast<Eigen::Index>(Nbf);
+      helfem::Matrix Pa_final = helfem::Matrix::Zero(N, N);
+      helfem::Matrix Pb_final = helfem::Matrix::Zero(N, N);
       for (size_t k = 0; k < nsym; ++k) {
         if (!dsym[k].n_elem) continue;
-        const arma::mat orb_a_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[k]);
-        const arma::vec occ_a    = helfem::to_arma(final_occs[k]);
+        const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+        const helfem::Matrix orb_a_ao = Sinvh[k] * final_orbs[k];
+        const helfem::Vector occ_a    = final_occs[k];
         if (restricted) {
-          const arma::mat P_block = 0.5 * (orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao));
-          arma::mat Pa_tmp = Pa_final; Pa_tmp(dsym[k], dsym[k]) += P_block; Pa_final = Pa_tmp;
-          arma::mat Pb_tmp = Pb_final; Pb_tmp(dsym[k], dsym[k]) += P_block; Pb_final = Pb_tmp;
+          const helfem::Matrix P_block = 0.5 * (orb_a_ao * occ_a.asDiagonal() * orb_a_ao.transpose());
+          Pa_final(idx, idx) += P_block;
+          Pb_final(idx, idx) += P_block;
         } else {
-          const arma::mat orb_b_ao = Sinvh_arma[k] * helfem::to_arma(final_orbs[nsym + k]);
-          const arma::vec occ_b    = helfem::to_arma(final_occs[nsym + k]);
-          arma::mat Pa_tmp = Pa_final;
-          Pa_tmp(dsym[k], dsym[k]) += orb_a_ao * arma::diagmat(occ_a) * arma::trans(orb_a_ao);
-          Pa_final = Pa_tmp;
-          arma::mat Pb_tmp = Pb_final;
-          Pb_tmp(dsym[k], dsym[k]) += orb_b_ao * arma::diagmat(occ_b) * arma::trans(orb_b_ao);
-          Pb_final = Pb_tmp;
+          const helfem::Matrix orb_b_ao = Sinvh[k] * final_orbs[nsym + k];
+          const helfem::Vector occ_b    = final_occs[nsym + k];
+          Pa_final(idx, idx) += orb_a_ao * occ_a.asDiagonal() * orb_a_ao.transpose();
+          Pb_final(idx, idx) += orb_b_ao * occ_b.asDiagonal() * orb_b_ao.transpose();
         }
       }
       return {Pa_final, Pb_final};
@@ -218,15 +239,13 @@ namespace helfem {
     ///   P_full(dsym[k], dsym[k]) += C_k . diag(occ_e) . C_k^T
     template <typename Real>
     inline void accumulate_density_block(
-        arma::mat & P_full, const std::vector<arma::uvec> & dsym, size_t k,
-        const std::vector<arma::mat> & Sinvh_arma,
+        helfem::Matrix & P_full, const std::vector<arma::uvec> & dsym, size_t k,
+        const std::vector<helfem::Matrix> & Sinvh,
         const helfem::Matrix & orb_e, const helfem::Vector & occ_e) {
       if (!dsym[k].n_elem) return;
-      const arma::mat orb  = helfem::to_arma(orb_e);
-      const arma::vec occ  = helfem::to_arma(occ_e);
-      const arma::mat C_k  = Sinvh_arma[k] * orb;
-      const arma::mat P_k  = C_k * arma::diagmat(occ) * C_k.t();
-      P_full(dsym[k], dsym[k]) += P_k;
+      const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+      const helfem::Matrix C_k = Sinvh[k] * orb_e;
+      P_full(idx, idx) += C_k * occ_e.asDiagonal() * C_k.transpose();
     }
 
     /// Fock-builder helper: extract block k of a full AO Fock matrix,
@@ -238,15 +257,15 @@ namespace helfem {
     inline void orthonormalize_fock_block(
         OpenOrbitalOptimizer::FockMatrix<Real> & fock, size_t b,
         const std::vector<arma::uvec> & dsym, size_t k,
-        const std::vector<arma::mat> & Sinvh_arma,
-        const arma::mat & F_full) {
+        const std::vector<helfem::Matrix> & Sinvh,
+        const helfem::Matrix & F_full) {
       if (!dsym[k].n_elem) {
         fock[b] = helfem::Matrix::Zero(0, 0);
         return;
       }
-      const arma::mat Fk_sub = F_full(dsym[k], dsym[k]);
-      const arma::mat F_orth = Sinvh_arma[k].t() * Fk_sub * Sinvh_arma[k];
-      fock[b] = helfem::to_eigen(F_orth);
+      const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+      const helfem::Matrix Fk_sub = F_full(idx, idx);
+      fock[b] = Sinvh[k].transpose() * Fk_sub * Sinvh[k];
     }
 
     /// Fock-builder helper: assemble the alpha/beta HF exchange
@@ -263,16 +282,16 @@ namespace helfem {
     /// contribution.
     template <typename ExchangeFn>
     inline void assemble_hf_exchange(
-        arma::mat & Ka, arma::mat & Kb, double & Exx,
-        const arma::mat & Pa, const arma::mat & Pb,
+        helfem::Matrix & Ka, helfem::Matrix & Kb, double & Exx,
+        const helfem::Matrix & Pa, const helfem::Matrix & Pb,
         bool restricted, bool have_exx, ExchangeFn exchange_fn) {
       Exx = 0.0;
       if (!have_exx) return;
       Ka = exchange_fn(Pa);
-      Exx = 0.5 * arma::trace(Pa * Ka);
+      Exx = 0.5 * (Pa * Ka).trace();
       if (!restricted) {
         Kb = exchange_fn(Pb);
-        Exx += 0.5 * arma::trace(Pb * Kb);
+        Exx += 0.5 * (Pb * Kb).trace();
       } else {
         Exx *= 2.0;
       }
@@ -294,23 +313,23 @@ namespace helfem {
     template <typename Real, typename ApplyMAvg, typename OrthoBlock>
     inline void assemble_fock_blocks(
         OpenOrbitalOptimizer::FockMatrix<Real> & fock,
-        const arma::mat & H1, const arma::mat & J,
-        const arma::mat & XCa, const arma::mat & XCb,
-        const arma::mat & Ka,  const arma::mat & Kb,
-        const arma::mat & S,
+        const helfem::Matrix & H1, const helfem::Matrix & J,
+        const helfem::Matrix & XCa, const helfem::Matrix & XCb,
+        const helfem::Matrix & Ka,  const helfem::Matrix & Kb,
+        const helfem::Matrix & S,
         size_t nsym, bool restricted,
         bool have_xc, bool have_exx, bool have_bfield, double Bz,
         ApplyMAvg apply_mavg, OrthoBlock orthonormalize_block) {
       if (restricted) {
-        arma::mat F_ao = H1 + J;
+        helfem::Matrix F_ao = H1 + J;
         if (have_xc)  F_ao += XCa;
         if (have_exx) F_ao += Ka;
         apply_mavg(F_ao);
         for (size_t k = 0; k < nsym; ++k)
           orthonormalize_block(fock, k, F_ao, k);
       } else {
-        arma::mat Fa_ao = H1 + J;
-        arma::mat Fb_ao = H1 + J;
+        helfem::Matrix Fa_ao = H1 + J;
+        helfem::Matrix Fb_ao = H1 + J;
         if (have_xc)  { Fa_ao += XCa; Fb_ao += XCb; }
         if (have_exx) { Fa_ao += Ka;  Fb_ao += Kb;  }
         // Spin-Zeeman: alpha <- -Bz/2 * S, beta <- +Bz/2 * S.


### PR DESCRIPTION
## What

Migrates the **shared OOO SCF-driver interface** (`scf_driver_common.h`) and its two consuming drivers from Armadillo to Eigen. These move together — the header's helpers are used by the atomic and diatomic Fock/density/load/save paths (sadatom/main uses only the non-matrix helpers and is unaffected).

**`src/general/scf_driver_common.h`** (59 arma → 12):
- Working matrices `arma::mat` → `helfem::Matrix`; per-block gather/scatter via **Eigen 3.4 indexed views** over `to_idx(dsym[k])` (the `dsym` index lists stay `arma::uvec` — they come from `basis.get_sym_idx`).
- **`arma::eig_sym` → Eigen `SelfAdjointEigenSolver`** in `fill_block_from_density`. This matters beyond tidiness: Eigen's solver is **scalar-generic**, where `arma::eig_sym` is LAPACK/double-only — a prerequisite for instantiating the SCF driver at extended precision.
- Return types: `build_per_block_Sinvh` → `std::vector<helfem::Matrix>`; `assemble_final_density` → `std::pair<helfem::Matrix,helfem::Matrix>`.

**`src/{atomic,diatomic}/main.cpp`** (51→14, 54→21):
- `Sinvh_arma` → `Sinvh` (`std::vector<helfem::Matrix>`); all `scf_driver::` call sites updated.
- All Fock-assembly working matrices (`S`/`T`/`Vnuc`/`Vel`/`Vmag`/`Vconf`/`H0`/`H1`/`J`/`K*`/`XC*`/`P*`/`F`) → `helfem::Matrix`, assigned **directly** from the now-Eigen basis/dftgrid (every `to_arma` bridge dropped). Traces → `(A*B).trace()`.
- Kept arma at the boundary: `dsym`/maverage index lists, `occs.dat`, `get_lval`/`get_mval`, checkpoint I/O (bridged), and the diatomic `TwoDGrid::model_potential` guess/finite-nucleus bridge. `OOO_Real = double` unchanged (this is arma→Eigen only; scalar templating is a separate step).

## Validation — every SCF path, both geometries, **all bit-exact vs master**

| case | migrated | master | path exercised |
|---|---|---|---|
| atomic He LDA | −2.7236397925 | = | restricted SCF, block ortho |
| atomic He HF | −2.8616799956 | = | + exact exchange |
| atomic Li UHF LDA | −7.1934018521 | = | unrestricted (2 particle types) |
| atomic He UHF LDA, **Bz=0.1** | −2.7214328946 | = | **Zeeman split** (`build_coreH` + `assemble_fock_blocks`) |
| diatomic H2 LDA | −1.0161291084 | = | diatomic restricted |
| diatomic H₂⁺ HF | −0.6026341889 | = | diatomic 2e/exchange |
| atomic `--save`→`--load` | −2.7236397926 | (converges to same) | **`fill_block_from_density` / `SelfAdjointEigenSolver`** + `assemble_final_density` |

The `--load` round-trip is the one that specifically exercises the eigensolver swap; it re-converges to the fresh-run energy.

Part of task #24. With this, the atomic and diatomic **SCF assembly paths are arma-free end to end** — the remaining arma is the checkpoint/index/analysis boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)