### PR TITLE
atomic: Cholesky-factorize the in-element two-electron integrals; exchange from RI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,10 @@ target_link_libraries(diatomic_purem_test helfem-common legendre)
 add_executable(diatomic_teirank diatomic/teirank.cpp)
 target_link_libraries(diatomic_teirank helfem-common legendre)
 
+# Same measurement for the atomic in-element integrals.
+add_executable(atomic_teirank atomic/teirank.cpp)
+target_link_libraries(atomic_teirank helfem-common legendre)
+
 add_library(legendre
   legendre/Legendre.cpp general/legendretable.cpp)
 target_compile_features(legendre PUBLIC cxx_std_17)

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -502,7 +502,7 @@ namespace helfem {
 
       std::vector<std::vector<helfem::Matrix>>
       TwoDBasis::radial_df_factors(double tol) const {
-        if (!prim_tei.size())
+        if (!prim_chol.size())
           throw std::logic_error(
               "Primitive teis have not been computed -- call "
               "compute_tei() before radial_df_factors().");
@@ -526,7 +526,7 @@ namespace helfem {
             return disjoint_m1L[(size_t) L * Nel + iel];
           };
           auto tw = [&, L](size_t iel) -> const helfem::Matrix & {
-            return prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel];
+            return prim_chol[(size_t) L * Nel + iel];
           };
 
           // -- 2. Initial diagonal D(i, j) = R^L(i, j, i, j) over the
@@ -570,7 +570,7 @@ namespace helfem {
                   P(j, i) = 0.5;
                 }
                 const helfem::Matrix J =
-                    helfem::atomic::basis::assemble_J_FE_one_multipole_cached(
+                    helfem::atomic::basis::assemble_J_FE_one_multipole_cached_chol(
                         radial, rs, rb, tw, P);
                 D(i, j) = J(i, j);
                 D(j, i) = D(i, j);
@@ -608,7 +608,7 @@ namespace helfem {
               P(j_star, i_star) = 0.5;
             }
             helfem::Matrix col =
-                helfem::atomic::basis::assemble_J_FE_one_multipole_cached(
+                helfem::atomic::basis::assemble_J_FE_one_multipole_cached_chol(
                     radial, rs, rb, tw, P);
 
             // Subtract projections onto already-found Cholesky vectors.
@@ -644,14 +644,23 @@ namespace helfem {
         const int N_L = 2 * lval.maxCoeff() + 1;
         atomic::basis::compute_disjoint_radial_integrals(
             radial, N_L, disjoint_L, disjoint_m1L);
-        atomic::basis::compute_in_element_tei(radial, N_L, prim_tei);
-        // The exchange matrix is K(jk) = (ij|kl) P(il); we precompute the
-        // (jk;il)-permuted form here so the cached K assembly path can
-        // consume the cache without re-permuting.
-        if (exchange) {
-          atomic::basis::compute_in_element_ktei_from_tei(
-              radial, N_L, prim_tei, prim_ktei);
-        }
+
+        // In-element integrals, kept in factorized form: T = L L' with L of
+        // shape (Ni^2 x r) and r ~ 30 rather than Ni^2 ~ 200. Both J and K are
+        // assembled from this one factor -- K via the RI contraction -- so no
+        // exchange-ordered tensor is built. (Its pairing is full rank, so
+        // there would be nothing to gain by compressing it anyway.)
+        const size_t Nel = radial.Nel();
+        prim_chol.assign((size_t) N_L * Nel, helfem::Matrix());
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2)
+#endif
+        for (int L = 0; L < N_L; ++L)
+          for (size_t iel = 0; iel < Nel; ++iel)
+            prim_chol[(size_t) L * Nel + iel] =
+                radial.twoe_integral_cholesky(L, iel, chol_tol);
+
+        (void) exchange;
       }
 
       void TwoDBasis::compute_yukawa(double lambda_) {
@@ -663,11 +672,19 @@ namespace helfem {
         // assembly.
         atomic::basis::compute_disjoint_radial_integrals(
             radial, N_L, disjoint_iL, disjoint_kL, /*yukawa=*/true, lambda);
-        std::vector<helfem::Matrix> rs_tei_yk;
-        atomic::basis::compute_in_element_tei(
-            radial, N_L, rs_tei_yk, /*yukawa=*/true, lambda);
-        atomic::basis::compute_in_element_ktei_from_tei(
-            radial, N_L, rs_tei_yk, rs_ktei);
+
+        // In-element Yukawa integrals, factorized exactly as the bare ones.
+        // The rank bound is a property of the orbital product basis, not of the
+        // kernel, so it carries over unchanged.
+        const size_t Nel = radial.Nel();
+        rs_chol.assign((size_t) N_L * Nel, helfem::Matrix());
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2)
+#endif
+        for (int L = 0; L < N_L; ++L)
+          for (size_t iel = 0; iel < Nel; ++iel)
+            rs_chol[(size_t) L * Nel + iel] =
+                radial.yukawa_integral_cholesky(L, lambda, iel, chol_tol);
       }
 
       void TwoDBasis::compute_erfc(double mu) {
@@ -682,7 +699,7 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::coulomb(const helfem::Matrix & P0_in) const {
-        if(!prim_tei.size())
+        if(!prim_chol.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
         // The atomic basis has no boundary reduction (expand/remove_boundaries
@@ -750,11 +767,11 @@ namespace helfem {
             return disjoint_m1L[L*Nel+iel];
           };
           auto tw = [&,L](size_t iel) -> const helfem::Matrix & {
-            return prim_tei[Nel*Nel*L + iel*Nel + iel];
+            return prim_chol[(size_t) L * Nel + iel];
           };
           for(int M=-std::min(L,Mmax);M<=std::min(L,Mmax);M++) {
             Jaux[L][M+Mmax] += Lfac *
-              helfem::atomic::basis::assemble_J_FE_one_multipole_cached(
+              helfem::atomic::basis::assemble_J_FE_one_multipole_cached_chol(
                 radial, rs, rb, tw, Paux[L][M+Mmax]);
           }
         }
@@ -787,7 +804,7 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::exchange(const helfem::Matrix & P0_in) const {
-        if(!prim_ktei.size())
+        if(!prim_chol.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
         // No boundary reduction in the atomic basis (expand/remove are
@@ -886,9 +903,12 @@ namespace helfem {
                   return disjoint_m1L[Lc*Nel+iel];
                 };
                 auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
-                  return prim_ktei[Nel*Nel*Lc + iel*Nel + iel];
+                  return prim_chol[(size_t) Lc * Nel + iel];
                 };
-                K_block += helfem::atomic::basis::assemble_K_FE_one_multipole_cached(
+                // RI-K on the J-ordered Cholesky factor: K_ac = sum_p M_p P M_p'.
+                // The exchange-ordered tensor is full rank, so this is the only
+                // way to compress K -- and it means none needs to be stored.
+                K_block += helfem::atomic::basis::assemble_K_FE_one_multipole_cached_chol(
                     radial, rs, rb, kt, Rmat[Lc]);
               }
               K.block(static_cast<Eigen::Index>(jang)*Nrad, static_cast<Eigen::Index>(kang)*Nrad, Nrad, Nrad) -= K_block;
@@ -900,7 +920,7 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::rs_exchange(const helfem::Matrix & P0_in) const {
-        if(!rs_ktei.size())
+        if(!rs_ktei.size() && !rs_chol.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
         // No boundary reduction in the atomic basis (expand/remove are
@@ -999,9 +1019,9 @@ namespace helfem {
                     return disjoint_kL[Lc*Nel+iel];
                   };
                   auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
-                    return rs_ktei[Nel*Nel*Lc + iel*Nel + iel];
+                    return rs_chol[(size_t) Lc * Nel + iel];
                   };
-                  K_block += helfem::atomic::basis::assemble_K_FE_one_multipole_cached(
+                  K_block += helfem::atomic::basis::assemble_K_FE_one_multipole_cached_chol(
                       radial, rs, rb, kt, Rmat[Lc]);
                 }
                 K.block(static_cast<Eigen::Index>(jang)*Nrad, static_cast<Eigen::Index>(kang)*Nrad, Nrad, Nrad) -= K_block;

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -60,9 +60,34 @@ namespace helfem {
         /// Auxiliary integrals for Yukawa separation
         std::vector<helfem::Matrix> disjoint_iL, disjoint_kL;
         /// Primitive two-electron integrals: <Nel^2 * (2L+1)>
-        std::vector<helfem::Matrix> prim_tei;
-        /// Primitive two-electron integrals: <Nel^2 * (2L+1)> sorted for exchange
-        std::vector<helfem::Matrix> prim_ktei;
+        /// Pivoted-Cholesky factors of the IN-ELEMENT two-electron integrals,
+        /// indexed [L*Nel + iel]: L_p of shape (Ni^2 x r) with T = L L'.
+        ///
+        /// The in-element block is the only 4-index object left -- the
+        /// cross-element contributions to J and K are already contracted in
+        /// factorized (disjoint r^L / r^-L-1) form. The kernel here is the
+        /// single-channel r_<^L / r_>^(L+1), which is a positive kernel, so a
+        /// genuine pivoted Cholesky applies (unlike the diatomic 2-channel
+        /// kernel, which is indefinite for odd |M| and needs signs).
+        ///
+        /// It compresses hard: rank 27-29 out of Ni^2 = 196-225 for 15-node
+        /// LIPs, reproducing the exact tensor to ~1e-16. Storage and the J
+        /// contraction go from O(Ni^4) to O(Ni^2 r).
+        ///
+        /// The exchange PAIRING of the same integrals is full rank (196/196),
+        /// so it cannot be compressed directly; K instead comes from the
+        /// standard RI contraction on these J-ordered factors, which is why no
+        /// exchange-ordered tensor is stored.
+        std::vector<helfem::Matrix> prim_chol;
+        /// Tolerance for the pivoted Cholesky above
+        double chol_tol = 1e-12;
+        /// Same factorization for the Yukawa-screened in-element integrals.
+        /// The rank bound 2*Nprim-1 is a property of the orbital PRODUCT basis,
+        /// not of the kernel, so it applies to the Yukawa kernel unchanged.
+        /// (The erfc path keeps its explicit tensors for now: there the
+        /// cross-element blocks are not multipole-separable and are stored in
+        /// full, so it needs its own treatment.)
+        std::vector<helfem::Matrix> rs_chol;
         /// Primitive range-separated two-electron integrals: <Nel^2 * (2L+1)> sorted for exchange
         std::vector<helfem::Matrix> rs_ktei;
 

--- a/src/atomic/teirank.cpp
+++ b/src/atomic/teirank.cpp
@@ -1,0 +1,109 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+
+// How compressible are the ATOMIC in-element two-electron integrals?
+//
+// Same question as src/diatomic/teirank.cpp, and the same situation: the
+// cross-element contributions to J and K are already contracted in factorized
+// (disjoint r^L / r^-L-1) form, so the in-element block is the only 4-index
+// object left. It is stored as an (Ni^2 x Ni^2) matrix per (element, L), and
+// again as an exchange-ordered copy (prim_ktei), so storage grows as nnodes^4.
+//
+// Here the kernel is the single-channel r_<^L / r_>^(L+1), which is a positive
+// kernel -- so unlike the diatomic 2-channel case (indefinite for odd |M|) a
+// genuine pivoted Cholesky should apply, with no sign bookkeeping.
+//
+// libhelfem already provides FEMRadialBasis::twoe_integral_cholesky(); this
+// probe measures the rank it finds, checks that L L' reproduces the exact
+// tensor, and confirms that the exchange PAIRING is full rank -- i.e. that K
+// must go through RI rather than compressing the exchange-ordered tensor.
+
+#include "../general/cmdline.h"
+#include "basis.h"
+#include "../general/tei_utils.h"
+#include "FiniteElementBasis.h"
+#include "RadialBasis.h"
+#include "PolynomialBasis.h"
+#include <ArmaEigen.h>
+#include <Eigen/Eigenvalues>
+#include <Eigen/SVD>
+#include <cstdio>
+
+using namespace helfem;
+
+int main(int argc, char **argv) {
+  cmdline::parser parser;
+  parser.add<double>("Rmax", 0, "practical infinity", false, 40.0);
+  parser.add<int>("nelem", 0, "number of elements", false, 5);
+  parser.add<int>("nnodes", 0, "nodes per element", false, 15);
+  parser.add<int>("primbas", 0, "primitive radial basis", false, 4);
+  parser.add<int>("Lmax", 0, "largest multipole to probe", false, 6);
+  parser.add<double>("tol", 0, "Cholesky tolerance", false, 1e-12);
+  parser.parse_check(argc, argv);
+
+  const double Rmax = parser.get<double>("Rmax");
+  const int Nelem = parser.get<int>("nelem");
+  const int Nnodes = parser.get<int>("nnodes");
+  const int primbas = parser.get<int>("primbas");
+  const int Lmax = parser.get<int>("Lmax");
+  const double tol = parser.get<double>("tol");
+
+  auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
+      polynomial_basis::get_basis(primbas, Nnodes));
+  const int Nquad = 5 * poly->get_nbf();
+
+  arma::vec bval(atomic::basis::normal_grid(Nelem, Rmax, 4, 1.0));
+  polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(bval),
+                                            true, false, true, false);
+  atomic::basis::FEMRadialBasis radial(fem, Nquad);
+
+  printf("nnodes = %i, nquad = %i, tol = %.0e\n\n", Nnodes, Nquad, tol);
+  printf("%3s %3s | %6s | %6s | %11s | %11s | %11s\n",
+         "iel", "L", "Ni^2", "rank", "|T-LL'|/|T|", "min eig", "K-pairing rank");
+  printf("---------------------------------------------------------------------------------\n");
+
+  for (size_t iel = 0; iel < (size_t) std::min(Nelem, 3); iel++) {
+    for (int L = 0; L <= Lmax; L++) {
+      const helfem::Matrix T = radial.twoe_integral(L, iel);
+      const Eigen::Index n = T.rows();
+      const size_t Ni = (size_t) std::lround(std::sqrt((double) n));
+
+      // Existing libhelfem pivoted Cholesky
+      const helfem::Matrix Lf = radial.twoe_integral_cholesky(L, iel, tol);
+      const double err = (T - Lf * Lf.transpose()).norm() / T.norm();
+
+      // Is it really PSD?
+      Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(
+          helfem::Matrix(0.5 * (T + T.transpose())), Eigen::EigenvaluesOnly);
+      const double emin = es.eigenvalues().minCoeff();
+      const double emax = es.eigenvalues().cwiseAbs().maxCoeff();
+
+      // Exchange pairing: is it compressible at all?
+      const helfem::Matrix Kt(helfem::to_eigen(
+          utils::exchange_tei(helfem::to_arma(T), Ni, Ni, Ni, Ni)));
+      Eigen::JacobiSVD<helfem::Matrix> svd(Kt);
+      const helfem::Vector sv = svd.singularValues();
+      int krank = 0;
+      for (Eigen::Index i = 0; i < sv.size(); i++)
+        if (sv(i) / sv(0) > 1e-12) krank++;
+
+      printf("%3i %3i | %6i | %6i | %11.2e | %11.2e | %6i / %i\n",
+             (int) iel, L, (int) n, (int) Lf.cols(), err, emin / emax,
+             krank, (int) n);
+    }
+    printf("\n");
+  }
+  return 0;
+}


### PR DESCRIPTION
The atomic counterpart of #232. Same situation: the cross-element contributions to J and K are already contracted in factorized (disjoint `r^L / r^-L-1`) form, so the in-element block was the only 4-index object left -- stored as an `(Ni^2 x Ni^2)` matrix per `(element, L)`, **and again** as an exchange-ordered copy, so storage grew as `nnodes^4`.

## The rank is known exactly, not empirically

A `k+1`-node LIP element spans polynomials of degree `<= k`, so the orbital **products** span degree `<= 2k` -- a space of dimension exactly `2k+1 = 2*Nprim - 1`. The two-electron tensor is a Gram matrix over that product space, so its rank is **bounded by construction**.

Measured, over every element and every multipole:

| nnodes | predicted `2*Nprim-1` | measured | `\|\|T - L L'\|\| / \|\|T\|\|` |
|---|---|---|---|
| 8 | 15 | **15** | ~5e-17 |
| 10 | 19 | **19** | ~6e-17 |
| 15 | 29 | **29** | ~9e-17 |

Element 0 comes out one lower on each side (13 / 17 / 27) -- exactly as it should, since the `r=0` boundary condition drops one function there, so its `Nprim` is one smaller.

So the factorization is **exact**, not an approximation: the tolerance discards only numerical zeros.

And because the bound is a property of the *product basis* rather than of the kernel, it applies to **any** kernel sandwiched between the same orbital products -- so the **Yukawa-screened** in-element integrals are factorized here too.

## Mostly wiring

libhelfem already had all of this -- `FEMRadialBasis::twoe_integral_cholesky`, `yukawa_integral_cholesky`, and the `assemble_{J,K}_FE_one_multipole_cached_chol` helpers, plus a note recording that the exchange-ordered tensor is essentially full rank and that both J and K should therefore go through the J-ordered factor. **None of it had a caller.** This PR wires it up:

* `prim_tei` / `prim_ktei` -> `prim_chol` (bare Coulomb)
* `rs_ktei` (Yukawa in-element) -> `rs_chol`
* J and K both assembled from the J-ordered factor, K via the RI contraction `K_ac = sum_p M_p P M_p'`. No exchange-ordered tensor is built.

The exchange **pairing** is full rank -- 196/196, 225/225, confirmed by the new `atomic_teirank` probe -- so compressing it directly is not an option. RI is the only route, which is precisely why nothing needs to be stored for it.

The **erfc** path is left alone: there the cross-element blocks are not multipole-separable and are stored in full, so it needs its own treatment (the same product-basis bound applies to them, so it should compress -- just not by this code path).

## Validation

Against a binary built from master (Ar, `lmax=2 nelem=5`):

| method | exercises | master | this PR |
|---|---|---|---|
| `hf` | J and K | -475.8712591129 | **-475.8712591129** |
| `hyb_gga_xc_b3lyp` | J and K | -476.7826564137 | **-476.7826564137** |
| `hyb_gga_xc_wb97x` | range-separated | -476.7838845799 | **-476.7838845799** |
| `hf`, `nnodes=25` | J and K | -475.8660441772 | **-475.8660441772** |

Peak RSS on the last one: **310 MB -> 172 MB**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
