### PR TITLE
Eigen-ize the shared index/grid plumbing (normal_grid, get_sym_idx, OOO block machinery)

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -193,25 +193,27 @@ namespace helfem {
       }
 
       template <typename T>
-      arma::uvec TwoDBasisT<T>::m_indices(int m) const {
+      std::vector<Eigen::Index> TwoDBasisT<T>::m_indices(int m) const {
         return helfem::collect_shell_indices(mval.size(),
             [&](size_t)   { return radial.Nbf(); },
             [&](size_t i) { return mval(i) == m; });
       }
 
       template <typename T>
-      arma::uvec TwoDBasisT<T>::lm_indices(int l, int m) const {
+      std::vector<Eigen::Index> TwoDBasisT<T>::lm_indices(int l, int m) const {
         return helfem::collect_shell_indices(mval.size(),
             [&](size_t)   { return radial.Nbf(); },
             [&](size_t i) { return mval(i) == m && lval(i) == l; });
       }
 
       template <typename T>
-      std::vector<arma::uvec> TwoDBasisT<T>::get_sym_idx(int symm) const {
-        std::vector<arma::uvec> idx;
+      std::vector<std::vector<Eigen::Index>> TwoDBasisT<T>::get_sym_idx(int symm) const {
+        std::vector<std::vector<Eigen::Index>> idx;
         if(symm==0) {
           idx.resize(1);
-          idx[0]=arma::linspace<arma::uvec>(0,Nbf()-1,Nbf());
+          idx[0].resize(Nbf());
+          for(Eigen::Index i=0;i<(Eigen::Index) Nbf();i++)
+            idx[0][i]=i;
         } else if(symm==1) {
           // Unique m values in ascending order (matches arma::find_unique).
           std::vector<int> mv;
@@ -247,19 +249,17 @@ namespace helfem {
           // columns are packed contiguously, so Sinvh maps orthonormal ->
           // AO with block-diagonal structure (scattered rows, contiguous
           // columns per block).
-          std::vector<arma::uvec> midx(get_sym_idx(sym));
+          std::vector<std::vector<Eigen::Index>> midx(get_sym_idx(sym));
           const Eigen::Index N = static_cast<Eigen::Index>(Nbf());
           helfem::Mat<T> Sinvh = helfem::Mat<T>::Zero(N, N);
           Eigen::Index ioff = 0;
           for(size_t i=0;i<midx.size();i++) {
-            const Eigen::Index n = static_cast<Eigen::Index>(midx[i].n_elem);
+            const Eigen::Index n = static_cast<Eigen::Index>(midx[i].size());
             if(!n)
               continue;
 
             // AO indices of this block.
-            std::vector<Eigen::Index> rows(n);
-            for(Eigen::Index k=0;k<n;k++)
-              rows[k] = static_cast<Eigen::Index>(midx[i](k));
+            const std::vector<Eigen::Index> & rows = midx[i];
 
             // Gather the block overlap, orthonormalize.
             helfem::Mat<T> Ssub(n, n);

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -251,11 +251,11 @@ namespace helfem {
 
 
         /// Get indices of basis functions with wanted m quantum number
-        arma::uvec m_indices(int m) const;
+        std::vector<Eigen::Index> m_indices(int m) const;
         /// Get indices of basis functions with wanted l and m quantum numbers
-        arma::uvec lm_indices(int l, int m) const;
-        /// Get indices for wanted symmetry
-        std::vector<arma::uvec> get_sym_idx(int isym) const;
+        std::vector<Eigen::Index> lm_indices(int l, int m) const;
+        /// Get indices for wanted symmetry (one index list per block)
+        std::vector<std::vector<Eigen::Index>> get_sym_idx(int isym) const;
 
         /// Evaluate basis functions (T = double only)
         arma::cx_mat eval_bf(size_t iel, double cth, double phi) const;

--- a/src/atomic/basis.cpp
+++ b/src/atomic/basis.cpp
@@ -49,8 +49,8 @@ namespace helfem {
         return ret;
       }
 
-      arma::vec normal_grid(int num_el, double rmax, int igrid, double zexp) {
-        return helfem::to_arma(utils::get_grid(rmax,num_el,igrid,zexp));
+      helfem::Vector normal_grid(int num_el, double rmax, int igrid, double zexp) {
+        return utils::get_grid(rmax,num_el,igrid,zexp);
       }
 
       arma::vec finite_nuclear_grid(int num_el, double rmax, int igrid, double zexp, int num_el_nuc, double rnuc, int igrid_nuc, double zexp_nuc) {
@@ -146,7 +146,8 @@ namespace helfem {
           bval=atomic::basis::offcenter_nuclear_grid(Nelem0,Z,std::max(Zl,Zr),Rhalf,Nelem,Rmax,igrid,zexp);
         } else {
           printf("Normal grid\n");
-          bval=atomic::basis::normal_grid(Nelem,Rmax,igrid,zexp);
+          // normal_grid returns Eigen; form_grid is still arma-native.
+          bval=helfem::to_arma(atomic::basis::normal_grid(Nelem,Rmax,igrid,zexp));
         }
 
 	if(add_el) {

--- a/src/atomic/basis.h
+++ b/src/atomic/basis.h
@@ -25,7 +25,7 @@ namespace helfem {
   namespace atomic {
     namespace basis {
       /// Get the element grid for a normal calculation
-      arma::vec normal_grid(int num_el, double rmax, int igrid, double zexp);
+      helfem::Vector normal_grid(int num_el, double rmax, int igrid, double zexp);
       /// Get the element grid for a finite nucleus
       arma::vec finite_nuclear_grid(int num_el, double rmax, int igrid, double zexp, int num_el_nuc, double rnuc, int igrid_nuc, double zexp_nuc);
       /// Get the element grid in the case of off-center nuclei

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -311,24 +311,24 @@ int main(int argc, char **argv) {
   // mmax == lmax and degrades gracefully when mmax < lmax (partial
   // m-average over the represented m subset -- a no-op when only m=0
   // is present, which is what you want).
-  std::vector<std::vector<arma::uvec>> l_idx;
+  std::vector<std::vector<std::vector<Eigen::Index>>> l_idx;
   if (maverage) {
     const arma::ivec l_all = basis.get_lval();
     const int lmax_bf = arma::max(l_all);
     l_idx.assign(lmax_bf + 1, {});
     for (int l = 0; l <= lmax_bf; ++l)
       for (int m = -l; m <= l; ++m) {
-        arma::uvec idx = basis.lm_indices(l, m);
-        if (idx.n_elem) l_idx[l].push_back(idx);
+        std::vector<Eigen::Index> idx = basis.lm_indices(l, m);
+        if (!idx.empty()) l_idx[l].push_back(idx);
       }
   }
 
   // --- Symmetry decomposition. symm==0 collapses to one block containing
   //     all basis functions.
-  std::vector<arma::uvec> dsym;
+  std::vector<std::vector<Eigen::Index>> dsym;
   if (symm_eff == 0) {
-    arma::uvec all(Nbf);
-    for (size_t i = 0; i < Nbf; ++i) all(i) = i;
+    std::vector<Eigen::Index> all(Nbf);
+    for (size_t i = 0; i < Nbf; ++i) all[i] = static_cast<Eigen::Index>(i);
     dsym.push_back(all);
   } else {
     dsym = basis.get_sym_idx(symm_eff);
@@ -557,17 +557,16 @@ int main(int argc, char **argv) {
     for (arma::uword i = 0; i < occs.n_rows; ++i) {
       const int nocca_i = static_cast<int>(occs(i, 0));
       const int noccb_i = static_cast<int>(occs(i, 1));
-      arma::uvec row_idx;
+      std::vector<Eigen::Index> row_idx;
       if (symm_eff == 1)
         row_idx = basis.m_indices(occs(i, 2));
       else
         row_idx = basis.lm_indices(occs(i, 2), occs(i, 3));
-      if (!row_idx.n_elem)
+      if (row_idx.empty())
         throw std::logic_error("occs.dat: row references a symmetry block with no basis functions.");
       int matched_block = -1;
       for (size_t k = 0; k < nsym; ++k) {
-        if (dsym[k].n_elem == row_idx.n_elem &&
-            arma::all(dsym[k] == row_idx)) { matched_block = static_cast<int>(k); break; }
+        if (dsym[k] == row_idx) { matched_block = static_cast<int>(k); break; }
       }
       if (matched_block < 0)
         throw std::logic_error("occs.dat: row does not match any current symmetry block.");

--- a/src/atomic/teirank.cpp
+++ b/src/atomic/teirank.cpp
@@ -64,8 +64,8 @@ int main(int argc, char **argv) {
       polynomial_basis::get_basis(primbas, Nnodes));
   const int Nquad = 5 * poly->get_nbf();
 
-  arma::vec bval(atomic::basis::normal_grid(Nelem, Rmax, 4, 1.0));
-  polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(bval),
+  const helfem::Vector bval = atomic::basis::normal_grid(Nelem, Rmax, 4, 1.0);
+  polynomial_basis::FiniteElementBasis fem(poly, bval,
                                             true, false, true, false);
   atomic::basis::FEMRadialBasis radial(fem, Nquad);
 

--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -111,12 +111,12 @@ int main(int argc, char **argv) {
     lmmax=arma::conv_to<arma::ivec>::from(lmmaxv);
   }
   // l and m values
-  arma::ivec lval, mval;
-  diatomic::basis::lm_to_l_m(lmmax,lval,mval);
+  Eigen::VectorXi lval, mval;
+  diatomic::basis::lm_to_l_m(helfem::to_eigen(lmmax),lval,mval);
 
   double Rhalf(0.5*Rbond);
   double mumax(utils::arcosh(Rmax/Rhalf));
-  arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, igrid, zexp));
+  const helfem::Vector bval = atomic::basis::normal_grid(Nelem, mumax, igrid, zexp);
 
   diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval, 0);
   chkpt.write(basis);

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -270,11 +270,11 @@ namespace helfem {
         return fem.eval_coord(xq, iel);
       }
 
-      void lm_to_l_m(const arma::ivec & lmax, arma::ivec & lval, arma::ivec & mval) {
+      void lm_to_l_m(const Eigen::VectorXi & lmax, Eigen::VectorXi & lval, Eigen::VectorXi & mval) {
         {
-          std::vector<arma::sword> lv, mv;
-          for(size_t mabs=0;mabs<lmax.n_elem;mabs++)
-            for(arma::sword l=mabs;l<=lmax(mabs);l++) {
+          std::vector<int> lv, mv;
+          for(int mabs=0;mabs<lmax.size();mabs++)
+            for(int l=mabs;l<=lmax(mabs);l++) {
               lv.push_back(l);
               mv.push_back(mabs);
               if(mabs>0) {
@@ -282,15 +282,15 @@ namespace helfem {
                 mv.push_back(-mabs);
               }
             }
-          lval=arma::conv_to<arma::ivec>::from(lv);
-          mval=arma::conv_to<arma::ivec>::from(mv);
+          lval=Eigen::Map<const Eigen::VectorXi>(lv.data(), (Eigen::Index) lv.size());
+          mval=Eigen::Map<const Eigen::VectorXi>(mv.data(), (Eigen::Index) mv.size());
         }
       }
 
       TwoDBasis::TwoDBasis() {
       }
 
-      TwoDBasis::TwoDBasis(int Z1_, int Z2_, double Rhalf_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, int n_quad, const arma::vec & bval, const arma::ivec & lval_, const arma::ivec & mval_, bool legendre) {
+      TwoDBasis::TwoDBasis(int Z1_, int Z2_, double Rhalf_, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, int n_quad, const helfem::Vector & bval, const Eigen::VectorXi & lval_, const Eigen::VectorXi & mval_, bool legendre) {
         // Nuclear charge
         Z1=Z1_;
         Z2=Z2_;
@@ -301,11 +301,12 @@ namespace helfem {
         bool zero_deriv_left=false;
         bool zero_func_right=true;
         bool zero_deriv_right=true;
-        polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(bval), zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
+        polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
         radial=RadialBasis(fem, n_quad);
-        // Angular basis
-        lval=lval_;
-        mval=mval_;
+        // Angular basis. Bridge the Eigen boundary inputs to the arma::ivec
+        // storage the interior still uses.
+        lval=helfem::to_arma(lval_);
+        mval=helfem::to_arma(mval_);
 
         // Gaunt coefficients
         int gmax(arma::max(lval)+2);
@@ -611,40 +612,48 @@ namespace helfem {
         return std::make_pair(kerr, rerr);
       }
 
-      arma::uvec TwoDBasis::m_indices(int m) const {
+      std::vector<Eigen::Index> TwoDBasis::m_indices(int m) const {
         return helfem::collect_shell_indices(mval.n_elem,
             [&](size_t i) { return (mval(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
             [&](size_t i) { return mval(i) == m; });
       }
 
-      arma::uvec TwoDBasis::m_indices(int m, bool odd) const {
+      std::vector<Eigen::Index> TwoDBasis::m_indices(int m, bool odd) const {
         return helfem::collect_shell_indices(mval.n_elem,
             [&](size_t i) { return (mval(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
             [&](size_t i) { return mval(i) == m && (lval(i) % 2 == odd); });
       }
 
-      std::vector<arma::uvec> TwoDBasis::get_sym_idx(int symm) const {
-        std::vector<arma::uvec> idx;
+      std::vector<std::vector<Eigen::Index>> TwoDBasis::get_sym_idx(int symm) const {
+        std::vector<std::vector<Eigen::Index>> idx;
         if(symm==0) {
           idx.resize(1);
-          idx[0]=arma::linspace<arma::uvec>(0,Nbf()-1,Nbf());
+          idx[0].resize(Nbf());
+          for(Eigen::Index i=0;i<(Eigen::Index) Nbf();i++)
+            idx[0][i]=i;
         } else if(symm==1) {
-          // Find unique m values
-          arma::uvec muni(arma::find_unique(mval));
-          arma::ivec mv(arma::sort(mval(muni),"ascend"));
+          // Unique m values in ascending order (matches arma::find_unique + sort).
+          std::vector<int> mv;
+          for(size_t i=0;i<mval.n_elem;i++)
+            if(std::find(mv.begin(),mv.end(),mval(i))==mv.end())
+              mv.push_back(mval(i));
+          std::sort(mv.begin(),mv.end());
 
-          idx.resize(mv.n_elem);
-          for(size_t i=0;i<mv.n_elem;i++)
-            idx[i]=m_indices(mv(i));
+          idx.resize(mv.size());
+          for(size_t i=0;i<mv.size();i++)
+            idx[i]=m_indices(mv[i]);
         } else if(symm==2) {
-          // Find unique m values
-          arma::uvec muni(arma::find_unique(mval));
-          arma::ivec mv(arma::sort(mval(muni),"ascend"));
+          // Unique m values in ascending order (matches arma::find_unique + sort).
+          std::vector<int> mv;
+          for(size_t i=0;i<mval.n_elem;i++)
+            if(std::find(mv.begin(),mv.end(),mval(i))==mv.end())
+              mv.push_back(mval(i));
+          std::sort(mv.begin(),mv.end());
 
-          idx.resize(2*mv.n_elem);
-          for(size_t i=0;i<mv.n_elem;i++) {
-            idx[2*i]=m_indices(mv(i),false);
-            idx[2*i+1]=m_indices(mv(i),true);
+          idx.resize(2*mv.size());
+          for(size_t i=0;i<mv.size();i++) {
+            idx[2*i]=m_indices(mv[i],false);
+            idx[2*i+1]=m_indices(mv[i],true);
           }
         } else
           throw std::logic_error("Unknown symmetry\n");
@@ -661,27 +670,27 @@ namespace helfem {
           return scf::form_Sinvh(S, chol);
         } else {
           // Get basis function indices
-          std::vector<arma::uvec> midx(get_sym_idx(sym));
+          std::vector<std::vector<Eigen::Index>> midx(get_sym_idx(sym));
           // Construct Sinvh in each subblock
           helfem::Matrix Sinvh(helfem::Matrix::Zero(Nbf(),Nbf()));
           size_t ioff=0;
           for(size_t i=0;i<midx.size();i++) {
-            if(!midx[i].n_elem)
+            if(midx[i].empty())
               continue;
 
             // Gather the S(midx,midx) subblock
-            const size_t n(midx[i].n_elem);
+            const size_t n(midx[i].size());
             helfem::Matrix Ssub(n,n);
             for(size_t a=0;a<n;a++)
               for(size_t b=0;b<n;b++)
-                Ssub(a,b)=S(midx[i](a), midx[i](b));
+                Ssub(a,b)=S(midx[i][a], midx[i][b]);
 
             helfem::Matrix block(scf::form_Sinvh(Ssub,chol));
 
             // Scatter into Sinvh(midx[i], ioff..ioff+n-1)
             for(size_t a=0;a<n;a++)
               for(size_t b=0;b<n;b++)
-                Sinvh(midx[i](a), ioff+b)=block(a,b);
+                Sinvh(midx[i][a], ioff+b)=block(a,b);
             // Increment offset
             ioff += n;
           }

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -115,7 +115,7 @@ namespace helfem {
       bool operator==(const lmidx_t & lh, const lmidx_t & rh);
 
       /// l(m) array to l, m arrays
-      void lm_to_l_m(const arma::ivec & lmmax, arma::ivec & lval, arma::ivec & mval);
+      void lm_to_l_m(const Eigen::VectorXi & lmmax, Eigen::VectorXi & lval, Eigen::VectorXi & mval);
 
       /// Two-dimensional basis set
       class TwoDBasis {
@@ -202,7 +202,7 @@ namespace helfem {
         // Dummy constructor
         TwoDBasis();
         /// Constructor
-        TwoDBasis(int Z1, int Z2, double Rhalf, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, int n_quad, const arma::vec & bval, const arma::ivec & lval, const arma::ivec & mval, bool legendre=true);
+        TwoDBasis(int Z1, int Z2, double Rhalf, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, int n_quad, const helfem::Vector & bval, const Eigen::VectorXi & lval, const Eigen::VectorXi & mval, bool legendre=true);
         /// Destructor
         ~TwoDBasis();
 
@@ -318,11 +318,11 @@ namespace helfem {
         std::pair<double,double> check_cd(size_t iel, int L, int M) const;
 
         /// Get indices of basis functions with wanted m quantum number
-        arma::uvec m_indices(int m) const;
+        std::vector<Eigen::Index> m_indices(int m) const;
         /// Get indices of basis functions with wanted m quantum number and parity
-        arma::uvec m_indices(int m, bool odd) const;
-        /// Get indices for wanted symmetry
-        std::vector<arma::uvec> get_sym_idx(int isym) const;
+        std::vector<Eigen::Index> m_indices(int m, bool odd) const;
+        /// Get indices for wanted symmetry (one index list per block)
+        std::vector<std::vector<Eigen::Index>> get_sym_idx(int isym) const;
 
         /// Evaluate basis functions at quadrature points
         arma::cx_mat eval_bf(size_t iel, size_t irad, double cth, double phi) const;

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -32,16 +32,16 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
 
   double Rhalf=0.5*Rbond;
   double mumax(utils::arcosh(Rmax/Rhalf));
-  arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, igrid, zexp));
+  const helfem::Vector bval = atomic::basis::normal_grid(Nelem, mumax, igrid, zexp);
 
-  arma::ivec lval, mval;
-  diatomic::basis::lm_to_l_m(lmmax,lval,mval);
+  Eigen::VectorXi lval, mval;
+  diatomic::basis::lm_to_l_m(helfem::to_eigen(lmmax),lval,mval);
 
   diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval, false);
 
   bool diag=true;
   // Symmetry indices
-  std::vector<arma::uvec> dsym=basis.get_sym_idx(symm);
+  std::vector<std::vector<Eigen::Index>> dsym=basis.get_sym_idx(symm);
 
   // Form overlap matrix
   arma::mat S(helfem::to_arma(basis.overlap()));

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -200,12 +200,12 @@ int main(int argc, char **argv) {
     mmax = static_cast<int>(lmmaxv.size()) - 1;
   }
 
-  arma::ivec lval, mval;
-  diatomic::basis::lm_to_l_m(lmmax, lval, mval);
+  Eigen::VectorXi lval, mval;
+  diatomic::basis::lm_to_l_m(helfem::to_eigen(lmmax), lval, mval);
 
   const double Rhalf = 0.5 * Rbond;
   const double mumax = utils::arcosh(Rmax / Rhalf);
-  arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, igrid, zexp));
+  const helfem::Vector bval = atomic::basis::normal_grid(Nelem, mumax, igrid, zexp);
 
   // Homonuclear g/u symmetry is not a valid decomposition for a
   // heteronuclear molecule -- get_sym_idx(2) still splits by (m, l%2)
@@ -284,11 +284,11 @@ int main(int argc, char **argv) {
   // f(+m) == f(-m). At m == 0 there is no partner so the group has a
   // single member and the "average" is a no-op on that block. Matches
   // src/diatomic/main.cpp lines 318..328.
-  std::vector<std::vector<arma::uvec>> mavg_idx;
+  std::vector<std::vector<std::vector<Eigen::Index>>> mavg_idx;
   if (maverage) {
     const int mmax_bf = arma::max(arma::abs(basis.get_mval()));
     for (int m = 0; m <= mmax_bf; ++m) {
-      std::vector<arma::uvec> entry;
+      std::vector<std::vector<Eigen::Index>> entry;
       entry.push_back(basis.m_indices(m));
       if (m > 0) entry.push_back(basis.m_indices(-m));
       mavg_idx.push_back(entry);
@@ -296,10 +296,10 @@ int main(int argc, char **argv) {
   }
 
   // Symmetry decomposition.
-  std::vector<arma::uvec> dsym;
+  std::vector<std::vector<Eigen::Index>> dsym;
   if (symm == 0) {
-    arma::uvec all(Nbf);
-    for (size_t i = 0; i < Nbf; ++i) all(i) = i;
+    std::vector<Eigen::Index> all(Nbf);
+    for (size_t i = 0; i < Nbf; ++i) all[i] = static_cast<Eigen::Index>(i);
     dsym.push_back(all);
   } else {
     dsym = basis.get_sym_idx(symm);
@@ -310,7 +310,7 @@ int main(int argc, char **argv) {
   const std::vector<helfem::Matrix> Sinvh =
       helfem::scf_driver::build_per_block_Sinvh(S, dsym);
 
-  const int lang = ldft_arg > 0 ? ldft_arg : 4 * arma::max(lval) + 12;
+  const int lang = ldft_arg > 0 ? ldft_arg : 4 * lval.maxCoeff() + 12;
   const int mang = mdft_arg > 0 ? mdft_arg : 4 * mmax + 12;
 
   // Pure-m fast path. With --symmetry >= 1 the orbitals cannot mix m, so every
@@ -525,7 +525,7 @@ int main(int argc, char **argv) {
     for (arma::uword i = 0; i < occs.n_rows; ++i) {
       const int nocca_i = static_cast<int>(occs(i, 0));
       const int noccb_i = static_cast<int>(occs(i, 1));
-      arma::uvec row_idx;
+      std::vector<Eigen::Index> row_idx;
       if (occs.n_cols == 3) {
         row_idx = basis.m_indices(occs(i, 2));
       } else {
@@ -533,12 +533,11 @@ int main(int argc, char **argv) {
           throw std::logic_error("occs.dat: parity column must be +1 or -1.");
         row_idx = basis.m_indices(occs(i, 2), (occs(i, 3) == -1));
       }
-      if (!row_idx.n_elem)
+      if (row_idx.empty())
         throw std::logic_error("occs.dat: row references a symmetry block with no basis functions.");
       int matched_block = -1;
       for (size_t k = 0; k < nsym; ++k) {
-        if (dsym[k].n_elem == row_idx.n_elem &&
-            arma::all(dsym[k] == row_idx)) { matched_block = static_cast<int>(k); break; }
+        if (dsym[k] == row_idx) { matched_block = static_cast<int>(k); break; }
       }
       if (matched_block < 0)
         throw std::logic_error("occs.dat: row does not match any current symmetry block.");

--- a/src/diatomic/purem_test.cpp
+++ b/src/diatomic/purem_test.cpp
@@ -116,21 +116,21 @@ int main(int argc, char **argv) {
   arma::ivec lmmax(mmax + 1);
   lmmax.ones();
   lmmax *= lmax;
-  arma::ivec lval, mval;
-  diatomic::basis::lm_to_l_m(lmmax, lval, mval);
+  Eigen::VectorXi lval, mval;
+  diatomic::basis::lm_to_l_m(helfem::to_eigen(lmmax), lval, mval);
 
   const double Rhalf = 0.5 * Rbond;
   const double mumax = utils::arcosh(Rmax / Rhalf);
-  arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, 4, 1.0));
+  const helfem::Vector bval = atomic::basis::normal_grid(Nelem, mumax, 4, 1.0);
 
   diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval);
   printf("Basis: %i angular x %i radial = %i functions\n",
           (int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf());
 
   const int lang = parser.get<int>("ldft") > 0 ? parser.get<int>("ldft")
-                                                : 4 * arma::max(lval) + 12;
+                                                : 4 * lval.maxCoeff() + 12;
   const int mang = parser.get<int>("mdft") > 0 ? parser.get<int>("mdft")
-                                                : 4 * arma::max(mval) + 5;
+                                                : 4 * mval.maxCoeff() + 5;
 
   // ------------------------------------------------------------------
   // 0) The angular substitution behind eval_lf, checked on the special
@@ -255,11 +255,11 @@ int main(int argc, char **argv) {
     helfem::Matrix Ma = helfem::Matrix::Zero(basis.Nbf(), basis.Nbf());
     helfem::Matrix Mb = helfem::Matrix::Zero(basis.Nbf(), basis.Nbf());
     for (int m = -mmax; m <= mmax; m++) {
-      const arma::uvec idx(basis.m_indices(m));
-      for (size_t i = 0; i < idx.n_elem; i++)
-        for (size_t j = 0; j < idx.n_elem; j++) {
-          Ma(idx(i), idx(j)) = Pa(idx(i), idx(j));
-          Mb(idx(i), idx(j)) = Pb(idx(i), idx(j));
+      const std::vector<Eigen::Index> idx(basis.m_indices(m));
+      for (size_t i = 0; i < idx.size(); i++)
+        for (size_t j = 0; j < idx.size(); j++) {
+          Ma(idx[i], idx[j]) = Pa(idx[i], idx[j]);
+          Mb(idx[i], idx[j]) = Pb(idx[i], idx[j]);
         }
     }
     printf("m-projection changed the density by %.2e (alpha)\n", (Ma - Pa).cwiseAbs().maxCoeff());
@@ -341,10 +341,10 @@ int main(int argc, char **argv) {
     if (dH > 1e-8) {
       int m_bi = -99, m_bj = -99;
       for (int m = -mmax; m <= mmax; m++) {
-        const arma::uvec idx(basis.m_indices(m));
-        for (size_t q = 0; q < idx.n_elem; q++) {
-          if ((Eigen::Index) idx(q) == bi) m_bi = m;
-          if ((Eigen::Index) idx(q) == bj) m_bj = m;
+        const std::vector<Eigen::Index> idx(basis.m_indices(m));
+        for (size_t q = 0; q < idx.size(); q++) {
+          if (idx[q] == bi) m_bi = m;
+          if (idx[q] == bj) m_bj = m;
         }
       }
       printf("%-14s   H3(%d,%d)=%.10e  HP=%.10e   [m(%d)=%d, m(%d)=%d]\n", "",

--- a/src/diatomic/teirank.cpp
+++ b/src/diatomic/teirank.cpp
@@ -66,12 +66,12 @@ int main(int argc, char **argv) {
   arma::ivec lmmax(mmax + 1);
   lmmax.ones();
   lmmax *= lmax;
-  arma::ivec lval, mval;
-  diatomic::basis::lm_to_l_m(lmmax, lval, mval);
+  Eigen::VectorXi lval, mval;
+  diatomic::basis::lm_to_l_m(helfem::to_eigen(lmmax), lval, mval);
 
   const double Rhalf = 0.5 * Rbond;
   const double mumax = utils::arcosh(Rmax / Rhalf);
-  arma::vec bval(atomic::basis::normal_grid(Nelem, mumax, 4, 1.0));
+  const helfem::Vector bval = atomic::basis::normal_grid(Nelem, mumax, 4, 1.0);
 
   diatomic::basis::TwoDBasis basis(7, 7, Rhalf, poly, Nquad, bval, lval, mval);
 

--- a/src/general/angular_index_helpers.h
+++ b/src/general/angular_index_helpers.h
@@ -15,8 +15,9 @@
 #ifndef HELFEM_ANGULAR_INDEX_HELPERS_H
 #define HELFEM_ANGULAR_INDEX_HELPERS_H
 
-#include <armadillo>
+#include <Eigen/Core>
 #include <cstddef>
+#include <vector>
 
 namespace helfem {
   // Collect global basis-function indices belonging to a subset of
@@ -28,26 +29,29 @@ namespace helfem {
   // atomic::TwoDBasis::m_indices / lm_indices and
   // diatomic::TwoDBasis::m_indices (both overloads).
   //
+  // Returns an ascending list of Eigen::Index, directly usable in the
+  // Eigen 3.4 indexed views the SCF-driver plumbing consumes.
+  //
   // Usage:
-  //   idx = collect_shell_indices(mval.n_elem,
+  //   idx = collect_shell_indices(mval.size(),
   //             [&](size_t)   { return radial.Nbf(); },   // shell size
   //             [&](size_t i) { return mval(i) == m; });  // predicate
   template <typename ShellSizeFn, typename PredicateFn>
-  inline arma::uvec collect_shell_indices(size_t nshells,
+  inline std::vector<Eigen::Index> collect_shell_indices(size_t nshells,
                                            ShellSizeFn shell_size,
                                            PredicateFn match) {
     size_t nm = 0;
     for (size_t i = 0; i < nshells; ++i)
       if (match(i)) nm += shell_size(i);
 
-    arma::uvec idx(nm);
+    std::vector<Eigen::Index> idx(nm);
     size_t ioff = 0;
     size_t ibf  = 0;
     for (size_t i = 0; i < nshells; ++i) {
       const size_t nsh = shell_size(i);
       if (match(i)) {
-        idx.subvec(ioff, ioff + nsh - 1) =
-            arma::linspace<arma::uvec>(ibf, ibf + nsh - 1, nsh);
+        for (size_t k = 0; k < nsh; ++k)
+          idx[ioff + k] = static_cast<Eigen::Index>(ibf + k);
         ioff += nsh;
       }
       ibf += nsh;

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -616,7 +616,7 @@ void Checkpoint::read(helfem::diatomic::basis::TwoDBasis & basis) {
   read("mval", mval);
 
   auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(poly_id,poly_nnodes)));
-  basis=helfem::diatomic::basis::TwoDBasis(Z1, Z2, Rhalf, poly, n_quad, bval, lval, mval);
+  basis=helfem::diatomic::basis::TwoDBasis(Z1, Z2, Rhalf, poly, n_quad, helfem::to_eigen(bval), helfem::to_eigen(lval), helfem::to_eigen(mval));
   
   if(cl) close();
 }

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -21,14 +21,13 @@
 // one place.
 //
 // The linear algebra is Eigen-native (helfem::Matrix / helfem::Vector);
-// the per-symmetry-block gather/scatter uses the arma::uvec index lists
-// the basis get_sym_idx returns, converted to Eigen index vectors once
-// per use. Keeping the working matrices Eigen (rather than arma/LAPACK)
-// is what lets the SCF driver be instantiated at extended precision --
-// Eigen's SelfAdjointEigenSolver is scalar-generic where arma::eig_sym
-// is LAPACK/double-only.
+// the per-symmetry-block gather/scatter uses the Eigen index lists
+// (std::vector<Eigen::Index>) the basis get_sym_idx returns directly.
+// Keeping the working matrices Eigen (rather than arma/LAPACK) is what
+// lets the SCF driver be instantiated at extended precision -- Eigen's
+// SelfAdjointEigenSolver is scalar-generic where arma::eig_sym is
+// LAPACK/double-only.
 
-#include <armadillo>
 #include <Eigen/Eigenvalues>
 #include <algorithm>
 #include <cstdio>
@@ -36,32 +35,22 @@
 #include <utility>
 #include <vector>
 #include "scf_helpers.h"
-#include <ArmaEigen.h>
 #include "openorbitaloptimizer/scfsolver.hpp"
 
 namespace helfem {
   namespace scf_driver {
-
-    /// Convert an arma::uvec index list (from basis get_sym_idx) into an
-    /// Eigen index vector usable in Eigen 3.4 indexed views.
-    inline std::vector<Eigen::Index> to_idx(const arma::uvec & u) {
-      std::vector<Eigen::Index> idx(u.n_elem);
-      for (arma::uword i = 0; i < u.n_elem; ++i)
-        idx[i] = static_cast<Eigen::Index>(u(i));
-      return idx;
-    }
 
     /// Per-block symmetric orthonormalisation of the AO overlap S
     /// restricted to each symmetry index set. Both drivers build this
     /// once and reuse it in the CoreH construction, the --load block
     /// projection, and the --save density reconstruction.
     inline std::vector<helfem::Matrix> build_per_block_Sinvh(
-        const helfem::Matrix & S, const std::vector<arma::uvec> & dsym) {
+        const helfem::Matrix & S, const std::vector<std::vector<Eigen::Index>> & dsym) {
       const size_t nsym = dsym.size();
       std::vector<helfem::Matrix> out(nsym);
       for (size_t k = 0; k < nsym; ++k) {
-        if (!dsym[k].n_elem) continue;
-        const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+        if (dsym[k].empty()) continue;
+        const std::vector<Eigen::Index> & idx = dsym[k];
         const helfem::Matrix Sk = S(idx, idx);
         out[k] = scf::form_Sinvh(Sk, /*chol=*/false);
       }
@@ -76,18 +65,18 @@ namespace helfem {
     template <typename Real>
     inline OpenOrbitalOptimizer::FockMatrix<Real> build_coreH_from_H0(
         const helfem::Matrix & H0, const helfem::Matrix & S,
-        const std::vector<arma::uvec> & dsym,
+        const std::vector<std::vector<Eigen::Index>> & dsym,
         const std::vector<helfem::Matrix> & Sinvh,
         size_t nparttype, bool have_bfield, double Bz) {
       const size_t nsym = dsym.size();
       OpenOrbitalOptimizer::FockMatrix<Real> CoreH(nsym * nparttype);
       for (size_t t = 0; t < nparttype; ++t) {
         for (size_t k = 0; k < nsym; ++k) {
-          if (!dsym[k].n_elem) {
+          if (dsym[k].empty()) {
             CoreH[t * nsym + k] = helfem::Matrix::Zero(0, 0);
             continue;
           }
-          const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+          const std::vector<Eigen::Index> & idx = dsym[k];
           helfem::Matrix H_sub = H0(idx, idx);
           if (have_bfield && nparttype == 2)
             H_sub += (t == 0 ? -0.5 : 0.5) * Bz * helfem::Matrix(S(idx, idx));
@@ -111,14 +100,13 @@ namespace helfem {
         size_t out_index,
         OpenOrbitalOptimizer::Orbitals<Real> & orbs,
         OpenOrbitalOptimizer::OrbitalOccupations<Real> & occs,
-        const helfem::Matrix & Pspin, const arma::uvec & idx_u,
+        const helfem::Matrix & Pspin, const std::vector<Eigen::Index> & idx,
         const helfem::Matrix & Sinvh_block, double max_occ) {
-      if (!idx_u.n_elem) {
+      if (idx.empty()) {
         orbs[out_index] = helfem::Matrix::Zero(0, 0);
         occs[out_index] = helfem::Vector::Zero(0);
         return;
       }
-      const std::vector<Eigen::Index> idx = to_idx(idx_u);
       const helfem::Matrix Pblk  = Pspin(idx, idx);
       const helfem::Matrix Porth = Sinvh_block.transpose() * Pblk * Sinvh_block;
       // SelfAdjointEigenSolver returns eigenvalues in ascending order;
@@ -146,7 +134,7 @@ namespace helfem {
     template <typename Real>
     inline std::pair<helfem::Matrix, helfem::Matrix> assemble_final_density(
         size_t Nbf, bool restricted,
-        const std::vector<arma::uvec> & dsym,
+        const std::vector<std::vector<Eigen::Index>> & dsym,
         const std::vector<helfem::Matrix> & Sinvh,
         const OpenOrbitalOptimizer::Orbitals<Real> & final_orbs,
         const OpenOrbitalOptimizer::OrbitalOccupations<Real> & final_occs) {
@@ -155,8 +143,8 @@ namespace helfem {
       helfem::Matrix Pa_final = helfem::Matrix::Zero(N, N);
       helfem::Matrix Pb_final = helfem::Matrix::Zero(N, N);
       for (size_t k = 0; k < nsym; ++k) {
-        if (!dsym[k].n_elem) continue;
-        const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+        if (dsym[k].empty()) continue;
+        const std::vector<Eigen::Index> & idx = dsym[k];
         const helfem::Matrix orb_a_ao = Sinvh[k] * final_orbs[k];
         const helfem::Vector occ_a    = final_occs[k];
         if (restricted) {
@@ -239,11 +227,11 @@ namespace helfem {
     ///   P_full(dsym[k], dsym[k]) += C_k . diag(occ_e) . C_k^T
     template <typename Real>
     inline void accumulate_density_block(
-        helfem::Matrix & P_full, const std::vector<arma::uvec> & dsym, size_t k,
+        helfem::Matrix & P_full, const std::vector<std::vector<Eigen::Index>> & dsym, size_t k,
         const std::vector<helfem::Matrix> & Sinvh,
         const helfem::Matrix & orb_e, const helfem::Vector & occ_e) {
-      if (!dsym[k].n_elem) return;
-      const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+      if (dsym[k].empty()) return;
+      const std::vector<Eigen::Index> & idx = dsym[k];
       const helfem::Matrix C_k = Sinvh[k] * orb_e;
       P_full(idx, idx) += C_k * occ_e.asDiagonal() * C_k.transpose();
     }
@@ -256,14 +244,14 @@ namespace helfem {
     template <typename Real>
     inline void orthonormalize_fock_block(
         OpenOrbitalOptimizer::FockMatrix<Real> & fock, size_t b,
-        const std::vector<arma::uvec> & dsym, size_t k,
+        const std::vector<std::vector<Eigen::Index>> & dsym, size_t k,
         const std::vector<helfem::Matrix> & Sinvh,
         const helfem::Matrix & F_full) {
-      if (!dsym[k].n_elem) {
+      if (dsym[k].empty()) {
         fock[b] = helfem::Matrix::Zero(0, 0);
         return;
       }
-      const std::vector<Eigen::Index> idx = to_idx(dsym[k]);
+      const std::vector<Eigen::Index> & idx = dsym[k];
       const helfem::Matrix Fk_sub = F_full(idx, idx);
       fock[b] = Sinvh[k].transpose() * Fk_sub * Sinvh[k];
     }

--- a/src/general/scf_helpers.cpp
+++ b/src/general/scf_helpers.cpp
@@ -26,13 +26,6 @@ namespace helfem {
     // Phase 5.10: Eigen-typed.
 
     namespace {
-      // Convert one arma::uvec (chemistry-side index list) to a vector
-      // of Eigen::Index, suitable for Eigen 3.4 (rows/cols) indexing.
-      inline std::vector<Eigen::Index> uvec_to_indices(const arma::uvec & u) {
-        std::vector<Eigen::Index> v(u.n_elem);
-        for (size_t i = 0; i < u.n_elem; ++i) v[i] = static_cast<Eigen::Index>(u(i));
-        return v;
-      }
       // Sort indices ascending by E values.
       inline std::vector<Eigen::Index> sort_index_ascending(const helfem::Vector & E) {
         std::vector<Eigen::Index> idx(E.size());
@@ -57,18 +50,17 @@ namespace helfem {
       C = Sinvh * es.eigenvectors();
     }
 
-    // Phase 5.12: Eigen matrices; m_idx kept arma::uvec until TwoDBasis
-    // ::get_sym_idx migrates.
+    // Eigen matrices; m_idx is a per-symmetry list of Eigen index lists.
     void eig_gsym_sub(helfem::Vector & E, helfem::Matrix & C,
                       const helfem::Matrix & F, const helfem::Matrix & Sinvh,
-                      const std::vector<arma::uvec> & m_idx, bool verbose) {
+                      const std::vector<std::vector<Eigen::Index>> & m_idx, bool verbose) {
       (void) verbose;
       E = helfem::Vector::Zero(F.rows());
       C = helfem::Matrix::Zero(F.rows(), F.rows());
 
       Eigen::Index iidx = 0;
       for (size_t isym = 0; isym < m_idx.size(); ++isym) {
-        const auto rows = uvec_to_indices(m_idx[isym]);
+        const std::vector<Eigen::Index> & rows = m_idx[isym];
         // Scmp = Sinvh(rows, :).
         const helfem::Matrix Scmp = Sinvh(rows, Eigen::all);
         // Snrm(j) = ||Scmp.col(j)||.
@@ -112,18 +104,18 @@ namespace helfem {
     // Phase 5.13: Eigen-typed.
 
     helfem::Matrix fock_symmetry_average(const helfem::Matrix & Fin,
-                                          const std::vector< std::vector<arma::uvec> > & sym_idx) {
+                                          const std::vector< std::vector<std::vector<Eigen::Index>> > & sym_idx) {
       helfem::Matrix Fout = Fin;
       for (size_t isym = 0; isym < sym_idx.size(); ++isym) {
-        const Eigen::Index n = static_cast<Eigen::Index>(sym_idx[isym][0].n_elem);
+        const Eigen::Index n = static_cast<Eigen::Index>(sym_idx[isym][0].size());
         helfem::Matrix Fmean = helfem::Matrix::Zero(n, n);
         for (size_t ic = 0; ic < sym_idx[isym].size(); ++ic) {
-          const auto idx = uvec_to_indices(sym_idx[isym][ic]);
+          const std::vector<Eigen::Index> & idx = sym_idx[isym][ic];
           Fmean += Fin(idx, idx);
         }
         Fmean /= static_cast<double>(sym_idx[isym].size());
         for (size_t ic = 0; ic < sym_idx[isym].size(); ++ic) {
-          const auto idx = uvec_to_indices(sym_idx[isym][ic]);
+          const std::vector<Eigen::Index> & idx = sym_idx[isym][ic];
           Fout(idx, idx) = Fmean;
         }
       }

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -20,13 +20,13 @@
 
 namespace helfem {
   namespace scf {
-    /// Average out the Fock matrix (Phase 5.13: Eigen).
-    helfem::Matrix fock_symmetry_average(const helfem::Matrix & Fin, const std::vector< std::vector<arma::uvec> > & sym_idx);
+    /// Average out the Fock matrix (Eigen index lists).
+    helfem::Matrix fock_symmetry_average(const helfem::Matrix & Fin, const std::vector< std::vector<std::vector<Eigen::Index>> > & sym_idx);
 
     /// Solve generalized eigenvalue problem (Phase 5.11: Eigen-typed).
     void eig_gsym(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh);
-    /// Solve generalized eigenvalue problem in subspaces (Phase 5.12: Eigen matrices; m_idx kept arma::uvec).
-    void eig_gsym_sub(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh, const std::vector<arma::uvec> & m_idx, bool verbose=true);
+    /// Solve generalized eigenvalue problem in subspaces (Eigen index lists).
+    void eig_gsym_sub(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh, const std::vector<std::vector<Eigen::Index>> & m_idx, bool verbose=true);
 
     /// Form half-inverse overlap (Phase 5.10: Eigen-typed). Templated on
     /// the scalar type; T is deduced from S, so every existing


### PR DESCRIPTION
Continues the arma->Eigen migration (#24). The app-level Fock paths (atomic, diatomic, sadatom) are already migrated; what remained was the **shared index/grid plumbing** every driver funnels through, which could not be salami-sliced because it is one coupled web: `normal_grid` / `lm_to_l_m` feed the `TwoDBasis` constructors, which feed `get_sym_idx`, which feeds the OOO per-symmetry-block machinery. This converts the whole chain in one pass.

## Converted

**Leaf helpers**
* `angular_index_helpers.h` — `collect_shell_indices` returns `std::vector<Eigen::Index>` (was `arma::uvec`).
* `atomic/basis` — `normal_grid` returns `helfem::Vector`.

**Basis classes**
* `atomic/TwoDBasis`, `diatomic/basis` — `m_indices`/`lm_indices` → `std::vector<Eigen::Index>`; `get_sym_idx` → `std::vector<std::vector<Eigen::Index>>`; `lm_to_l_m` args → `Eigen::VectorXi`; the per-block `Sinvh` consumers updated.

**Shared SCF plumbing**
* `scf_helpers` (`fock_symmetry_average`, `eig_gsym_sub`) and `scf_driver_common.h` (`build_per_block_Sinvh`, `build_coreH_from_H0`, `fill_block_from_density`, `assemble_final_density`, `accumulate_density_block`, `orthonormalize_fock_block`) take Eigen index lists. **The `to_idx(arma::uvec)` shim is removed** — its call sites now use the index vectors directly.

**Drivers/tools** — `atomic/main`, `diatomic/main`, `corebasis`, `1e`, both `teirank`, `purem_test` updated; the `--readocc` block-match becomes `std::vector ==`.

## The one real risk: block order

`get_sym_idx` order defines the OOO block order, so a reordering would silently misassign occupations. It is preserved exactly: `symm==0` is an ascending `0..Nbf-1` fill; `symm==1/2` keep the ascending unique-m order (`arma::find_unique`+sort → std `find`+`std::sort`). This is confirmed by bit-identical results on the **symmetry=2 and unrestricted** cases below, which are precisely what a block-order bug would break.

## Bit-exact (branch vs a master-built binary, OMP_NUM_THREADS=1)

| case | energy | |
|---|---|---|
| atomic Ar HF | -475.8712591129 | ✓ |
| atomic Ne unrestricted | -123.2747918860 | ✓ |
| diatomic N2 LDA symmetry=2 | -79.4807491233 | ✓ |
| diatomic O2 unrestricted symmetry=2 | -121.0627706145 | ✓ |
| gensap Ne (all iterations + final, core guess) | -127.4907408299 | ✓ bit-identical trace |

## One bridge left, deliberately

`Checkpoint::read(diatomic::TwoDBasis&)` reads `bval`/`lval`/`mval` from HDF5 as arma (Checkpoint has no Eigen integer overload) and passes them through `to_eigen` into the now-Eigen constructor -- mirroring the atomic checkpoint path. The diatomic `TwoDBasis` also keeps its `arma::ivec` *internal* `lval`/`mval` storage (the Fock-path interior still reads them as arma); the constructor bridges the Eigen inputs once. That interior storage was out of scope here -- the coupled signatures are now all Eigen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
