### PR TITLE
diatomic: take arma off the Fock path (Eigen-native boundary expansion)

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -404,6 +404,15 @@ namespace helfem {
 
           gaunt=gaunt::Gaunt(lrval,midval,lrval);
         }
+
+        // Cache the real->dummy index map once. pure_indices() rebuilds it on
+        // every call, and boundary expansion / removal runs on every Fock build.
+        {
+          const arma::uvec idx(pure_indices());
+          pure_idx.resize(idx.n_elem);
+          for(size_t i=0;i<idx.n_elem;i++)
+            pure_idx[i] = (Eigen::Index) idx(i);
+        }
       }
 
       TwoDBasis::~TwoDBasis() {
@@ -722,7 +731,7 @@ namespace helfem {
         // Plug in prefactor
         S*=std::pow(Rhalf,3);
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(S)));
+        return remove_boundaries(S);
       }
 
       helfem::Matrix TwoDBasis::overlap(const TwoDBasis & rh) const {
@@ -785,7 +794,7 @@ namespace helfem {
         // Plug in prefactor
         T*=Rhalf/2.0;
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(T)));
+        return remove_boundaries(T);
       }
 
       helfem::Matrix TwoDBasis::nuclear() const {
@@ -823,7 +832,7 @@ namespace helfem {
         // Plug in prefactor
         V*=-std::pow(Rhalf,2);
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(V)));
+        return remove_boundaries(V);
       }
 
       helfem::Matrix TwoDBasis::dipole_z() const {
@@ -861,7 +870,7 @@ namespace helfem {
         // Plug in prefactors
         V*=std::pow(Rhalf,4);
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(V)));
+        return remove_boundaries(V);
       }
 
       helfem::Matrix TwoDBasis::quadrupole_zz() const {
@@ -904,7 +913,7 @@ namespace helfem {
         // Plug in prefactors
         V*=std::pow(Rhalf,5)/2;
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(V)));
+        return remove_boundaries(V);
       }
 
       helfem::Matrix TwoDBasis::Bz_field(double B) const {
@@ -956,7 +965,7 @@ namespace helfem {
           }
         }
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(V)));
+        return remove_boundaries(V);
       }
 
 
@@ -1183,10 +1192,8 @@ namespace helfem {
         if(!cd_B.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
-        // Public boundary Eigen. The boundary-expansion trimmer is still
-        // arma, so bridge around it: to_arma -> expand_boundaries -> to_eigen.
-        // The interior is Eigen-native.
-        helfem::Matrix P(helfem::to_eigen(expand_boundaries(helfem::to_arma(P_in))));
+        // Eigen throughout: no arma bridge on the Fock path.
+        const helfem::Matrix P(expand_boundaries(P_in));
 
         // Number of radial elements
         size_t Nel(radial.Nel());
@@ -1369,16 +1376,15 @@ namespace helfem {
           }
         }
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(J)));
+        return remove_boundaries(J);
       }
 
       helfem::Matrix TwoDBasis::exchange(const helfem::Matrix & P_in) const {
         if(!cd_B.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
-        // Public boundary Eigen. Bridge around the still-arma boundary
-        // expander; the interior is Eigen-native.
-        helfem::Matrix P(helfem::to_eigen(expand_boundaries(helfem::to_arma(P_in))));
+        // Eigen throughout: no arma bridge on the Fock path.
+        const helfem::Matrix P(expand_boundaries(P_in));
 
         // Number of radial elements
         size_t Nel(radial.Nel());
@@ -1576,7 +1582,36 @@ namespace helfem {
           }
         }
 
-        return helfem::to_eigen(remove_boundaries(helfem::to_arma(K)));
+        return remove_boundaries(K);
+      }
+
+      helfem::Matrix TwoDBasis::remove_boundaries(const helfem::Matrix & Fnob) const {
+        const Eigen::Index N = (Eigen::Index) Ndummy();
+        if(Fnob.rows() != N || Fnob.cols() != N) {
+          std::ostringstream oss;
+          oss << "Matrix does not have expected size! Got " << Fnob.rows() << " x " << Fnob.cols() << ", expected " << N << " x " << N << "!\n";
+          throw std::logic_error(oss.str());
+        }
+        const Eigen::Index n = (Eigen::Index) pure_idx.size();
+        helfem::Matrix Fpure(n, n);
+        for(Eigen::Index j=0;j<n;j++)
+          for(Eigen::Index i=0;i<n;i++)
+            Fpure(i,j) = Fnob(pure_idx[i], pure_idx[j]);
+        return Fpure;
+      }
+
+      helfem::Matrix TwoDBasis::expand_boundaries(const helfem::Matrix & Ppure) const {
+        const Eigen::Index n = (Eigen::Index) pure_idx.size();
+        if(Ppure.rows() != n || Ppure.cols() != n) {
+          std::ostringstream oss;
+          oss << "Matrix does not have expected size! Got " << Ppure.rows() << " x " << Ppure.cols() << ", expected " << n << " x " << n << "!\n";
+          throw std::logic_error(oss.str());
+        }
+        helfem::Matrix Pnob(helfem::Matrix::Zero((Eigen::Index) Ndummy(), (Eigen::Index) Ndummy()));
+        for(Eigen::Index j=0;j<n;j++)
+          for(Eigen::Index i=0;i<n;i++)
+            Pnob(pure_idx[i], pure_idx[j]) = Ppure(i,j);
+        return Pnob;
       }
 
       arma::mat TwoDBasis::remove_boundaries(const arma::mat & Fnob) const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -136,6 +136,11 @@ namespace helfem {
         /// Legendre function table
         legendretable::LegendreTable legtab;
 
+        /// Cached pure_indices(): dummy index of each real basis function.
+        /// Built once; pure_indices() itself rebuilt it on every call, and it
+        /// is called on every boundary expansion / removal.
+        std::vector<Eigen::Index> pure_idx;
+
         /// L, |M| map
         std::vector<lmidx_t> lm_map;
         /// L, M map
@@ -230,6 +235,17 @@ namespace helfem {
         arma::mat expand_boundaries(const arma::mat & H) const;
         /// Remove boundary conditions
         arma::mat remove_boundaries(const arma::mat & H) const;
+
+        /// Eigen-native boundary expansion / removal.
+        ///
+        /// These run on every Fock build -- coulomb(), exchange() and the XC
+        /// grid all bridge a density in and a matrix out -- and the arma
+        /// versions above went through arma's generic index-pair submatrix
+        /// (subview_elem2), which showed up as ~5% of the run time. They also
+        /// rebuilt the index list on every call. These use the cached index
+        /// list and a plain gather/scatter loop.
+        helfem::Matrix expand_boundaries(const helfem::Matrix & Ppure) const;
+        helfem::Matrix remove_boundaries(const helfem::Matrix & Fnob) const;
 
 
         /// Compute two-electron integrals

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -57,8 +57,7 @@ namespace helfem {
         if(!P0.size()) {
           throw std::runtime_error("Error - density matrix is empty!\n");
         }
-        // expand_boundaries stays arma at the basis boundary; bridge locally.
-        arma::mat Pexp(basp->expand_boundaries(helfem::to_arma(P0)));
+        const helfem::Matrix Pexp(basp->expand_boundaries(P0));
         helfem::Matrix P(bf_ind.size(), bf_ind.size());
         for(size_t i=0;i<bf_ind.size();i++)
           for(size_t j=0;j<bf_ind.size();j++)
@@ -571,7 +570,7 @@ namespace helfem {
         Ekin=ekin;
         Nel=nel;
 
-        H_e=helfem::to_eigen(basp->remove_boundaries(helfem::to_arma(H)));
+        H_e=basp->remove_boundaries(H);
       }
 
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
@@ -612,8 +611,8 @@ namespace helfem {
         Nel=nel;
 
         // Clean up matrices
-        Ha_e=helfem::to_eigen(basp->remove_boundaries(helfem::to_arma(Ha)));
-        Hb_e=helfem::to_eigen(basp->remove_boundaries(helfem::to_arma(Hb)));
+        Ha_e=basp->remove_boundaries(Ha);
+        Hb_e=basp->remove_boundaries(Hb);
       }
 
     }

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -225,7 +225,7 @@ namespace helfem {
         // expanded into the dummy basis before it can be gathered -- exactly
         // as the general 3D worker does. Nbf() == Ndummy() only when every m
         // block keeps all its radial functions, i.e. mmax == 0.
-        const helfem::Matrix P(helfem::to_eigen(basp->expand_boundaries(helfem::to_arma(P0))));
+        const helfem::Matrix P(basp->expand_boundaries(P0));
 
         const Eigen::Index nang = cth.size();
         const size_t nm = mlist.size();
@@ -310,8 +310,8 @@ namespace helfem {
         polarized = true;
 
         // See the restricted overload: bf_ind_m indexes the dummy basis.
-        const helfem::Matrix Pa(helfem::to_eigen(basp->expand_boundaries(helfem::to_arma(Pa0))));
-        const helfem::Matrix Pb(helfem::to_eigen(basp->expand_boundaries(helfem::to_arma(Pb0))));
+        const helfem::Matrix Pa(basp->expand_boundaries(Pa0));
+        const helfem::Matrix Pb(basp->expand_boundaries(Pb0));
 
         const Eigen::Index nang = cth.size();
         const size_t nm = mlist.size();
@@ -618,7 +618,7 @@ namespace helfem {
           }
         }
         Exc = exc; Ekin = ekin; Nel = nel;
-        H_e = helfem::to_eigen(basp->remove_boundaries(helfem::to_arma(H)));
+        H_e = basp->remove_boundaries(H);
       }
 
       void PureMDFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars,
@@ -649,9 +649,9 @@ namespace helfem {
           }
         }
         Exc = exc; Ekin = ekin; Nel = nel;
-        Ha_e = helfem::to_eigen(basp->remove_boundaries(helfem::to_arma(Ha)));
+        Ha_e = basp->remove_boundaries(Ha);
         if (beta)
-          Hb_e = helfem::to_eigen(basp->remove_boundaries(helfem::to_arma(Hb)));
+          Hb_e = basp->remove_boundaries(Hb);
       }
 
     }


### PR DESCRIPTION
Progress on the arma -> Eigen migration (#24), picked because it was also the last big item left in the profile: `arma::subview_elem2` was ~5% of a diatomic run.

## What was happening

Every Fock build bridged through arma **twice**. `coulomb()`, `exchange()` and both XC grids each did

```cpp
to_eigen(expand_boundaries(to_arma(P)))   ...   to_eigen(remove_boundaries(to_arma(F)))
```

so the density was copied Eigen -> arma, expanded, copied back -- and the same in reverse for the result.

Worse, the expansion itself used arma's generic index-pair submatrix,

```cpp
Pnob(idx, idx) = Ppure;
```

which goes through `subview_elem2`, **and** it rebuilt the index list by calling `pure_indices()` on *every call*.

## What this does

* Caches the real -> dummy index map once in the constructor instead of rebuilding it per call.
* Adds Eigen-native `expand_boundaries` / `remove_boundaries` overloads that do a plain gather/scatter over the cached indices.
* Points `coulomb()`, `exchange()`, `overlap()`, `kinetic()`, `nuclear()`, the field matrices and both XC grids at those directly -- no arma round trip anywhere on the Fock path.

The arma overloads stay for the callers that are still arma-side.

## Results

Bit-exact:

| | master | this PR |
|---|---|---|
| N2 LDA | -79.4807491233 | **-79.4807491233** |
| N2 B3LYP | -80.7740786973 | **-80.7740786973** |

Instruction counts (callgrind -- see #234 for why timings on this machine are unusable):

| | master | this PR | |
|---|---|---|---|
| LDA | 3.89 G | 3.37 G | **-13.4 %** |
| B3LYP | 6.06 G | 5.46 G | **-9.9 %** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
