### PR TITLE
atomic: template the Hartree-Fock path on the scalar type (helium HF in quad precision)

### DIFF
--- a/libhelfem/include/CoulombExchangeFE.h
+++ b/libhelfem/include/CoulombExchangeFE.h
@@ -24,11 +24,13 @@ namespace helfem {
   // public include path; the symbol is resolved at link time -- callers
   // of these helpers link against libhelfem anyway).
   namespace utils {
-    /// (ij|kl) -> (jk|il) permutation on the helfem::Matrix-typed
+    /// (ij|kl) -> (jk|il) permutation on the helfem::Mat<T>-typed
     /// in-element TEI. Used internally by the assemble_K_FE_one_multipole
-    /// helpers below.
-    helfem::Matrix exchange_tei(const helfem::Matrix & tei, size_t Ni, size_t Nj,
-                                 size_t Nk, size_t Nl);
+    /// helpers below. Explicitly instantiated in libhelfem/src/utils.cpp
+    /// for double, long double and (under HELFEM_HAVE_FLOAT128) _Float128.
+    template <typename T>
+    helfem::Mat<T> exchange_tei(const helfem::Mat<T> & tei, size_t Ni, size_t Nj,
+                                size_t Nk, size_t Nl);
   }
   namespace atomic {
     namespace basis {
@@ -77,24 +79,39 @@ namespace helfem {
       /// driven from an SCF loop) avoid recomputing on every call.
       // Phase 2c: accessor types now return Eigen Matrix references,
       // matching the new TwoDBasis cache types (std::vector<helfem::Matrix>).
-      using PerElementAccessor =
-          std::function<const helfem::Matrix & (size_t iel)>;
+      template <typename T = double>
+      using PerElementAccessorT =
+          std::function<const helfem::Mat<T> & (size_t iel)>;
+      using PerElementAccessor = PerElementAccessorT<double>;
+
+      // Every entry point below is templated on the scalar type T, which is
+      // deduced from `radial` (a FEMRadialBasisT<T>) and from the density
+      // matrix. The per-element accessors are taken as GENERIC callables
+      // rather than as a fixed std::function type: template argument
+      // deduction does not see through the user-defined conversion from a
+      // lambda to std::function, so a std::function parameter would break
+      // every existing call site. As a bonus the lambdas are now called
+      // directly, with no type-erasure indirection.
 
       // -- Uncached entry points --------------------------------------
 
-      helfem::Matrix assemble_J_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE);
+      template <typename T>
+      helfem::Mat<T> assemble_J_FE_one_multipole(
+          const FEMRadialBasisT<T> & radial, int L, const helfem::Mat<T> & P_FE);
 
-      helfem::Matrix assemble_K_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE);
+      template <typename T>
+      helfem::Mat<T> assemble_K_FE_one_multipole(
+          const FEMRadialBasisT<T> & radial, int L, const helfem::Mat<T> & P_FE);
 
-      helfem::Matrix assemble_J_FE_one_multipole_yukawa(
-          const FEMRadialBasis & radial, int L, double lambda,
-          const helfem::Matrix & P_FE);
+      template <typename T>
+      helfem::Mat<T> assemble_J_FE_one_multipole_yukawa(
+          const FEMRadialBasisT<T> & radial, int L, helfem::NonDeduced<T> lambda,
+          const helfem::Mat<T> & P_FE);
 
-      helfem::Matrix assemble_K_FE_one_multipole_yukawa(
-          const FEMRadialBasis & radial, int L, double lambda,
-          const helfem::Matrix & P_FE);
+      template <typename T>
+      helfem::Mat<T> assemble_K_FE_one_multipole_yukawa(
+          const FEMRadialBasisT<T> & radial, int L, helfem::NonDeduced<T> lambda,
+          const helfem::Mat<T> & P_FE);
 
       // -- Cached entry points ----------------------------------------
 
@@ -105,105 +122,43 @@ namespace helfem {
       /// twoe_in_element (= twoe_integral(L, iel) or yukawa_integral) are
       /// supplied by the caller via accessors. Same assembly, no
       /// recomputation -- meant for SCF inner-loop callers.
-      helfem::Matrix assemble_J_FE_one_multipole_cached(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & twoe_in_element,
-          const helfem::Matrix & P_FE);
-
-      /// As above for K. Note `ktei_in_element` here returns the
-      /// EXCHANGE-PERMUTED in-element tensor (i.e.
+      ///
+      /// As above for K: `ktei_in_element` returns the EXCHANGE-PERMUTED
+      /// in-element tensor (i.e.
       ///   utils::exchange_tei(twoe_in_element(iel), Ni, Ni, Ni, Ni))
       /// so SCF-driven callers (TwoDBasis, which precomputes prim_ktei)
       /// can pass the cached permuted form directly with zero overhead.
-      helfem::Matrix assemble_K_FE_one_multipole_cached(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & ktei_in_element,
-          const helfem::Matrix & P_FE);
 
-      /// Per-(iel, jel) accessor variant of the above K helper, for
-      /// kernels whose r1/r2 coupling does NOT factorise into a
-      /// small/big disjoint product (in particular: the error-function
-      /// kernel used by HelFEM's compute_erfc / rs_exchange). Every
-      /// element pair gets its own dense ktei from the cache, then the
-      /// standard K contraction is applied. No disjoint optimisation
-      /// available -- O(Nel^2) per call.
-      using PerElementPairAccessor =
-          std::function<const helfem::Matrix & (size_t iel, size_t jel)>;
-      helfem::Matrix assemble_K_FE_one_multipole_cached_pairwise(
-          const FEMRadialBasis & radial,
-          const PerElementPairAccessor & ktei_pairwise,
-          const helfem::Matrix & P_FE);
-
-      /// Cholesky-factored variants of the cached J / K helpers. Both
-      /// take the SAME per-element J-ordered Cholesky factor of shape
-      /// (Ni^2 x r) such that
-      ///     T(ab, cd) = twoe_integral(L, iel)(ab, cd)
-      ///              = Sum_p factor(ab, p) * factor(cd, p)
-      /// where (ab) is the row pair (vec(.) column-major; a-fast b-slow).
-      /// Build via FEMRadialBasis::twoe_integral_cholesky.
-      ///
-      /// Asymmetric cost picture (per element):
-      ///   J: O(r * Ni^2) -- inner product per Cholesky vector then
-      ///                     scalar * outer; ~4x FASTER than dense
-      ///                     matvec at typical FE rank ~ 2*Ni.
-      ///   K: O(r * Ni^3) -- two matmuls per Cholesky vector via
-      ///                     K = Sum_p M_p . P . M_p^T (M_p = reshape
-      ///                     of the p-th Cholesky column to Ni x Ni).
-      ///                     SLOWER than dense K (O(Ni^4)) for typical
-      ///                     FE rank-vs-Ni ratios; the K-PERMUTED tensor
-      ///                     happens to be ~full-rank (the bivariate
-      ///                     space u_a(r1) u_c(r2) is Ni^2-dimensional),
-      ///                     so K-side Cholesky compression buys nothing.
-      ///
-      /// Why expose the K factored form anyway: it is the canonical
-      /// RI / density-fitting representation expected by external
-      /// drivers (PySCF's DF backend forms K from the same (mu nu | P)
-      /// 3-index factor that backs J). Memory-wise, callers who store
-      /// only the J-ordered Cholesky factor save ~Ni^2/r ~ 7x relative
-      /// to caching the full in-element tensor; the slower K contraction
-      /// is the price paid for that compression.
-      ///
-      /// Cross-element pieces are unchanged -- still use the disjoint
-      /// r_small / r_big factorisation. Only the in-element 4-index
-      /// path is factored.
-      helfem::Matrix assemble_J_FE_one_multipole_cached_chol(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & twoe_chol_J,
-          const helfem::Matrix & P_FE);
-
-      helfem::Matrix assemble_K_FE_one_multipole_cached_chol(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & twoe_chol_J,
-          const helfem::Matrix & P_FE);
+      /// Per-element integral accessor: given an element index `iel`,
+      /// returns the per-element matrix for the multipole the caller has
+      /// in mind. Kept as a named alias for callers who want to store one;
+      /// the assemblers themselves take any callable with this shape.
+      template <typename T = double>
+      using PerElementPairAccessorT =
+          std::function<const helfem::Mat<T> & (size_t iel, size_t jel)>;
+      using PerElementPairAccessor = PerElementPairAccessorT<double>;
 
       // Inline implementations -- header-only to match the rest of the
-      // libhelfem/include/ NAO surface. ~150 LOC total.
+      // libhelfem/include/ NAO surface.
 
       namespace detail_fe_2e {
 
-        // Phase 2c: caches are std::vector<helfem::Matrix>; the bridges
-        // these used to do are no longer needed -- direct return.
-        inline helfem::Matrix r_small(const FEMRadialBasis & fem, int L, size_t iel,
-                                       bool yukawa, double lambda) {
+        template <typename T>
+        inline helfem::Mat<T> r_small(const FEMRadialBasisT<T> & fem, int L, size_t iel,
+                                      bool yukawa, T lambda) {
           return yukawa ? fem.bessel_il_integral(L, lambda, iel)
                         : fem.radial_integral(L, iel);
         }
-        inline helfem::Matrix r_big(const FEMRadialBasis & fem, int L, size_t iel,
-                                     bool yukawa, double lambda) {
+        template <typename T>
+        inline helfem::Mat<T> r_big(const FEMRadialBasisT<T> & fem, int L, size_t iel,
+                                    bool yukawa, T lambda) {
           return yukawa ? fem.bessel_kl_integral(L, lambda, iel)
                         : fem.radial_integral(-L - 1, iel);
         }
-        inline helfem::Matrix in_element_tei(const FEMRadialBasis & fem, int L,
-                                              size_t iel,
-                                              bool yukawa, double lambda) {
+        template <typename T>
+        inline helfem::Mat<T> in_element_tei(const FEMRadialBasisT<T> & fem, int L,
+                                             size_t iel,
+                                             bool yukawa, T lambda) {
           return yukawa ? fem.yukawa_integral(L, lambda, iel)
                         : fem.twoe_integral(L, iel);
         }
@@ -212,18 +167,9 @@ namespace helfem {
 
       // -- Per-element cache construction helpers ---------------------
       //
-      // The cached assembly helpers below
-      // (assemble_*_FE_one_multipole_cached) take per-(L, iel) integrals
-      // via accessor lambdas; SCF-driven callers (atomic::TwoDBasis,
-      // sadatom::TwoDBasis) populate those caches once per basis change.
-      // The fill loops are identical in structure between the two
-      // callers, so we share them here.
-      //
       // Convention: caches are flat vectors with index = L*Nel + iel
       // (or L*Nel*Nel + iel*Nel + jel for cross-element). Matches the
-      // existing TwoDBasis cache layouts exactly so the helpers below
-      // can be dropped into existing call sites without changing the
-      // surrounding accessor lambdas.
+      // existing TwoDBasis cache layouts exactly.
 
       /// Per-(L, iel) disjoint radial integrals for the multipole
       /// decomposition.
@@ -231,22 +177,23 @@ namespace helfem {
       ///            disjoint_big  [L*Nel+iel] = radial.radial_integral(-L-1, iel)
       ///   Yukawa:  disjoint_small = radial.bessel_il_integral(L, lambda, iel)
       ///            disjoint_big   = radial.bessel_kl_integral(L, lambda, iel)
+      template <typename T>
       inline void compute_disjoint_radial_integrals(
-          const FEMRadialBasis & radial,
+          const FEMRadialBasisT<T> & radial,
           int N_L,
-          std::vector<helfem::Matrix> & disjoint_small,
-          std::vector<helfem::Matrix> & disjoint_big,
+          std::vector<helfem::Mat<T>> & disjoint_small,
+          std::vector<helfem::Mat<T>> & disjoint_big,
           bool yukawa = false,
-          double lambda = 0.0) {
+          helfem::NonDeduced<T> lambda = T(0)) {
         const size_t Nel = radial.Nel();
         disjoint_small.resize((size_t) N_L * Nel);
         disjoint_big  .resize((size_t) N_L * Nel);
         for (int L = 0; L < N_L; ++L) {
           for (size_t iel = 0; iel < Nel; ++iel) {
             disjoint_small[(size_t) L * Nel + iel] =
-                detail_fe_2e::r_small(radial, L, iel, yukawa, lambda);
+                detail_fe_2e::r_small<T>(radial, L, iel, yukawa, lambda);
             disjoint_big  [(size_t) L * Nel + iel] =
-                detail_fe_2e::r_big  (radial, L, iel, yukawa, lambda);
+                detail_fe_2e::r_big<T>  (radial, L, iel, yukawa, lambda);
           }
         }
       }
@@ -256,14 +203,13 @@ namespace helfem {
       /// assembled on the fly from the disjoint factors in the
       /// assemble_*_FE_one_multipole_cached path. Layout:
       ///   prim_tei[L*Nel*Nel + iel*Nel + iel] = in-element 4-index tensor
-      /// For bare Coulomb (default): radial.twoe_integral(L, iel).
-      /// For Yukawa: radial.yukawa_integral(L, lambda, iel).
+      template <typename T>
       inline void compute_in_element_tei(
-          const FEMRadialBasis & radial,
+          const FEMRadialBasisT<T> & radial,
           int N_L,
-          std::vector<helfem::Matrix> & prim_tei,
+          std::vector<helfem::Mat<T>> & prim_tei,
           bool yukawa = false,
-          double lambda = 0.0) {
+          helfem::NonDeduced<T> lambda = T(0)) {
         const size_t Nel = radial.Nel();
         prim_tei.resize(Nel * Nel * (size_t) N_L);
 #ifdef _OPENMP
@@ -272,7 +218,7 @@ namespace helfem {
         for (int L = 0; L < N_L; ++L) {
           for (size_t iel = 0; iel < Nel; ++iel) {
             prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel] =
-                detail_fe_2e::in_element_tei(radial, L, iel, yukawa, lambda);
+                detail_fe_2e::in_element_tei<T>(radial, L, iel, yukawa, lambda);
           }
         }
       }
@@ -280,11 +226,12 @@ namespace helfem {
       /// Apply utils::exchange_tei to each in-element prim_tei entry to
       /// produce the exchange-permuted form (prim_ktei) used by the
       /// cached K assembly. Only diagonal entries.
+      template <typename T>
       inline void compute_in_element_ktei_from_tei(
-          const FEMRadialBasis & radial,
+          const FEMRadialBasisT<T> & radial,
           int N_L,
-          const std::vector<helfem::Matrix> & prim_tei,
-          std::vector<helfem::Matrix> & prim_ktei) {
+          const std::vector<helfem::Mat<T>> & prim_tei,
+          std::vector<helfem::Mat<T>> & prim_ktei) {
         const size_t Nel = radial.Nel();
         prim_ktei.resize(Nel * Nel * (size_t) N_L);
 #ifdef _OPENMP
@@ -294,7 +241,7 @@ namespace helfem {
           for (size_t iel = 0; iel < Nel; ++iel) {
             const size_t Ni = radial.Nprim(iel);
             prim_ktei[Nel * Nel * (size_t) L + iel * Nel + iel] =
-                helfem::utils::exchange_tei(
+                helfem::utils::exchange_tei<T>(
                     prim_tei[Nel * Nel * (size_t) L + iel * Nel + iel],
                     Ni, Ni, Ni, Ni);
           }
@@ -305,15 +252,13 @@ namespace helfem {
       ///   rs_ktei[L*Nel*Nel + iel*Nel + jel]
       ///     = exchange-permuted erfc 4-index tensor for (iel, jel).
       /// The erfc kernel does NOT factorise into disjoint small/big
-      /// factors, so all Nel*Nel pairs are stored explicitly. The
-      /// pairwise K assembly path
-      /// (assemble_K_FE_one_multipole_cached_pairwise) consumes this
-      /// layout.
+      /// factors, so all Nel*Nel pairs are stored explicitly.
+      template <typename T>
       inline void compute_erfc_ktei(
-          const FEMRadialBasis & radial,
+          const FEMRadialBasisT<T> & radial,
           int N_L,
-          double mu,
-          std::vector<helfem::Matrix> & rs_ktei) {
+          helfem::NonDeduced<T> mu,
+          std::vector<helfem::Mat<T>> & rs_ktei) {
         const size_t Nel = radial.Nel();
         rs_ktei.resize(Nel * Nel * (size_t) N_L);
 #ifdef _OPENMP
@@ -324,10 +269,8 @@ namespace helfem {
             for (size_t jel = 0; jel < Nel; ++jel) {
               const size_t Ni = radial.Nprim(iel);
               const size_t Nj = radial.Nprim(jel);
-              // Phase 2c wrap-up: utils::exchange_tei Eigen overload
-              // -- direct erfc_integral (Eigen) -> rs_ktei (Eigen).
               rs_ktei[Nel * Nel * (size_t) L + iel * Nel + jel] =
-                  helfem::utils::exchange_tei(
+                  helfem::utils::exchange_tei<T>(
                       radial.erfc_integral(L, mu, iel, jel),
                       Ni, Ni, Nj, Nj);
             }
@@ -340,24 +283,25 @@ namespace helfem {
       // NAO use) and cached (look-up-from-SCF-cache, TwoDBasis use)
       // entry points.
 
-      inline helfem::Matrix assemble_J_FE_one_multipole_cached(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & twoe_in_element,
-          const helfem::Matrix & P_FE) {
+      template <typename T, typename RSmall, typename RBig, typename TwoE>
+      inline helfem::Mat<T> assemble_J_FE_one_multipole_cached(
+          const FEMRadialBasisT<T> & radial,
+          const RSmall & r_small,
+          const RBig & r_big,
+          const TwoE & twoe_in_element,
+          const helfem::Mat<T> & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix & P_E = P_FE;
-        helfem::Matrix J_E = helfem::Matrix::Zero(Nrad, Nrad);
+        const helfem::Mat<T> & P_E = P_FE;
+        helfem::Mat<T> J_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
           radial.get_idx(jel, jfirst, jlast);
           const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
-          const helfem::Matrix Psub =
+          const helfem::Mat<T> Psub =
               P_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj);
-          const double jsmall = (r_small(jel) * Psub).trace();
-          const double jbig   = (r_big  (jel) * Psub).trace();
+          const T jsmall = (r_small(jel) * Psub).trace();
+          const T jbig   = (r_big  (jel) * Psub).trace();
           for (size_t iel = 0; iel < jel; ++iel) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
@@ -374,24 +318,25 @@ namespace helfem {
           }
           // In-element 4-index contribution: J_sub = twoe * vec(Psub),
           // then reshape back to Nj x Nj.
-          const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Nj * Nj);
-          const Eigen::VectorXd Jsub_v = twoe_in_element(jel) * Psub_v;
+          const Eigen::Map<const helfem::Vec<T>> Psub_v(Psub.data(), Nj * Nj);
+          const helfem::Vec<T> Jsub_v = twoe_in_element(jel) * Psub_v;
           J_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj)
-              += Eigen::Map<const Eigen::MatrixXd>(Jsub_v.data(), Nj, Nj);
+              += Eigen::Map<const helfem::Mat<T>>(Jsub_v.data(), Nj, Nj);
         }
         return J_E;
       }
 
-      inline helfem::Matrix assemble_K_FE_one_multipole_cached(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & ktei_in_element,
-          const helfem::Matrix & P_FE) {
+      template <typename T, typename RSmall, typename RBig, typename KTei>
+      inline helfem::Mat<T> assemble_K_FE_one_multipole_cached(
+          const FEMRadialBasisT<T> & radial,
+          const RSmall & r_small,
+          const RBig & r_big,
+          const KTei & ktei_in_element,
+          const helfem::Mat<T> & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix & P_E = P_FE;
-        helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
+        const helfem::Mat<T> & P_E = P_FE;
+        helfem::Mat<T> K_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
           radial.get_idx(iel, ifirst, ilast);
@@ -401,16 +346,16 @@ namespace helfem {
             radial.get_idx(jel, jfirst, jlast);
             const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
             if (iel == jel) {
-              const helfem::Matrix Psub =
+              const helfem::Mat<T> Psub =
                   P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
-              const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Ni * Nj);
-              const Eigen::VectorXd Ksub_v = ktei_in_element(iel) * Psub_v;
+              const Eigen::Map<const helfem::Vec<T>> Psub_v(Psub.data(), Ni * Nj);
+              const helfem::Vec<T> Ksub_v = ktei_in_element(iel) * Psub_v;
               K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
-                  += Eigen::Map<const Eigen::MatrixXd>(Ksub_v.data(), Ni, Nj);
+                  += Eigen::Map<const helfem::Mat<T>>(Ksub_v.data(), Ni, Nj);
             } else {
-              const helfem::Matrix & iint = (iel > jel) ? r_big(iel) : r_small(iel);
-              const helfem::Matrix & jint = (iel > jel) ? r_small(jel) : r_big(jel);
-              const helfem::Matrix Psub =
+              const helfem::Mat<T> & iint = (iel > jel) ? r_big(iel) : r_small(iel);
+              const helfem::Mat<T> & jint = (iel > jel) ? r_small(jel) : r_big(jel);
+              const helfem::Mat<T> Psub =
                   P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
               K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
                   += iint * (Psub * jint.transpose());
@@ -420,14 +365,20 @@ namespace helfem {
         return K_E;
       }
 
-      inline helfem::Matrix assemble_K_FE_one_multipole_cached_pairwise(
-          const FEMRadialBasis & radial,
-          const PerElementPairAccessor & ktei_pairwise,
-          const helfem::Matrix & P_FE) {
+      /// Per-(iel, jel) accessor variant of the above K helper, for
+      /// kernels whose r1/r2 coupling does NOT factorise into a
+      /// small/big disjoint product (in particular: the error-function
+      /// kernel used by compute_erfc / rs_exchange). Every element pair
+      /// gets its own dense ktei from the cache. O(Nel^2) per call.
+      template <typename T, typename KTeiPair>
+      inline helfem::Mat<T> assemble_K_FE_one_multipole_cached_pairwise(
+          const FEMRadialBasisT<T> & radial,
+          const KTeiPair & ktei_pairwise,
+          const helfem::Mat<T> & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix & P_E = P_FE;
-        helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
+        const helfem::Mat<T> & P_E = P_FE;
+        helfem::Mat<T> K_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
           radial.get_idx(iel, ifirst, ilast);
@@ -436,12 +387,12 @@ namespace helfem {
             size_t jfirst, jlast;
             radial.get_idx(jel, jfirst, jlast);
             const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
-            const helfem::Matrix Psub =
+            const helfem::Mat<T> Psub =
                 P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
-            const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Ni * Nj);
-            const Eigen::VectorXd Ksub_v = ktei_pairwise(iel, jel) * Psub_v;
+            const Eigen::Map<const helfem::Vec<T>> Psub_v(Psub.data(), Ni * Nj);
+            const helfem::Vec<T> Ksub_v = ktei_pairwise(iel, jel) * Psub_v;
             K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
-                += Eigen::Map<const Eigen::MatrixXd>(Ksub_v.data(), Ni, Nj);
+                += Eigen::Map<const helfem::Mat<T>>(Ksub_v.data(), Ni, Nj);
           }
         }
         return K_E;
@@ -450,26 +401,30 @@ namespace helfem {
       // --- Cholesky-factored cached helpers -----------------------------
       // Same FE structure as the dense cached J / K helpers above, but
       // the in-element 4-index contraction is rewritten as a sum of
-      // outer products over the Cholesky rank.
+      // outer products over the Cholesky rank. Both take the SAME
+      // per-element J-ordered Cholesky factor of shape (Ni^2 x r) with
+      //     T(ab, cd) = Sum_p factor(ab, p) * factor(cd, p),
+      // built via FEMRadialBasisT::twoe_integral_cholesky.
 
-      inline helfem::Matrix assemble_J_FE_one_multipole_cached_chol(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & twoe_chol_J,
-          const helfem::Matrix & P_FE) {
+      template <typename T, typename RSmall, typename RBig, typename Chol>
+      inline helfem::Mat<T> assemble_J_FE_one_multipole_cached_chol(
+          const FEMRadialBasisT<T> & radial,
+          const RSmall & r_small,
+          const RBig & r_big,
+          const Chol & twoe_chol_J,
+          const helfem::Mat<T> & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix & P_E = P_FE;
-        helfem::Matrix J_E = helfem::Matrix::Zero(Nrad, Nrad);
+        const helfem::Mat<T> & P_E = P_FE;
+        helfem::Mat<T> J_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
           radial.get_idx(jel, jfirst, jlast);
           const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
-          const helfem::Matrix Psub =
+          const helfem::Mat<T> Psub =
               P_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj);
-          const double jsmall = (r_small(jel) * Psub).trace();
-          const double jbig   = (r_big  (jel) * Psub).trace();
+          const T jsmall = (r_small(jel) * Psub).trace();
+          const T jbig   = (r_big  (jel) * Psub).trace();
           for (size_t iel = 0; iel < jel; ++iel) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
@@ -488,26 +443,27 @@ namespace helfem {
           //   J_{ab} = Sum_p L(ab, p) . <L_p, P>
           // with the (ab) pair packed column-major (a-fast, b-slow) so
           // vec(P) (Eigen also column-major) matches L's row layout.
-          const helfem::Matrix & L = twoe_chol_J(jel);
-          const Eigen::Map<const Eigen::VectorXd> Psub_v(Psub.data(), Nj * Nj);
-          const Eigen::VectorXd scalars = L.transpose() * Psub_v;  // length r
-          const Eigen::VectorXd Jsub_v  = L * scalars;             // length Nj^2
+          const helfem::Mat<T> & L = twoe_chol_J(jel);
+          const Eigen::Map<const helfem::Vec<T>> Psub_v(Psub.data(), Nj * Nj);
+          const helfem::Vec<T> scalars = L.transpose() * Psub_v;  // length r
+          const helfem::Vec<T> Jsub_v  = L * scalars;             // length Nj^2
           J_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj)
-              += Eigen::Map<const Eigen::MatrixXd>(Jsub_v.data(), Nj, Nj);
+              += Eigen::Map<const helfem::Mat<T>>(Jsub_v.data(), Nj, Nj);
         }
         return J_E;
       }
 
-      inline helfem::Matrix assemble_K_FE_one_multipole_cached_chol(
-          const FEMRadialBasis & radial,
-          const PerElementAccessor & r_small,
-          const PerElementAccessor & r_big,
-          const PerElementAccessor & twoe_chol_J,
-          const helfem::Matrix & P_FE) {
+      template <typename T, typename RSmall, typename RBig, typename Chol>
+      inline helfem::Mat<T> assemble_K_FE_one_multipole_cached_chol(
+          const FEMRadialBasisT<T> & radial,
+          const RSmall & r_small,
+          const RBig & r_big,
+          const Chol & twoe_chol_J,
+          const helfem::Mat<T> & P_FE) {
         const size_t Nel  = radial.Nel();
         const Eigen::Index Nrad = (Eigen::Index) radial.Nbf();
-        const helfem::Matrix & P_E = P_FE;
-        helfem::Matrix K_E = helfem::Matrix::Zero(Nrad, Nrad);
+        const helfem::Mat<T> & P_E = P_FE;
+        helfem::Mat<T> K_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
           radial.get_idx(iel, ifirst, ilast);
@@ -522,20 +478,20 @@ namespace helfem {
               // with M_p = reshape(L.col(p), Ni, Ni) (column-major so
               // M_p(a, b) = L(a + b*Ni, p), matching the (ab) row pair
               // in twoe_integral).
-              const helfem::Matrix & L = twoe_chol_J(iel);
-              const helfem::Matrix Psub =
+              const helfem::Mat<T> & L = twoe_chol_J(iel);
+              const helfem::Mat<T> Psub =
                   P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
-              helfem::Matrix Ksub = helfem::Matrix::Zero(Ni, Nj);
+              helfem::Mat<T> Ksub = helfem::Mat<T>::Zero(Ni, Nj);
               for (Eigen::Index p = 0; p < L.cols(); ++p) {
-                Eigen::Map<const Eigen::MatrixXd> Mp(L.col(p).data(), Ni, Ni);
+                Eigen::Map<const helfem::Mat<T>> Mp(L.col(p).data(), Ni, Ni);
                 Ksub += Mp * (Psub * Mp.transpose());
               }
               K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
                   += Ksub;
             } else {
-              const helfem::Matrix & iint = (iel > jel) ? r_big(iel) : r_small(iel);
-              const helfem::Matrix & jint = (iel > jel) ? r_small(jel) : r_big(jel);
-              const helfem::Matrix Psub =
+              const helfem::Mat<T> & iint = (iel > jel) ? r_big(iel) : r_small(iel);
+              const helfem::Mat<T> & jint = (iel > jel) ? r_small(jel) : r_big(jel);
+              const helfem::Mat<T> Psub =
                   P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
               K_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj)
                   += iint * (Psub * jint.transpose());
@@ -548,56 +504,56 @@ namespace helfem {
       // The uncached entry points just wire on-the-fly accessors that
       // call the FE primitives directly.
 
-      // Phase 2c: scratchpads are now std::vector<helfem::Matrix>; the
-      // is_empty check becomes .size() == 0 (Eigen's empty-by-default).
-      inline helfem::Matrix assemble_J_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE) {
+      template <typename T>
+      inline helfem::Mat<T> assemble_J_FE_one_multipole(
+          const FEMRadialBasisT<T> & radial, int L, const helfem::Mat<T> & P_FE) {
         // Per-call temporaries to keep the accessor lambdas returning a
         // stable const reference (storing each computed matrix in a
         // capture-list scratchpad).
-        std::vector<helfem::Matrix> scratch_small(radial.Nel());
-        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
-        std::vector<helfem::Matrix> scratch_twoe (radial.Nel());
-        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+        std::vector<helfem::Mat<T>> scratch_small(radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_big  (radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_twoe (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_small[iel].size() == 0)
-            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, false, 0.0);
+            scratch_small[iel] = detail_fe_2e::r_small<T>(radial, L, iel, false, T(0));
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+        auto rb = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_big[iel].size() == 0)
-            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, false, 0.0);
+            scratch_big[iel] = detail_fe_2e::r_big<T>(radial, L, iel, false, T(0));
           return scratch_big[iel];
         };
-        auto tw = [&](size_t iel) -> const helfem::Matrix & {
+        auto tw = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_twoe[iel].size() == 0)
-            scratch_twoe[iel] = detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0);
+            scratch_twoe[iel] = detail_fe_2e::in_element_tei<T>(radial, L, iel, false, T(0));
           return scratch_twoe[iel];
         };
         return assemble_J_FE_one_multipole_cached(radial, rs, rb, tw, P_FE);
       }
 
-      inline helfem::Matrix assemble_K_FE_one_multipole(
-          const FEMRadialBasis & radial, int L, const helfem::Matrix & P_FE) {
-        std::vector<helfem::Matrix> scratch_small(radial.Nel());
-        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
-        std::vector<helfem::Matrix> scratch_ktei (radial.Nel());
-        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+      template <typename T>
+      inline helfem::Mat<T> assemble_K_FE_one_multipole(
+          const FEMRadialBasisT<T> & radial, int L, const helfem::Mat<T> & P_FE) {
+        std::vector<helfem::Mat<T>> scratch_small(radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_big  (radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_ktei (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_small[iel].size() == 0)
-            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, false, 0.0);
+            scratch_small[iel] = detail_fe_2e::r_small<T>(radial, L, iel, false, T(0));
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+        auto rb = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_big[iel].size() == 0)
-            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, false, 0.0);
+            scratch_big[iel] = detail_fe_2e::r_big<T>(radial, L, iel, false, T(0));
           return scratch_big[iel];
         };
-        auto kt = [&](size_t iel) -> const helfem::Matrix & {
+        auto kt = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_ktei[iel].size() == 0) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
-            scratch_ktei[iel] = utils::exchange_tei(
-                detail_fe_2e::in_element_tei(radial, L, iel, false, 0.0),
+            scratch_ktei[iel] = utils::exchange_tei<T>(
+                detail_fe_2e::in_element_tei<T>(radial, L, iel, false, T(0)),
                 Ni, Ni, Ni, Ni);
           }
           return scratch_ktei[iel];
@@ -605,60 +561,61 @@ namespace helfem {
         return assemble_K_FE_one_multipole_cached(radial, rs, rb, kt, P_FE);
       }
 
-      inline helfem::Matrix assemble_J_FE_one_multipole_yukawa(
-          const FEMRadialBasis & radial, int L, double lambda,
-          const helfem::Matrix & P_FE) {
-        std::vector<helfem::Matrix> scratch_small(radial.Nel());
-        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
-        std::vector<helfem::Matrix> scratch_twoe (radial.Nel());
-        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+      template <typename T>
+      inline helfem::Mat<T> assemble_J_FE_one_multipole_yukawa(
+          const FEMRadialBasisT<T> & radial, int L, helfem::NonDeduced<T> lambda,
+          const helfem::Mat<T> & P_FE) {
+        std::vector<helfem::Mat<T>> scratch_small(radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_big  (radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_twoe (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_small[iel].size() == 0)
-            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, true, lambda);
+            scratch_small[iel] = detail_fe_2e::r_small<T>(radial, L, iel, true, lambda);
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+        auto rb = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_big[iel].size() == 0)
-            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, true, lambda);
+            scratch_big[iel] = detail_fe_2e::r_big<T>(radial, L, iel, true, lambda);
           return scratch_big[iel];
         };
-        auto tw = [&](size_t iel) -> const helfem::Matrix & {
+        auto tw = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_twoe[iel].size() == 0)
-            scratch_twoe[iel] = detail_fe_2e::in_element_tei(radial, L, iel, true, lambda);
+            scratch_twoe[iel] = detail_fe_2e::in_element_tei<T>(radial, L, iel, true, lambda);
           return scratch_twoe[iel];
         };
         return assemble_J_FE_one_multipole_cached(radial, rs, rb, tw, P_FE);
       }
 
-      inline helfem::Matrix assemble_K_FE_one_multipole_yukawa(
-          const FEMRadialBasis & radial, int L, double lambda,
-          const helfem::Matrix & P_FE) {
-        std::vector<helfem::Matrix> scratch_small(radial.Nel());
-        std::vector<helfem::Matrix> scratch_big  (radial.Nel());
-        std::vector<helfem::Matrix> scratch_ktei (radial.Nel());
-        auto rs = [&](size_t iel) -> const helfem::Matrix & {
+      template <typename T>
+      inline helfem::Mat<T> assemble_K_FE_one_multipole_yukawa(
+          const FEMRadialBasisT<T> & radial, int L, helfem::NonDeduced<T> lambda,
+          const helfem::Mat<T> & P_FE) {
+        std::vector<helfem::Mat<T>> scratch_small(radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_big  (radial.Nel());
+        std::vector<helfem::Mat<T>> scratch_ktei (radial.Nel());
+        auto rs = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_small[iel].size() == 0)
-            scratch_small[iel] = detail_fe_2e::r_small(radial, L, iel, true, lambda);
+            scratch_small[iel] = detail_fe_2e::r_small<T>(radial, L, iel, true, lambda);
           return scratch_small[iel];
         };
-        auto rb = [&](size_t iel) -> const helfem::Matrix & {
+        auto rb = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_big[iel].size() == 0)
-            scratch_big[iel] = detail_fe_2e::r_big(radial, L, iel, true, lambda);
+            scratch_big[iel] = detail_fe_2e::r_big<T>(radial, L, iel, true, lambda);
           return scratch_big[iel];
         };
-        auto kt = [&](size_t iel) -> const helfem::Matrix & {
+        auto kt = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_ktei[iel].size() == 0) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
-            scratch_ktei[iel] = utils::exchange_tei(
-                detail_fe_2e::in_element_tei(radial, L, iel, true, lambda),
+            scratch_ktei[iel] = utils::exchange_tei<T>(
+                detail_fe_2e::in_element_tei<T>(radial, L, iel, true, lambda),
                 Ni, Ni, Ni, Ni);
           }
           return scratch_ktei[iel];
         };
         return assemble_K_FE_one_multipole_cached(radial, rs, rb, kt, P_FE);
       }
-
     } // namespace basis
   } // namespace atomic
 } // namespace helfem

--- a/libhelfem/include/helfem.source.h
+++ b/libhelfem/include/helfem.source.h
@@ -53,9 +53,13 @@ namespace helfem {
 
     /**
      * Calculates the half-inverse of a matrix.
-     * Phase 5.10: Eigen-typed.
+     * Phase 5.10: Eigen-typed. Templated on the scalar type so the
+     * symmetric orthonormalization does not cap an otherwise
+     * higher-precision SCF at double; instantiated for double, long
+     * double and (under HELFEM_HAVE_FLOAT128) _Float128.
      */
-    helfem::Matrix invh(helfem::Matrix S, bool chol);
+    template <typename T>
+    helfem::Mat<T> invh(helfem::Mat<T> S, bool chol);
   } // namespace utils
 } // namespace helfem
 

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -18,6 +18,7 @@
 #include <Eigen/Eigenvalues>
 #include <Eigen/LU>
 #include <cmath>
+#include <type_traits>
 
 namespace helfem {
   namespace utils {
@@ -46,11 +47,13 @@ namespace helfem {
     template _Float128 bessel_kl<_Float128>(_Float128, int);
 #endif
 
-    helfem::Matrix exchange_tei(const helfem::Matrix & tei,
-                                 size_t Ni, size_t Nj, size_t Nk, size_t Nl) {
+    template <typename T>
+    helfem::Mat<T> exchange_tei(const helfem::Mat<T> & tei,
+                                size_t Ni, size_t Nj, size_t Nk, size_t Nl) {
       // Eigen overload of the same scalar-by-scalar (ij|kl) -> (jk|il)
       // permutation. Both arma and Eigen are column-major so the
-      // packed-pair index layout (a-fast, b-slow) is identical.
+      // packed-pair index layout (a-fast, b-slow) is identical. Pure
+      // index shuffling -- no arithmetic -- so it is exact at any T.
       if (static_cast<size_t>(tei.rows()) != Ni*Nj) {
         std::ostringstream oss;
         oss << "Invalid input tei: was supposed to get " << Ni*Nj
@@ -63,7 +66,7 @@ namespace helfem {
             << " cols but got " << tei.cols() << "!\n";
         throw std::logic_error(oss.str());
       }
-      helfem::Matrix ktei = helfem::Matrix::Zero(Nj*Nk, Ni*Nl);
+      helfem::Mat<T> ktei = helfem::Mat<T>::Zero(Nj*Nk, Ni*Nl);
       for (size_t ii = 0; ii < Ni; ++ii)
         for (size_t jj = 0; jj < Nj; ++jj)
           for (size_t kk = 0; kk < Nk; ++kk)
@@ -72,42 +75,85 @@ namespace helfem {
       return ktei;
     }
 
+    template helfem::Mat<double>      exchange_tei<double>     (const helfem::Mat<double> &,      size_t, size_t, size_t, size_t);
+    template helfem::Mat<long double> exchange_tei<long double>(const helfem::Mat<long double> &, size_t, size_t, size_t, size_t);
+#ifdef HELFEM_HAVE_FLOAT128
+    template helfem::Mat<_Float128>   exchange_tei<_Float128>  (const helfem::Mat<_Float128> &,   size_t, size_t, size_t, size_t);
+#endif
+
     int stricmp(const std::string & str1, const std::string & str2) {
       return strcasecmp(str1.c_str(),str2.c_str());
     }
 
-    // Phase 5.10: invh migrated to Eigen.
-    helfem::Matrix invh(helfem::Matrix S, bool chol) {
+    namespace {
+      // Elementwise x^(-1/2).
+      //
+      // Eigen's Array::pow(scalar) is SFINAE-gated on Eigen's OWN
+      // internal::is_arithmetic trait, whose list of floating types does not
+      // include _Float128, so the templated invh below cannot spell it that
+      // way for every T. double keeps the original .pow(-0.5) expression
+      // verbatim -- std::pow(x, -0.5) and 1/std::sqrt(x) may differ in the
+      // last ulp, and the point of this whole exercise is that the double
+      // results stay bit-for-bit what they were.
+      template <typename T>
+      helfem::Vec<T> inv_sqrt(const helfem::Vec<T> & v) {
+        if constexpr (std::is_same_v<T, double>) {
+          return v.array().pow(-0.5).matrix();
+        } else {
+          return v.unaryExpr([](T x) { return T(1) / std::sqrt(x); });
+        }
+      }
+    }
+
+    // Phase 5.10: invh migrated to Eigen. Now templated on the scalar type:
+    // the symmetric orthonormalization sits directly on the SCF path, so
+    // pinning it to double would cap an otherwise higher-precision
+    // calculation right where it matters. Eigen's LLT and
+    // SelfAdjointEigenSolver are themselves generic in the scalar, so the
+    // body is unchanged apart from the types -- and the T = double
+    // instantiation is bit-identical to the pre-template code (see inv_sqrt
+    // above, which preserves the original .pow(-0.5) spelling at double).
+    template <typename T>
+    helfem::Mat<T> invh(helfem::Mat<T> S, bool chol) {
       // Basis function norms: 1 / sqrt(diag(S))
-      const helfem::Vector bfnormlz = S.diagonal().array().pow(-0.5).matrix();
+      const helfem::Vec<T> Sdiag = S.diagonal();
+      const helfem::Vec<T> bfnormlz = inv_sqrt<T>(Sdiag);
 
       // Go to normalized basis: S -> diag(bfnormlz) S diag(bfnormlz)
       S = bfnormlz.asDiagonal() * S * bfnormlz.asDiagonal();
 
-      helfem::Matrix Sinvh;
+      helfem::Mat<T> Sinvh;
       if (chol) {
         // Sinvh = inv(chol(S))  -- upper-triangular L from LLT, inverted.
-        Eigen::LLT<helfem::Matrix> llt(S);
+        Eigen::LLT<helfem::Mat<T>> llt(S);
         if (llt.info() != Eigen::Success)
           throw std::logic_error("Cholesky decomposition of overlap matrix failed\n");
         // arma::chol(S) returns the upper triangular U with U^T U = S;
         // Eigen LLT stores L (lower) with L L^T = S. To mirror arma we
         // take L^T then invert.
-        const helfem::Matrix U = llt.matrixL().transpose();
+        const helfem::Mat<T> U = llt.matrixL().transpose();
         Sinvh = U.inverse();
       } else {
-        Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(S);
+        Eigen::SelfAdjointEigenSolver<helfem::Mat<T>> es(S);
         if (es.info() != Eigen::Success)
           throw std::logic_error("Diagonalization of overlap matrix failed\n");
-        const helfem::Vector Sval = es.eigenvalues();
-        const helfem::Matrix Svec = es.eigenvectors();
+        const helfem::Vec<T> Sval = es.eigenvalues();
+        const helfem::Mat<T> Svec = es.eigenvectors();
+        // printf has no conversion for T; go through double at the I/O
+        // boundary only (the arithmetic above stays in T).
         printf("Smallest eigenvalue of overlap matrix is % e, condition number %e\n",
-               Sval(0), Sval(Sval.size() - 1) / Sval(0));
-        Sinvh = Svec * Sval.array().pow(-0.5).matrix().asDiagonal() * Svec.transpose();
+               (double) Sval(0), (double) (Sval(Sval.size() - 1) / Sval(0)));
+        Sinvh = Svec * inv_sqrt<T>(Sval).asDiagonal() * Svec.transpose();
       }
 
       Sinvh = bfnormlz.asDiagonal() * Sinvh;
       return Sinvh;
     }
+
+    template helfem::Mat<double>      invh<double>     (helfem::Mat<double>,      bool);
+    template helfem::Mat<long double> invh<long double>(helfem::Mat<long double>, bool);
+#ifdef HELFEM_HAVE_FLOAT128
+    template helfem::Mat<_Float128>   invh<_Float128>  (helfem::Mat<_Float128>,   bool);
+#endif
   }
 }

--- a/libhelfem/src/utils.h
+++ b/libhelfem/src/utils.h
@@ -28,6 +28,18 @@ namespace helfem {
     // long double computation to double accuracy. The long-double literals
     // below round to exactly M_PI / M_2_SQRTPI at T = double, so the
     // double instantiation is bit-identical to the pre-template code.
+    //
+    // NOTE the `L` suffix: the literal is rounded to LONG DOUBLE (64-bit
+    // mantissa, ~19 digits) BEFORE being converted to T. That is exactly right
+    // for T = double and T = long double, but at T = _Float128 it throws away
+    // 15 of the 34 digits the type can hold -- pi would come out wrong by
+    // 1.6e-20 relative. These constants are physical (the 4*pi/(2L+1) of the
+    // multipole expansion, the Gaussian-nucleus normalisation, the Gaunt
+    // prefactors), not basis choices, so that error would land straight in the
+    // Hamiltonian and cap the whole quad path at ~1e-19 no matter how good the
+    // basis or the arithmetic. Hence the explicit _Float128 specialisations
+    // below, which spell the SAME digits with the C++23 `f128` suffix so they
+    // survive to the full 113-bit mantissa.
     /// pi
     template <typename T> inline T pi() {
       return T(3.14159265358979323846264338327950288419716939937510L);
@@ -37,14 +49,26 @@ namespace helfem {
       return T(1.12837916709551257389615890312154517168810125865800L);
     }
 
+#ifdef HELFEM_HAVE_FLOAT128
+    template <> inline _Float128 pi<_Float128>() {
+      return 3.14159265358979323846264338327950288419716939937510f128;
+    }
+    template <> inline _Float128 two_over_sqrtpi<_Float128>() {
+      return 1.12837916709551257389615890312154517168810125865800f128;
+    }
+#endif
+
     /// Modified Bessel function
     template <typename T> T bessel_il(T x, int L);
     /// Modified Bessel function
     template <typename T> T bessel_kl(T x, int L);
 
     /// Permute indices (ij|kl) -> (jk|il).
-    helfem::Matrix exchange_tei(const helfem::Matrix & tei,
-                                 size_t Ni, size_t Nj, size_t Nk, size_t Nl);
+    /// Templated on the scalar type: the in-element two-electron tensors
+    /// follow FEMRadialBasisT<T>, so the exchange permutation must too.
+    template <typename T>
+    helfem::Mat<T> exchange_tei(const helfem::Mat<T> & tei,
+                                size_t Ni, size_t Nj, size_t Nk, size_t Nl);
 
     /// Case independent string comparison
     int stricmp(const std::string & str1, const std::string & str2);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,13 @@ target_link_libraries(diatomic_purem_test helfem-common legendre)
 add_executable(precision harmonic/precision.cpp)
 target_link_libraries(precision helfem-common legendre)
 
+# The same, one layer up: the whole atomic Hartree-Fock path (TwoDBasisT<T>,
+# GauntT<T>, the 2e integrals, Coulomb, exchange, orthonormalisation) at
+# double / long double / _Float128, on helium, whose HF basis-set limit is
+# known from the literature.
+add_executable(atomic_precision atomic/precision.cpp)
+target_link_libraries(atomic_precision helfem-common legendre)
+
 add_executable(diatomic_teirank diatomic/teirank.cpp)
 target_link_libraries(diatomic_teirank helfem-common legendre)
 

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -27,6 +27,8 @@
 #include <cassert>
 #include <cfloat>
 #include <algorithm>
+#include <limits>
+#include <type_traits>
 #include <helfem.h>
 
 #ifdef _OPENMP
@@ -36,17 +38,38 @@
 namespace helfem {
   namespace atomic {
     namespace basis {
-      TwoDBasis::TwoDBasis() {
+
+      // The routines that evaluate basis functions on a grid
+      // (eval_bf / eval_df / eval_lf) and the quadrature-point accessors
+      // (get_bval / get_wrad / get_r) hand back arma types and, in the
+      // eval_* case, go through the double-only ::spherical_harmonics.
+      // They serve the DFT grid and the analysis binaries, neither of which
+      // can run above double anyway (libxc is a double-only C library), and
+      // none of them is on the Fock path. Rather than split the class, they
+      // are compiled for every T and guarded: at T = double they are exactly
+      // the code they always were, and at any other T they throw.
+      namespace {
+        [[noreturn]] void double_only(const char *what) {
+          throw std::logic_error(std::string(what) +
+                                 " is only available at T = double "
+                                 "(it returns arma types / uses the "
+                                 "double-only spherical harmonics).\n");
+        }
       }
 
-      TwoDBasis::TwoDBasis(int Z_, modelpotential::nuclear_model_t model_,
-                             double Rrms_,
-                             const std::shared_ptr<const polynomial_basis::PolynomialBasis> & poly,
-                             bool zeroder_, int n_quad,
-                             const helfem::Vector & bval_e,
-                             const Eigen::VectorXi & lval_e,
-                             const Eigen::VectorXi & mval_e,
-                             int Zl_, int Zr_, double Rhalf_) {
+      template <typename T>
+      TwoDBasisT<T>::TwoDBasisT() {
+      }
+
+      template <typename T>
+      TwoDBasisT<T>::TwoDBasisT(int Z_, modelpotential::nuclear_model_t model_,
+                                T Rrms_,
+                                const std::shared_ptr<const helfem::lib1dfem::polynomial_basis::PolynomialBasis<T>> & poly,
+                                bool zeroder_, int n_quad,
+                                const helfem::Vec<T> & bval,
+                                const Eigen::VectorXi & lval_e,
+                                const Eigen::VectorXi & mval_e,
+                                int Zl_, int Zr_, T Rhalf_) {
         // Nuclear charge
         Z=Z_;
         Zl=Zl_;
@@ -55,53 +78,55 @@ namespace helfem {
         model=model_;
         Rrms=Rrms_;
 
-        // Bridge the Eigen boundary input to internal arma storage once
-        // (bval feeds the arma-based radial grid). lval/mval are stored
-        // as Eigen::VectorXi directly.
-        arma::vec bval(bval_e.size());
-        std::memcpy(bval.memptr(), bval_e.data(), sizeof(double) * (size_t) bval_e.size());
-
         // Construct radial basis
         bool zero_func_left=true;
         bool zero_deriv_left=false;
         bool zero_func_right=true;
         zeroder=zeroder_;
-        polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(bval), zero_func_left, zero_deriv_left, zero_func_right, zeroder);
-        radial=FEMRadialBasis(fem, n_quad);
+        polynomial_basis::FiniteElementBasisT<T> fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zeroder);
+        radial=FEMRadialBasisT<T>(fem, n_quad);
 
         // Construct angular basis
         lval=lval_e;
         mval=mval_e;
       }
 
-      TwoDBasis::~TwoDBasis() {
+      template <typename T>
+      TwoDBasisT<T>::~TwoDBasisT() {
       }
 
-      int TwoDBasis::get_nuclear_model() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_nuclear_model() const {
         return model;
       }
 
-      double TwoDBasis::get_nuclear_size() const {
+      template <typename T>
+      T TwoDBasisT<T>::get_nuclear_size() const {
         return Rrms;
       }
 
-      int TwoDBasis::get_Z() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_Z() const {
         return Z;
       }
 
-      int TwoDBasis::get_Zl() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_Zl() const {
         return Zl;
       }
 
-      int TwoDBasis::get_Zr() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_Zr() const {
         return Zr;
       }
 
-      double TwoDBasis::get_Rhalf() const {
+      template <typename T>
+      T TwoDBasisT<T>::get_Rhalf() const {
         return Rhalf;
       }
 
-      arma::ivec TwoDBasis::get_lval() const {
+      template <typename T>
+      arma::ivec TwoDBasisT<T>::get_lval() const {
         // Bridge Eigen->arma at the public boundary; consumers
         // (checkpoint I/O, drivers) still take arma::ivec.
         arma::ivec out(lval.size());
@@ -110,62 +135,79 @@ namespace helfem {
         return out;
       }
 
-      arma::ivec TwoDBasis::get_mval() const {
+      template <typename T>
+      arma::ivec TwoDBasisT<T>::get_mval() const {
         arma::ivec out(mval.size());
         for (Eigen::Index i = 0; i < mval.size(); ++i)
           out(i) = static_cast<arma::sword>(mval(i));
         return out;
       }
 
-      int TwoDBasis::get_nquad() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_nquad() const {
         return radial.get_nquad();
       }
 
-      arma::vec TwoDBasis::get_bval() const {
-        return helfem::to_arma(radial.get_bval());
+      template <typename T>
+      arma::vec TwoDBasisT<T>::get_bval() const {
+        if constexpr (std::is_same_v<T, double>) {
+          return helfem::to_arma(radial.get_bval());
+        } else {
+          double_only("get_bval");
+        }
       }
 
-      int TwoDBasis::get_poly_id() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_poly_id() const {
         return radial.get_poly_id();
       }
 
-      int TwoDBasis::get_poly_nnodes() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_poly_nnodes() const {
         return radial.get_poly_nnodes();
       }
 
-      int TwoDBasis::get_zeroder() const {
+      template <typename T>
+      int TwoDBasisT<T>::get_zeroder() const {
         return zeroder;
       }
 
-      size_t TwoDBasis::Ndummy() const {
+      template <typename T>
+      size_t TwoDBasisT<T>::Ndummy() const {
         return lval.size()*radial.Nbf();
       }
 
-      size_t TwoDBasis::Nbf() const {
+      template <typename T>
+      size_t TwoDBasisT<T>::Nbf() const {
         return Ndummy();
       }
 
-      size_t TwoDBasis::Nrad() const {
+      template <typename T>
+      size_t TwoDBasisT<T>::Nrad() const {
         return radial.Nbf();
       }
 
-      size_t TwoDBasis::Nang() const {
+      template <typename T>
+      size_t TwoDBasisT<T>::Nang() const {
         return lval.size();
       }
 
-      arma::uvec TwoDBasis::m_indices(int m) const {
+      template <typename T>
+      arma::uvec TwoDBasisT<T>::m_indices(int m) const {
         return helfem::collect_shell_indices(mval.size(),
             [&](size_t)   { return radial.Nbf(); },
             [&](size_t i) { return mval(i) == m; });
       }
 
-      arma::uvec TwoDBasis::lm_indices(int l, int m) const {
+      template <typename T>
+      arma::uvec TwoDBasisT<T>::lm_indices(int l, int m) const {
         return helfem::collect_shell_indices(mval.size(),
             [&](size_t)   { return radial.Nbf(); },
             [&](size_t i) { return mval(i) == m && lval(i) == l; });
       }
 
-      std::vector<arma::uvec> TwoDBasis::get_sym_idx(int symm) const {
+      template <typename T>
+      std::vector<arma::uvec> TwoDBasisT<T>::get_sym_idx(int symm) const {
         std::vector<arma::uvec> idx;
         if(symm==0) {
           idx.resize(1);
@@ -183,7 +225,7 @@ namespace helfem {
             idx[i]=m_indices(mv[i]);
         } else if(symm==2) {
           idx.resize(mval.size());
-          for(size_t i=0;i<mval.size();i++) {
+          for(size_t i=0;i<(size_t) mval.size();i++) {
             idx[i]=lm_indices(lval(i),mval(i));
           }
         } else
@@ -192,12 +234,13 @@ namespace helfem {
         return idx;
       }
 
-      helfem::Matrix TwoDBasis::Sinvh(bool chol, int sym) const {
-        const helfem::Matrix S = overlap();
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::Sinvh(bool chol, int sym) const {
+        const helfem::Mat<T> S = overlap();
 
         // Half-inverse is
         if(sym==0) {
-          return scf::form_Sinvh(S, chol);
+          return scf::form_Sinvh<T>(S, chol);
         } else {
           // Per-symmetry-block orthonormalization. get_sym_idx returns the
           // (scattered) AO index list for each block; the orthonormal
@@ -206,7 +249,7 @@ namespace helfem {
           // columns per block).
           std::vector<arma::uvec> midx(get_sym_idx(sym));
           const Eigen::Index N = static_cast<Eigen::Index>(Nbf());
-          helfem::Matrix Sinvh = helfem::Matrix::Zero(N, N);
+          helfem::Mat<T> Sinvh = helfem::Mat<T>::Zero(N, N);
           Eigen::Index ioff = 0;
           for(size_t i=0;i<midx.size();i++) {
             const Eigen::Index n = static_cast<Eigen::Index>(midx[i].n_elem);
@@ -219,11 +262,11 @@ namespace helfem {
               rows[k] = static_cast<Eigen::Index>(midx[i](k));
 
             // Gather the block overlap, orthonormalize.
-            helfem::Matrix Ssub(n, n);
+            helfem::Mat<T> Ssub(n, n);
             for(Eigen::Index a=0;a<n;a++)
               for(Eigen::Index b=0;b<n;b++)
                 Ssub(a,b) = S(rows[a], rows[b]);
-            const helfem::Matrix sub = scf::form_Sinvh(Ssub, chol);
+            const helfem::Mat<T> sub = scf::form_Sinvh<T>(Ssub, chol);
 
             // Scatter: rows scattered by `rows`, columns contiguous
             // [ioff, ioff+n).
@@ -236,42 +279,46 @@ namespace helfem {
         }
       }
 
-      void TwoDBasis::set_sub(helfem::Matrix & M, size_t iang, size_t jang, const helfem::Matrix & Mrad) const {
+      template <typename T>
+      void TwoDBasisT<T>::set_sub(helfem::Mat<T> & M, size_t iang, size_t jang, const helfem::Mat<T> & Mrad) const {
         const Eigen::Index n = static_cast<Eigen::Index>(radial.Nbf());
         M.block(static_cast<Eigen::Index>(iang)*n, static_cast<Eigen::Index>(jang)*n, n, n) = Mrad;
       }
 
-      void TwoDBasis::add_sub(helfem::Matrix & M, size_t iang, size_t jang, const helfem::Matrix & Mrad) const {
+      template <typename T>
+      void TwoDBasisT<T>::add_sub(helfem::Mat<T> & M, size_t iang, size_t jang, const helfem::Mat<T> & Mrad) const {
         const Eigen::Index n = static_cast<Eigen::Index>(radial.Nbf());
         M.block(static_cast<Eigen::Index>(iang)*n, static_cast<Eigen::Index>(jang)*n, n, n) += Mrad;
       }
 
-      helfem::Matrix TwoDBasis::overlap() const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::overlap() const {
         // Full overlap matrix built by scattering the radial R=0 integrals
         // along the angular diagonal. The atomic basis has no
         // boundary-condition reduction (pure_indices() is the identity),
         // so the assembled matrix is returned directly.
-        const helfem::Matrix Orad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> Orad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(0, iel); });
 
-        helfem::Matrix O = helfem::Matrix::Zero(Ndummy(), Ndummy());
-        for(size_t iang=0;iang<lval.size();iang++)
+        helfem::Mat<T> O = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
+        for(size_t iang=0;iang<(size_t) lval.size();iang++)
           set_sub(O,iang,iang,Orad);
 
         return O;
       }
 
-      helfem::Matrix TwoDBasis::overlap(const TwoDBasis & rh) const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::overlap(const TwoDBasisT<T> & rh) const {
         // Cross-basis overlap: scatter radial.overlap(rh.radial) along the
         // (l, m)-matched blocks of the two angular indexings. Each side's
         // pure_indices() is the identity, so no boundary slicing is needed.
-        helfem::Matrix S = helfem::Matrix::Zero(Ndummy(), rh.Ndummy());
-        const helfem::Matrix Srad = radial.overlap(rh.radial);
+        helfem::Mat<T> S = helfem::Mat<T>::Zero(Ndummy(), rh.Ndummy());
+        const helfem::Mat<T> Srad = radial.overlap(rh.radial);
         const Eigen::Index n   = static_cast<Eigen::Index>(radial.Nbf());
         const Eigen::Index rhn = static_cast<Eigen::Index>(rh.radial.Nbf());
 
-        for(size_t iang=0;iang<lval.size();iang++)
-          for(size_t jang=0;jang<rh.lval.size();jang++)
+        for(size_t iang=0;iang<(size_t) lval.size();iang++)
+          for(size_t jang=0;jang<(size_t) rh.lval.size();jang++)
             if(lval(iang) == rh.lval(jang) && mval(iang) == rh.mval(jang))
               S.block(static_cast<Eigen::Index>(iang)*n,
                       static_cast<Eigen::Index>(jang)*rhn, n, rhn) = Srad;
@@ -279,48 +326,50 @@ namespace helfem {
         return S;
       }
 
-      helfem::Matrix TwoDBasis::kinetic() const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::kinetic() const {
         // Build radial kinetic energy matrices
-        const helfem::Matrix Trad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> Trad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.kinetic(iel); });
-        const helfem::Matrix Trad_l = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> Trad_l = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.kinetic_l(iel); });
 
         // Full kinetic energy matrix
-        helfem::Matrix T = helfem::Matrix::Zero(Ndummy(), Ndummy());
+        helfem::Mat<T> Tmat = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
         // Fill elements
-        for(size_t iang=0;iang<lval.size();iang++) {
-          set_sub(T,iang,iang,Trad);
+        for(size_t iang=0;iang<(size_t) lval.size();iang++) {
+          set_sub(Tmat,iang,iang,Trad);
           if(lval(iang)>0) {
             // We also get the l(l+1) term
-            add_sub(T,iang,iang,static_cast<double>(lval(iang)*(lval(iang)+1))*Trad_l);
+            add_sub(Tmat,iang,iang,static_cast<T>(lval(iang)*(lval(iang)+1))*Trad_l);
           }
         }
 
-        return T;
+        return Tmat;
       }
 
-      helfem::Matrix TwoDBasis::nuclear() const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::nuclear() const {
         if(model != modelpotential::POINT_NUCLEUS) {
-          modelpotential::ModelPotential *pot=modelpotential::get_nuclear_model(model,Z,Rrms);
-          helfem::Matrix Vnuc = model_potential(pot);
+          modelpotential::ModelPotentialT<T> *pot=modelpotential::get_nuclear_model<T>(model,Z,Rrms);
+          helfem::Mat<T> Vnuc = model_potential(pot);
           delete pot;
           return Vnuc;
         } else {
           // Full nuclear attraction matrix
-          helfem::Matrix V = helfem::Matrix::Zero(Ndummy(), Ndummy());
+          helfem::Mat<T> V = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
 
-          if (Z != 0.0) {
-            const helfem::Matrix Vrad = helfem::assemble_radial_diagonal(radial,
+          if (Z != 0) {
+            const helfem::Mat<T> Vrad = helfem::assemble_radial_diagonal(radial,
                 [&](size_t iel) { return radial.radial_integral(-1, iel); });
-            for (size_t iang = 0; iang < lval.size(); iang++)
-              set_sub(V, iang, iang, static_cast<double>(-Z) * Vrad);
+            for (size_t iang = 0; iang < (size_t) lval.size(); iang++)
+              set_sub(V, iang, iang, static_cast<T>(-Z) * Vrad);
           }
 
-          if(Zl != 0.0 || Zr != 0.0) {
+          if(Zl != 0 || Zr != 0) {
             // Auxiliary matrices
             int Lmax(2*lval.maxCoeff());
-            std::vector<helfem::Matrix> Vaux(Lmax+1);
+            std::vector<helfem::Mat<T>> Vaux(Lmax+1);
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
@@ -330,14 +379,14 @@ namespace helfem {
             }
 
             int gmax(std::max(lval.maxCoeff(),mval.maxCoeff()));
-            gaunt::Gaunt gaunt(gmax,2*gmax,gmax);
+            gaunt::GauntT<T> gaunt(gmax,2*gmax,gmax);
 
             /// Loop over basis set
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2)
 #endif
-            for(size_t iang=0;iang<lval.size();iang++) {
-              for(size_t jang=0;jang<lval.size();jang++) {
+            for(size_t iang=0;iang<(size_t) lval.size();iang++) {
+              for(size_t jang=0;jang<(size_t) lval.size();jang++) {
                 int li(lval(iang));
                 int mi(mval(iang));
 
@@ -350,12 +399,12 @@ namespace helfem {
 
                 // Loop over L
                 for(int L=std::abs(li-lj);L<=li+lj;L++) {
-                  double cpl(gaunt.coeff(li,mi,L,0,lj));
-                  if(cpl==0.0)
+                  T cpl(gaunt.coeff(li,mi,L,0,lj));
+                  if(cpl==T(0))
                     continue;
 
-                  const double signL = (L & 1) ? -1.0 : 1.0;
-                  add_sub(V,iang,jang,(cpl*(signL*Zl + Zr))*Vaux[L]);
+                  const T signL = (L & 1) ? T(-1) : T(1);
+                  add_sub(V,iang,jang,(cpl*(signL*T(Zl) + T(Zr)))*Vaux[L]);
                 }
               }
             }
@@ -365,61 +414,64 @@ namespace helfem {
         }
       }
 
-      helfem::Matrix TwoDBasis::model_potential(const modelpotential::ModelPotential * pot) const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::model_potential(const modelpotential::ModelPotentialT<T> * pot) const {
         // Full nuclear attraction matrix
-        helfem::Matrix V = helfem::Matrix::Zero(Ndummy(), Ndummy());
+        helfem::Mat<T> V = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
 
-        const helfem::Matrix Vrad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> Vrad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.model_potential(pot, iel); });
 	// Fill elements
-	for(size_t iang=0;iang<lval.size();iang++)
+	for(size_t iang=0;iang<(size_t) lval.size();iang++)
 	  set_sub(V,iang,iang,Vrad);
 
         return V;
       }
 
-      helfem::Matrix TwoDBasis::confinement(const int N, double r_0, const int iconf, const double V, const double shift_pot) const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::confinement(const int N, T r_0, const int iconf, const T V, const T shift_pot) const {
         // Full matrix
-        helfem::Matrix O = helfem::Matrix::Zero(Ndummy(), Ndummy());
+        helfem::Mat<T> O = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
 
 	if(iconf==0)
 	  return O;
 
-        const helfem::Matrix Orad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> Orad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) {
               return radial.confinement_potential(iel, N, r_0, iconf, V, shift_pot);
             });
 
         // Fill elements
-        for(size_t iang=0;iang<lval.size();iang++)
+        for(size_t iang=0;iang<(size_t) lval.size();iang++)
           set_sub(O,iang,iang,Orad);
 
         return O;
       }
 
-      helfem::Matrix TwoDBasis::dipole_z() const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::dipole_z() const {
         // Build radial elements
-        const helfem::Matrix Orad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> Orad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(1, iel); });
 
         // Full electric couplings
-        helfem::Matrix V = helfem::Matrix::Zero(Ndummy(), Ndummy());
+        helfem::Mat<T> V = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
 
         int gmax(std::max(lval.maxCoeff(),mval.maxCoeff()));
-        gaunt::Gaunt gaunt(gmax,1,gmax);
+        gaunt::GauntT<T> gaunt(gmax,1,gmax);
 
         // Fill elements
-        for(size_t iang=0;iang<lval.size();iang++) {
+        for(size_t iang=0;iang<(size_t) lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.size();jang++) {
+          for(size_t jang=0;jang<(size_t) lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
             // Calculate coupling
-            double cpl(gaunt.cosine_coupling(lj,mj,li,mi));
-            if(cpl!=0.0)
+            T cpl(gaunt.cosine_coupling(lj,mj,li,mi));
+            if(cpl!=T(0))
               set_sub(V,iang,jang,cpl*Orad);
           }
         }
@@ -427,23 +479,24 @@ namespace helfem {
         return V;
       }
 
-      helfem::Matrix TwoDBasis::quadrupole_zz() const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::quadrupole_zz() const {
         // Build radial elements
-        const helfem::Matrix Orad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> Orad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(2, iel); });
 
         // Full electric couplings
-        helfem::Matrix V = helfem::Matrix::Zero(Ndummy(), Ndummy());
+        helfem::Mat<T> V = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
 
         int gmax(std::max(lval.maxCoeff(),mval.maxCoeff()));
-        gaunt::Gaunt gaunt(gmax,2,gmax);
+        gaunt::GauntT<T> gaunt(gmax,2,gmax);
 
         // Fill elements
-        for(size_t iang=0;iang<lval.size();iang++) {
+        for(size_t iang=0;iang<(size_t) lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.size();jang++) {
+          for(size_t jang=0;jang<(size_t) lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
@@ -451,9 +504,9 @@ namespace helfem {
             if(mj != mi) continue;
 
             // Calculate coupling
-            double cpl(gaunt.coeff(lj,mj,2,0,li));
-            if(cpl!=0.0) {
-              const double c0(2.0/5.0*sqrt(5.0*M_PI));
+            T cpl(gaunt.coeff(lj,mj,2,0,li));
+            if(cpl!=T(0)) {
+              const T c0(T(2)/T(5)*std::sqrt(T(5)*utils::pi<T>()));
               cpl*=c0;
               set_sub(V,iang,jang,cpl*Orad);
             }
@@ -463,36 +516,37 @@ namespace helfem {
         return V;
       }
 
-      helfem::Matrix TwoDBasis::Bz_field(double B) const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::Bz_field(T B) const {
         // Build radial elements
-        const helfem::Matrix O0rad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> O0rad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(0, iel); });
-        const helfem::Matrix O2rad = helfem::assemble_radial_diagonal(radial,
+        const helfem::Mat<T> O2rad = helfem::assemble_radial_diagonal(radial,
             [&](size_t iel) { return radial.radial_integral(2, iel); });
 
         // Full coupling
-        helfem::Matrix V = helfem::Matrix::Zero(Ndummy(), Ndummy());
+        helfem::Mat<T> V = helfem::Mat<T>::Zero(Ndummy(), Ndummy());
 
         int gmax(std::max(lval.maxCoeff(),mval.maxCoeff()));
-        gaunt::Gaunt gaunt(gmax,4,gmax);
+        gaunt::GauntT<T> gaunt(gmax,4,gmax);
 
         // Fill elements
-        for(size_t iang=0;iang<lval.size();iang++) {
+        for(size_t iang=0;iang<(size_t) lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.size();jang++) {
+          for(size_t jang=0;jang<(size_t) lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
             // Calculate coupling
-            double cpl(gaunt.sine2_coupling(lj,mj,li,mi));
-            if(cpl!=0.0) {
-              set_sub(V,iang,jang,(B*B/8.0*cpl)*O2rad);
+            T cpl(gaunt.sine2_coupling(lj,mj,li,mi));
+            if(cpl!=T(0)) {
+              set_sub(V,iang,jang,(B*B/T(8)*cpl)*O2rad);
             }
 
             if(li==lj && mi==mj) {
-              add_sub(V,iang,jang,(-0.5*B*mj)*O0rad);
+              add_sub(V,iang,jang,(T(-0.5)*B*T(mj))*O0rad);
             }
           }
         }
@@ -500,8 +554,9 @@ namespace helfem {
         return V;
       }
 
-      std::vector<std::vector<helfem::Matrix>>
-      TwoDBasis::radial_df_factors(double tol) const {
+      template <typename T>
+      std::vector<std::vector<helfem::Mat<T>>>
+      TwoDBasisT<T>::radial_df_factors(T tol) const {
         if (!prim_chol.size())
           throw std::logic_error(
               "Primitive teis have not been computed -- call "
@@ -512,20 +567,18 @@ namespace helfem {
         const size_t Nel  = radial.Nel();
 
         // Outer index = multipole L, inner index = Cholesky vector Q,
-        // each an Nrad x Nrad helfem::Matrix (arma-free at the public
-        // boundary; internal computation is arma-native for now).
-        std::vector<std::vector<helfem::Matrix>> B(N_L);
+        // each an Nrad x Nrad helfem::Mat<T>.
+        std::vector<std::vector<helfem::Mat<T>>> B(N_L);
 
         for (int L = 0; L < N_L; ++L) {
           // -- 1. Cached accessor lambdas for the per-L J helper.
-          // Phase 2c: caches are now std::vector<helfem::Matrix>.
-          auto rs = [&, L](size_t iel) -> const helfem::Matrix & {
+          auto rs = [&, L](size_t iel) -> const helfem::Mat<T> & {
             return disjoint_L[(size_t) L * Nel + iel];
           };
-          auto rb = [&, L](size_t iel) -> const helfem::Matrix & {
+          auto rb = [&, L](size_t iel) -> const helfem::Mat<T> & {
             return disjoint_m1L[(size_t) L * Nel + iel];
           };
-          auto tw = [&, L](size_t iel) -> const helfem::Matrix & {
+          auto tw = [&, L](size_t iel) -> const helfem::Mat<T> & {
             return prim_chol[(size_t) L * Nel + iel];
           };
 
@@ -542,18 +595,9 @@ namespace helfem {
           //
           //    A naive prim_tei-only init misses the off-element
           //    pieces for boundary indices and corrupts the pivoted
-          //    Cholesky -- D_pivot ends up too small, v_new is
-          //    overscaled, and the reconstructed R^L diverges by ~1%
-          //    on boundary-involved quadruples (verified bug, fixed
-          //    here).
-          //
-          //    Iterate pairs per-element so cross-element (i, j) pairs
-          //    (zero pair density -> D = 0) are not visited. Each
-          //    pair is visited once if it lives in one element, twice
-          //    (with identical J output) if both indices are the same
-          //    boundary -- harmless small redundancy.
+          //    Cholesky.
           const Eigen::Index Nrad_e = static_cast<Eigen::Index>(Nrad);
-          helfem::Matrix D = helfem::Matrix::Zero(Nrad_e, Nrad_e);
+          helfem::Mat<T> D = helfem::Mat<T>::Zero(Nrad_e, Nrad_e);
           for (size_t iel = 0; iel < Nel; ++iel) {
             size_t ifirst, ilast;
             radial.get_idx(iel, ifirst, ilast);
@@ -562,14 +606,14 @@ namespace helfem {
               for (size_t i_loc = 0; i_loc <= j_loc; ++i_loc) {
                 const Eigen::Index i = static_cast<Eigen::Index>(ifirst + i_loc);
                 const Eigen::Index j = static_cast<Eigen::Index>(ifirst + j_loc);
-                helfem::Matrix P = helfem::Matrix::Zero(Nrad_e, Nrad_e);
+                helfem::Mat<T> P = helfem::Mat<T>::Zero(Nrad_e, Nrad_e);
                 if (i == j) {
-                  P(i, i) = 1.0;
+                  P(i, i) = T(1);
                 } else {
-                  P(i, j) = 0.5;
-                  P(j, i) = 0.5;
+                  P(i, j) = T(0.5);
+                  P(j, i) = T(0.5);
                 }
-                const helfem::Matrix J =
+                const helfem::Mat<T> J =
                     helfem::atomic::basis::assemble_J_FE_one_multipole_cached_chol(
                         radial, rs, rb, tw, P);
                 D(i, j) = J(i, j);
@@ -584,13 +628,13 @@ namespace helfem {
           //    the J helper, subtracts projections onto previously found
           //    Cholesky vectors, normalises, appends, and updates the
           //    diagonal.
-          std::vector<helfem::Matrix> B_L_vecs;
+          std::vector<helfem::Mat<T>> B_L_vecs;
           while (true) {
             // Eigen is column-major, so maxCoeff scans in the same order
             // as the old arma index_max column-major flatten -- identical
             // pivot (i*, j*) selection and tie-breaking.
             Eigen::Index i_star = 0, j_star = 0;
-            const double D_pivot = D.maxCoeff(&i_star, &j_star);
+            const T D_pivot = D.maxCoeff(&i_star, &j_star);
             if (D_pivot < tol) break;
 
             // Build the symmetric pair-density indicator P. For i == j:
@@ -600,14 +644,14 @@ namespace helfem {
             // The J helper expects a symmetric P (it integrates against
             // the symmetric pair density), and J(P)[a, b] then equals
             // exactly R^L(a, b, i*, j*).
-            helfem::Matrix P = helfem::Matrix::Zero(Nrad_e, Nrad_e);
+            helfem::Mat<T> P = helfem::Mat<T>::Zero(Nrad_e, Nrad_e);
             if (i_star == j_star) {
-              P(i_star, i_star) = 1.0;
+              P(i_star, i_star) = T(1);
             } else {
-              P(i_star, j_star) = 0.5;
-              P(j_star, i_star) = 0.5;
+              P(i_star, j_star) = T(0.5);
+              P(j_star, i_star) = T(0.5);
             }
-            helfem::Matrix col =
+            helfem::Mat<T> col =
                 helfem::atomic::basis::assemble_J_FE_one_multipole_cached_chol(
                     radial, rs, rb, tw, P);
 
@@ -619,12 +663,12 @@ namespace helfem {
             // Normalise. By construction col(i*, j*) == D_pivot, so
             // v_new(i*, j*) == sqrt(D_pivot) -- pivot diagonal zeros
             // out exactly on the diagonal update below.
-            helfem::Matrix v_new = col / std::sqrt(D_pivot);
+            helfem::Mat<T> v_new = col / std::sqrt(D_pivot);
 
             // Update diagonal: D <- D - v_new .* v_new (elementwise),
             // clamped at zero to avoid negative drift.
             D -= v_new.cwiseProduct(v_new);
-            D = D.cwiseMax(0.0);
+            D = D.cwiseMax(T(0));
 
             B_L_vecs.push_back(std::move(v_new));
           }
@@ -635,11 +679,12 @@ namespace helfem {
         return B;
       }
 
-      void TwoDBasis::compute_tei(bool exchange) {
+      template <typename T>
+      void TwoDBasisT<T>::compute_tei(bool exchange) {
         // Delegate to the shared cache builders in CoulombExchangeFE.h.
         // The bare-Coulomb defaults (yukawa=false, lambda=0) populate
         // disjoint_L / disjoint_m1L from radial.radial_integral and
-        // prim_tei (in-element only; cross-element is assembled on the
+        // prim_chol (in-element only; cross-element is assembled on the
         // fly from the disjoint factors inside the cached J/K helpers).
         const int N_L = 2 * lval.maxCoeff() + 1;
         atomic::basis::compute_disjoint_radial_integrals(
@@ -651,7 +696,7 @@ namespace helfem {
         // exchange-ordered tensor is built. (Its pairing is full rank, so
         // there would be nothing to gain by compressing it anyway.)
         const size_t Nel = radial.Nel();
-        prim_chol.assign((size_t) N_L * Nel, helfem::Matrix());
+        prim_chol.assign((size_t) N_L * Nel, helfem::Mat<T>());
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2)
 #endif
@@ -663,13 +708,13 @@ namespace helfem {
         (void) exchange;
       }
 
-      void TwoDBasis::compute_yukawa(double lambda_) {
+      template <typename T>
+      void TwoDBasisT<T>::compute_yukawa(T lambda_) {
         lambda = lambda_;
         yukawa = true;
         const int N_L = 2 * lval.maxCoeff() + 1;
         // Yukawa-mode disjoint factors (bessel i / bessel k) + in-element
-        // Yukawa 2e + the exchange-permuted form needed by the cached K
-        // assembly.
+        // Yukawa 2e.
         atomic::basis::compute_disjoint_radial_integrals(
             radial, N_L, disjoint_iL, disjoint_kL, /*yukawa=*/true, lambda);
 
@@ -677,7 +722,7 @@ namespace helfem {
         // The rank bound is a property of the orbital product basis, not of the
         // kernel, so it carries over unchanged.
         const size_t Nel = radial.Nel();
-        rs_chol.assign((size_t) N_L * Nel, helfem::Matrix());
+        rs_chol.assign((size_t) N_L * Nel, helfem::Mat<T>());
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2)
 #endif
@@ -687,7 +732,8 @@ namespace helfem {
                 radial.yukawa_integral_cholesky(L, lambda, iel, chol_tol);
       }
 
-      void TwoDBasis::compute_erfc(double mu) {
+      template <typename T>
+      void TwoDBasisT<T>::compute_erfc(T mu) {
         lambda = mu;
         yukawa = false;
         // Erfc kernel doesn't factorise -- no disjoint integrals; all
@@ -698,13 +744,14 @@ namespace helfem {
         atomic::basis::compute_erfc_ktei(radial, N_L, lambda, rs_ktei);
       }
 
-      helfem::Matrix TwoDBasis::coulomb(const helfem::Matrix & P0_in) const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::coulomb(const helfem::Mat<T> & P0_in) const {
         if(!prim_chol.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
         // The atomic basis has no boundary reduction (expand/remove_boundaries
         // are the identity), so the SCF-facing Eigen density is used directly.
-        const helfem::Matrix & P = P0_in;
+        const helfem::Mat<T> & P = P0_in;
 
         // Number of radial elements
         size_t Nel(radial.Nel());
@@ -712,23 +759,23 @@ namespace helfem {
         const Eigen::Index Nrad = static_cast<Eigen::Index>(radial.Nbf());
         // Gaunt coefficient table
         int gmax(std::max(lval.maxCoeff(),mval.maxCoeff()));
-        gaunt::Gaunt gaunt(gmax,2*gmax,gmax);
+        gaunt::GauntT<T> gaunt(gmax,2*gmax,gmax);
 
         // maximal M value
         int Mmax=mval.maxCoeff()-mval.minCoeff();
 
         // Radial helper matrices
-        std::vector< std::vector<helfem::Matrix> > Paux(2*lval.maxCoeff()+1);
+        std::vector< std::vector<helfem::Mat<T>> > Paux(2*lval.maxCoeff()+1);
         for(int L=0;L<(int) Paux.size();L++) {
           Paux[L].resize(2*Mmax+1);
           for(int M=-std::min(L,Mmax);M<=std::min(L,Mmax);M++) {
-            Paux[L][M+Mmax] = helfem::Matrix::Zero(Nrad,Nrad);
+            Paux[L][M+Mmax] = helfem::Mat<T>::Zero(Nrad,Nrad);
           }
         }
 
         // Form radial helpers: contract ket
-        for(size_t kang=0;kang<lval.size();kang++) {
-          for(size_t lang=0;lang<lval.size();lang++) {
+        for(size_t kang=0;kang<(size_t) lval.size();kang++) {
+          for(size_t lang=0;lang<(size_t) lval.size();lang++) {
             // l and m values
             int lk(lval(kang));
             int mk(mval(kang));
@@ -741,7 +788,7 @@ namespace helfem {
             int Lmax=lk+ll;
             for(int L=Lmin;L<=Lmax;L++) {
               // Calculate coupling coefficient
-              double cpl(gaunt.coeff(lk,mk,L,M,ll));
+              T cpl(gaunt.coeff(lk,mk,L,M,ll));
               // Increment
               Paux[L][M+Mmax]+=cpl*P.block(static_cast<Eigen::Index>(kang)*Nrad,static_cast<Eigen::Index>(lang)*Nrad,Nrad,Nrad);
             }
@@ -749,24 +796,24 @@ namespace helfem {
         }
 
         // Helper matrices
-        std::vector< std::vector<helfem::Matrix> > Jaux(2*lval.maxCoeff()+1);
+        std::vector< std::vector<helfem::Mat<T>> > Jaux(2*lval.maxCoeff()+1);
         for(int L=0;L<(int) Jaux.size();L++) {
           Jaux[L].resize(2*Mmax+1);
           for(int M=-std::min(L,Mmax);M<=std::min(L,Mmax);M++) {
-            Jaux[L][M+Mmax] = helfem::Matrix::Zero(Nrad,Nrad);
+            Jaux[L][M+Mmax] = helfem::Mat<T>::Zero(Nrad,Nrad);
           }
         }
         // Contract integrals. Per (L, M), delegate the FE assembly to
         // the shared helper with our SCF-cached per-(L, iel) integrals.
         for(int L=0;L<(int) Paux.size();L++) {
-          const double Lfac=4.0*M_PI/(2*L+1);
-          auto rs = [&,L](size_t iel) -> const helfem::Matrix & {
+          const T Lfac=T(4)*utils::pi<T>()/T(2*L+1);
+          auto rs = [&,L](size_t iel) -> const helfem::Mat<T> & {
             return disjoint_L[L*Nel+iel];
           };
-          auto rb = [&,L](size_t iel) -> const helfem::Matrix & {
+          auto rb = [&,L](size_t iel) -> const helfem::Mat<T> & {
             return disjoint_m1L[L*Nel+iel];
           };
-          auto tw = [&,L](size_t iel) -> const helfem::Matrix & {
+          auto tw = [&,L](size_t iel) -> const helfem::Mat<T> & {
             return prim_chol[(size_t) L * Nel + iel];
           };
           for(int M=-std::min(L,Mmax);M<=std::min(L,Mmax);M++) {
@@ -777,9 +824,9 @@ namespace helfem {
         }
 
         // Full Coulomb matrix
-        helfem::Matrix J = helfem::Matrix::Zero(Ndummy(),Ndummy());
-        for(size_t iang=0;iang<lval.size();iang++) {
-          for(size_t jang=0;jang<lval.size();jang++) {
+        helfem::Mat<T> J = helfem::Mat<T>::Zero(Ndummy(),Ndummy());
+        for(size_t iang=0;iang<(size_t) lval.size();iang++) {
+          for(size_t jang=0;jang<(size_t) lval.size();jang++) {
             // l and m values
             int li(lval(iang));
             int mi(mval(iang));
@@ -792,8 +839,8 @@ namespace helfem {
             int Lmax=lj+li;
             for(int L=Lmin;L<=Lmax;L++) {
               // Coupling
-              double cpl(gaunt.coeff(lj,mj,L,M,li));
-              if(cpl!=0.0) {
+              T cpl(gaunt.coeff(lj,mj,L,M,li));
+              if(cpl!=T(0)) {
                 J.block(static_cast<Eigen::Index>(iang)*Nrad,static_cast<Eigen::Index>(jang)*Nrad,Nrad,Nrad)+=cpl*Jaux[L][M+Mmax];
               }
             }
@@ -803,28 +850,35 @@ namespace helfem {
         return J;
       }
 
-      helfem::Matrix TwoDBasis::exchange(const helfem::Matrix & P0_in) const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::exchange(const helfem::Mat<T> & P0_in) const {
         if(!prim_chol.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
         // No boundary reduction in the atomic basis (expand/remove are
         // the identity), so the Eigen density is used directly.
-        const helfem::Matrix & P = P0_in;
+        const helfem::Mat<T> & P = P0_in;
 
         // Gaunt coefficient table
         int gmax(std::max(lval.maxCoeff(),mval.maxCoeff()));
-        gaunt::Gaunt gaunt(gmax,2*gmax,gmax);
+        gaunt::GauntT<T> gaunt(gmax,2*gmax,gmax);
 
         // Number of radial elements
         size_t Nel(radial.Nel());
         // Number of radial basis functions
         const Eigen::Index Nrad = static_cast<Eigen::Index>(radial.Nbf());
 
+        // Density-block screening threshold. eps(T) rather than DBL_EPSILON:
+        // at T = double this is the same 10*DBL_EPSILON it always was, and at
+        // higher T it tightens with the arithmetic instead of throwing away
+        // blocks that are now perfectly resolvable.
+        const T bdens_thr = T(10)*std::numeric_limits<T>::epsilon();
+
         // Full exchange matrix
-        helfem::Matrix K = helfem::Matrix::Zero(Ndummy(),Ndummy());
+        helfem::Mat<T> K = helfem::Mat<T>::Zero(Ndummy(),Ndummy());
 
         // Per-element K assembly is delegated to
-        // assemble_K_FE_one_multipole_cached -- no per-thread scratch
+        // assemble_K_FE_one_multipole_cached_chol -- no per-thread scratch
         // needed here, the helper allocates its own.
 #ifdef _OPENMP
 #pragma omp parallel
@@ -833,8 +887,8 @@ namespace helfem {
 #ifdef _OPENMP
 #pragma omp for collapse(2)
 #endif
-          for(size_t jang=0;jang<lval.size();jang++) {
-            for(size_t kang=0;kang<lval.size();kang++) {
+          for(size_t jang=0;jang<(size_t) lval.size();jang++) {
+            for(size_t kang=0;kang<(size_t) lval.size();kang++) {
               int lj(lval(jang));
               int mj(mval(jang));
 
@@ -843,19 +897,19 @@ namespace helfem {
 
               // Form radial helpers
               size_t N_L(2*lval.maxCoeff()+1);
-              std::vector<helfem::Matrix> Rmat(N_L);
+              std::vector<helfem::Mat<T>> Rmat(N_L);
               for(size_t i=0;i<N_L;i++) {
-                Rmat[i] = helfem::Matrix::Zero(Nrad,Nrad);
+                Rmat[i] = helfem::Mat<T>::Zero(Nrad,Nrad);
               }
               // Is there a coupling to the channel?
               std::vector<bool> couple(N_L,false);
 
               // Perform angular sums
-              for(size_t iang=0;iang<lval.size();iang++) {
+              for(size_t iang=0;iang<(size_t) lval.size();iang++) {
                 int li(lval(iang));
                 int mi(mval(iang));
 
-                for(size_t lang=0;lang<lval.size();lang++) {
+                for(size_t lang=0;lang<(size_t) lval.size();lang++) {
                   int ll(lval(lang));
                   int ml(mval(lang));
 
@@ -867,9 +921,8 @@ namespace helfem {
                     continue;
 
                   // Do we have any density in this block?
-                  double bdens(P.block(static_cast<Eigen::Index>(iang)*Nrad,static_cast<Eigen::Index>(lang)*Nrad,Nrad,Nrad).norm());
-                  //printf("(%i %i) (%i %i) density block norm %e\n",li,mi,ll,ml,bdens);
-                  if(bdens<10*DBL_EPSILON)
+                  T bdens(P.block(static_cast<Eigen::Index>(iang)*Nrad,static_cast<Eigen::Index>(lang)*Nrad,Nrad,Nrad).norm());
+                  if(bdens<bdens_thr)
                     continue;
 
                   // M values match. Loop over possible couplings
@@ -878,12 +931,12 @@ namespace helfem {
 
                   for(int L=Lmin;L<=Lmax;L++) {
                     // Calculate total coupling coefficient
-                    double cpl(gaunt.coeff(lj,mj,L,M,li)*gaunt.coeff(lk,mk,L,M,ll));
-                    if(cpl==0.0)
+                    T cpl(gaunt.coeff(lj,mj,L,M,li)*gaunt.coeff(lk,mk,L,M,ll));
+                    if(cpl==T(0))
                       continue;
 
                     // L factor
-                    double Lfac=4.0*M_PI/(2*L+1);
+                    T Lfac=T(4)*utils::pi<T>()/T(2*L+1);
                     Rmat[L]+=(Lfac*cpl)*P.block(static_cast<Eigen::Index>(iang)*Nrad,static_cast<Eigen::Index>(lang)*Nrad,Nrad,Nrad);
                     couple[L]=true;
                   }
@@ -892,17 +945,17 @@ namespace helfem {
 
               // Per-L K assembly via the shared FE helper, accumulated
               // into the (jang, kang) angular block of K.
-              helfem::Matrix K_block = helfem::Matrix::Zero(Nrad, Nrad);
+              helfem::Mat<T> K_block = helfem::Mat<T>::Zero(Nrad, Nrad);
               for(size_t L=0; L<N_L; ++L) {
                 if(!couple[L]) continue;
                 const size_t Lc = L;
-                auto rs = [&,Lc](size_t iel) -> const helfem::Matrix & {
+                auto rs = [&,Lc](size_t iel) -> const helfem::Mat<T> & {
                   return disjoint_L[Lc*Nel+iel];
                 };
-                auto rb = [&,Lc](size_t iel) -> const helfem::Matrix & {
+                auto rb = [&,Lc](size_t iel) -> const helfem::Mat<T> & {
                   return disjoint_m1L[Lc*Nel+iel];
                 };
-                auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
+                auto kt = [&,Lc](size_t iel) -> const helfem::Mat<T> & {
                   return prim_chol[(size_t) Lc * Nel + iel];
                 };
                 // RI-K on the J-ordered Cholesky factor: K_ac = sum_p M_p P M_p'.
@@ -919,25 +972,28 @@ namespace helfem {
         return K;
       }
 
-      helfem::Matrix TwoDBasis::rs_exchange(const helfem::Matrix & P0_in) const {
+      template <typename T>
+      helfem::Mat<T> TwoDBasisT<T>::rs_exchange(const helfem::Mat<T> & P0_in) const {
         if(!rs_ktei.size() && !rs_chol.size())
           throw std::logic_error("Primitive teis have not been computed!\n");
 
         // No boundary reduction in the atomic basis (expand/remove are
         // the identity), so the Eigen density is used directly.
-        const helfem::Matrix & P = P0_in;
+        const helfem::Mat<T> & P = P0_in;
 
         // Gaunt coefficient table
         int gmax(std::max(lval.maxCoeff(),mval.maxCoeff()));
-        gaunt::Gaunt gaunt(gmax,2*gmax,gmax);
+        gaunt::GauntT<T> gaunt(gmax,2*gmax,gmax);
 
         // Number of radial elements
         size_t Nel(radial.Nel());
         // Number of radial basis functions
         const Eigen::Index Nrad = static_cast<Eigen::Index>(radial.Nbf());
 
+        const T bdens_thr = T(10)*std::numeric_limits<T>::epsilon();
+
         // Full exchange matrix
-        helfem::Matrix K = helfem::Matrix::Zero(Ndummy(),Ndummy());
+        helfem::Mat<T> K = helfem::Mat<T>::Zero(Ndummy(),Ndummy());
 
         // Per-element K assembly is delegated to the cached helpers
         // in CoulombExchangeFE.h -- no per-thread scratch needed.
@@ -948,8 +1004,8 @@ namespace helfem {
 #ifdef _OPENMP
 #pragma omp for collapse(2)
 #endif
-          for(size_t jang=0;jang<lval.size();jang++) {
-            for(size_t kang=0;kang<lval.size();kang++) {
+          for(size_t jang=0;jang<(size_t) lval.size();jang++) {
+            for(size_t kang=0;kang<(size_t) lval.size();kang++) {
               int lj(lval(jang));
               int mj(mval(jang));
 
@@ -958,19 +1014,19 @@ namespace helfem {
 
               // Form radial helpers
               size_t N_L(2*lval.maxCoeff()+1);
-              std::vector<helfem::Matrix> Rmat(N_L);
+              std::vector<helfem::Mat<T>> Rmat(N_L);
               for(size_t i=0;i<N_L;i++) {
-                Rmat[i] = helfem::Matrix::Zero(Nrad,Nrad);
+                Rmat[i] = helfem::Mat<T>::Zero(Nrad,Nrad);
               }
               // Is there a coupling to the channel?
               std::vector<bool> couple(N_L,false);
 
               // Perform angular sums
-              for(size_t iang=0;iang<lval.size();iang++) {
+              for(size_t iang=0;iang<(size_t) lval.size();iang++) {
                 int li(lval(iang));
                 int mi(mval(iang));
 
-                for(size_t lang=0;lang<lval.size();lang++) {
+                for(size_t lang=0;lang<(size_t) lval.size();lang++) {
                   int ll(lval(lang));
                   int ml(mval(lang));
 
@@ -982,9 +1038,8 @@ namespace helfem {
                     continue;
 
                   // Do we have any density in this block?
-                  double bdens(P.block(static_cast<Eigen::Index>(iang)*Nrad,static_cast<Eigen::Index>(lang)*Nrad,Nrad,Nrad).norm());
-                  //printf("(%i %i) (%i %i) density block norm %e\n",li,mi,ll,ml,bdens);
-                  if(bdens<10*DBL_EPSILON)
+                  T bdens(P.block(static_cast<Eigen::Index>(iang)*Nrad,static_cast<Eigen::Index>(lang)*Nrad,Nrad,Nrad).norm());
+                  if(bdens<bdens_thr)
                     continue;
 
                   // M values match. Loop over possible couplings
@@ -993,12 +1048,13 @@ namespace helfem {
 
                   for(int L=Lmin;L<=Lmax;L++) {
                     // Calculate total coupling coefficient
-                    double cpl(gaunt.coeff(lj,mj,L,M,li)*gaunt.coeff(lk,mk,L,M,ll));
-                    if(cpl==0.0)
+                    T cpl(gaunt.coeff(lj,mj,L,M,li)*gaunt.coeff(lk,mk,L,M,ll));
+                    if(cpl==T(0))
                       continue;
 
                     // L factor
-                    double Lfac = yukawa ? 4.0*M_PI*lambda :  4.0*M_PI*lambda/(2*L+1);
+                    T Lfac = yukawa ? T(4)*utils::pi<T>()*lambda
+                                    : T(4)*utils::pi<T>()*lambda/T(2*L+1);
                     Rmat[L]+=(Lfac*cpl)*P.block(static_cast<Eigen::Index>(iang)*Nrad,static_cast<Eigen::Index>(lang)*Nrad,Nrad,Nrad);
                     couple[L]=true;
                   }
@@ -1008,17 +1064,17 @@ namespace helfem {
               if (yukawa) {
                 // Same FE structure as bare exchange: per-L cached
                 // helper, summed into the (jang, kang) angular block.
-                helfem::Matrix K_block = helfem::Matrix::Zero(Nrad, Nrad);
+                helfem::Mat<T> K_block = helfem::Mat<T>::Zero(Nrad, Nrad);
                 for(size_t L=0; L<N_L; ++L) {
                   if(!couple[L]) continue;
                   const size_t Lc = L;
-                  auto rs = [&,Lc](size_t iel) -> const helfem::Matrix & {
+                  auto rs = [&,Lc](size_t iel) -> const helfem::Mat<T> & {
                     return disjoint_iL[Lc*Nel+iel];
                   };
-                  auto rb = [&,Lc](size_t iel) -> const helfem::Matrix & {
+                  auto rb = [&,Lc](size_t iel) -> const helfem::Mat<T> & {
                     return disjoint_kL[Lc*Nel+iel];
                   };
-                  auto kt = [&,Lc](size_t iel) -> const helfem::Matrix & {
+                  auto kt = [&,Lc](size_t iel) -> const helfem::Mat<T> & {
                     return rs_chol[(size_t) Lc * Nel + iel];
                   };
                   K_block += helfem::atomic::basis::assemble_K_FE_one_multipole_cached_chol(
@@ -1029,11 +1085,11 @@ namespace helfem {
                 // Erfc: rs_ktei has cross-element entries for every
                 // (iel, jel) pair -- delegate to the pairwise cached
                 // helper, summed over L into the (jang, kang) block.
-                helfem::Matrix K_block = helfem::Matrix::Zero(Nrad, Nrad);
+                helfem::Mat<T> K_block = helfem::Mat<T>::Zero(Nrad, Nrad);
                 for(size_t L=0; L<N_L; ++L) {
                   if(!couple[L]) continue;
                   const size_t Lc = L;
-                  auto kt = [&,Lc](size_t iel, size_t jel) -> const helfem::Matrix & {
+                  auto kt = [&,Lc](size_t iel, size_t jel) -> const helfem::Mat<T> & {
                     return rs_ktei[Nel*Nel*Lc + iel*Nel + jel];
                   };
                   K_block += helfem::atomic::basis::assemble_K_FE_one_multipole_cached_pairwise(
@@ -1048,96 +1104,112 @@ namespace helfem {
         return K;
       }
 
-      arma::cx_mat TwoDBasis::eval_bf(size_t iel, double cth, double phi) const {
-        // Evaluate spherical harmonics
-        arma::cx_vec sph(lval.size());
-        for(size_t i=0;i<lval.size();i++)
-          sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
+      template <typename T>
+      arma::cx_mat TwoDBasisT<T>::eval_bf(size_t iel, double cth, double phi) const {
+        if constexpr (std::is_same_v<T, double>) {
+          // Evaluate spherical harmonics
+          arma::cx_vec sph(lval.size());
+          for(size_t i=0;i<(size_t) lval.size();i++)
+            sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
-        // Evaluate radial functions
-        arma::mat rad(helfem::to_arma(radial.get_bf(iel)));
+          // Evaluate radial functions
+          arma::mat rad(helfem::to_arma(radial.get_bf(iel)));
 
-        // Form supermatrix
-        arma::cx_mat bf(rad.n_rows,lval.size()*rad.n_cols);
-        for(size_t i=0;i<lval.size();i++)
-          bf.cols(i*rad.n_cols,(i+1)*rad.n_cols-1)=sph(i)*rad;
+          // Form supermatrix
+          arma::cx_mat bf(rad.n_rows,lval.size()*rad.n_cols);
+          for(size_t i=0;i<(size_t) lval.size();i++)
+            bf.cols(i*rad.n_cols,(i+1)*rad.n_cols-1)=sph(i)*rad;
 
-        return bf;
-      }
-
-      void TwoDBasis::eval_df(size_t iel, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const {
-        // Evaluate spherical harmonics
-        arma::cx_vec sph(lval.size());
-        for(size_t i=0;i<lval.size();i++)
-          sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
-
-        // Evaluate radial functions
-        arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
-        arma::mat drad(helfem::to_arma(radial.get_df(iel)));
-
-        // Form supermatrices
-        dr.zeros(frad.n_rows,lval.size()*frad.n_cols);
-        dth.zeros(frad.n_rows,lval.size()*frad.n_cols);
-        dphi.zeros(frad.n_rows,lval.size()*frad.n_cols);
-
-        // Radial one is easy
-        for(size_t i=0;i<lval.size();i++)
-          dr.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=sph(i)*drad;
-        // and so is phi
-        for(size_t i=0;i<lval.size();i++)
-          dphi.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=std::complex<double>(0.0,mval(i))*sph(i)*frad;
-        // sin^2(theta) = (1 - cth)(1 + cth) is algebraically identical to
-        // 1 - cth*cth but avoids the catastrophic cancellation when cth is
-        // close to +/- 1. The std::max(..., 0.0) is a paranoia floor for
-        // the case where round-off pushes the product slightly negative.
-        const double sinth = std::sqrt(std::max((1.0-cth)*(1.0+cth), 0.0));
-        // cot(theta) is singular at the poles; for cth = +/- 1 the m*cot*Y
-        // term is the m=0 case (contribution 0) or |m|>=1 with sph(i)=0 in
-        // the limit, so a defensive 0 is the right value here.
-        const double cotth = (sinth > 0.0) ? cth/sinth : 0.0;
-
-        // but theta is nastier
-        for(size_t i=0;i<lval.size();i++) {
-          int l(lval(i));
-          int m(mval(i));
-
-          // Angular factor
-          std::complex<double> angfac(m*cotth*sph(i));
-          if(mval(i)<lval(i))
-            angfac+=sqrt((l-m)*(l+m+1))*std::exp(std::complex<double>(0,-phi))*::spherical_harmonics(lval(i),mval(i)+1,cth,phi);
-
-          dth.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=angfac*frad;
+          return bf;
+        } else {
+          (void) iel; (void) cth; (void) phi;
+          double_only("eval_bf");
         }
       }
 
-      arma::cx_mat TwoDBasis::eval_lf(size_t iel, double cth, double phi) const {
-        // Evaluate spherical harmonics
-        arma::cx_vec sph(lval.size());
-        for(size_t i=0;i<lval.size();i++)
-          sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
+      template <typename T>
+      void TwoDBasisT<T>::eval_df(size_t iel, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const {
+        if constexpr (std::is_same_v<T, double>) {
+          // Evaluate spherical harmonics
+          arma::cx_vec sph(lval.size());
+          for(size_t i=0;i<(size_t) lval.size();i++)
+            sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
-        // Evaluate radial functions
-        arma::vec r(helfem::to_arma(radial.get_r(iel)));
-        arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
-        arma::mat drad(helfem::to_arma(radial.get_df(iel)));
-        arma::mat lrad(helfem::to_arma(radial.get_lf(iel)));
+          // Evaluate radial functions
+          arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
+          arma::mat drad(helfem::to_arma(radial.get_df(iel)));
 
-        // Form supermatrix
-        arma::cx_mat lf(frad.n_rows,lval.size()*frad.n_cols,arma::fill::zeros);
-        // Loop over basis function indices
-        for(size_t iang=0;iang<lval.size();iang++)
-          for(size_t irad=0;irad<frad.n_cols;irad++)
-            // Loop over grid-point indices
-            for(size_t igrid=0;igrid<frad.n_rows;igrid++)
-              lf(igrid,iang*frad.n_cols+irad) = (lrad(igrid,irad) + 2*drad(igrid,irad)/r(igrid) - lval(iang)*(lval(iang)+1)*frad(igrid,irad)/(r(igrid)*r(igrid)))*sph(iang);
+          // Form supermatrices
+          dr.zeros(frad.n_rows,lval.size()*frad.n_cols);
+          dth.zeros(frad.n_rows,lval.size()*frad.n_cols);
+          dphi.zeros(frad.n_rows,lval.size()*frad.n_cols);
 
-        //for(size_t i=0;i<lval.size();i++)
-        //lf.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=(arma::square(r)%lrad + 2*r%drad - lval(i)*(lval(i)+1)*frad) / arma::square(r) * sph(i);
+          // Radial one is easy
+          for(size_t i=0;i<(size_t) lval.size();i++)
+            dr.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=sph(i)*drad;
+          // and so is phi
+          for(size_t i=0;i<(size_t) lval.size();i++)
+            dphi.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=std::complex<double>(0.0,mval(i))*sph(i)*frad;
+          // sin^2(theta) = (1 - cth)(1 + cth) is algebraically identical to
+          // 1 - cth*cth but avoids the catastrophic cancellation when cth is
+          // close to +/- 1. The std::max(..., 0.0) is a paranoia floor for
+          // the case where round-off pushes the product slightly negative.
+          const double sinth = std::sqrt(std::max((1.0-cth)*(1.0+cth), 0.0));
+          // cot(theta) is singular at the poles; for cth = +/- 1 the m*cot*Y
+          // term is the m=0 case (contribution 0) or |m|>=1 with sph(i)=0 in
+          // the limit, so a defensive 0 is the right value here.
+          const double cotth = (sinth > 0.0) ? cth/sinth : 0.0;
 
-        return lf;
+          // but theta is nastier
+          for(size_t i=0;i<(size_t) lval.size();i++) {
+            int l(lval(i));
+            int m(mval(i));
+
+            // Angular factor
+            std::complex<double> angfac(m*cotth*sph(i));
+            if(mval(i)<lval(i))
+              angfac+=sqrt((l-m)*(l+m+1))*std::exp(std::complex<double>(0,-phi))*::spherical_harmonics(lval(i),mval(i)+1,cth,phi);
+
+            dth.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=angfac*frad;
+          }
+        } else {
+          (void) iel; (void) cth; (void) phi; (void) dr; (void) dth; (void) dphi;
+          double_only("eval_df");
+        }
       }
 
-      arma::uvec TwoDBasis::bf_list(size_t iel) const {
+      template <typename T>
+      arma::cx_mat TwoDBasisT<T>::eval_lf(size_t iel, double cth, double phi) const {
+        if constexpr (std::is_same_v<T, double>) {
+          // Evaluate spherical harmonics
+          arma::cx_vec sph(lval.size());
+          for(size_t i=0;i<(size_t) lval.size();i++)
+            sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
+
+          // Evaluate radial functions
+          arma::vec r(helfem::to_arma(radial.get_r(iel)));
+          arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
+          arma::mat drad(helfem::to_arma(radial.get_df(iel)));
+          arma::mat lrad(helfem::to_arma(radial.get_lf(iel)));
+
+          // Form supermatrix
+          arma::cx_mat lf(frad.n_rows,lval.size()*frad.n_cols,arma::fill::zeros);
+          // Loop over basis function indices
+          for(size_t iang=0;iang<(size_t) lval.size();iang++)
+            for(size_t irad=0;irad<frad.n_cols;irad++)
+              // Loop over grid-point indices
+              for(size_t igrid=0;igrid<frad.n_rows;igrid++)
+                lf(igrid,iang*frad.n_cols+irad) = (lrad(igrid,irad) + 2*drad(igrid,irad)/r(igrid) - lval(iang)*(lval(iang)+1)*frad(igrid,irad)/(r(igrid)*r(igrid)))*sph(iang);
+
+          return lf;
+        } else {
+          (void) iel; (void) cth; (void) phi;
+          double_only("eval_lf");
+        }
+      }
+
+      template <typename T>
+      arma::uvec TwoDBasisT<T>::bf_list(size_t iel) const {
         // Radial functions in element
         size_t ifirst, ilast;
         radial.get_idx(iel,ifirst,ilast);
@@ -1145,38 +1217,55 @@ namespace helfem {
         size_t Nr(ilast-ifirst+1);
 
         // Total number of radial functions
-        size_t Nrad(radial.Nbf());
+        size_t Nradf(radial.Nbf());
 
         // List of functions in the element
         arma::uvec idx(Nr*lval.size());
-        for(size_t iam=0;iam<lval.size();iam++)
+        for(size_t iam=0;iam<(size_t) lval.size();iam++)
           for(size_t j=0;j<Nr;j++)
-            idx(iam*Nr+j)=Nrad*iam+ifirst+j;
-
-        //printf("Basis function in element %i\n",(int) iel);
-        //idx.print();
+            idx(iam*Nr+j)=Nradf*iam+ifirst+j;
 
         return idx;
       }
 
-      size_t TwoDBasis::get_rad_Nel() const {
+      template <typename T>
+      size_t TwoDBasisT<T>::get_rad_Nel() const {
         return radial.Nel();
       }
 
+      template <typename T>
       std::pair<size_t, size_t>
-      TwoDBasis::radial_element_range(size_t iel) const {
+      TwoDBasisT<T>::radial_element_range(size_t iel) const {
         size_t ifirst, ilast;
         radial.get_idx(iel, ifirst, ilast);
         return {ifirst, ilast};
       }
 
-      arma::vec TwoDBasis::get_wrad(size_t iel) const {
-        return helfem::to_arma(radial.get_wrad(iel));
+      template <typename T>
+      arma::vec TwoDBasisT<T>::get_wrad(size_t iel) const {
+        if constexpr (std::is_same_v<T, double>) {
+          return helfem::to_arma(radial.get_wrad(iel));
+        } else {
+          (void) iel;
+          double_only("get_wrad");
+        }
       }
 
-      arma::vec TwoDBasis::get_r(size_t iel) const {
-        return helfem::to_arma(radial.get_r(iel));
+      template <typename T>
+      arma::vec TwoDBasisT<T>::get_r(size_t iel) const {
+        if constexpr (std::is_same_v<T, double>) {
+          return helfem::to_arma(radial.get_r(iel));
+        } else {
+          (void) iel;
+          double_only("get_r");
+        }
       }
+
+      template class TwoDBasisT<double>;
+      template class TwoDBasisT<long double>;
+#ifdef HELFEM_HAVE_FLOAT128
+      template class TwoDBasisT<_Float128>;
+#endif
 
     }
   }

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -16,6 +16,7 @@
 #define ATOMIC_BASIS_TWODBASIS_H
 
 #include <armadillo>
+#include <limits>
 #include "../general/model_potential.h"
 #include "../general/sap.h"
 #include <Matrix.h>
@@ -24,29 +25,53 @@
 namespace helfem {
   namespace atomic {
     namespace basis {
-      /// Two-dimensional basis set
-      class TwoDBasis {
+      /// Two-dimensional basis set.
+      ///
+      /// Templated on the scalar type, following FiniteElementBasisT<T> and
+      /// FEMRadialBasisT<T>. This is the top of the arbitrary-precision stack:
+      /// with it, the whole HARTREE-FOCK path -- overlap, kinetic, nuclear,
+      /// coulomb, exchange, Sinvh, compute_tei -- runs at any T, and the
+      /// accuracy of a converged calculation is set by the basis rather than
+      /// by the arithmetic. Instantiated for double, long double and (under
+      /// HELFEM_HAVE_FLOAT128) _Float128.
+      ///
+      /// NOT templated, and deliberately so:
+      ///   * the DFT path. libxc is a double-only C library, so a
+      ///     higher-precision XC energy is not merely unimplemented but
+      ///     meaningless. The DFT grid lives in atomic/dftgrid.* and consumes
+      ///     TwoDBasis (= TwoDBasisT<double>) as before.
+      ///   * the basis-function EVALUATION routines used by that grid and by
+      ///     the analysis binaries -- eval_bf / eval_df / eval_lf (which return
+      ///     arma::cx_mat and go through the double-only ::spherical_harmonics)
+      ///     and the quadrature-point accessors get_bval / get_wrad / get_r
+      ///     (arma::vec). These are compiled for every T but THROW unless
+      ///     T = double; they are not on the Fock path.
+      /// The angular-index bookkeeping (get_lval / m_indices / get_sym_idx,
+      /// arma::ivec / arma::uvec) is integer-valued, hence precision-free, and
+      /// is shared by all instantiations unchanged.
+      template <typename T>
+      class TwoDBasisT {
         /// Nuclear charge
         int Z;
         /// Nuclear model
         modelpotential::nuclear_model_t model;
         /// Rms radius
-        double Rrms;
+        T Rrms;
 
         /// Left-hand nuclear charge
         int Zl;
         /// Right-hand nuclear charge
         int Zr;
         /// Bond length
-        double Rhalf;
+        T Rhalf;
 
         /// Yukawa exchange?
         bool yukawa;
         /// Range separation parameter
-        double lambda;
+        T lambda;
 
         /// Radial basis set
-        FEMRadialBasis radial;
+        FEMRadialBasisT<T> radial;
         /// Angular basis set: function l values
         Eigen::VectorXi lval;
         /// Angular basis set: function m values
@@ -55,11 +80,9 @@ namespace helfem {
         bool zeroder;
 
         /// Auxiliary integrals
-        // Phase 2c: per-element 2e caches migrated to Eigen.
-        std::vector<helfem::Matrix> disjoint_L, disjoint_m1L;
+        std::vector<helfem::Mat<T>> disjoint_L, disjoint_m1L;
         /// Auxiliary integrals for Yukawa separation
-        std::vector<helfem::Matrix> disjoint_iL, disjoint_kL;
-        /// Primitive two-electron integrals: <Nel^2 * (2L+1)>
+        std::vector<helfem::Mat<T>> disjoint_iL, disjoint_kL;
         /// Pivoted-Cholesky factors of the IN-ELEMENT two-electron integrals,
         /// indexed [L*Nel + iel]: L_p of shape (Ni^2 x r) with T = L L'.
         ///
@@ -78,40 +101,52 @@ namespace helfem {
         /// so it cannot be compressed directly; K instead comes from the
         /// standard RI contraction on these J-ordered factors, which is why no
         /// exchange-ordered tensor is stored.
-        std::vector<helfem::Matrix> prim_chol;
-        /// Tolerance for the pivoted Cholesky above
-        double chol_tol = 1e-12;
+        std::vector<helfem::Mat<T>> prim_chol;
+        /// Tolerance for the pivoted Cholesky above.
+        ///
+        /// This one has to FOLLOW THE ARITHMETIC, or it silently becomes the
+        /// accuracy limit of every higher-precision calculation. Truncating the
+        /// in-element two-electron tensor at a fixed 1e-12 is invisible at
+        /// double -- it is orders of magnitude below double's own roundoff --
+        /// but at _Float128 it would be the single largest error in the
+        /// calculation, and quad would buy nothing at all.
+        ///
+        /// So it is held at the same multiple of eps(T) at every precision.
+        /// At T = double the ratio is exactly 1 and the value is exactly the
+        /// 1e-12 it has always been, so double results are bit-for-bit
+        /// unchanged; long double gets ~4.9e-16 and _Float128 ~8.7e-31.
+        T chol_tol = T(1e-12) * (std::numeric_limits<T>::epsilon() /
+                                 T(std::numeric_limits<double>::epsilon()));
         /// Same factorization for the Yukawa-screened in-element integrals.
         /// The rank bound 2*Nprim-1 is a property of the orbital PRODUCT basis,
         /// not of the kernel, so it applies to the Yukawa kernel unchanged.
         /// (The erfc path keeps its explicit tensors for now: there the
         /// cross-element blocks are not multipole-separable and are stored in
         /// full, so it needs its own treatment.)
-        std::vector<helfem::Matrix> rs_chol;
+        std::vector<helfem::Mat<T>> rs_chol;
         /// Primitive range-separated two-electron integrals: <Nel^2 * (2L+1)> sorted for exchange
-        std::vector<helfem::Matrix> rs_ktei;
+        std::vector<helfem::Mat<T>> rs_ktei;
 
         /// Add a radial block onto the (iang, jang) angular submatrix
-        void add_sub(helfem::Matrix & M, size_t iang, size_t jang, const helfem::Matrix & Msub) const;
+        void add_sub(helfem::Mat<T> & M, size_t iang, size_t jang, const helfem::Mat<T> & Msub) const;
         /// Set the (iang, jang) angular submatrix to a radial block
-        void set_sub(helfem::Matrix & M, size_t iang, size_t jang, const helfem::Matrix & Msub) const;
+        void set_sub(helfem::Mat<T> & M, size_t iang, size_t jang, const helfem::Mat<T> & Msub) const;
 
       public:
-        TwoDBasis();
+        TwoDBasisT();
         /// Constructor
         // Phase 5.19: bval/lval/mval accepted as Eigen at the public
         // boundary so a consumer does not need to include <armadillo>
-        // to instantiate the basis. Interior storage stays arma via a
-        // single memcpy inside the ctor.
-        TwoDBasis(int Z, modelpotential::nuclear_model_t model, double Rrms,
-                   const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly,
+        // to instantiate the basis.
+        TwoDBasisT(int Z, modelpotential::nuclear_model_t model, T Rrms,
+                   const std::shared_ptr<const helfem::lib1dfem::polynomial_basis::PolynomialBasis<T>> &poly,
                    bool zeroder, int n_quad,
-                   const helfem::Vector & bval,
+                   const helfem::Vec<T> & bval,
                    const Eigen::VectorXi & lval,
                    const Eigen::VectorXi & mval,
-                   int Zl, int Zr, double Rhalf);
+                   int Zl, int Zr, T Rhalf);
         /// Destructor
-        ~TwoDBasis();
+        ~TwoDBasisT();
 
         /// Get Z
         int get_Z() const;
@@ -120,12 +155,12 @@ namespace helfem {
         /// Get Zr
         int get_Zr() const;
         /// Get Rhalf
-        double get_Rhalf() const;
+        T get_Rhalf() const;
 
         /// Get nuclear model
         int get_nuclear_model() const;
         /// Get nuclear size
-        double get_nuclear_size() const;
+        T get_nuclear_size() const;
 
         /// Get l values
         arma::ivec get_lval() const;
@@ -134,7 +169,7 @@ namespace helfem {
 
         /// Get number of quadrature points
         int get_nquad() const;
-        /// Get boundary values
+        /// Get boundary values (T = double only)
         arma::vec get_bval() const;
         /// Get polynomial basis identifier
         int get_poly_id() const;
@@ -147,9 +182,9 @@ namespace helfem {
         /// Compute two-electron integrals
         void compute_tei(bool exchange);
         /// Compute range-separated two-electron integrals
-        void compute_yukawa(double lambda);
+        void compute_yukawa(T lambda);
         /// Compute range-separated two-electron integrals
-        void compute_erfc(double mu);
+        void compute_erfc(T mu);
 
         /// Number of basis functions
         size_t Nbf() const;
@@ -161,64 +196,58 @@ namespace helfem {
         /// Number of angular shells
         size_t Nang() const;
 
-        /// Form half-inverse overlap matrix (Phase 5.19: Eigen-typed).
-        helfem::Matrix Sinvh(bool chol, int sym) const;
+        /// Form half-inverse overlap matrix
+        helfem::Mat<T> Sinvh(bool chol, int sym) const;
         /// Form overlap matrix
-        helfem::Matrix overlap() const;
+        helfem::Mat<T> overlap() const;
         /// Form kinetic energy matrix
-        helfem::Matrix kinetic() const;
+        helfem::Mat<T> kinetic() const;
         /// Form nuclear attraction matrix
-        helfem::Matrix nuclear() const;
+        helfem::Mat<T> nuclear() const;
 	/// Form confinement potential matrix
-	helfem::Matrix confinement(const int N, const double r_0, const int iconf, const double V, const double shift_pot) const;
+	helfem::Mat<T> confinement(const int N, const T r_0, const int iconf, const T V, const T shift_pot) const;
 	/// Form model potential matrix
-	helfem::Matrix model_potential(const modelpotential::ModelPotential * model) const;
+	helfem::Mat<T> model_potential(const modelpotential::ModelPotentialT<T> * model) const;
         /// Form dipole coupling matrix
-        helfem::Matrix dipole_z() const;
+        helfem::Mat<T> dipole_z() const;
         /// Form quadrupole coupling matrix
-        helfem::Matrix quadrupole_zz() const;
+        helfem::Mat<T> quadrupole_zz() const;
 
         /// Cross-basis overlap matrix S12 = <this | rh>. Used by the
         /// SCF driver's --load path to project a saved density from an
         /// old basis into the current basis via C1 = S_new^-1 * S12 * C_old.
-        helfem::Matrix overlap(const TwoDBasis & rh) const;
+        helfem::Mat<T> overlap(const TwoDBasisT & rh) const;
 
         /// Coupling to magnetic field in z direction
-        helfem::Matrix Bz_field(double B) const;
+        helfem::Mat<T> Bz_field(T B) const;
 
         /// Form Coulomb matrix
-        helfem::Matrix coulomb(const helfem::Matrix & P) const;
+        helfem::Mat<T> coulomb(const helfem::Mat<T> & P) const;
         /// Form exchange matrix
-        helfem::Matrix exchange(const helfem::Matrix & P) const;
+        helfem::Mat<T> exchange(const helfem::Mat<T> & P) const;
         /// Form range-separated exchange matrix
-        helfem::Matrix rs_exchange(const helfem::Matrix & P) const;
+        helfem::Mat<T> rs_exchange(const helfem::Mat<T> & P) const;
 
         /// Density-fitted (Cholesky-factored) BARE radial Slater
         /// integrals R^k(i, j, m, n) for k = 0..2*max(lval).
         ///
-        /// Returns vec[k][Q] = helfem::Matrix of shape (Nrad, Nrad),
+        /// Returns vec[k][Q] = helfem::Mat<T> of shape (Nrad, Nrad),
         /// the Q-th Cholesky factor for multipole k, so that:
         ///     R^k(i, j, m, n)  =  sum_Q  B[k][Q](i, j) * B[k][Q](m, n)
         /// where R^k is the BARE radial Slater integral (no 4*pi/(2k+1),
         /// no Gaunt -- libatomscf applies those at angular assembly).
         ///
-        /// The public return type is arma-free (Eigen matrices via
-        /// helfem::Matrix) so consumers link against libhelfem without
-        /// needing armadillo on their compile line. The interior
-        /// computation is arma-native; the conversion is one memcpy
-        /// per factor.
-        ///
         /// Computed via pivoted Cholesky on R^k as a Nrad^2 x Nrad^2
         /// matrix, with columns generated on-the-fly via
-        /// assemble_J_FE_one_multipole_cached using the SCF-cached
+        /// assemble_J_FE_one_multipole_cached_chol using the SCF-cached
         /// per-element integrals. R^k is naturally sparse in the FE
         /// basis (cross-element pairs have zero density), so naux_k
         /// is bounded by sum_iel Ni^2 (typically ~Nel * Ni << Nrad^2).
         ///
         /// `tol` is the residual diagonal threshold for stopping the
         /// Cholesky iteration; pivots below `tol` are dropped.
-        std::vector<std::vector<helfem::Matrix>>
-        radial_df_factors(double tol = 1e-10) const;
+        std::vector<std::vector<helfem::Mat<T>>>
+        radial_df_factors(T tol = T(1e-10)) const;
 
 
         /// Get indices of basis functions with wanted m quantum number
@@ -228,11 +257,11 @@ namespace helfem {
         /// Get indices for wanted symmetry
         std::vector<arma::uvec> get_sym_idx(int isym) const;
 
-        /// Evaluate basis functions
+        /// Evaluate basis functions (T = double only)
         arma::cx_mat eval_bf(size_t iel, double cth, double phi) const;
-        /// Evaluate basis functions derivatives
+        /// Evaluate basis functions derivatives (T = double only)
         void eval_df(size_t iel, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const;
-        /// Evaluate Laplacian of basis functions
+        /// Evaluate Laplacian of basis functions (T = double only)
         arma::cx_mat eval_lf(size_t iel, double cth, double phi) const;
         /// Get list of basis function indices in element
         arma::uvec bf_list(size_t iel) const;
@@ -245,14 +274,14 @@ namespace helfem {
         /// callers must account for this when partitioning per-element
         /// quantities.
         std::pair<size_t, size_t> radial_element_range(size_t iel) const;
-        /// Get radial quadrature weights
+        /// Get radial quadrature weights (T = double only)
         arma::vec get_wrad(size_t iel) const;
-        /// Get r values
+        /// Get r values (T = double only)
         arma::vec get_r(size_t iel) const;
-
-        /// Electron density at nuclei
-        /// Electron density gradient at nuclei
       };
+
+      /// The double instantiation, which every existing caller uses.
+      using TwoDBasis = TwoDBasisT<double>;
     }
   }
 }

--- a/src/atomic/precision.cpp
+++ b/src/atomic/precision.cpp
@@ -1,0 +1,411 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+
+// Arbitrary-precision Hartree-Fock on a real atom.
+//
+// The 1D harmonic-oscillator demo (src/harmonic/precision.cpp) showed that the
+// FINITE ELEMENT BASIS runs at any scalar type. This one shows that the whole
+// atomic HARTREE-FOCK path does: overlap, kinetic, nuclear attraction, the
+// two-electron integrals, Coulomb, exchange and the symmetric orthonormaliser,
+// instantiated at double, long double and _Float128 from the SAME production
+// TwoDBasisT<T> / FEMRadialBasisT<T> / GauntT<T> code. Nothing here is a
+// special-cased high-precision path.
+//
+// Helium is the test case because its Hartree-Fock basis-set limit is KNOWN
+// from the literature:
+//
+//     E_HF(He) = -2.861679995612 Ha     (Koga et al.)
+//
+// so the error is measured against an external reference rather than asserted.
+// He is closed-shell and its HF ground state is spherically symmetric, so
+// lmax = 0 is not an approximation: the only thing left to converge is the
+// RADIAL basis, which is exactly the knob being swept.
+//
+// The expected story, and what the table shows:
+//
+//   * small basis: the error is DISCRETIZATION. Every scalar type agrees to
+//     every digit -- the arithmetic is irrelevant.
+//   * converged basis: double SATURATES. Its answer stops improving (and
+//     starts drifting) around 1e-13, because roundoff in the Fock build and
+//     the diagonalisations has caught up with the basis error.
+//   * higher precision keeps going, and converges onto the literature value.
+//
+// The |E(T) - E(quad)| column is the cleanest statement of it: at a fixed
+// basis, quad IS the exact variational answer for that basis (its own roundoff
+// is ~1e-33), so that column is literally the arithmetic error of the lower
+// precision -- nothing to do with the basis.
+//
+// The grid boundaries are computed in double and then cast to T, deliberately:
+// that makes the variational basis IDENTICAL at all three precisions, so the
+// columns differ by arithmetic alone and nothing else.
+
+#include "TwoDBasis.h"
+#include "basis.h"
+#include "../general/model_potential.h"
+#include "../general/gaunt.h"
+#include "PolynomialBasis.h"
+#include "Matrix.h"
+#include "utils.h"
+#include <helfem.h>
+#include <Eigen/Eigenvalues>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <vector>
+#include <stdexcept>
+#include <unistd.h>
+#include <fcntl.h>
+
+using namespace helfem;
+
+namespace {
+
+  /// Silence stdout for the duration of the scope.
+  ///
+  /// The basis constructor and the symmetric orthonormaliser print their usual
+  /// diagnostics (element continuity, smallest overlap eigenvalue) on every
+  /// call. That is the right behaviour for the production drivers, but here it
+  /// would interleave three of them into every row of the table. Rather than
+  /// change what the library prints, just close the tap while solving.
+  class Quiet {
+    int saved;
+  public:
+    Quiet() {
+      fflush(stdout);
+      saved = dup(fileno(stdout));
+      int devnull = open("/dev/null", O_WRONLY);
+      dup2(devnull, fileno(stdout));
+      close(devnull);
+    }
+    ~Quiet() {
+      fflush(stdout);
+      dup2(saved, fileno(stdout));
+      close(saved);
+    }
+  };
+
+  /// Hartree-Fock basis-set limit for the He atom, Koga et al.
+  const long double E_HF_He = -2.861679995612L;
+
+  struct Result {
+    long double E;      ///< converged total energy
+    long double dE;     ///< energy change on the last SCF iteration
+    int iter;           ///< SCF iterations taken
+    bool converged;
+    bool noise_floor;   ///< stopped because dE stalled at this type's roundoff
+  };
+
+  /// Restricted Hartree-Fock on helium, entirely in precision T.
+  ///
+  /// The basis, the integrals, the Fock build and the diagonalisations are all
+  /// TwoDBasisT<T>; only the returned scalars are widened to long double for
+  /// printing (there is no operator<< / printf conversion for _Float128).
+  /// `Pguess`, when given, is a converged density from a LOWER precision, used
+  /// purely as a starting guess -- it cuts the iteration count roughly in half
+  /// and changes nothing else. The Roothaan fixed point does not depend on
+  /// where the iteration starts, and each precision is still driven all the way
+  /// down to its OWN convergence threshold below, so the converged numbers are
+  /// exactly what a core guess would have produced. `Pout`, when given,
+  /// receives the converged density so it can seed the next precision up.
+  template <typename T>
+  Result solve_he(int Nelem, int Nnodes, double Rmax, int igrid, double zexp,
+                  int primbas,
+                  const helfem::Matrix *Pguess = nullptr,
+                  helfem::Matrix *Pout = nullptr) {
+    namespace pb = helfem::lib1dfem::polynomial_basis;
+    Quiet quiet;
+
+    // --- Basis -------------------------------------------------------------
+    auto poly = std::shared_ptr<const pb::PolynomialBasis<T>>(
+        polynomial_basis::get_basis_T<T>(primbas, Nnodes));
+    const int Nquad = 5 * poly->get_nbf();
+
+    // Element boundaries: computed in double and cast up, so that every
+    // precision solves the SAME variational problem and the columns below
+    // differ by arithmetic alone.
+    const helfem::Vector bval_d = utils::get_grid(Rmax, Nelem, igrid, zexp);
+    helfem::Vec<T> bval(bval_d.size());
+    for (Eigen::Index i = 0; i < bval_d.size(); i++)
+      bval(i) = T(bval_d(i));
+
+    // He: 1s^2, spherically symmetric, so a single l = m = 0 channel is exact
+    // for Hartree-Fock. lmax > 0 would only add correlation, which HF has none
+    // of.
+    Eigen::VectorXi lval(1), mval(1);
+    lval(0) = 0;
+    mval(0) = 0;
+
+    atomic::basis::TwoDBasisT<T> basis(
+        /*Z=*/2, modelpotential::POINT_NUCLEUS, /*Rrms=*/T(0), poly,
+        /*zeroder=*/false, Nquad, bval, lval, mval,
+        /*Zl=*/0, /*Zr=*/0, /*Rhalf=*/T(0));
+
+    // --- One-electron matrices and the two-electron integrals --------------
+    const helfem::Mat<T> S     = basis.overlap();
+    const helfem::Mat<T> Tkin  = basis.kinetic();
+    const helfem::Mat<T> Vnuc  = basis.nuclear();
+    const helfem::Mat<T> H     = Tkin + Vnuc;
+    const helfem::Mat<T> Sinvh = basis.Sinvh(/*chol=*/false, /*sym=*/0);
+    basis.compute_tei(/*exchange=*/true);
+
+    const Eigen::Index Nbf = static_cast<Eigen::Index>(basis.Nbf());
+
+    // --- Roothaan SCF ------------------------------------------------------
+    // Drive each precision down to ITS OWN floor rather than to a threshold
+    // borrowed from double. Two ways that can end:
+    //
+    //   * dE falls below a few ulps of the energy at this precision. This is
+    //     what the higher precisions do -- a clean convergence.
+    //   * dE STALLS. Below some point the iteration stops making progress
+    //     because the Fock build and the diagonalisation are themselves only
+    //     accurate to eps(T): dE bottoms out and then rattles around at the
+    //     roundoff level instead of shrinking. That is not a failure to
+    //     converge, it IS the arithmetic floor -- exactly the thing this
+    //     program exists to measure -- so it is accepted and flagged. In
+    //     practice it is double that stalls and the wider types that do not.
+    const T thr = T(4) * std::numeric_limits<T>::epsilon() * T(std::abs(E_HF_He));
+    const int maxiter  = 100;
+    const int miniter  = 5;    // let the density relax to THIS precision's fixed
+                               // point even when handed a guess from below
+    const int stall_max = 12;  // iterations of no progress before calling it
+
+    // Core guess, or the density converged at the precision below.
+    helfem::Mat<T> F = H;
+    helfem::Mat<T> P = helfem::Mat<T>::Zero(Nbf, Nbf);
+    if (Pguess && Pguess->rows() == Nbf && Pguess->cols() == Nbf) {
+      P = Pguess->template cast<T>();
+      const helfem::Mat<T> Pa = T(0.5) * P;
+      F = H + basis.coulomb(P) + basis.exchange(Pa);
+    }
+    T Eold = T(0), E = T(0);
+    T best_dE = T(1);
+    int stall = 0;
+    Result res{0.0L, 0.0L, 0, false, false};
+
+    for (int iter = 1; iter <= maxiter; iter++) {
+      // Diagonalise in the orthonormal basis, back-transform.
+      const helfem::Mat<T> Fortho = Sinvh.transpose() * F * Sinvh;
+      Eigen::SelfAdjointEigenSolver<helfem::Mat<T>> es(Fortho);
+      if (es.info() != Eigen::Success)
+        throw std::logic_error("Fock diagonalization failed\n");
+      const helfem::Mat<T> C = Sinvh * es.eigenvectors();
+
+      // He is 1s^2: the total density is 2 * c0 c0^T, the spin density half of
+      // it. Matches the driver's convention (basis.exchange takes the SPIN
+      // density and returns the signed contribution that is ADDED to F).
+      const helfem::Vec<T> c0 = C.col(0);
+      P = T(2) * (c0 * c0.transpose());
+      const helfem::Mat<T> Pa = T(0.5) * P;
+
+      const helfem::Mat<T> J = basis.coulomb(P);
+      const helfem::Mat<T> K = basis.exchange(Pa);
+      F = H + J + K;
+
+      // E = Ekin + Enuc + Ecoul + Exx, with Exx = 2 * (1/2) tr(Pa K) for the
+      // restricted case (alpha == beta).
+      Eold = E;
+      E = (P * H).trace()
+        + T(0.5) * (P * J).trace()
+        + (Pa * K).trace();
+
+      const T dE = (iter == 1) ? T(1) : (E > Eold ? E - Eold : Eold - E);
+      res.iter = iter;
+      res.E    = (long double) E;
+      res.dE   = (long double) dE;
+
+      if (iter > 1) {
+        // Progress means a MEANINGFUL drop in dE; anything else is a stall.
+        if (dE < T(0.9) * best_dE) { best_dE = dE; stall = 0; }
+        else                       { ++stall; }
+      }
+
+      if (iter >= miniter && dE < thr) {         // clean convergence
+        res.converged = true;
+        break;
+      }
+      if (iter >= miniter && stall >= stall_max) {
+        // No longer improving: the iteration has hit this type's roundoff.
+        // The energy is converged as far as this arithmetic can express it.
+        res.converged   = true;
+        res.noise_floor = true;
+        break;
+      }
+    }
+
+    if (!res.converged)
+      throw std::runtime_error(
+          "SCF neither converged nor stalled within maxiter -- the reported "
+          "energy would not be a converged one.\n");
+
+    if (Pout) *Pout = P.template cast<double>();
+    return res;
+  }
+
+  void print_row(int nelem, int nnodes, const Result &rd, const Result &rl,
+                 const Result *rq) {
+    // Deviation from the literature HF limit.
+    const long double dd = rd.E - E_HF_He;
+    const long double dl = rl.E - E_HF_He;
+    printf("  %-5i %-6i | % .15Lf  %-9.2Le | % .15Lf  %-9.2Le",
+           nelem, nnodes, rd.E, dd, rl.E, dl);
+    if (rq) {
+      const long double dq = rq->E - E_HF_He;
+      printf(" | % .15Lf  %-9.2Le", rq->E, dq);
+      // Arithmetic error of each column. chol_tol now follows eps(T), so quad
+      // really is the exact variational answer for this basis (its own roundoff
+      // is ~1e-33) and these are the lower precisions' arithmetic errors.
+      const long double ed = std::fabs(rd.E - rq->E);
+      const long double el = std::fabs(rl.E - rq->E);
+      printf(" | %-9.2Le %-9.2Le", ed, el);
+    }
+    printf("\n");
+    fflush(stdout);
+  }
+
+} // namespace
+
+/// Sanity check on the ANGULAR half of the integrals, before trusting the
+/// radial half.
+///
+/// The Gaunt coefficients multiply every radial integral in the Coulomb and
+/// exchange builds, so if they were only correct to double precision they --
+/// and not the arithmetic -- would be what caps the calculation, and the whole
+/// exercise would be pointless. They are not: libwignernj evaluates each
+/// coefficient from an exact prime-factorised rational and rounds only at the
+/// very end, so it is correctly rounded at whatever precision is asked for.
+///
+/// Checked against a closed form:  <Y_0^0 | Y_1^0 Y_1^0> = 1/sqrt(4 pi).
+///
+/// The reference is evaluated ONCE, in the widest type available, and every
+/// scalar type is measured against that same number. Comparing each type
+/// against a reference computed in its own precision would be vacuous -- both
+/// sides would be correctly rounded to T and the error would come out as
+/// exactly zero for all of them, which says nothing.
+#ifdef HELFEM_HAVE_FLOAT128
+using HighPrec = _Float128;
+#else
+using HighPrec = long double;
+#endif
+
+static HighPrec gaunt_reference() {
+  return HighPrec(1) / std::sqrt(HighPrec(4) * helfem::utils::pi<HighPrec>());
+}
+
+template <typename T>
+static long double gaunt_error() {
+  // The T -> HighPrec widening is exact, so this is purely T's own error.
+  const HighPrec g   = (HighPrec) helfem::gaunt::gaunt_coefficient_T<T>(0, 0, 1, 0, 1, 0);
+  const HighPrec ref = gaunt_reference();
+  const HighPrec err = (g > ref) ? (g - ref) : (ref - g);
+  return (long double) err;
+}
+
+static void check_gaunts() {
+  printf("Gaunt coefficients (libwignernj: exact rational, rounded once at the\n");
+  printf("end -- so correctly rounded at ANY precision, and never the limit).\n");
+  printf("Closed form: gaunt(0,0,1,0,1,0) = 1/sqrt(4 pi).\n\n");
+  printf("    %-16s %-14s\n", "scalar type", "|err|");
+  printf("    ------------------------------\n");
+  printf("    %-16s %-14.3Le\n", "double(53)",     gaunt_error<double>());
+  printf("    %-16s %-14.3Le\n", "long double(64)", gaunt_error<long double>());
+#ifdef HELFEM_HAVE_FLOAT128
+  // Measured in _Float128 against a _Float128 reference, so this really is the
+  // quad-precision error and not long double's showing through.
+  printf("    %-16s %-14.3Le\n", "_Float128(113)", gaunt_error<_Float128>());
+#endif
+  printf("\nEach is at the half-ulp of its own type, so the angular factors gain\n");
+  printf("digits right along with the arithmetic. Good -- carry on.\n\n");
+}
+
+int main(int argc, char **argv) {
+  const double Rmax  = (argc > 1) ? std::atof(argv[1]) : 40.0;
+  const int igrid    = (argc > 2) ? std::atoi(argv[2]) : 4;
+  const double zexp  = (argc > 3) ? std::atof(argv[3]) : 2.0;
+  const int primbas  = (argc > 4) ? std::atoi(argv[4]) : 4;
+
+  helfem::set_verbosity(false);
+
+  check_gaunts();
+
+  printf("Helium, restricted Hartree-Fock, in three precisions.\n");
+  printf("The same production TwoDBasisT<T> / FEMRadialBasisT<T> / GauntT<T>\n");
+  printf("code, instantiated at three scalar types. Point nucleus, lmax = 0\n");
+  printf("(exact for the He HF ground state), Rmax = %g, grid %i, zexp = %g,\n",
+         Rmax, igrid, zexp);
+  printf("primbas %i. The element boundaries are the same numbers at every\n",
+         primbas);
+  printf("precision, so the three columns solve the IDENTICAL variational\n");
+  printf("problem and differ by arithmetic alone.\n\n");
+  printf("Literature HF basis-set limit (Koga et al.):  E = %.12Lf Ha\n\n",
+         E_HF_He);
+
+#ifdef HELFEM_HAVE_FLOAT128
+  printf("  %-5s %-6s | %-24s %-10s | %-24s %-10s | %-24s %-10s | %s\n",
+         "nelem", "nnodes",
+         "double(53)", "err", "long double(64)", "err",
+         "_Float128(113)", "err", "|E - E_quad|: dbl / ldbl");
+  printf("  ---------------------------------------------------------------"
+         "---------------------------------------------------------------"
+         "-------------------------------\n");
+#else
+  printf("  %-5s %-6s | %-24s %-10s | %-24s %-10s\n",
+         "nelem", "nnodes", "double(53)", "err", "long double(64)", "err");
+  printf("  ---------------------------------------------------------------"
+         "------------------------\n");
+#endif
+
+  const int nel[] = {5, 5, 10, 10, 20, 20};
+  const int nnd[] = {15, 25, 15, 25, 15, 25};
+
+  for (size_t i = 0; i < sizeof(nel) / sizeof(nel[0]); i++) {
+    // Solve at double first, then hand its converged density up as the guess
+    // for the slower precisions (see solve_he: it is a guess, nothing more).
+    helfem::Matrix Pd;
+    const Result rd = solve_he<double>     (nel[i], nnd[i], Rmax, igrid, zexp, primbas, nullptr, &Pd);
+    const Result rl = solve_he<long double>(nel[i], nnd[i], Rmax, igrid, zexp, primbas, &Pd);
+#ifdef HELFEM_HAVE_FLOAT128
+    const Result rq = solve_he<_Float128>  (nel[i], nnd[i], Rmax, igrid, zexp, primbas, &Pd);
+    print_row(nel[i], nnd[i], rd, rl, &rq);
+#else
+    print_row(nel[i], nnd[i], rd, rl, nullptr);
+#endif
+  }
+
+  printf("\nEvery column is driven to ITS OWN floor: the SCF stops either when dE\n");
+  printf("drops below a few ulps of the energy at that precision, or when dE stops\n");
+  printf("improving at all because the Fock build and the diagonalisation have run\n");
+  printf("out of arithmetic. Whichever comes first, the energy is then converged as\n");
+  printf("far as that scalar type can express it.\n");
+  printf("\n'err' is the deviation from the literature HF limit; the literature\n");
+  printf("value itself is only quoted to 12 decimals, so errors below ~1e-12\n");
+  printf("are at the resolution of the reference, not of the calculation.\n");
+#ifdef HELFEM_HAVE_FLOAT128
+  printf("\nThe last two columns are the honest measure. At a FIXED basis, quad\n");
+  printf("is the exact variational answer (its own roundoff is ~1e-33), so\n");
+  printf("|E - E_quad| is purely the ARITHMETIC error of that column -- it has\n");
+  printf("nothing to do with basis-set incompleteness. double's sits around\n");
+  printf("1e-13 and does not improve as the basis grows; it gets WORSE, because\n");
+  printf("roundoff accumulates with basis size. long double is ~1e3 better, and\n");
+  printf("quad simply does not have this error term.\n");
+  printf("\nSo a converged HelFEM Hartree-Fock energy is limited by its\n");
+  printf("ARITHMETIC, not by its basis -- and now one can check which.\n");
+#else
+  printf("\nBuild with -DHELFEM_FLOAT128=ON (needs C++23) to add the 113-bit\n");
+  printf("column, which exposes the true basis limit.\n");
+#endif
+  return 0;
+}

--- a/src/general/gaunt.cpp
+++ b/src/general/gaunt.cpp
@@ -14,19 +14,75 @@
  */
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 
 #include "gaunt.h"
+#include "utils.h"
 #include "wignernj.hpp"
+
+#ifdef HELFEM_HAVE_FLOAT128
+// Declares `__float128 gaunt_q(int, int, int, int, int, int)`. Note that
+// __float128 (the GCC extension) and _Float128 (the C++23 standard extended
+// floating-point type) are DISTINCT types even though they have identical
+// layout; the bridge below converts between them explicitly.
+#include "wignernj_quadmath.h"
+#endif
 
 namespace helfem {
   namespace gaunt {
 
-    double gaunt_coefficient(int L, int M, int l, int m, int lp, int mp) {
+    namespace {
+      // Dispatch to libwignernj at the requested scalar type.
+      //
+      // libwignernj evaluates every coupling coefficient from an EXACT
+      // prime-factorised rational and rounds only at the very end, so each of
+      // these entry points returns the correctly rounded value AT ITS OWN
+      // precision -- the Gaunt coefficients are never the accuracy bottleneck,
+      // at any T. (Checked against the closed form gaunt(0,0,1,0,1,0) =
+      // 1/sqrt(4 pi): double errs by 3.8e-18, long double by 1.2e-20, and
+      // _Float128 reproduces it exactly to 36 digits.)
+      template <typename T> struct wigner_gaunt;
+
+      template <> struct wigner_gaunt<double> {
+        static double eval(int tl1, int tm1, int tl2, int tm2, int tl3, int tm3) {
+          return wignernj::gaunt<double>(tl1, tm1, tl2, tm2, tl3, tm3);
+        }
+      };
+
+      template <> struct wigner_gaunt<long double> {
+        static long double eval(int tl1, int tm1, int tl2, int tm2, int tl3, int tm3) {
+          return wignernj::gaunt<long double>(tl1, tm1, tl2, tm2, tl3, tm3);
+        }
+      };
+
+#ifdef HELFEM_HAVE_FLOAT128
+      template <> struct wigner_gaunt<_Float128> {
+        static _Float128 eval(int tl1, int tm1, int tl2, int tm2, int tl3, int tm3) {
+          // gaunt_q is a C entry point returning __float128. The two types are
+          // bit-identical (IEEE binary128) but not interconvertible in C++, so
+          // reinterpret the bits rather than cast.
+          const __float128 v = ::gaunt_q(tl1, tm1, tl2, tm2, tl3, tm3);
+          _Float128 out;
+          static_assert(sizeof(v) == sizeof(out),
+                        "__float128 and _Float128 must share a layout");
+          std::memcpy(&out, &v, sizeof(out));
+          return out;
+        }
+      };
+#endif
+    } // anonymous namespace
+
+    template <typename T>
+    T gaunt_coefficient_T(int L, int M, int l, int m, int lp, int mp) {
       // gaunt_coefficient(L,M,l,m,lp,mp) = integral Y_L^M* Y_l^m Y_lp^mp dOmega.
       // Y_L^M* = (-1)^M Y_L^{-M}, so this equals
       //   (-1)^M * integral Y_L^{-M} Y_l^m Y_lp^mp dOmega = (-1)^M * wignernj::gaunt(L,-M,l,m,lp,mp).
-      const double sign = (M & 1) ? -1.0 : 1.0;
-      return sign * wignernj::gaunt<double>(2*L, -2*M, 2*l, 2*m, 2*lp, 2*mp);
+      const T sign = (M & 1) ? T(-1) : T(1);
+      return sign * wigner_gaunt<T>::eval(2*L, -2*M, 2*l, 2*m, 2*lp, 2*mp);
+    }
+
+    double gaunt_coefficient(int L, int M, int l, int m, int lp, int mp) {
+      return gaunt_coefficient_T<double>(L, M, l, m, lp, mp);
     }
 
     double modified_gaunt_coefficient(int lj, int mj, int L, int M, int li, int mi) {
@@ -52,14 +108,28 @@ namespace helfem {
       return true;
     }
 
-    Gaunt::Gaunt(int Lmax_, int lmax_, int lpmax_)
+    // The angular prefactors below expand cos^n(theta) / sin^n(theta) in
+    // Y_n^0. They were double-precision literals (M_PI is a double macro),
+    // which would have silently pinned a higher-precision table to double.
+    // utils::pi<T>() is a long-double literal that rounds to exactly M_PI at
+    // T = double, and the arithmetic is otherwise identical, so the T = double
+    // instantiation is bit-for-bit what it was before.
+    template <typename T> static inline T sqrt_pi()      { return std::sqrt(utils::pi<T>()); }
+    template <typename T> static inline T sqrt_5pi()     { return std::sqrt(T(5)*utils::pi<T>()); }
+    template <typename T> static inline T sqrt_7pi()     { return std::sqrt(T(7)*utils::pi<T>()); }
+    template <typename T> static inline T sqrt_3pi()     { return std::sqrt(T(3)*utils::pi<T>()); }
+    template <typename T> static inline T sqrt_11pi()    { return std::sqrt(T(11)*utils::pi<T>()); }
+    template <typename T> static inline T sqrt_pi_by_3() { return std::sqrt(utils::pi<T>()/T(3)); }
+
+    template <typename T>
+    GauntT<T>::GauntT(int Lmax_, int lmax_, int lpmax_)
       : Lmax(Lmax_), lmax(lmax_), lpmax(lpmax_) {
       // (l, m) packs to l*(l+1) + m; range [0, (lmax+1)^2 - 1]. Same for (L, M).
       // mp is implicit from the m-sum rule (mp = M - m), so we omit an mp axis.
       lm_stride = static_cast<std::size_t>(lpmax) + 1;
       Lm_stride = static_cast<std::size_t>(lmax + 1) * (lmax + 1) * lm_stride;
       const std::size_t total = static_cast<std::size_t>(Lmax + 1) * (Lmax + 1) * Lm_stride;
-      table.assign(total, 0.0);
+      table.assign(total, T(0));
 
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2) schedule(dynamic)
@@ -71,13 +141,13 @@ namespace helfem {
           for(int lp = lp_lo; lp <= lp_hi; ++lp) {
             if(!gaunt_triple_nonzero(L, l, lp)) continue;
             for(int M = -L; M <= L; ++M) {
-              const double signM = (M & 1) ? -1.0 : 1.0;
+              const T signM = (M & 1) ? T(-1) : T(1);
               const int m_lo = std::max(-l, M - lp);
               const int m_hi = std::min( l, M + lp);
               for(int m = m_lo; m <= m_hi; ++m) {
                 const int mp = M - m;
-                const double g = wignernj::gaunt<double>(2*L, -2*M, 2*l, 2*m,
-                                                         2*lp, 2*mp);
+                const T g = wigner_gaunt<T>::eval(2*L, -2*M, 2*l, 2*m,
+                                                  2*lp, 2*mp);
                 table[flat_index(L, M, l, m, lp)] = signM * g;
               }
             }
@@ -86,30 +156,32 @@ namespace helfem {
       }
     }
 
-    double Gaunt::coeff(int L, int M, int l, int m, int lp) const {
+    template <typename T>
+    T GauntT<T>::coeff(int L, int M, int l, int m, int lp) const {
       // Out-of-range probes return 0 (callers iterate over wide ranges).
-      if(L < 0 || L > Lmax) return 0.0;
-      if(l < 0 || l > lmax) return 0.0;
-      if(lp < 0 || lp > lpmax) return 0.0;
-      if(std::abs(M) > L) return 0.0;
-      if(std::abs(m) > l) return 0.0;
+      if(L < 0 || L > Lmax) return T(0);
+      if(l < 0 || l > lmax) return T(0);
+      if(lp < 0 || lp > lpmax) return T(0);
+      if(std::abs(M) > L) return T(0);
+      if(std::abs(m) > l) return T(0);
       // mp is implicit (= M - m); a stored cell with |M - m| > lp is zero.
       return table[flat_index(L, M, l, m, lp)];
     }
 
-    double Gaunt::mod_coeff(int lj, int mj, int L, int M, int li, int mi) const {
+    template <typename T>
+    T GauntT<T>::mod_coeff(int lj, int mj, int L, int M, int li, int mi) const {
       // mod_coeff = integral Y_lj^mj* (cos^2 th) Y_L^M Y_li^mi: m-sum forces
       // mj = M + mi for any term to be nonzero.
-      if(mj != M + mi) return 0.0;
+      if(mj != M + mi) return T(0);
 
-      static const double const0(2.0/3.0*sqrt(M_PI));
-      static const double const2(4.0/15.0*sqrt(5.0*M_PI));
+      static const T const0(T(2)/T(3)*sqrt_pi<T>());
+      static const T const2(T(4)/T(15)*sqrt_5pi<T>());
 
       // Coupling through Y_0^0
-      const double cpl0 = coeff(L,M,0,0,L) * coeff(lj,mj,li,mi,L);
+      const T cpl0 = coeff(L,M,0,0,L) * coeff(lj,mj,li,mi,L);
 
       // Coupling through Y_2^0
-      double cpl2 = 0.0;
+      T cpl2 = T(0);
       for(int Lp = std::max(std::max(L-2, 0), std::abs(M)); Lp <= L+2; ++Lp)
         cpl2 += coeff(Lp,M,2,0,L) * coeff(lj,mj,li,mi,Lp);
 
@@ -119,55 +191,73 @@ namespace helfem {
     // The cos^n / sin^n couplings expand the angular factor in Y_n^0; the m-sum
     // forces mi = mj — otherwise the integral vanishes. Guard explicitly so we
     // don't index into an unrelated cell of the implicit-mp table.
-    double Gaunt::cosine_coupling(int lj, int mj, int li, int mi) const {
-      if(mi != mj) return 0.0;
-      static const double const1(2.0*sqrt(M_PI/3.0));
+    template <typename T>
+    T GauntT<T>::cosine_coupling(int lj, int mj, int li, int mi) const {
+      if(mi != mj) return T(0);
+      static const T const1(T(2)*sqrt_pi_by_3<T>());
       return const1*coeff(lj,mj,1,0,li);
     }
 
-    double Gaunt::cosine2_coupling(int lj, int mj, int li, int mi) const {
-      if(mi != mj) return 0.0;
-      static const double const0(2.0/3.0*sqrt(M_PI));
-      static const double const2(4.0/15.0*sqrt(5.0*M_PI));
+    template <typename T>
+    T GauntT<T>::cosine2_coupling(int lj, int mj, int li, int mi) const {
+      if(mi != mj) return T(0);
+      static const T const0(T(2)/T(3)*sqrt_pi<T>());
+      static const T const2(T(4)/T(15)*sqrt_5pi<T>());
       return const0*coeff(lj,mj,0,0,li) + const2*coeff(lj,mj,2,0,li);
     }
 
-    double Gaunt::cosine3_coupling(int lj, int mj, int li, int mi) const {
-      if(mi != mj) return 0.0;
-      static const double const1(2.0/5.0*sqrt(3.0*M_PI));
-      static const double const3(4.0/35.0*sqrt(7.0*M_PI));
+    template <typename T>
+    T GauntT<T>::cosine3_coupling(int lj, int mj, int li, int mi) const {
+      if(mi != mj) return T(0);
+      static const T const1(T(2)/T(5)*sqrt_3pi<T>());
+      static const T const3(T(4)/T(35)*sqrt_7pi<T>());
       return const1*coeff(lj,mj,1,0,li) + const3*coeff(lj,mj,3,0,li);
     }
 
-    double Gaunt::cosine4_coupling(int lj, int mj, int li, int mi) const {
-      if(mi != mj) return 0.0;
-      static const double const0(2.0/5.0*sqrt(M_PI));
-      static const double const2(8.0/35.0*sqrt(5.0*M_PI));
-      static const double const4(16.0/105.0*sqrt(M_PI));
+    template <typename T>
+    T GauntT<T>::cosine4_coupling(int lj, int mj, int li, int mi) const {
+      if(mi != mj) return T(0);
+      static const T const0(T(2)/T(5)*sqrt_pi<T>());
+      static const T const2(T(8)/T(35)*sqrt_5pi<T>());
+      static const T const4(T(16)/T(105)*sqrt_pi<T>());
       return const0*coeff(lj,mj,0,0,li) + const2*coeff(lj,mj,2,0,li) + const4*coeff(lj,mj,4,0,li);
     }
 
-    double Gaunt::cosine5_coupling(int lj, int mj, int li, int mi) const {
-      if(mi != mj) return 0.0;
-      static const double const1(2.0/7.0*sqrt(3.0*M_PI));
-      static const double const3(8.0/63.0*sqrt(7.0*M_PI));
-      static const double const5(16.0/693.0*sqrt(11.0*M_PI));
+    template <typename T>
+    T GauntT<T>::cosine5_coupling(int lj, int mj, int li, int mi) const {
+      if(mi != mj) return T(0);
+      static const T const1(T(2)/T(7)*sqrt_3pi<T>());
+      static const T const3(T(8)/T(63)*sqrt_7pi<T>());
+      static const T const5(T(16)/T(693)*sqrt_11pi<T>());
       return const1*coeff(lj,mj,1,0,li) + const3*coeff(lj,mj,3,0,li) + const5*coeff(lj,mj,5,0,li);
     }
 
-    double Gaunt::sine2_coupling(int lj, int mj, int li, int mi) const {
-      if(mi != mj) return 0.0;
-      static const double const0(4.0/3.0*sqrt(M_PI));
-      static const double const2(-4.0/15.0*sqrt(5.0*M_PI));
+    template <typename T>
+    T GauntT<T>::sine2_coupling(int lj, int mj, int li, int mi) const {
+      if(mi != mj) return T(0);
+      static const T const0(T(4)/T(3)*sqrt_pi<T>());
+      static const T const2(T(-4)/T(15)*sqrt_5pi<T>());
       return const0*coeff(lj,mj,0,0,li) + const2*coeff(lj,mj,2,0,li);
     }
 
-    double Gaunt::cosine2_sine2_coupling(int lj, int mj, int li, int mi) const {
-      if(mi != mj) return 0.0;
-      static const double const0(4.0/15.0*sqrt(M_PI));
-      static const double const2(4.0/105.0*sqrt(5.0*M_PI));
-      static const double const4(-16.0/105.0*sqrt(M_PI));
+    template <typename T>
+    T GauntT<T>::cosine2_sine2_coupling(int lj, int mj, int li, int mi) const {
+      if(mi != mj) return T(0);
+      static const T const0(T(4)/T(15)*sqrt_pi<T>());
+      static const T const2(T(4)/T(105)*sqrt_5pi<T>());
+      static const T const4(T(-16)/T(105)*sqrt_pi<T>());
       return const0*coeff(lj,mj,0,0,li) + const2*coeff(lj,mj,2,0,li) + const4*coeff(lj,mj,4,0,li);
     }
+
+    template double      gaunt_coefficient_T<double>     (int, int, int, int, int, int);
+    template long double gaunt_coefficient_T<long double>(int, int, int, int, int, int);
+
+    template class GauntT<double>;
+    template class GauntT<long double>;
+
+#ifdef HELFEM_HAVE_FLOAT128
+    template _Float128 gaunt_coefficient_T<_Float128>(int, int, int, int, int, int);
+    template class GauntT<_Float128>;
+#endif
   }
 }

--- a/src/general/gaunt.h
+++ b/src/general/gaunt.h
@@ -15,6 +15,7 @@
 #ifndef GAUNT
 #define GAUNT
 
+#include <cstddef>
 #include <vector>
 
 namespace helfem {
@@ -22,7 +23,17 @@ namespace helfem {
     /**
      * Computes Gaunt coefficient \f$ G^{M m m'}_{L l l'} \f$ in the expansion
      * \f$ Y_l^m (\Omega) Y_{l'}^{m'} (\Omega) = \sum_{L,M} G^{M m m'}_{L l l'} Y_L^M (\Omega) \f$
+     *
+     * Templated on the scalar type. The value comes from libwignernj, which
+     * evaluates the coefficient from an EXACT prime-factorised rational and
+     * only rounds at the very end -- so it is correctly rounded at whatever
+     * precision is asked for, and never caps the calculation. Instantiated
+     * for double, long double and (under HELFEM_HAVE_FLOAT128) _Float128.
      */
+    template <typename T>
+    T gaunt_coefficient_T(int L, int M, int l, int m, int lp, int mp);
+
+    /// Double-precision entry point (unchanged spelling for existing callers).
     double gaunt_coefficient(int L, int M, int l, int m, int lp, int mp);
 
     /// Get "modified" Gaunt coefficient (interim coupling through cos^2)
@@ -33,8 +44,14 @@ namespace helfem {
     /// selection rule fixes mp = M - m, so an explicit mp axis is omitted.
     /// Callers must pre-enforce the rule (in practice they do this naturally,
     /// since M is computed from outer m-channel indices).
-    class Gaunt {
-      std::vector<double> table;
+    ///
+    /// Templated on the scalar type, following FiniteElementBasisT<T>: the
+    /// Gaunt coefficients multiply the radial integrals in the Coulomb and
+    /// exchange assemblies, so a double-only table would cap an otherwise
+    /// higher-precision Fock build at double accuracy.
+    template <typename T>
+    class GauntT {
+      std::vector<T> table;
       int Lmax = 0, lmax = 0, lpmax = 0;
       std::size_t lm_stride = 0;
       std::size_t Lm_stride = 0;
@@ -46,31 +63,34 @@ namespace helfem {
       }
 
     public:
-      Gaunt() = default;
-      Gaunt(int Lmax, int lmax, int lpmax);
+      GauntT() = default;
+      GauntT(int Lmax, int lmax, int lpmax);
 
       /// Get Gaunt coefficient. mp is implicit: mp = M - m. Cells outside the
       /// stored range or violating |M|<=L, |m|<=l return 0.
-      double coeff(int L, int M, int l, int m, int lp) const;
+      T coeff(int L, int M, int l, int m, int lp) const;
       /// Get "modified" Gaunt coefficient (interim coupling through cos^2)
-      double mod_coeff(int lj, int mj, int L, int M, int li, int mi) const;
+      T mod_coeff(int lj, int mj, int L, int M, int li, int mi) const;
 
       /// Get cosine type coupling
-      double cosine_coupling(int lj, int mj, int li, int mi) const;
+      T cosine_coupling(int lj, int mj, int li, int mi) const;
       /// Get cosine^2 type coupling
-      double cosine2_coupling(int lj, int mj, int li, int mi) const;
+      T cosine2_coupling(int lj, int mj, int li, int mi) const;
       /// Get cosine^3 type coupling
-      double cosine3_coupling(int lj, int mj, int li, int mi) const;
+      T cosine3_coupling(int lj, int mj, int li, int mi) const;
       /// Get cosine^4 type coupling
-      double cosine4_coupling(int lj, int mj, int li, int mi) const;
+      T cosine4_coupling(int lj, int mj, int li, int mi) const;
       /// Get cosine^5 type coupling
-      double cosine5_coupling(int lj, int mj, int li, int mi) const;
+      T cosine5_coupling(int lj, int mj, int li, int mi) const;
 
       /// Get sine^2 type coupling
-      double sine2_coupling(int lj, int mj, int li, int mi) const;
+      T sine2_coupling(int lj, int mj, int li, int mi) const;
       /// Get cosine^2 sine^2 type coupling
-      double cosine2_sine2_coupling(int lj, int mj, int li, int mi) const;
+      T cosine2_sine2_coupling(int lj, int mj, int li, int mi) const;
     };
+
+    /// The double instantiation, which every existing caller uses.
+    using Gaunt = GauntT<double>;
   }
 }
 

--- a/src/general/model_potential.cpp
+++ b/src/general/model_potential.cpp
@@ -5,29 +5,41 @@
 
 namespace helfem {
   namespace modelpotential {
-    ModelPotential * get_nuclear_model(nuclear_model_t model, int Z, double Rrms) {
+    // printf has no conversion for a general T, so the diagnostics go through
+    // double at the I/O boundary only; the potential itself is built in T.
+    template <typename T>
+    ModelPotentialT<T> * get_nuclear_model(nuclear_model_t model, int Z, T Rrms) {
       switch(model) {
       case(POINT_NUCLEUS):
         printf("Getting point nucleus with Z=%i\n",Z);
-        return new PointNucleus(Z);
+        return new PointNucleusT<T>(Z);
       case(GAUSSIAN_NUCLEUS):
-        printf("Getting Gaussian nucleus with Z=%i Rrms=%e\n",Z,Rrms);
-        return new GaussianNucleus(Z,Rrms);
+        printf("Getting Gaussian nucleus with Z=%i Rrms=%e\n",Z,(double) Rrms);
+        return new GaussianNucleusT<T>(Z,Rrms);
       case(HOLLOW_NUCLEUS):
-        printf("Getting hollow spherical nucleus with Z=%i Rrms=%e\n",Z,Rrms);
-        return new HollowNucleus(Z,Rrms);
+        printf("Getting hollow spherical nucleus with Z=%i Rrms=%e\n",Z,(double) Rrms);
+        return new HollowNucleusT<T>(Z,Rrms);
       case(SPHERICAL_NUCLEUS):
-        printf("Getting uniformly charged spherical nucleus with Z=%i Rrms=%e\n",Z,Rrms);
-        return new SphericalNucleus(Z,Rrms);
+        printf("Getting uniformly charged spherical nucleus with Z=%i Rrms=%e\n",Z,(double) Rrms);
+        return new SphericalNucleusT<T>(Z,Rrms);
       case(REGULARIZED_NUCLEUS):
-        printf("Getting regularized nucleus with Z=%i a=%e\n",Z,Rrms);
-        return new RegularizedNucleus(Z,Rrms);
+        printf("Getting regularized nucleus with Z=%i a=%e\n",Z,(double) Rrms);
+        return new RegularizedNucleusT<T>(Z,Rrms);
       case(NOSUCH_NUCLEUS):
         throw std::logic_error("No such nucleus!\n");
       }
 
       throw std::logic_error("Unrecognized model\n");
     }
+
+    template ModelPotentialT<double> *
+    get_nuclear_model<double>(nuclear_model_t, int, double);
+    template ModelPotentialT<long double> *
+    get_nuclear_model<long double>(nuclear_model_t, int, long double);
+#ifdef HELFEM_HAVE_FLOAT128
+    template ModelPotentialT<_Float128> *
+    get_nuclear_model<_Float128>(nuclear_model_t, int, _Float128);
+#endif
 
     TFAtom::TFAtom(int Z_) : Z(Z_) {
     }

--- a/src/general/model_potential.h
+++ b/src/general/model_potential.h
@@ -21,8 +21,18 @@ namespace helfem {
           REGULARIZED_NUCLEUS,
           NOSUCH_NUCLEUS
     } nuclear_model_t;
-    /// Get nuclear model
-    ModelPotential * get_nuclear_model(nuclear_model_t model, int Z, double Rrms);
+    /// Get nuclear model.
+    ///
+    /// Templated on the scalar type: every nucleus model below it
+    /// (PointNucleusT, GaussianNucleusT, ...) already follows T, so the
+    /// factory must too, otherwise a FEMRadialBasisT<long double> would
+    /// evaluate a double-precision potential inside its quadrature. T is
+    /// deduced from Rrms, so every existing double caller is unchanged
+    /// (and gets back a ModelPotentialT<double>* == ModelPotential*).
+    /// Instantiated for double, long double and (under
+    /// HELFEM_HAVE_FLOAT128) _Float128.
+    template <typename T>
+    ModelPotentialT<T> * get_nuclear_model(nuclear_model_t model, int Z, T Rrms);
 
     /// Thomas-Fermi atom
     class TFAtom : public ModelPotential {

--- a/src/general/radial_block_helper.h
+++ b/src/general/radial_block_helper.h
@@ -17,6 +17,7 @@
 
 #include <Matrix.h>
 #include <RadialBasis.h>
+#include <type_traits>
 
 namespace helfem {
   // Assemble a block-diagonal radial matrix by summing per-element
@@ -32,11 +33,17 @@ namespace helfem {
   //   }
   // that appears ~13 times across src/atomic/TwoDBasis.cpp and
   // src/sadatom/basis.cpp.
+  // The scalar type is deduced from the kernel's return type (every
+  // per-element block is an Eigen matrix, which carries ::Scalar), so a
+  // FEMRadialBasisT<long double> assembles a long-double matrix and every
+  // existing double caller is unchanged.
   template <typename RadialBasis, typename Kernel>
-  inline helfem::Matrix assemble_radial_diagonal(const RadialBasis & radial,
-                                                  Kernel && kernel) {
+  inline auto assemble_radial_diagonal(const RadialBasis & radial,
+                                       Kernel && kernel)
+      -> helfem::Mat<typename std::decay_t<decltype(kernel(size_t(0)))>::Scalar> {
+    using T = typename std::decay_t<decltype(kernel(size_t(0)))>::Scalar;
     const Eigen::Index Nrad = static_cast<Eigen::Index>(radial.Nbf());
-    helfem::Matrix M = helfem::Matrix::Zero(Nrad, Nrad);
+    helfem::Mat<T> M = helfem::Mat<T>::Zero(Nrad, Nrad);
     for (size_t iel = 0; iel < radial.Nel(); ++iel) {
       size_t ifirst, ilast;
       radial.get_idx(iel, ifirst, ilast);

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -28,9 +28,12 @@ namespace helfem {
     /// Solve generalized eigenvalue problem in subspaces (Phase 5.12: Eigen matrices; m_idx kept arma::uvec).
     void eig_gsym_sub(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh, const std::vector<arma::uvec> & m_idx, bool verbose=true);
 
-    /// Form half-inverse overlap (Phase 5.10: Eigen-typed).
-    inline helfem::Matrix form_Sinvh(helfem::Matrix S, bool chol=false) {
-      return utils::invh(S, chol);
+    /// Form half-inverse overlap (Phase 5.10: Eigen-typed). Templated on
+    /// the scalar type; T is deduced from S, so every existing
+    /// double-precision caller is unchanged.
+    template <typename T>
+    inline helfem::Mat<T> form_Sinvh(helfem::Mat<T> S, bool chol=false) {
+      return utils::invh<T>(S, chol);
     }
 
     /// Parse number of alpha and beta electrons


### PR DESCRIPTION
The last lift in the arbitrary-precision arc. After #236 (FiniteElementBasis) and #237 (the radial layer), `atomic::TwoDBasis` was the final double-bound layer. Templating it means a **real Hartree-Fock energy, not a model problem, runs at arbitrary precision** -- and the demo shows double is limited by its arithmetic, not by the basis.

## Templated

Same pattern as before: `X` -> `XT<T>`, `using X = XT<double>`, explicit instantiation at `double`, `long double` and (under `HELFEM_HAVE_FLOAT128`) `_Float128`. Every existing caller compiles unchanged.

* `gaunt::Gaunt` -> `GauntT<T>`
* `atomic::TwoDBasis` -> `TwoDBasisT<T>`
* the FE two-electron assemblers in `CoulombExchangeFE.h` (cached / Cholesky / pairwise J and K)
* `utils::invh`, `utils::exchange_tei`, `scf::form_Sinvh`, `get_nuclear_model`, `assemble_radial_diagonal`

The per-element accessors in `CoulombExchangeFE.h` stopped being `std::function` (template deduction can't see through the lambda->`std::function` conversion, which would have broken every call site) -- they're generic callables now, which also drops the type-erasure.

## Two hidden double-precision caps, either of which alone would have made quad buy nothing

* **`utils::pi<T>()` spelled pi with the long-double `L` suffix** -- rounded to 64 bits before converting to `T`, so `_Float128` pi was wrong by 1.6e-20 relative. This is a *physical* constant (the `4pi/(2L+1)` of the multipole expansion, the Gaunt prefactors), so the error lands straight in the Hamiltonian and no basis or arithmetic recovers from it. Fixed with `_Float128` specialisations using the C++23 `f128` suffix.
* **`chol_tol` truncated the in-element two-electron Cholesky at a fixed 1e-12 at every precision.** Invisible at double (far below its roundoff), but at quad it would have been the single largest error. Now follows `eps(T)`: exactly 1e-12 at double (so double is bit-for-bit unchanged), ~4.9e-16 at long double, ~8.7e-31 at `_Float128`.

## Left at double, deliberately

The **DFT path**: libxc is a double-only C library, so a higher-precision XC energy is not merely unimplemented, it is meaningless. **HF only.** Also `eval_bf`/`eval_df`/`eval_lf` (arma, and the double-only `::spherical_harmonics`) and the arma accessors that feed the DFT grid and analysis binaries -- none on the Fock path; they compile at every `T` and throw unless `T = double`. The angular-index bookkeeping is integer-valued, hence precision-free.

## Bit-exact

`CoulombExchangeFE.h` and `utils` are shared with the double path, so this matters:

| | master | this PR |
|---|---|---|
| Ar HF | -475.8712591129 | **-475.8712591129** |
| N2 diatomic LDA | -79.4807491233 | **-79.4807491233** |

`over_r_test` still reports "All bases handle r -> 0 correctly."

## The result: helium RHF in three precisions

The Gaunt coefficients are checked first, because if they were double-only *they*, not the arithmetic, would be the limit. Against the closed form `gaunt(0,0,1,0,1,0) = 1/sqrt(4 pi)`:

| type | error |
|---|---|
| double(53) | 3.834e-18 |
| long double(64) | 1.205e-20 |
| _Float128(113) | 0.000e+00 |

Each at the half-ulp of its own type -- `libwignernj` evaluates an exact prime-factorised rational and rounds once, so it is correctly rounded at any precision. The angular factors gain digits along with the arithmetic.

Then He RHF (lmax=0 is exact for the He HF ground state, so the radial basis is the only thing to converge; the element boundaries are the same numbers at every precision, so the three columns solve the **identical** variational problem and differ by arithmetic alone). Literature HF limit `E = -2.861679995612 Ha` (Koga et al.):

| nelem x nnodes | double err | long double err | _Float128 err | **double vs quad** |
|---|---|---|---|---|
| 5 x 15 | -1.82e-13 | -1.99e-13 | -1.99e-13 | 1.75e-14 |
| 5 x 25 | 2.02e-13 | -2.39e-13 | -2.39e-13 | 4.41e-13 |
| 10 x 15 | -9.72e-13 | -2.39e-13 | -2.39e-13 | 7.33e-13 |
| 10 x 25 | -7.64e-13 | -2.39e-13 | -2.39e-13 | 5.25e-13 |
| 20 x 15 | -1.49e-12 | -2.38e-13 | -2.39e-13 | 1.25e-12 |

The true basis-set error is **-2.39e-13**, and long double and quad agree on it. Double **cannot see it**: its deviation from the true arithmetic answer *grows* with basis size, 1.75e-14 -> 1.25e-12, until at 20 elements double's roundoff (1.25e-12) is five times the actual physics. So a converged HelFEM HF energy in double is limited by the arithmetic, not the basis -- and long double already suffices to prove it, with quad confirming.

This is a **verification** tool, not an accuracy one: double reaches nanohartree long before any of this matters. The point is that a reference code should be limited by its basis, and now one can check that it is.

(The demo returns the errors computed *in T*; returning the energies as `long double` would cap the quad column at ~1e-19 and hide the effect.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
