### PR TITLE
diatomic: Eigen-ize the analysis-path evaluators and TwoDGrid::model_potential

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -1663,119 +1663,119 @@ namespace helfem {
         return Pnob;
       }
 
-      arma::cx_mat TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, double phi) const {
+      Eigen::MatrixXcd TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, double phi) const {
         // Evaluate spherical harmonics
-        arma::cx_vec sph(lval.n_elem);
-        for(size_t i=0;i<lval.n_elem;i++)
+        Eigen::VectorXcd sph(lval.n_elem);
+        for(size_t i=0;i<(size_t) lval.n_elem;i++)
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
-        // Evaluate radial functions
-        arma::mat rad(helfem::to_arma(radial.get_bf(iel)));
-        rad=rad.rows(irad,irad);
+        // Evaluate radial functions (single quadrature point, 1 x Nc row)
+        const helfem::Matrix rad(radial.get_bf(iel).row(irad));
+        const Eigen::Index Nc = rad.cols();
 
-        // Form supermatrix
-        arma::cx_mat bf(rad.n_rows,lval.n_elem*rad.n_cols);
-        for(size_t i=0;i<lval.n_elem;i++)
-          bf.cols(i*rad.n_cols,(i+1)*rad.n_cols-1)=sph(i)*rad;
+        // Form supermatrix. sph(i) is complex, rad is real -> cast rad.
+        Eigen::MatrixXcd bf(rad.rows(),lval.n_elem*Nc);
+        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+          bf.middleCols(i*Nc,Nc)=sph(i)*rad.cast<std::complex<double>>();
 
         return bf;
       }
 
-      arma::mat TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m) const {
-        return eval_bf(iel, irad, cth, m, helfem::to_arma(radial.get_bf(iel)));
+      helfem::Matrix TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m) const {
+        return eval_bf(iel, irad, cth, m, radial.get_bf(iel));
       }
 
-      arma::mat TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m, const arma::mat & rad_all) const {
+      helfem::Matrix TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m, const helfem::Matrix & rad_all) const {
         // Figure out list of functions
-        std::vector<arma::uword> flist;
-        for(size_t i=0;i<mval.n_elem;i++)
+        std::vector<size_t> flist;
+        for(size_t i=0;i<(size_t) mval.n_elem;i++)
           if(mval(i)==m)
             flist.push_back(i);
 
         // Evaluate spherical harmonics
-        arma::vec sph(flist.size());
+        helfem::Vector sph(flist.size());
         for(size_t i=0;i<flist.size();i++)
           sph(i)=std::real(::spherical_harmonics(lval(flist[i]),mval(flist[i]),cth,0.0));
 
-        // Radial functions at this quadrature point
-        arma::mat rad(rad_all.rows(irad,irad));
+        // Radial functions at this quadrature point (1 x Nc row)
+        const helfem::Matrix rad(rad_all.row(irad));
+        const Eigen::Index Nc = rad.cols();
 
         // Form supermatrix
-        arma::mat bf(rad.n_rows,flist.size()*rad.n_cols);
+        helfem::Matrix bf(rad.rows(),flist.size()*Nc);
         for(size_t i=0;i<flist.size();i++)
-          bf.cols(i*rad.n_cols,(i+1)*rad.n_cols-1)=sph(i)*rad;
+          bf.middleCols(i*Nc,Nc)=sph(i)*rad;
 
         return bf;
       }
 
-      arma::cx_vec TwoDBasis::eval_bf(double mu, double cth, double phi) const {
+      Eigen::VectorXcd TwoDBasis::eval_bf(double mu, double cth, double phi) const {
 	// Find out which element mu belongs to
-	arma::vec bval(helfem::to_arma(radial.get_bval()));
-	size_t iel;
-	for(iel=0;iel<bval.n_elem-1;iel++)
+	const helfem::Vector bval(radial.get_bval());
+	Eigen::Index iel;
+	for(iel=0;iel<bval.size()-1;iel++)
 	  if(bval(iel)<=mu && mu<=bval(iel+1))
 	    break;
-	if(iel==bval.n_elem-1) {
+	if(iel==bval.size()-1) {
 	  std::ostringstream oss;
 	  oss << "mu value " << mu << " not found!\n";
 	  throw std::logic_error(oss.str());
 	}
 
 	// x value is then
-	arma::vec x(1);
+	helfem::Vector x(1);
 	x(0)=2.0*(mu-bval(iel))/(bval(iel+1)-bval(iel)) - 1.0;
 
 	// Evaluate spherical harmonics
-        arma::cx_vec sph(lval.n_elem);
-        for(size_t i=0;i<lval.n_elem;i++)
+        Eigen::VectorXcd sph(lval.n_elem);
+        for(size_t i=0;i<(size_t) lval.n_elem;i++)
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
-        // Evaluate radial functions
-        arma::mat rad(helfem::to_arma(radial.get_bf(iel,helfem::to_eigen(x))));
+        // Evaluate radial functions (1 x Nc row)
+        const helfem::Matrix rad(radial.get_bf(iel,x));
 
 	// Get indices of radial functions
 	size_t ifirst, ilast;
         radial.get_idx(iel,ifirst,ilast);
 
-        // Form supermatrix
-	arma::cx_vec bf;
-	bf.zeros(Ndummy());
-	for(size_t i=0;i<lval.n_elem;i++) {
-	  bf.subvec(i*radial.Nbf()+ifirst,i*radial.Nbf()+ilast)=sph(i)*arma::trans(rad);
+        // Form supermatrix. arma used trans() on a real matrix = plain
+        // transpose; sph(i) is complex so cast the transposed radial row.
+	Eigen::VectorXcd bf(Eigen::VectorXcd::Zero(Ndummy()));
+	for(size_t i=0;i<(size_t) lval.n_elem;i++) {
+	  bf.segment(i*radial.Nbf()+ifirst,ilast-ifirst+1)=sph(i)*rad.transpose().cast<std::complex<double>>();
 	}
 
-	return bf(pure_indices());
+	return bf(pure_idx);
       }
 
-      void TwoDBasis::eval_df(size_t iel, size_t irad, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const {
+      void TwoDBasis::eval_df(size_t iel, size_t irad, double cth, double phi, Eigen::MatrixXcd & dr, Eigen::MatrixXcd & dth, Eigen::MatrixXcd & dphi) const {
         // Evaluate spherical harmonics
-        arma::cx_vec sph(lval.n_elem);
-        for(size_t i=0;i<lval.n_elem;i++)
+        Eigen::VectorXcd sph(lval.n_elem);
+        for(size_t i=0;i<(size_t) lval.n_elem;i++)
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
-        // Evaluate radial functions
-        arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
-        arma::mat drad(helfem::to_arma(radial.get_df(iel)));
-        frad=frad.rows(irad,irad);
-        drad=drad.rows(irad,irad);
+        // Evaluate radial functions (single quadrature point, 1 x Nc rows)
+        const helfem::Matrix frad(radial.get_bf(iel).row(irad));
+        const helfem::Matrix drad(radial.get_df(iel).row(irad));
+        const Eigen::Index Nc = frad.cols();
 
         // Form supermatrices
-        dr.zeros(frad.n_rows,lval.n_elem*frad.n_cols);
-        dth.zeros(frad.n_rows,lval.n_elem*frad.n_cols);
-        dphi.zeros(frad.n_rows,lval.n_elem*frad.n_cols);
+        dr = Eigen::MatrixXcd::Zero(frad.rows(),lval.n_elem*Nc);
+        dth = Eigen::MatrixXcd::Zero(frad.rows(),lval.n_elem*Nc);
+        dphi = Eigen::MatrixXcd::Zero(frad.rows(),lval.n_elem*Nc);
 
-        // Radial one is easy
-        for(size_t i=0;i<lval.n_elem;i++)
-          dr.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=sph(i)*drad;
+        // Radial one is easy (complex scalar * real matrix -> cast)
+        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+          dr.middleCols(i*Nc,Nc)=sph(i)*drad.cast<std::complex<double>>();
         // and so is phi
-        for(size_t i=0;i<lval.n_elem;i++)
-          dphi.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=std::complex<double>(0.0,mval(i))*sph(i)*frad;
+        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+          dphi.middleCols(i*Nc,Nc)=(std::complex<double>(0.0,mval(i))*sph(i))*frad.cast<std::complex<double>>();
         // sin^2(theta) = (1 - cth)(1 + cth) avoids the catastrophic
         // cancellation in 1 - cth*cth when cth is close to +/- 1.
         const double sinth = std::sqrt(std::max((1.0-cth)*(1.0+cth), 0.0));
         const double cotth = (sinth > 0.0) ? cth/sinth : 0.0;
 
         // but theta is nastier
-        for(size_t i=0;i<lval.n_elem;i++) {
+        for(size_t i=0;i<(size_t) lval.n_elem;i++) {
           int l(lval(i));
           int m(mval(i));
 
@@ -1784,15 +1784,15 @@ namespace helfem {
           if(mval(i)<lval(i))
             angfac+=sqrt((l-m)*(l+m+1))*std::exp(std::complex<double>(0,-phi))*::spherical_harmonics(lval(i),mval(i)+1,cth,phi);
 
-          dth.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=angfac*frad;
+          dth.middleCols(i*Nc,Nc)=angfac*frad.cast<std::complex<double>>();
         }
       }
 
-      void TwoDBasis::eval_df(size_t iel, size_t irad, double cth, int m, arma::mat & dr, arma::mat & dth) const {
+      void TwoDBasis::eval_df(size_t iel, size_t irad, double cth, int m, helfem::Matrix & dr, helfem::Matrix & dth) const {
         // Functions belonging to this m block (same selection as
         // eval_bf(iel,irad,cth,m), so the columns line up).
-        std::vector<arma::uword> flist;
-        for(size_t i=0;i<mval.n_elem;i++)
+        std::vector<size_t> flist;
+        for(size_t i=0;i<(size_t) mval.n_elem;i++)
           if(mval(i)==m)
             flist.push_back(i);
 
@@ -1802,7 +1802,7 @@ namespace helfem {
         const double cotth = (sinth > 0.0) ? cth/sinth : 0.0;
 
         // Angular factors, evaluated at phi = 0 where they are real.
-        arma::vec sph(flist.size()), dsph(flist.size());
+        helfem::Vector sph(flist.size()), dsph(flist.size());
         for(size_t i=0;i<flist.size();i++) {
           const int l(lval(flist[i]));
           const int mm(mval(flist[i]));
@@ -1817,24 +1817,23 @@ namespace helfem {
         }
 
         // Radial functions and their derivatives at the single radial point
-        arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
-        arma::mat drad(helfem::to_arma(radial.get_df(iel)));
-        frad=frad.rows(irad,irad);
-        drad=drad.rows(irad,irad);
+        const helfem::Matrix frad(radial.get_bf(iel).row(irad));
+        const helfem::Matrix drad(radial.get_df(iel).row(irad));
+        const Eigen::Index Nc = frad.cols();
 
-        dr.zeros(frad.n_rows,flist.size()*frad.n_cols);
-        dth.zeros(frad.n_rows,flist.size()*frad.n_cols);
+        dr = helfem::Matrix::Zero(frad.rows(),flist.size()*Nc);
+        dth = helfem::Matrix::Zero(frad.rows(),flist.size()*Nc);
         for(size_t i=0;i<flist.size();i++) {
-          dr.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=sph(i)*drad;
-          dth.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=dsph(i)*frad;
+          dr.middleCols(i*Nc,Nc)=sph(i)*drad;
+          dth.middleCols(i*Nc,Nc)=dsph(i)*frad;
         }
       }
 
-      void TwoDBasis::eval_lf(size_t iel, size_t irad, double cth, int m, arma::mat & lf) const {
+      void TwoDBasis::eval_lf(size_t iel, size_t irad, double cth, int m, helfem::Matrix & lf) const {
         // Same function selection as eval_bf(iel,irad,cth,m) so the columns
         // line up.
-        std::vector<arma::uword> flist;
-        for(size_t i=0;i<mval.n_elem;i++)
+        std::vector<size_t> flist;
+        for(size_t i=0;i<(size_t) mval.n_elem;i++)
           if(mval(i)==m)
             flist.push_back(i);
 
@@ -1850,23 +1849,21 @@ namespace helfem {
         // m != 0 the basis functions vanish as sinh^|m|(mu) on the axis anyway.
         const double m2_sh2((shmu>0.0) ? (m*m)/(shmu*shmu) : 0.0);
 
-        // Radial functions and their first two mu derivatives
-        arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
-        arma::mat drad(helfem::to_arma(radial.get_df(iel)));
-        arma::mat d2rad(helfem::to_arma(radial.get_d2f(iel)));
-        frad=frad.rows(irad,irad);
-        drad=drad.rows(irad,irad);
-        d2rad=d2rad.rows(irad,irad);
+        // Radial functions and their first two mu derivatives (1 x Nc rows)
+        const helfem::Matrix frad(radial.get_bf(iel).row(irad));
+        const helfem::Matrix drad(radial.get_df(iel).row(irad));
+        const helfem::Matrix d2rad(radial.get_d2f(iel).row(irad));
+        const Eigen::Index Nc = frad.cols();
 
         // R'' + coth(mu) R' is common to every l in the block
-        const arma::mat radop(d2rad + cothmu*drad);
+        const helfem::Matrix radop(d2rad + cothmu*drad);
 
-        lf.zeros(frad.n_rows,flist.size()*frad.n_cols);
+        lf = helfem::Matrix::Zero(frad.rows(),flist.size()*Nc);
         for(size_t i=0;i<flist.size();i++) {
           const int l(lval(flist[i]));
           const double sph(std::real(::spherical_harmonics(l,m,cth,0.0)));
           const double lfac(l*(l+1) + m2_sh2);
-          lf.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)
+          lf.middleCols(i*Nc,Nc)
             = (sph/h2)*(radop - lfac*frad);
         }
       }
@@ -1953,16 +1950,16 @@ namespace helfem {
         return radial.Nel();
       }
 
-      arma::mat TwoDBasis::get_rad_bf(size_t iel) const {
-        return helfem::to_arma(radial.get_bf(iel));
+      helfem::Matrix TwoDBasis::get_rad_bf(size_t iel) const {
+        return radial.get_bf(iel);
       }
 
-      arma::mat TwoDBasis::get_rad_df(size_t iel) const {
-        return helfem::to_arma(radial.get_df(iel));
+      helfem::Matrix TwoDBasis::get_rad_df(size_t iel) const {
+        return radial.get_df(iel);
       }
 
-      arma::mat TwoDBasis::get_rad_d2f(size_t iel) const {
-        return helfem::to_arma(radial.get_d2f(iel));
+      helfem::Matrix TwoDBasis::get_rad_d2f(size_t iel) const {
+        return radial.get_d2f(iel);
       }
 
       arma::vec TwoDBasis::get_wrad(size_t iel) const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -325,22 +325,22 @@ namespace helfem {
         std::vector<std::vector<Eigen::Index>> get_sym_idx(int isym) const;
 
         /// Evaluate basis functions at quadrature points
-        arma::cx_mat eval_bf(size_t iel, size_t irad, double cth, double phi) const;
+        Eigen::MatrixXcd eval_bf(size_t iel, size_t irad, double cth, double phi) const;
         /// Evaluate basis functions at wanted x value
         /// Evaluate basis functions with m=m at quadrature point
-        arma::mat eval_bf(size_t iel, size_t irad, double cth, int m) const;
+        helfem::Matrix eval_bf(size_t iel, size_t irad, double cth, int m) const;
         /// Same, but with the element's radial functions already evaluated
         /// (rad_all = get_rad_bf(iel), rows = radial points). The FEM
         /// polynomials depend only on the element, so callers that loop over
         /// angular points should hoist that evaluation out of the loop rather
         /// than redo it -- and throw away all but one row -- per angular point.
-        arma::mat eval_bf(size_t iel, size_t irad, double cth, int m, const arma::mat & rad_all) const;
+        helfem::Matrix eval_bf(size_t iel, size_t irad, double cth, int m, const helfem::Matrix & rad_all) const;
 
 	/// Evaluate basis functions at wanted point
-	arma::cx_vec eval_bf(double mu, double cth, double phi) const;
+	Eigen::VectorXcd eval_bf(double mu, double cth, double phi) const;
 
         /// Evaluate basis functions derivatives at quadrature points
-        void eval_df(size_t iel, size_t irad, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const;
+        void eval_df(size_t iel, size_t irad, double cth, double phi, Eigen::MatrixXcd & dr, Eigen::MatrixXcd & dth, Eigen::MatrixXcd & dphi) const;
 
         /// Evaluate the REAL derivatives of the m-block basis functions at a
         /// (mu, nu) quadrature point. Companion to eval_bf(iel,irad,cth,m):
@@ -354,7 +354,7 @@ namespace helfem {
         /// contributes only the analytic term m^2 |psi|^2 / h_phi^2 (needed for
         /// tau); the density gradient has no phi component at all since
         /// |e^{i m phi}| = 1 makes rho phi-independent.
-        void eval_df(size_t iel, size_t irad, double cth, int m, arma::mat & dr, arma::mat & dth) const;
+        void eval_df(size_t iel, size_t irad, double cth, int m, helfem::Matrix & dr, helfem::Matrix & dth) const;
 
         /// Evaluate the REAL Laplacian of the m-block basis functions at a
         /// (mu, nu) quadrature point. Used by the pure-m DFT grid for
@@ -377,7 +377,7 @@ namespace helfem {
         ///
         ///   grad^2 f = (1/h^2) [ R'' + coth(mu) R'
         ///                        - ( l(l+1) + m^2/sinh^2(mu) ) R ] Y_l^m.
-        void eval_lf(size_t iel, size_t irad, double cth, int m, arma::mat & lf) const;
+        void eval_lf(size_t iel, size_t irad, double cth, int m, helfem::Matrix & lf) const;
         /// Translate dummy indices to real indices
         arma::uvec dummy_idx_to_real_idx(const arma::uvec & idx) const;
         /// Get list of basis function dummy indices in element
@@ -395,11 +395,11 @@ namespace helfem {
         arma::vec get_r(size_t iel) const;
         /// Get radial basis functions at the quadrature points of element iel
         /// (rows = radial points, cols = element primitives)
-        arma::mat get_rad_bf(size_t iel) const;
+        helfem::Matrix get_rad_bf(size_t iel) const;
         /// Get their first mu derivatives, same layout
-        arma::mat get_rad_df(size_t iel) const;
+        helfem::Matrix get_rad_df(size_t iel) const;
         /// Get their second mu derivatives, same layout
-        arma::mat get_rad_d2f(size_t iel) const;
+        helfem::Matrix get_rad_d2f(size_t iel) const;
 
         /// Electron density at nuclei
       };

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -44,16 +44,16 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   std::vector<std::vector<Eigen::Index>> dsym=basis.get_sym_idx(symm);
 
   // Form overlap matrix
-  arma::mat S(helfem::to_arma(basis.overlap()));
+  const helfem::Matrix S(basis.overlap());
   // Form kinetic energy matrix
-  arma::mat T(helfem::to_arma(basis.kinetic()));
+  const helfem::Matrix T(basis.kinetic());
   // Get half-inverse
-  arma::mat Sinvh(helfem::to_arma(basis.Sinvh(!diag,symm)));
+  const helfem::Matrix Sinvh(basis.Sinvh(!diag,symm));
   // Form nuclear attraction energy matrix
-  arma::mat Vnuc;
+  helfem::Matrix Vnuc;
 
   if(imodel==0) {
-    Vnuc=helfem::to_arma(basis.nuclear());
+    Vnuc=basis.nuclear();
   } else {
     modelpotential::ModelPotential * p1, * p2;
     if(imodel == 1) {
@@ -85,32 +85,27 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   }
 
   // Form Hamiltonian
-  arma::mat H0(T+Vnuc);
+  helfem::Matrix H0(T+Vnuc);
   if(Ez!=0.0)
-    H0+=Ez*helfem::to_arma(basis.dipole_z());
+    H0+=Ez*basis.dipole_z();
   // Quadrupole coupling
   if(Qzz!=0.0)
-    H0+=Qzz*helfem::to_arma(basis.quadrupole_zz())/3.0;
+    H0+=Qzz*basis.quadrupole_zz()/3.0;
   // Magnetic field coupling
   if(Bz!=0.0) {
     printf("Bz=%e\n",Bz);
-    H0+=helfem::to_arma(basis.Bz_field(Bz))-Bz*S/2.0;
+    H0+=basis.Bz_field(Bz)-Bz*S/2.0;
   }
-  // Use core guess
-  arma::vec Ev;
-  arma::mat C;
-  { // Phase 5.12 bridge: eig_gsym_sub is Eigen.
-    helfem::Vector Ev_e; helfem::Matrix C_e;
-    scf::eig_gsym_sub(Ev_e, C_e, helfem::to_eigen(H0), helfem::to_eigen(Sinvh), dsym);
-    Ev = helfem::to_arma(Ev_e);
-    C = helfem::to_arma(C_e);
-  }
-  //scf::eig_gsym(Ev,C,H0,Sinvh);
+  // Use core guess (eig_gsym_sub is Eigen-native)
+  helfem::Vector Ev;
+  helfem::Matrix C;
+  scf::eig_gsym_sub(Ev, C, H0, Sinvh, dsym);
 
   // Sanity check
-  norb=std::min((int) Ev.n_elem,norb);
-  Eval=Ev.subvec(0,norb-1);
-  E=arma::sum(Eval);
+  norb=std::min((int) Ev.size(),norb);
+  // Eval is an arma out-param (main prints it via arma); bridge the head.
+  Eval=helfem::to_arma(helfem::Vector(Ev.head(norb)));
+  E=Ev.head(norb).sum();
   nang=basis.Nang();
   nrad=basis.Nrad();
 }

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -106,7 +106,9 @@ int main(int argc, char **argv) {
   // Evaluate radial functions
   std::vector<arma::mat> radbf(basis.get_rad_Nel());
   for(size_t iel=0;iel<mu.size();iel++) {
-    radbf[iel] = basis.get_rad_bf(iel);
+    // get_rad_bf is now Eigen-typed; bridge back for the arma-native
+    // density accumulation and Checkpoint (HDF5) output below.
+    radbf[iel] = helfem::to_arma(basis.get_rad_bf(iel));
   }
 
   // Density arrays

--- a/src/diatomic/density_line.cpp
+++ b/src/diatomic/density_line.cpp
@@ -78,10 +78,8 @@ int main(int argc, char **argv) {
       den(iz, 0) = zi;
       continue;
     }
-    // basis.eval_bf returns arma::cx_vec; bridge to Eigen VectorXcd.
-    const arma::cx_vec bf_a = basis.eval_bf(mu, eta, phi);
-    Eigen::VectorXcd bf(bf_a.n_elem);
-    for (arma::uword i = 0; i < bf_a.n_elem; ++i) bf(i) = bf_a(i);
+    // basis.eval_bf returns the basis functions in the real (pure) basis.
+    const Eigen::VectorXcd bf = basis.eval_bf(mu, eta, phi);
     // rho_spin = Re(bf^* . P . bf) with P symmetric real.
     const double rhoa = (bf.adjoint() * Pa * bf).real().value();
     const double rhob = (bf.adjoint() * Pb * bf).real().value();

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -471,19 +471,15 @@ namespace helfem {
 #pragma omp parallel for
 #endif
         for(Eigen::Index ia=0;ia<cth.size();ia++) {
-          // Evaluate basis functions at angular point (eval_bf returns arma; bridge).
-          arma::cx_mat abf(basp->eval_bf(iel, irad, cth(ia), phi(ia)));
-          if((size_t) abf.n_cols != bf_ind.size()) {
+          // Evaluate basis functions at angular point (Eigen-native).
+          const Eigen::MatrixXcd abf(basp->eval_bf(iel, irad, cth(ia), phi(ia)));
+          if((size_t) abf.cols() != bf_ind.size()) {
             std::ostringstream oss;
-            oss << "Mismatch! Have " << bf_ind.size() << " basis function indices but " << abf.n_cols << " basis functions!\n";
+            oss << "Mismatch! Have " << bf_ind.size() << " basis function indices but " << abf.cols() << " basis functions!\n";
             throw std::logic_error(oss.str());
           }
-          Eigen::MatrixXcd abf_e(abf.n_rows, abf.n_cols);
-          for(arma::uword c=0;c<abf.n_cols;c++)
-            for(arma::uword rr=0;rr<abf.n_rows;rr++)
-              abf_e(rr,c)=abf(rr,c);
-          // Store functions (arma::trans is the conjugate transpose -> adjoint).
-          bf.middleCols(ia*nwrad,nwrad)=abf_e.adjoint();
+          // Store functions (arma::trans was the conjugate transpose -> adjoint).
+          bf.middleCols(ia*nwrad,nwrad)=abf.adjoint();
         }
 
         if(do_grad) {
@@ -495,25 +491,18 @@ namespace helfem {
 #pragma omp parallel for
 #endif
           for(Eigen::Index ia=0;ia<cth.size();ia++) {
-            // Evaluate basis functions at angular point (eval_df returns arma; bridge).
-            arma::cx_mat dr, dth, dphi;
+            // Evaluate basis functions at angular point (Eigen-native).
+            Eigen::MatrixXcd dr, dth, dphi;
             basp->eval_df(iel, irad, cth(ia), phi(ia), dr, dth, dphi);
-            if((size_t) dr.n_cols != bf_ind.size()) {
+            if((size_t) dr.cols() != bf_ind.size()) {
               std::ostringstream oss;
-              oss << "Mismatch! Have " << bf_ind.size() << " basis function indices but " << dr.n_cols << " basis functions!\n";
+              oss << "Mismatch! Have " << bf_ind.size() << " basis function indices but " << dr.cols() << " basis functions!\n";
               throw std::logic_error(oss.str());
             }
-            Eigen::MatrixXcd dr_e(dr.n_rows, dr.n_cols), dth_e(dth.n_rows, dth.n_cols), dphi_e(dphi.n_rows, dphi.n_cols);
-            for(arma::uword c=0;c<dr.n_cols;c++)
-              for(arma::uword rr=0;rr<dr.n_rows;rr++) {
-                dr_e(rr,c)=dr(rr,c);
-                dth_e(rr,c)=dth(rr,c);
-                dphi_e(rr,c)=dphi(rr,c);
-              }
-            // Store functions (arma::trans -> adjoint).
-            bf_rho.middleCols(ia*nwrad,nwrad)=dr_e.adjoint();
-            bf_theta.middleCols(ia*nwrad,nwrad)=dth_e.adjoint();
-            bf_phi.middleCols(ia*nwrad,nwrad)=dphi_e.adjoint();
+            // Store functions (arma::trans was the conjugate transpose -> adjoint).
+            bf_rho.middleCols(ia*nwrad,nwrad)=dr.adjoint();
+            bf_theta.middleCols(ia*nwrad,nwrad)=dth.adjoint();
+            bf_phi.middleCols(ia*nwrad,nwrad)=dphi.adjoint();
           }
         }
 

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -123,11 +123,11 @@ namespace helfem {
         // once per element instead of once per (radial point, angular point,
         // m block) -- see the note in the header.
         if (!cache_valid || iel != cached_iel) {
-          rad_f = helfem::to_eigen(basp->get_rad_bf(iel));
+          rad_f = basp->get_rad_bf(iel);
           if (need_df) {
-            rad_df = helfem::to_eigen(basp->get_rad_df(iel));
+            rad_df = basp->get_rad_df(iel);
             if (do_lapl)
-              rad_d2f = helfem::to_eigen(basp->get_rad_d2f(iel));
+              rad_d2f = basp->get_rad_d2f(iel);
           }
           cached_iel  = iel;
           cache_valid = true;

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -255,8 +255,7 @@ int main(int argc, char **argv) {
         modelpotential::get_nuclear_model((modelpotential::nuclear_model_t) finitenuc, Z2, Rrms2);
     const int lquad = 4 * arma::max(lmmax) + 12;
     helfem::diatomic::twodquad::TwoDGrid qgrid(&basis, lquad);
-    // TwoDGrid::model_potential still returns arma::mat -> bridge to Eigen.
-    Vnuc = helfem::to_eigen(qgrid.model_potential(pot1, pot2));
+    Vnuc = qgrid.model_potential(pot1, pot2);
     delete pot1;
     delete pot2;
     printf("Using finite nuclear model %d (Rrms1=%g, Rrms2=%g)\n", finitenuc, Rrms1, Rrms2);
@@ -485,8 +484,7 @@ int main(int argc, char **argv) {
     }
     const int lquad = 4 * arma::max(lmmax) + 12;
     helfem::diatomic::twodquad::TwoDGrid qgrid(&basis, lquad);
-    // TwoDGrid::model_potential still returns arma::mat -> bridge to Eigen.
-    Vguess = helfem::to_eigen(qgrid.model_potential(p1, p2));
+    Vguess = qgrid.model_potential(p1, p2);
     delete p1;
     delete p2;
   }

--- a/src/diatomic/purem_test.cpp
+++ b/src/diatomic/purem_test.cpp
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
         if (mu - bv(iel) < edge || bv(iel + 1) - mu < edge) continue;
         nchecked++;
         for (double nu : {0.7, 1.3, 2.2}) {
-          arma::mat lf;
+          helfem::Matrix lf;
           basis.eval_lf(iel, irad, std::cos(nu), m, lf);
 
           // Map the m-block columns back to dummy indices so the same

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -213,7 +213,7 @@ namespace helfem {
         // quadrature point and then keeps a single row, so calling it inside
         // the angular loop redid that work cth.size() times over. Hoisted
         // above the parallel region, which also keeps it read-only shared.
-        const arma::mat rad_all(basp->get_rad_bf(iel));
+        const helfem::Matrix rad_all(basp->get_rad_bf(iel));
 
         // Loop over angular grid
 #ifdef _OPENMP
@@ -221,7 +221,7 @@ namespace helfem {
 #endif
         for(size_t ia=0;ia<(size_t) cth.size();ia++) {
           // Evaluate basis functions at angular point
-          helfem::Matrix abf(helfem::to_eigen(basp->eval_bf(iel, irad, cth(ia), m, rad_all)));
+          helfem::Matrix abf(basp->eval_bf(iel, irad, cth(ia), m, rad_all));
           if((size_t) abf.cols() != bf_ind.size()) {
             std::ostringstream oss;
             oss << "Mismatch! Have " << bf_ind.size() << " basis function indices but " << abf.cols() << " basis functions!\n";
@@ -381,10 +381,10 @@ namespace helfem {
       TwoDGrid::~TwoDGrid() {
       }
 
-      arma::mat TwoDGrid::model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2) {
+      helfem::Matrix TwoDGrid::model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2) {
         helfem::Matrix H = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
 
-        // Get unique m values in basis set
+        // Get unique m values in basis set (get_mval is still arma-typed).
         arma::ivec muni(basp->get_mval());
         muni=muni(arma::find_unique(muni));
         {
@@ -401,8 +401,9 @@ namespace helfem {
           }
         }
 
-        // remove_boundaries is still arma-typed; bridge around it.
-        return basp->remove_boundaries(helfem::to_arma(H));
+        // Use the Eigen-native boundary removal (same cached pure index list
+        // as the Fock path); no arma round trip.
+        return basp->remove_boundaries(H);
       }
 
       arma::mat TwoDGrid::gto_projection(int l, int m, const arma::vec & expn, probe_t p) {

--- a/src/diatomic/twodquadrature.h
+++ b/src/diatomic/twodquadrature.h
@@ -113,7 +113,7 @@ namespace helfem {
         ~TwoDGrid();
 
         /// Compute model potential matrix
-        arma::mat model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2);
+        helfem::Matrix model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2);
 
         /// Compute GTO projection
         arma::mat gto_projection(int l, int m, const arma::vec & expn, probe_t p);


### PR DESCRIPTION
Continues the arma->Eigen migration (#24) through the diatomic **analysis path** -- the evaluator family and `TwoDGrid::model_potential`. These are not purely "analysis": the `eval_bf`/`eval_df` overloads also feed the XC grids, so the work had to keep DFT energies bit-exact, not just tool output.

## Converted

**Evaluators** (`basis.{h,cpp}`)
* real: `eval_bf(...,m)`, `eval_bf(...,m,rad_all)`, `eval_df(...,m,dr,dth)`, `eval_lf(...,m,lf)` -> `helfem::Matrix`
* complex: `eval_bf(...,phi)` -> `Eigen::MatrixXcd`, `eval_bf(mu,cth,phi)` -> `Eigen::VectorXcd`, `eval_df(...,phi,dr,dth,dphi)` -> `Eigen::MatrixXcd`
* `get_rad_bf/df/d2f` -> `helfem::Matrix`
* `twodquadrature`: `TwoDGrid::model_potential` -> `helfem::Matrix`

**Consumers**: `dftgrid.cpp` (3D grid, complex evaluators), `dftgrid_purem.cpp` (pure-m grid, real evaluators), `main.cpp`, `corebasis.cpp`, `density_line.cpp`, `density_grid.cpp`, `purem_test.cpp`.

## The complex-arithmetic trap, handled correctly

`arma::dot` does not conjugate but Eigen `.dot()` does, and `arma::trans` on complex is a conjugate transpose. Each complex operation was matched to intent, and audited:
* 3D XC grid stores `abf`/`dr`/`dth`/`dphi` via `arma::trans` (conjugate) -> `.adjoint()` on the now-native `Eigen::MatrixXcd` (and the redundant element-wise copy loop dropped).
* `density_line` `rho = Re(bf^H P bf)` is genuinely conjugating -> `.adjoint()`.
* `eval_bf(mu,cth,phi)` does `sph * trans(rad)` where `rad` is **real**, so that `trans` is a *plain* transpose -> `.transpose().cast<complex>()`, **not** `.adjoint()`.
* **No bare Eigen `.dot()` is introduced anywhere** (verified by diff) -- the one idiom that would silently conjugate is absent.

## Bit-exact (branch vs a master-built binary, OMP_NUM_THREADS=1)

`verify_anal.sh` -> `ALL PASS`, exercising the risky surfaces:

| case | energy |
|---|---|
| N2 GGA pbe, 3D grid (complex eval) | -80.2138396145 |
| N2 mGGA tpss, 3D grid (complex eval) | -80.3218946809 |
| N2 GGA pbe, pure-m grid (real eval) | -80.2138396145 |
| N2 mGGA tpss, pure-m grid (real eval) | -80.3218946809 |
| N2 LDA, SAP guess (model_potential) | -79.4807491233 |
| corebasis energies | identical |
| purem_test | unchanged |

## Left arma, deliberately (reported, none on a numeric path)

* the diatomic `TwoDBasis` **interior `arma::ivec lval/mval` storage** and the `get_r`/`get_wrad`/`get_lval`/`pure_indices`/`bf_list_dummy` accessors -- read on the driver/Fock-path interior, out of scope here.
* **`completeness.cpp`** -- arma-native linear algebra (`eig_sym`, `find`, `diagmat`, `submat`, `.save(raw_ascii)`) with **no gate coverage**; converting it blind would be reckless, so it and the `TwoDGrid::{gto,sto,atomic}_projection` helpers it alone consumes stay arma.
* **`density_grid.cpp`, `diatomic_1e.cpp`** -- output through Checkpoint HDF5 (arma-typed), with `arma::cdot` reductions; a single `to_arma` bridge remains on `density_grid`'s one changed accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
