### PR TITLE
Remove allocation churn from the two-electron integral build

### DIFF
--- a/src/diatomic/quadrature.cpp
+++ b/src/diatomic/quadrature.cpp
@@ -187,50 +187,71 @@ namespace helfem {
         const Eigen::Index nq  = el.x.size();
         const Eigen::Index nbf = el.bf.cols();
 
+        // Scratch, allocated ONCE per call and reused. Previously every one of
+        // the nq subintervals allocated its own wp/wbf/prod, and each outer()
+        // call copied the whole (nq x nbf^2) bfprod table just to scale it by
+        // the weights -- hundreds of MB of allocation traffic through
+        // compute_tei, which the profile saw as malloc/memmove/memset.
+        helfem::Matrix inner(nq, nbf*nbf);
+        helfem::Matrix wbf(nq, nbf);
+        helfem::Matrix prod(nbf, nbf);
+        helfem::Vector acc(nbf*nbf);
+        helfem::Vector wp(nq);
+        helfem::Matrix wbfprod(nq, nbf*nbf);
+        helfem::Vector legscratch(nq);
+
         // Inner integrals as a function of the outer point, accumulated over
         // the subintervals. Depends on l (through cosh^l) and on (L, M)
         // (through P_{L|M|}), but on no polynomial evaluation.
         auto inner_integral = [&](int lval) {
-          helfem::Matrix inner(nq, nbf*nbf);
-          helfem::Vector acc = helfem::Vector::Zero(nbf*nbf);
+          acc.setZero();
           for(Eigen::Index ip=0;ip<nq;ip++) {
             const TwoElectronElement::Subinterval & si = el.sub[ip];
 
-            helfem::Vector wp = si.mulen*el.wx;
+            wp = si.mulen*el.wx;
             wp.array() *= si.shmu.array();
             if(lval!=0)
               wp.array() *= si.chmu.array().pow(lval);
-            wp.array() *= Plm(tab, L, M, si.chmu).array();
+            // Fill via the scalar accessor: the vector-returning overload
+            // bridges Eigen -> arma, allocates, and copies back, three
+            // allocations per subinterval.
+            for(Eigen::Index i=0;i<nq;i++)
+              legscratch(i) = tab.get_Plm(L, M, si.chmu(i));
+            wp.array() *= legscratch.array();
 
-            helfem::Matrix wbf = si.bf;
+            wbf = si.bf;
             for(Eigen::Index i=0;i<wbf.cols();i++)
               wbf.col(i).array() *= wp.array();
 
-            const helfem::Matrix prod = wbf.transpose()*si.bf;
+            prod.noalias() = wbf.transpose()*si.bf;
             acc += Eigen::Map<const helfem::Vector>(prod.data(), prod.size());
             inner.row(ip) = acc.transpose();
           }
-          return inner;
         };
 
         // Outer integral, for the (k, l) ordering
-        auto outer = [&](int kval, int lval) {
-          const helfem::Matrix inner = inner_integral(lval);
+        auto outer = [&](int kval, int lval, helfem::Matrix & out) {
+          inner_integral(lval);
 
-          helfem::Vector wp = el.mulen*el.wx;
+          wp = el.mulen*el.wx;
           wp.array() *= el.shmu.array();
           if(kval!=0)
             wp.array() *= el.chmu.array().pow(kval);
-          wp.array() *= Qlm(tab, L, M, el.chmu).array();
+          for(Eigen::Index i=0;i<nq;i++)
+            legscratch(i) = tab.get_Qlm(L, M, el.chmu(i));
+          wp.array() *= legscratch.array();
 
-          helfem::Matrix bfprod = el.bfprod;
-          for(Eigen::Index i=0;i<bfprod.cols();i++)
-            bfprod.col(i).array() *= wp.array();
+          wbfprod = el.bfprod;
+          for(Eigen::Index i=0;i<wbfprod.cols();i++)
+            wbfprod.col(i).array() *= wp.array();
 
-          return helfem::Matrix(bfprod.transpose()*inner);
+          out.noalias() = wbfprod.transpose()*inner;
         };
 
-        return outer(k,l) + helfem::Matrix(outer(l,k).transpose());
+        helfem::Matrix t1(nbf*nbf, nbf*nbf), t2(nbf*nbf, nbf*nbf);
+        outer(k, l, t1);
+        outer(l, k, t2);
+        return helfem::Matrix(t1 + t2.transpose());
       }
 
     }

--- a/src/general/legendretable.cpp
+++ b/src/general/legendretable.cpp
@@ -34,10 +34,17 @@ namespace helfem {
     }
 
     size_t LegendreTable::get_index(double xi, bool check) const {
-      legendre_table_t p;
-      p.xi=xi;
-
-      std::vector<legendre_table_t>::const_iterator low(std::lower_bound(stor.begin(),stor.end(),p));
+      // Search on xi alone. Constructing a legendre_table_t just to carry the
+      // search key would construct -- and immediately destroy -- its two
+      // arma::mat members on EVERY lookup, and get_index is called once per
+      // quadrature point, inside the (L, M, subinterval) loops of the
+      // two-electron integral build. That churn showed up as several percent
+      // of the run time in malloc/memmove.
+      std::vector<legendre_table_t>::const_iterator low(
+          std::lower_bound(stor.begin(), stor.end(), xi,
+                           [](const legendre_table_t & e, double v) {
+                             return e.xi < v;
+                           }));
       if(check && low == stor.end()) {
         std::ostringstream oss;
         oss << "Could not find xi=" << xi << " on the list!\n";


### PR DESCRIPTION
Profiling put roughly a third of a diatomic run in `malloc` / `memmove` / `memset`, most of it under `compute_tei`. Two causes, both pure waste.

## 1. `LegendreTable::get_index` allocated two matrices per lookup

```cpp
legendre_table_t p;      // holds TWO arma::mat members
p.xi = xi;
std::lower_bound(stor.begin(), stor.end(), p);
```

It constructed a full table entry -- **two `arma::mat`** -- just to carry a `double` search key, then destroyed it. And `get_index` is called **once per quadrature point**, inside the `(L, M, subinterval)` loops of the two-electron integral build. It now searches on `xi` directly with a projection comparator and allocates nothing.

## 2. `quadrature::twoe_integral` allocated its scratch inside its loops

Every one of the `nq` subintervals allocated a fresh `wp` / `wbf` / `prod`, and each `outer()` call **copied the whole `(nq x nbf^2)` `bfprod` table** just to scale it by the weights. Scratch is now allocated once per call and reused.

The per-subinterval Legendre values were also fetched through the arma-returning overload, which bridges Eigen -> arma, allocates the result, and copies back -- three allocations per subinterval. They are now filled into scratch through the scalar accessor.

## Correctness

No functional change. Bit-exact energies, identical SCF iteration counts:

| | master | this PR |
|---|---|---|
| N2 diatomic LDA | -79.4807491233 | **-79.4807491233** |
| N2 diatomic B3LYP | -80.7740786973 | **-80.7740786973** |
| Ar atomic HF | -475.8712591129 | **-475.8712591129** |

## Speed, and a measurement caveat worth recording

| | master | this PR | |
|---|---|---|---|
| LDA | 4.19 G | 3.89 G | **-7.2 %** |
| B3LYP | 6.35 G | 6.06 G | **-4.7 %** |

These are **callgrind** instruction counts, not timings. The machine I have is loaded by unrelated jobs, and wall clock, CPU time *and* `perf`'s instructions-retired counter all swung by 15-40 % run-to-run **on identical work** -- at one point suggesting a 40 % regression that did not exist. Only callgrind (which simulates, so it is deterministic and load-immune) gave a stable answer.

The gain is smaller than the profile's malloc/memmove share suggests, because that share is *cycles* (memory stalls), not instructions. The wall-clock effect on an idle machine should be larger than the instruction count implies -- but I have no way to measure that here, so I am not claiming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
