### PR TITLE
diatomic: stop re-evaluating the FEM polynomials in the TEI build and twodquadrature

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -196,6 +196,15 @@ namespace helfem {
         return tei;
       }
 
+      quadrature::TwoElectronElement RadialBasis::twoe_element(size_t iel) const {
+        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
+        return quadrature::twoe_element(fem.element_begin(iel), fem.element_end(iel), xq, wq, p);
+      }
+
+      helfem::Matrix RadialBasis::twoe_integral(int alpha, int beta, const quadrature::TwoElectronElement & el, int L, int M, const legendretable::LegendreTable & legtab) const {
+        return quadrature::twoe_integral(el, alpha, beta, L, M, legtab);
+      }
+
       helfem::Vector RadialBasis::get_chmu_quad() const {
         // Quadrature points for normal integrals
         helfem::Vector muq(fem.get_nelem()*xq.size()*(xq.size()+1));
@@ -889,20 +898,29 @@ namespace helfem {
         prim_tei20.resize(Nel*Nel*lm_map.size());
         prim_tei22.resize(Nel*Nel*lm_map.size());
 
-        for(size_t ilm=0;ilm<lm_map.size();ilm++) {
-          int L(lm_map[ilm].first);
-          int M(lm_map[ilm].second);
+        // Element loop is OUTSIDE the (L,M) loop: everything about the element
+        // -- its basis functions, the B_i B_j product table, and the
+        // subinterval geometry of the inner integral -- is independent of
+        // (L, M) and of (alpha, beta), so it is built once here instead of
+        // being re-derived for each of the 4 x lm_map.size() calls that used
+        // to go through radial.twoe_integral(alpha,beta,iel,L,M).
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+        for(size_t iel=0;iel<Nel;iel++) {
+          const quadrature::TwoElectronElement eldata(radial.twoe_element(iel));
 
-          for(size_t iel=0;iel<Nel;iel++) {
-            // Index in array
+          for(size_t ilm=0;ilm<lm_map.size();ilm++) {
+            int L(lm_map[ilm].first);
+            int M(lm_map[ilm].second);
             {
               const size_t idx(Nel*Nel*ilm + iel*Nel + iel);
 
               // In-element integrals
-              prim_tei00[idx]=radial.twoe_integral(0,0,iel,L,M,legtab);
-              prim_tei02[idx]=radial.twoe_integral(0,2,iel,L,M,legtab);
-              prim_tei20[idx]=radial.twoe_integral(2,0,iel,L,M,legtab);
-              prim_tei22[idx]=radial.twoe_integral(2,2,iel,L,M,legtab);
+              prim_tei00[idx]=radial.twoe_integral(0,0,eldata,L,M,legtab);
+              prim_tei02[idx]=radial.twoe_integral(0,2,eldata,L,M,legtab);
+              prim_tei20[idx]=radial.twoe_integral(2,0,eldata,L,M,legtab);
+              prim_tei22[idx]=radial.twoe_integral(2,2,eldata,L,M,legtab);
             }
 
             /*
@@ -1502,6 +1520,10 @@ namespace helfem {
       }
 
       arma::mat TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m) const {
+        return eval_bf(iel, irad, cth, m, helfem::to_arma(radial.get_bf(iel)));
+      }
+
+      arma::mat TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m, const arma::mat & rad_all) const {
         // Figure out list of functions
         std::vector<arma::uword> flist;
         for(size_t i=0;i<mval.n_elem;i++)
@@ -1513,9 +1535,8 @@ namespace helfem {
         for(size_t i=0;i<flist.size();i++)
           sph(i)=std::real(::spherical_harmonics(lval(flist[i]),mval(flist[i]),cth,0.0));
 
-        // Evaluate radial functions
-        arma::mat rad(helfem::to_arma(radial.get_bf(iel)));
-        rad=rad.rows(irad,irad);
+        // Radial functions at this quadrature point
+        arma::mat rad(rad_all.rows(irad,irad));
 
         // Form supermatrix
         arma::mat bf(rad.n_rows,flist.size()*rad.n_cols);

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -19,6 +19,7 @@
 #include "FiniteElementBasis.h"
 #include "../general/gaunt.h"
 #include "../general/legendretable.h"
+#include "quadrature.h"
 
 namespace helfem {
   namespace diatomic {
@@ -82,6 +83,13 @@ namespace helfem {
         helfem::Matrix Qlm_integral(int alpha, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const;
         /// Compute primitive two-electron integral
         helfem::Matrix twoe_integral(int alpha, int beta, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const;
+
+        /// Build the element-only two-electron data (basis functions, product
+        /// table, subinterval geometry). Independent of (alpha, beta, L, M), so
+        /// compute_tei builds it once per element and reuses it across them.
+        quadrature::TwoElectronElement twoe_element(size_t iel) const;
+        /// Primitive two-electron integral from precomputed element data
+        helfem::Matrix twoe_integral(int alpha, int beta, const quadrature::TwoElectronElement & el, int L, int M, const legendretable::LegendreTable & legtab) const;
 
         /// Get quadrature points
         helfem::Vector get_chmu_quad() const;
@@ -254,6 +262,12 @@ namespace helfem {
         /// Evaluate basis functions at wanted x value
         /// Evaluate basis functions with m=m at quadrature point
         arma::mat eval_bf(size_t iel, size_t irad, double cth, int m) const;
+        /// Same, but with the element's radial functions already evaluated
+        /// (rad_all = get_rad_bf(iel), rows = radial points). The FEM
+        /// polynomials depend only on the element, so callers that loop over
+        /// angular points should hoist that evaluation out of the loop rather
+        /// than redo it -- and throw away all but one row -- per angular point.
+        arma::mat eval_bf(size_t iel, size_t irad, double cth, int m, const arma::mat & rad_all) const;
 
 	/// Evaluate basis functions at wanted point
 	arma::cx_vec eval_bf(double mu, double cth, double phi) const;

--- a/src/diatomic/quadrature.cpp
+++ b/src/diatomic/quadrature.cpp
@@ -127,6 +127,112 @@ namespace helfem {
       helfem::Matrix twoe_integral(double mumin, double mumax, int k, int l, const helfem::Vector & x, const helfem::Vector & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L, int M, const legendretable::LegendreTable & tab) {
         return twoe_integral_wrk(mumin,mumax,k,l,x,wx,poly,L,M,tab) + twoe_integral_wrk(mumin,mumax,l,k,x,wx,poly,L,M,tab).transpose();
       }
+
+      TwoElectronElement twoe_element(double mumin, double mumax, const helfem::Vector & x, const helfem::Vector & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly) {
+        if(x.size() != wx.size()) {
+          std::ostringstream oss;
+          oss << "x and wx not compatible: " << x.size() << " vs " << wx.size() << "!\n";
+          throw std::logic_error(oss.str());
+        }
+
+        TwoElectronElement el;
+        el.x  = x;
+        el.wx = wx;
+
+        // Element midpoint and half-length
+        const double mumid(0.5*(mumax+mumin));
+        el.mulen = 0.5*(mumax-mumin);
+
+        // Outer quadrature points
+        el.mu   = mumid*helfem::Vector::Ones(x.size()) + el.mulen*x;
+        el.chmu = el.mu.array().cosh();
+        el.shmu = el.mu.array().sinh();
+
+        // Outer basis functions and the product table B_i B_j. Neither depends
+        // on k, l, L or M.
+        el.bf = poly->eval_dnf(x, 0, el.mulen);
+        const Eigen::Index nbf = el.bf.cols();
+        el.bfprod.resize(el.bf.rows(), nbf*nbf);
+        for(Eigen::Index fi=0;fi<nbf;fi++)
+          for(Eigen::Index fj=0;fj<nbf;fj++)
+            el.bfprod.col(fi*nbf+fj) = el.bf.col(fi).cwiseProduct(el.bf.col(fj));
+
+        // Inner (cumulative) integral: subinterval ip spans [mu(ip-1), mu(ip)],
+        // with [mumin, mu(0)] for ip = 0. Each uses a fresh set of nquad points,
+        // and the polynomials there depend only on where those points fall.
+        el.sub.resize(x.size());
+        for(Eigen::Index ip=0;ip<x.size();ip++) {
+          const double submin = (ip==0) ? mumin : el.mu(ip-1);
+          const double submax = el.mu(ip);
+
+          const double submid(0.5*(submax+submin));
+          const double sublen(0.5*(submax-submin));
+
+          const helfem::Vector submu = submid*helfem::Vector::Ones(x.size()) + sublen*x;
+
+          TwoElectronElement::Subinterval & si = el.sub[ip];
+          si.mulen = sublen;
+          si.chmu  = submu.array().cosh();
+          si.shmu  = submu.array().sinh();
+          // The polynomials are those of the PARENT element, evaluated at the
+          // subinterval's points -- hence the element midpoint / half-length.
+          const helfem::Vector xpoly = (submu - mumid*helfem::Vector::Ones(x.size())) / el.mulen;
+          si.bf = poly->eval_dnf(xpoly, 0, el.mulen);
+        }
+
+        return el;
+      }
+
+      helfem::Matrix twoe_integral(const TwoElectronElement & el, int k, int l, int L, int M, const legendretable::LegendreTable & tab) {
+        const Eigen::Index nq  = el.x.size();
+        const Eigen::Index nbf = el.bf.cols();
+
+        // Inner integrals as a function of the outer point, accumulated over
+        // the subintervals. Depends on l (through cosh^l) and on (L, M)
+        // (through P_{L|M|}), but on no polynomial evaluation.
+        auto inner_integral = [&](int lval) {
+          helfem::Matrix inner(nq, nbf*nbf);
+          helfem::Vector acc = helfem::Vector::Zero(nbf*nbf);
+          for(Eigen::Index ip=0;ip<nq;ip++) {
+            const TwoElectronElement::Subinterval & si = el.sub[ip];
+
+            helfem::Vector wp = si.mulen*el.wx;
+            wp.array() *= si.shmu.array();
+            if(lval!=0)
+              wp.array() *= si.chmu.array().pow(lval);
+            wp.array() *= Plm(tab, L, M, si.chmu).array();
+
+            helfem::Matrix wbf = si.bf;
+            for(Eigen::Index i=0;i<wbf.cols();i++)
+              wbf.col(i).array() *= wp.array();
+
+            const helfem::Matrix prod = wbf.transpose()*si.bf;
+            acc += Eigen::Map<const helfem::Vector>(prod.data(), prod.size());
+            inner.row(ip) = acc.transpose();
+          }
+          return inner;
+        };
+
+        // Outer integral, for the (k, l) ordering
+        auto outer = [&](int kval, int lval) {
+          const helfem::Matrix inner = inner_integral(lval);
+
+          helfem::Vector wp = el.mulen*el.wx;
+          wp.array() *= el.shmu.array();
+          if(kval!=0)
+            wp.array() *= el.chmu.array().pow(kval);
+          wp.array() *= Qlm(tab, L, M, el.chmu).array();
+
+          helfem::Matrix bfprod = el.bfprod;
+          for(Eigen::Index i=0;i<bfprod.cols();i++)
+            bfprod.col(i).array() *= wp.array();
+
+          return helfem::Matrix(bfprod.transpose()*inner);
+        };
+
+        return outer(k,l) + helfem::Matrix(outer(l,k).transpose());
+      }
+
     }
   }
 }

--- a/src/diatomic/quadrature.h
+++ b/src/diatomic/quadrature.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include "../general/legendretable.h"
 #include "PolynomialBasis.h"
+#include <vector>
 
 namespace helfem {
   namespace diatomic {
@@ -35,6 +36,54 @@ namespace helfem {
        * Note that the routine needs the polynomial representation.
        */
       helfem::Matrix twoe_integral(double rmin, double rmax, int k, int l, const helfem::Vector & x, const helfem::Vector & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly, int L, int M, const legendretable::LegendreTable & tab);
+
+      /**
+       * Everything in the two-electron in-element integrals that depends only
+       * on the ELEMENT and the quadrature rule -- not on (k, l, L, M).
+       *
+       * The polynomials are the expensive part (profiling put the FEM
+       * evaluation at ~35% of a run), and they were being re-evaluated inside
+       * the (L, M) x (alpha, beta) loops: compute_tei asks for 4 (alpha,beta)
+       * combinations per (element, L, M), each of which runs twoe_integral_wrk
+       * twice, and each of those re-evaluated the outer basis, the outer
+       * product table, and one inner basis per subinterval. None of that
+       * depends on k, l, L or M.
+       *
+       * Build this once per element and hand it to twoe_integral() below.
+       */
+      struct TwoElectronElement {
+        /// Quadrature nodes and weights on [-1, 1]
+        helfem::Vector x, wx;
+        /// Half-length of the element in mu
+        double mulen;
+        /// Outer quadrature: mu, cosh(mu), sinh(mu) at the element's points
+        helfem::Vector mu, chmu, shmu;
+        /// Outer basis functions, (nquad x nbf)
+        helfem::Matrix bf;
+        /// Outer product table B_i(mu) B_j(mu), (nquad x nbf^2)
+        helfem::Matrix bfprod;
+
+        /// Per-subinterval data for the cumulative inner integral. Subinterval
+        /// ip runs from mu(ip-1) to mu(ip) (and from mumin to mu(0) for ip=0),
+        /// and each uses a fresh set of nquad points.
+        struct Subinterval {
+          /// Half-length of the subinterval
+          double mulen;
+          /// cosh(mu), sinh(mu) at the subinterval's points
+          helfem::Vector chmu, shmu;
+          /// Basis functions there, (nquad x nbf)
+          helfem::Matrix bf;
+        };
+        std::vector<Subinterval> sub;
+      };
+
+      /// Build the element-only data above. Call once per element.
+      TwoElectronElement twoe_element(double mumin, double mumax, const helfem::Vector & x, const helfem::Vector & wx, const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly);
+
+      /// Primitive two-electron in-element integral, reusing precomputed
+      /// element data. Equivalent to the twoe_integral() above, but without
+      /// re-evaluating any polynomial.
+      helfem::Matrix twoe_integral(const TwoElectronElement & el, int k, int l, int L, int M, const legendretable::LegendreTable & tab);
     }
   }
 }

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -206,13 +206,22 @@ namespace helfem {
 
         // Compute basis function values
         bf=helfem::Matrix::Zero(bf_ind.size(),wtot.size());
+
+        // The element's FEM polynomials depend only on the element, so
+        // evaluate them ONCE here rather than once per angular point:
+        // eval_bf(iel,irad,...) evaluates the whole element at every
+        // quadrature point and then keeps a single row, so calling it inside
+        // the angular loop redid that work cth.size() times over. Hoisted
+        // above the parallel region, which also keeps it read-only shared.
+        const arma::mat rad_all(basp->get_rad_bf(iel));
+
         // Loop over angular grid
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
         for(size_t ia=0;ia<(size_t) cth.size();ia++) {
           // Evaluate basis functions at angular point
-          helfem::Matrix abf(helfem::to_eigen(basp->eval_bf(iel, irad, cth(ia), m)));
+          helfem::Matrix abf(helfem::to_eigen(basp->eval_bf(iel, irad, cth(ia), m, rad_all)));
           if((size_t) abf.cols() != bf_ind.size()) {
             std::ostringstream oss;
             oss << "Mismatch! Have " << bf_ind.size() << " basis function indices but " << abf.cols() << " basis functions!\n";


### PR DESCRIPTION
Follow-up to #230. The same redundancy -- re-evaluating an element's FEM polynomials inside a loop that does not depend on them -- turned out to be in two more places. Unlike the XC-grid one, **these are on the path of every diatomic run**: HF or DFT, any `--symmetry`, pure-m or not.

## 1. Two-electron integrals (`quadrature.cpp`)

`compute_tei` asks for 4 `(alpha, beta)` combinations per `(element, L, M)`; each runs `twoe_integral_wrk` twice, and each of those re-derived

* the outer basis functions, `eval_dnf(x, 0, mulen)`,
* the outer product table `B_i(mu) B_j(mu)`, `(nquad x nbf^2)`, and
* one inner basis per subinterval, `eval_dnf(xpoly, 0, mulen0)` -- `nquad` of them.

None of that depends on `k`, `l`, `L` or `M`. Only the *weights* do, through `cosh^l`, `P_{L|M|}` and `Q_{L|M|}`. With `nquad = 75` and ~25 `(L,|M|)` pairs, the polynomial evaluation was being repeated on the order of **200 times**.

New `quadrature::TwoElectronElement` holds exactly the element-only data (outer points, `cosh`/`sinh`, basis, product table, and the per-subinterval geometry and basis of the cumulative inner integral). It is built once per element by `twoe_element()`, and consumed by a `twoe_integral()` overload that evaluates **no polynomial at all**. `compute_tei` now loops elements *outside* `(L,M)` so it can build it once, and parallelises over elements.

## 2. Model-potential quadrature (`twodquadrature.cpp`)

`TwoDGridWorker::compute_bf` called `eval_bf(iel, irad, cth(ia), m)` inside its angular loop. Each call evaluates the whole element at all `nquad` points and keeps a single row, so the work was redone `cth.size()` times. The radial evaluation is hoisted above the loop -- and above the OpenMP parallel region, where it is read-only shared, so no cache can race there.

`TwoDBasis::eval_bf` gains an overload taking the element's already-evaluated radial functions; the old signature delegates to it, so every other caller is unaffected. This path is the SAP / GSZ initial guess.

## Correctness

Bit-exact. N2 LDA (`lmax=3 mmax=2`) still converges to `-93.9491317741` and (`lmax=2 mmax=1`) to `-79.4807491233`. `diatomic_purem_test` reproduces every number, including `max|dH|` of 5.34e-16 (`lda_x`) and 8.53e-14 (`mgga_x_tpss`) against the independent 3D grid. The N2 runs use the SAP guess, so they exercise `twodquadrature` too.

## Speed

Single-threaded CPU time on N2 (`lmax=3 mmax=2`):

| | CPU |
|---|---|
| master | 1m35s |
| + XC-grid hoist (#230) | 1m01s |
| + TEI hoist | 0m54s |
| + twodquadrature hoist | **0m48s** |

**2.0x over master overall**, of which 1.28x comes from this PR. Wall clock is not quoted: the machine was loaded by unrelated jobs.

`eval_lip_prim_dnf`, which started out as >50% of the profile, is no longer the leading entry anywhere.

Since the TEI build is a fixed startup cost per geometry, this matters most for scans over many bond lengths -- i.e. exactly the periodic-table-of-diatomics use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
