### PR TITLE
Eliminate arma, wave 2: basis interior integer/vector storage + accessors

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -40,14 +40,15 @@ namespace helfem {
     namespace basis {
 
       // The routines that evaluate basis functions on a grid
-      // (eval_bf / eval_df / eval_lf) and the quadrature-point accessors
-      // (get_bval / get_wrad / get_r) hand back arma types and, in the
-      // eval_* case, go through the double-only ::spherical_harmonics.
-      // They serve the DFT grid and the analysis binaries, neither of which
-      // can run above double anyway (libxc is a double-only C library), and
-      // none of them is on the Fock path. Rather than split the class, they
-      // are compiled for every T and guarded: at T = double they are exactly
-      // the code they always were, and at any other T they throw.
+      // (eval_bf / eval_df / eval_lf) return arma::cx_mat and go through the
+      // double-only ::spherical_harmonics. They serve the DFT grid and the
+      // analysis binaries, neither of which can run above double anyway (libxc
+      // is a double-only C library), and none is on the Fock path. Rather than
+      // split the class they are compiled for every T and guarded: at
+      // T = double they are exactly the code they always were, and at any
+      // other T they throw. (The quadrature-point accessors get_bval /
+      // get_wrad / get_r are now precision-generic helfem::Vec<T> and need no
+      // guard.)
       namespace {
         [[noreturn]] void double_only(const char *what) {
           throw std::logic_error(std::string(what) +
@@ -126,21 +127,13 @@ namespace helfem {
       }
 
       template <typename T>
-      arma::ivec TwoDBasisT<T>::get_lval() const {
-        // Bridge Eigen->arma at the public boundary; consumers
-        // (checkpoint I/O, drivers) still take arma::ivec.
-        arma::ivec out(lval.size());
-        for (Eigen::Index i = 0; i < lval.size(); ++i)
-          out(i) = static_cast<arma::sword>(lval(i));
-        return out;
+      Eigen::VectorXi TwoDBasisT<T>::get_lval() const {
+        return lval;
       }
 
       template <typename T>
-      arma::ivec TwoDBasisT<T>::get_mval() const {
-        arma::ivec out(mval.size());
-        for (Eigen::Index i = 0; i < mval.size(); ++i)
-          out(i) = static_cast<arma::sword>(mval(i));
-        return out;
+      Eigen::VectorXi TwoDBasisT<T>::get_mval() const {
+        return mval;
       }
 
       template <typename T>
@@ -149,12 +142,8 @@ namespace helfem {
       }
 
       template <typename T>
-      arma::vec TwoDBasisT<T>::get_bval() const {
-        if constexpr (std::is_same_v<T, double>) {
-          return helfem::to_arma(radial.get_bval());
-        } else {
-          double_only("get_bval");
-        }
+      helfem::Vec<T> TwoDBasisT<T>::get_bval() const {
+        return radial.get_bval();
       }
 
       template <typename T>
@@ -1209,7 +1198,7 @@ namespace helfem {
       }
 
       template <typename T>
-      arma::uvec TwoDBasisT<T>::bf_list(size_t iel) const {
+      std::vector<Eigen::Index> TwoDBasisT<T>::bf_list(size_t iel) const {
         // Radial functions in element
         size_t ifirst, ilast;
         radial.get_idx(iel,ifirst,ilast);
@@ -1220,10 +1209,10 @@ namespace helfem {
         size_t Nradf(radial.Nbf());
 
         // List of functions in the element
-        arma::uvec idx(Nr*lval.size());
+        std::vector<Eigen::Index> idx(Nr*lval.size());
         for(size_t iam=0;iam<(size_t) lval.size();iam++)
           for(size_t j=0;j<Nr;j++)
-            idx(iam*Nr+j)=Nradf*iam+ifirst+j;
+            idx[iam*Nr+j]=(Eigen::Index) (Nradf*iam+ifirst+j);
 
         return idx;
       }
@@ -1242,23 +1231,13 @@ namespace helfem {
       }
 
       template <typename T>
-      arma::vec TwoDBasisT<T>::get_wrad(size_t iel) const {
-        if constexpr (std::is_same_v<T, double>) {
-          return helfem::to_arma(radial.get_wrad(iel));
-        } else {
-          (void) iel;
-          double_only("get_wrad");
-        }
+      helfem::Vec<T> TwoDBasisT<T>::get_wrad(size_t iel) const {
+        return radial.get_wrad(iel);
       }
 
       template <typename T>
-      arma::vec TwoDBasisT<T>::get_r(size_t iel) const {
-        if constexpr (std::is_same_v<T, double>) {
-          return helfem::to_arma(radial.get_r(iel));
-        } else {
-          (void) iel;
-          double_only("get_r");
-        }
+      helfem::Vec<T> TwoDBasisT<T>::get_r(size_t iel) const {
+        return radial.get_r(iel);
       }
 
       template class TwoDBasisT<double>;

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -42,13 +42,13 @@ namespace helfem {
       ///     TwoDBasis (= TwoDBasisT<double>) as before.
       ///   * the basis-function EVALUATION routines used by that grid and by
       ///     the analysis binaries -- eval_bf / eval_df / eval_lf (which return
-      ///     arma::cx_mat and go through the double-only ::spherical_harmonics)
-      ///     and the quadrature-point accessors get_bval / get_wrad / get_r
-      ///     (arma::vec). These are compiled for every T but THROW unless
-      ///     T = double; they are not on the Fock path.
+      ///     arma::cx_mat and go through the double-only ::spherical_harmonics).
+      ///     These are compiled for every T but THROW unless T = double; they
+      ///     are not on the Fock path. (The quadrature-point accessors get_bval
+      ///     / get_wrad / get_r are precision-generic helfem::Vec<T>.)
       /// The angular-index bookkeeping (get_lval / m_indices / get_sym_idx,
-      /// arma::ivec / arma::uvec) is integer-valued, hence precision-free, and
-      /// is shared by all instantiations unchanged.
+      /// Eigen::VectorXi / std::vector<Eigen::Index>) is integer-valued, hence
+      /// precision-free, and is shared by all instantiations unchanged.
       template <typename T>
       class TwoDBasisT {
         /// Nuclear charge
@@ -163,14 +163,14 @@ namespace helfem {
         T get_nuclear_size() const;
 
         /// Get l values
-        arma::ivec get_lval() const;
+        Eigen::VectorXi get_lval() const;
         /// Get m values
-        arma::ivec get_mval() const;
+        Eigen::VectorXi get_mval() const;
 
         /// Get number of quadrature points
         int get_nquad() const;
-        /// Get boundary values (T = double only)
-        arma::vec get_bval() const;
+        /// Get boundary values
+        helfem::Vec<T> get_bval() const;
         /// Get polynomial basis identifier
         int get_poly_id() const;
         /// Get number of nodes in polynomial
@@ -264,7 +264,7 @@ namespace helfem {
         /// Evaluate Laplacian of basis functions (T = double only)
         arma::cx_mat eval_lf(size_t iel, double cth, double phi) const;
         /// Get list of basis function indices in element
-        arma::uvec bf_list(size_t iel) const;
+        std::vector<Eigen::Index> bf_list(size_t iel) const;
 
         /// Get number of radial elements
         size_t get_rad_Nel() const;
@@ -274,10 +274,10 @@ namespace helfem {
         /// callers must account for this when partitioning per-element
         /// quantities.
         std::pair<size_t, size_t> radial_element_range(size_t iel) const;
-        /// Get radial quadrature weights (T = double only)
-        arma::vec get_wrad(size_t iel) const;
-        /// Get r values (T = double only)
-        arma::vec get_r(size_t iel) const;
+        /// Get radial quadrature weights
+        helfem::Vec<T> get_wrad(size_t iel) const;
+        /// Get r values
+        helfem::Vec<T> get_r(size_t iel) const;
       };
 
       /// The double instantiation, which every existing caller uses.

--- a/src/atomic/basis.cpp
+++ b/src/atomic/basis.cpp
@@ -172,14 +172,14 @@ namespace helfem {
         return bval;
       }
 
-      void angular_basis(int lmax, int mmax, arma::ivec & lval, arma::ivec & mval) {
+      void angular_basis(int lmax, int mmax, Eigen::VectorXi & lval, Eigen::VectorXi & mval) {
         size_t nang=0;
         for(int l=0;l<=lmax;l++)
           nang+=2*std::min(mmax,l)+1;
 
         // Allocate memory
-        lval.zeros(nang);
-        mval.zeros(nang);
+        lval=Eigen::VectorXi::Zero(nang);
+        mval=Eigen::VectorXi::Zero(nang);
 
         // Store values
         size_t iang=0;
@@ -194,7 +194,7 @@ namespace helfem {
               iang++;
             }
           }
-        if(iang!=lval.n_elem)
+        if(iang!=(size_t) lval.size())
           throw std::logic_error("Error.\n");
       }
     }

--- a/src/atomic/basis.h
+++ b/src/atomic/basis.h
@@ -37,7 +37,7 @@ namespace helfem {
       arma::vec form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf, bool add_el, double r);
 
       /// Constructs an angular basis
-      void angular_basis(int lmax, int mmax, arma::ivec & lval, arma::ivec & mval);
+      void angular_basis(int lmax, int mmax, Eigen::VectorXi & lval, Eigen::VectorXi & mval);
     }
   }
 }

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -473,17 +473,13 @@ namespace helfem {
       // inherited from helfem::dftgrid_common::DFTGridWorkerBase.
 
       void DFTGridWorker::compute_bf(size_t iel) {
-        // Update function list (bf_list returns arma::uvec -- bridge to
-        // a plain index vector).
-        arma::uvec bf_ind_arma(basp->bf_list(iel));
-        bf_ind.assign(bf_ind_arma.n_elem, 0);
-        for(size_t k=0;k<bf_ind_arma.n_elem;k++)
-          bf_ind[k]=(Eigen::Index) bf_ind_arma(k);
+        // Update function list
+        bf_ind=basp->bf_list(iel);
         const Eigen::Index nbf=(Eigen::Index) bf_ind.size();
 
-        // Get radii and radial weights (basp returns arma::vec -- bridge).
-        helfem::Vector r(helfem::to_eigen(basp->get_r(iel)));
-        helfem::Vector wrad(helfem::to_eigen(basp->get_wrad(iel)));
+        // Get radii and radial weights
+        helfem::Vector r(basp->get_r(iel));
+        helfem::Vector wrad(basp->get_wrad(iel));
         const Eigen::Index nrad=wrad.size();
         const Eigen::Index nang=wang.size();
 

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -254,8 +254,9 @@ int main(int argc, char **argv) {
       throw std::logic_error("Off-centre charges require --nelem0 >= 1 (radial elements between the origin and the off-centre nuclei).\n");
   }
 
-  arma::ivec lval, mval;
+  Eigen::VectorXi lval, mval;
   atomic::basis::angular_basis(lmax, mmax, lval, mval);
+  // form_grid is still arma-native; bridge once.
   arma::vec bval = atomic::basis::form_grid(
       (modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax,
       igrid, zexp, Nelem0, igrid0, zexp0, Z, Zl, Zr, Rhalf,
@@ -264,8 +265,8 @@ int main(int argc, char **argv) {
   atomic::basis::TwoDBasis basis(Z, (modelpotential::nuclear_model_t) finitenuc,
                                   Rrms, poly, zeroder, Nquad,
                                   helfem::to_eigen(bval),
-                                  helfem::to_eigen(lval),
-                                  helfem::to_eigen(mval),
+                                  lval,
+                                  mval,
                                   Zl, Zr, Rhalf);
   const size_t Nbf = basis.Nbf();
   printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
@@ -313,8 +314,8 @@ int main(int argc, char **argv) {
   // is present, which is what you want).
   std::vector<std::vector<std::vector<Eigen::Index>>> l_idx;
   if (maverage) {
-    const arma::ivec l_all = basis.get_lval();
-    const int lmax_bf = arma::max(l_all);
+    const Eigen::VectorXi l_all = basis.get_lval();
+    const int lmax_bf = l_all.maxCoeff();
     l_idx.assign(lmax_bf + 1, {});
     for (int l = 0; l <= lmax_bf; ++l)
       for (int m = -l; m <= l; ++m) {

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -303,13 +303,12 @@ namespace helfem {
         bool zero_deriv_right=true;
         polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
         radial=RadialBasis(fem, n_quad);
-        // Angular basis. Bridge the Eigen boundary inputs to the arma::ivec
-        // storage the interior still uses.
-        lval=helfem::to_arma(lval_);
-        mval=helfem::to_arma(mval_);
+        // Angular basis.
+        lval=lval_;
+        mval=mval_;
 
         // Gaunt coefficients
-        int gmax(arma::max(lval)+2);
+        int gmax(lval.maxCoeff()+2);
 
         // Legendre function values
         if(legendre) {
@@ -319,8 +318,8 @@ namespace helfem {
           // Form L|M| and LM maps
           lm_map.clear();
           LM_map.clear();
-          for(size_t iang=0;iang<lval.n_elem;iang++) {
-            for(size_t jang=0;jang<lval.n_elem;jang++) {
+          for(size_t iang=0;iang<lval.size();iang++) {
+            for(size_t jang=0;jang<lval.size();jang++) {
               // l and m values
               int li(lval(iang));
               int mi(mval(iang));
@@ -401,19 +400,14 @@ namespace helfem {
           // One-electron matrices need gmax,5,gmax
           int lrval(gmax);
           int midval(5);
-          int Mmax=arma::max(mval)-arma::min(mval);
+          int Mmax=mval.maxCoeff()-mval.minCoeff();
 
           gaunt=gaunt::Gaunt(lrval,midval,lrval);
         }
 
         // Cache the real->dummy index map once. pure_indices() rebuilds it on
         // every call, and boundary expansion / removal runs on every Fock build.
-        {
-          const arma::uvec idx(pure_indices());
-          pure_idx.resize(idx.n_elem);
-          for(size_t i=0;i<idx.n_elem;i++)
-            pure_idx[i] = (Eigen::Index) idx(i);
-        }
+        pure_idx = pure_indices();
       }
 
       TwoDBasis::~TwoDBasis() {
@@ -431,11 +425,11 @@ namespace helfem {
         return Rhalf;
       }
 
-      arma::ivec TwoDBasis::get_lval() const {
+      Eigen::VectorXi TwoDBasis::get_lval() const {
         return lval;
       }
 
-      arma::ivec TwoDBasis::get_mval() const {
+      Eigen::VectorXi TwoDBasis::get_mval() const {
         return mval;
       }
 
@@ -443,8 +437,8 @@ namespace helfem {
         return radial.get_nquad();
       }
 
-      arma::vec TwoDBasis::get_bval() const {
-        return helfem::to_arma(radial.get_bval());
+      helfem::Vector TwoDBasis::get_bval() const {
+        return radial.get_bval();
       }
 
       double TwoDBasis::get_mumax() const {
@@ -461,13 +455,13 @@ namespace helfem {
       }
 
       size_t TwoDBasis::Ndummy() const {
-        return lval.n_elem*radial.Nbf();
+        return lval.size()*radial.Nbf();
       }
 
       size_t TwoDBasis::Nbf() const {
         // Count total number of basis functions
         size_t nbf=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
+        for(size_t i=0;i<mval.size();i++) {
           nbf+=radial.Nbf();
           if(mval(i)!=0)
             // Remove first function
@@ -482,21 +476,23 @@ namespace helfem {
       }
 
       size_t TwoDBasis::Nang() const {
-        return lval.n_elem;
+        return lval.size();
       }
 
-      arma::uvec TwoDBasis::pure_indices() const {
+      std::vector<Eigen::Index> TwoDBasis::pure_indices() const {
         // Indices of the pure functions
-        arma::uvec idx(Nbf());
+        std::vector<Eigen::Index> idx(Nbf());
 
         size_t ioff=0;
-        for(size_t i=0;i<mval.n_elem;i++) {
+        for(size_t i=0;i<(size_t) mval.size();i++) {
           if(mval(i)==0) {
-            idx.subvec(ioff,ioff+radial.Nbf()-1)=arma::linspace<arma::uvec>(i*radial.Nbf(),(i+1)*radial.Nbf()-1,radial.Nbf());
+            for(size_t j=0;j<radial.Nbf();j++)
+              idx[ioff+j]=(Eigen::Index) (i*radial.Nbf()+j);
             ioff+=radial.Nbf();
           } else {
 	    // Just drop the first function
-            idx.subvec(ioff,ioff+radial.Nbf()-2)=arma::linspace<arma::uvec>(i*radial.Nbf()+1,(i+1)*radial.Nbf()-1,radial.Nbf()-1);
+            for(size_t j=0;j<radial.Nbf()-1;j++)
+              idx[ioff+j]=(Eigen::Index) (i*radial.Nbf()+1+j);
             ioff+=radial.Nbf()-1;
           }
         }
@@ -613,13 +609,13 @@ namespace helfem {
       }
 
       std::vector<Eigen::Index> TwoDBasis::m_indices(int m) const {
-        return helfem::collect_shell_indices(mval.n_elem,
+        return helfem::collect_shell_indices(mval.size(),
             [&](size_t i) { return (mval(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
             [&](size_t i) { return mval(i) == m; });
       }
 
       std::vector<Eigen::Index> TwoDBasis::m_indices(int m, bool odd) const {
-        return helfem::collect_shell_indices(mval.n_elem,
+        return helfem::collect_shell_indices(mval.size(),
             [&](size_t i) { return (mval(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
             [&](size_t i) { return mval(i) == m && (lval(i) % 2 == odd); });
       }
@@ -634,7 +630,7 @@ namespace helfem {
         } else if(symm==1) {
           // Unique m values in ascending order (matches arma::find_unique + sort).
           std::vector<int> mv;
-          for(size_t i=0;i<mval.n_elem;i++)
+          for(size_t i=0;i<mval.size();i++)
             if(std::find(mv.begin(),mv.end(),mval(i))==mv.end())
               mv.push_back(mval(i));
           std::sort(mv.begin(),mv.end());
@@ -645,7 +641,7 @@ namespace helfem {
         } else if(symm==2) {
           // Unique m values in ascending order (matches arma::find_unique + sort).
           std::vector<int> mv;
-          for(size_t i=0;i<mval.n_elem;i++)
+          for(size_t i=0;i<mval.size();i++)
             if(std::find(mv.begin(),mv.end(),mval(i))==mv.end())
               mv.push_back(mval(i));
           std::sort(mv.begin(),mv.end());
@@ -716,11 +712,11 @@ namespace helfem {
         // Full overlap matrix
         helfem::Matrix S(helfem::Matrix::Zero(Ndummy(),Ndummy()));
         // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.n_elem;jang++) {
+          for(size_t jang=0;jang<lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
@@ -752,10 +748,10 @@ namespace helfem {
         const size_t Ni(radial.Nbf());
         const size_t Nj(rh.radial.Nbf());
         helfem::Matrix S(helfem::Matrix::Zero(Ndummy(), rh.Ndummy()));
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
-          for(size_t jang=0;jang<rh.lval.n_elem;jang++) {
+          for(size_t jang=0;jang<rh.lval.size();jang++) {
             int lj(rh.lval(jang));
             int mj(rh.mval(jang));
             if(mi==mj) {
@@ -769,13 +765,13 @@ namespace helfem {
         }
         S *= std::pow(Rhalf, 3);
         // Trim boundaries on both sides so shapes align with Sinvh_new /
-        // Sinvh_old. pure_indices() (kept arma) gives the gather lists.
-        arma::uvec ridx(pure_indices());
-        arma::uvec cidx(rh.pure_indices());
-        helfem::Matrix Strim(ridx.n_elem, cidx.n_elem);
-        for(size_t a=0;a<ridx.n_elem;a++)
-          for(size_t b=0;b<cidx.n_elem;b++)
-            Strim(a,b)=S(ridx(a), cidx(b));
+        // Sinvh_old. pure_indices() gives the gather lists.
+        std::vector<Eigen::Index> ridx(pure_indices());
+        std::vector<Eigen::Index> cidx(rh.pure_indices());
+        helfem::Matrix Strim(ridx.size(), cidx.size());
+        for(size_t a=0;a<ridx.size();a++)
+          for(size_t b=0;b<cidx.size();b++)
+            Strim(a,b)=S(ridx[a], cidx[b]);
         return Strim;
       }
 
@@ -788,7 +784,7 @@ namespace helfem {
         // Full kinetic energy matrix
         helfem::Matrix T(helfem::Matrix::Zero(Ndummy(),Ndummy()));
         // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
           set_sub(T,iang,iang,Trad);
           if(lval(iang)!=0) {
             // We also get the l(l+1) term
@@ -815,11 +811,11 @@ namespace helfem {
         helfem::Matrix V(helfem::Matrix::Zero(Ndummy(),Ndummy()));
 
         // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.n_elem;jang++) {
+          for(size_t jang=0;jang<lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
@@ -853,11 +849,11 @@ namespace helfem {
         helfem::Matrix I13(radial.radial_integral(1,3));
 
         // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.n_elem;jang++) {
+          for(size_t jang=0;jang<lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
@@ -892,11 +888,11 @@ namespace helfem {
         helfem::Matrix I14(radial.radial_integral(1,4));
 
         // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.n_elem;jang++) {
+          for(size_t jang=0;jang<lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
@@ -936,11 +932,11 @@ namespace helfem {
         helfem::Matrix I32(radial.radial_integral(3,2)*std::pow(Rhalf,5));
 
         // Fill elements
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
           int li(lval(iang));
           int mi(mval(iang));
 
-          for(size_t jang=0;jang<lval.n_elem;jang++) {
+          for(size_t jang=0;jang<lval.size();jang++) {
             int lj(lval(jang));
             int mj(mval(jang));
 
@@ -1218,8 +1214,8 @@ namespace helfem {
         }
 
         // Form radial helpers: contract ket
-        for(size_t kang=0;kang<lval.n_elem;kang++) {
-          for(size_t lang=0;lang<lval.n_elem;lang++) {
+        for(size_t kang=0;kang<lval.size();kang++) {
+          for(size_t lang=0;lang<lval.size();lang++) {
             // l and m values
             int lk(lval(kang));
             int mk(mval(kang));
@@ -1356,8 +1352,8 @@ namespace helfem {
 
         // Full Coulomb matrix
         helfem::Matrix J(helfem::Matrix::Zero(Ndummy(),Ndummy()));
-        for(size_t iang=0;iang<lval.n_elem;iang++) {
-          for(size_t jang=0;jang<lval.n_elem;jang++) {
+        for(size_t iang=0;iang<lval.size();iang++) {
+          for(size_t jang=0;jang<lval.size();jang++) {
             // l and m values
             int li(lval(iang));
             int mi(mval(iang));
@@ -1416,8 +1412,8 @@ namespace helfem {
 #ifdef _OPENMP
 #pragma omp for collapse(2)
 #endif
-          for(size_t jang=0;jang<lval.n_elem;jang++) {
-            for(size_t kang=0;kang<lval.n_elem;kang++) {
+          for(size_t jang=0;jang<lval.size();jang++) {
+            for(size_t kang=0;kang<lval.size();kang++) {
               int lj(lval(jang));
               int mj(mval(jang));
 
@@ -1439,11 +1435,11 @@ namespace helfem {
               std::vector<bool> couple(lm_map.size(),false);
 
               // Perform angular sums
-              for(size_t iang=0;iang<lval.n_elem;iang++) {
+              for(size_t iang=0;iang<lval.size();iang++) {
                 int li(lval(iang));
                 int mi(mval(iang));
 
-                for(size_t lang=0;lang<lval.n_elem;lang++) {
+                for(size_t lang=0;lang<lval.size();lang++) {
                   int ll(lval(lang));
                   int ml(mval(lang));
 
@@ -1623,50 +1619,10 @@ namespace helfem {
         return Pnob;
       }
 
-      arma::mat TwoDBasis::remove_boundaries(const arma::mat & Fnob) const {
-        if(Fnob.n_rows != Ndummy() || Fnob.n_cols != Ndummy()) {
-          std::ostringstream oss;
-          oss << "Matrix does not have expected size! Got " << Fnob.n_rows << " x " << Fnob.n_cols << ", expected " << Ndummy() << " x " << Ndummy() << "!\n";
-          throw std::logic_error(oss.str());
-        }
-
-        // Get indices
-        arma::uvec idx(pure_indices());
-
-        // Matrix with the boundary conditions removed
-        arma::mat Fpure(Fnob(idx,idx));
-
-        //Fnob.print("Input: w/o built-in boundaries");
-        //Fpure.print("Output: w built-in boundaries");
-
-        return Fpure;
-      }
-
-      arma::mat TwoDBasis::expand_boundaries(const arma::mat & Ppure) const {
-        if(Ppure.n_rows != Nbf() || Ppure.n_cols != Nbf()) {
-          std::ostringstream oss;
-          oss << "Matrix does not have expected size! Got " << Ppure.n_rows << " x " << Ppure.n_cols << ", expected " << Nbf() << " x " << Nbf() << "!\n";
-          throw std::logic_error(oss.str());
-        }
-
-        // Get indices
-        arma::uvec idx(pure_indices());
-
-        // Matrix with the boundary conditions removed
-        arma::mat Pnob(Ndummy(),Ndummy());
-        Pnob.zeros();
-        Pnob(idx,idx)=Ppure;
-
-        //Ppure.print("Input: w built-in boundaries");
-        //Pnob.print("Output: w/o built-in boundaries");
-
-        return Pnob;
-      }
-
       Eigen::MatrixXcd TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, double phi) const {
         // Evaluate spherical harmonics
-        Eigen::VectorXcd sph(lval.n_elem);
-        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+        Eigen::VectorXcd sph(lval.size());
+        for(size_t i=0;i<(size_t) lval.size();i++)
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
         // Evaluate radial functions (single quadrature point, 1 x Nc row)
@@ -1674,8 +1630,8 @@ namespace helfem {
         const Eigen::Index Nc = rad.cols();
 
         // Form supermatrix. sph(i) is complex, rad is real -> cast rad.
-        Eigen::MatrixXcd bf(rad.rows(),lval.n_elem*Nc);
-        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+        Eigen::MatrixXcd bf(rad.rows(),lval.size()*Nc);
+        for(size_t i=0;i<(size_t) lval.size();i++)
           bf.middleCols(i*Nc,Nc)=sph(i)*rad.cast<std::complex<double>>();
 
         return bf;
@@ -1688,7 +1644,7 @@ namespace helfem {
       helfem::Matrix TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m, const helfem::Matrix & rad_all) const {
         // Figure out list of functions
         std::vector<size_t> flist;
-        for(size_t i=0;i<(size_t) mval.n_elem;i++)
+        for(size_t i=0;i<(size_t) mval.size();i++)
           if(mval(i)==m)
             flist.push_back(i);
 
@@ -1727,8 +1683,8 @@ namespace helfem {
 	x(0)=2.0*(mu-bval(iel))/(bval(iel+1)-bval(iel)) - 1.0;
 
 	// Evaluate spherical harmonics
-        Eigen::VectorXcd sph(lval.n_elem);
-        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+        Eigen::VectorXcd sph(lval.size());
+        for(size_t i=0;i<(size_t) lval.size();i++)
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
         // Evaluate radial functions (1 x Nc row)
         const helfem::Matrix rad(radial.get_bf(iel,x));
@@ -1740,7 +1696,7 @@ namespace helfem {
         // Form supermatrix. arma used trans() on a real matrix = plain
         // transpose; sph(i) is complex so cast the transposed radial row.
 	Eigen::VectorXcd bf(Eigen::VectorXcd::Zero(Ndummy()));
-	for(size_t i=0;i<(size_t) lval.n_elem;i++) {
+	for(size_t i=0;i<(size_t) lval.size();i++) {
 	  bf.segment(i*radial.Nbf()+ifirst,ilast-ifirst+1)=sph(i)*rad.transpose().cast<std::complex<double>>();
 	}
 
@@ -1749,8 +1705,8 @@ namespace helfem {
 
       void TwoDBasis::eval_df(size_t iel, size_t irad, double cth, double phi, Eigen::MatrixXcd & dr, Eigen::MatrixXcd & dth, Eigen::MatrixXcd & dphi) const {
         // Evaluate spherical harmonics
-        Eigen::VectorXcd sph(lval.n_elem);
-        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+        Eigen::VectorXcd sph(lval.size());
+        for(size_t i=0;i<(size_t) lval.size();i++)
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
         // Evaluate radial functions (single quadrature point, 1 x Nc rows)
@@ -1759,15 +1715,15 @@ namespace helfem {
         const Eigen::Index Nc = frad.cols();
 
         // Form supermatrices
-        dr = Eigen::MatrixXcd::Zero(frad.rows(),lval.n_elem*Nc);
-        dth = Eigen::MatrixXcd::Zero(frad.rows(),lval.n_elem*Nc);
-        dphi = Eigen::MatrixXcd::Zero(frad.rows(),lval.n_elem*Nc);
+        dr = Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*Nc);
+        dth = Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*Nc);
+        dphi = Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*Nc);
 
         // Radial one is easy (complex scalar * real matrix -> cast)
-        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+        for(size_t i=0;i<(size_t) lval.size();i++)
           dr.middleCols(i*Nc,Nc)=sph(i)*drad.cast<std::complex<double>>();
         // and so is phi
-        for(size_t i=0;i<(size_t) lval.n_elem;i++)
+        for(size_t i=0;i<(size_t) lval.size();i++)
           dphi.middleCols(i*Nc,Nc)=(std::complex<double>(0.0,mval(i))*sph(i))*frad.cast<std::complex<double>>();
         // sin^2(theta) = (1 - cth)(1 + cth) avoids the catastrophic
         // cancellation in 1 - cth*cth when cth is close to +/- 1.
@@ -1775,7 +1731,7 @@ namespace helfem {
         const double cotth = (sinth > 0.0) ? cth/sinth : 0.0;
 
         // but theta is nastier
-        for(size_t i=0;i<(size_t) lval.n_elem;i++) {
+        for(size_t i=0;i<(size_t) lval.size();i++) {
           int l(lval(i));
           int m(mval(i));
 
@@ -1792,7 +1748,7 @@ namespace helfem {
         // Functions belonging to this m block (same selection as
         // eval_bf(iel,irad,cth,m), so the columns line up).
         std::vector<size_t> flist;
-        for(size_t i=0;i<(size_t) mval.n_elem;i++)
+        for(size_t i=0;i<(size_t) mval.size();i++)
           if(mval(i)==m)
             flist.push_back(i);
 
@@ -1833,7 +1789,7 @@ namespace helfem {
         // Same function selection as eval_bf(iel,irad,cth,m) so the columns
         // line up.
         std::vector<size_t> flist;
-        for(size_t i=0;i<(size_t) mval.n_elem;i++)
+        for(size_t i=0;i<(size_t) mval.size();i++)
           if(mval(i)==m)
             flist.push_back(i);
 
@@ -1868,39 +1824,38 @@ namespace helfem {
         }
       }
 
-      arma::uvec TwoDBasis::dummy_idx_to_real_idx(const arma::uvec & idx) const {
-        if(arma::max(idx)>=Ndummy())
-          throw std::logic_error("Invalid index vector!\n");
+      std::vector<Eigen::Index> TwoDBasis::dummy_idx_to_real_idx(const std::vector<Eigen::Index> & idx) const {
+        for(size_t i=0;i<idx.size();i++)
+          if((size_t) idx[i]>=Ndummy())
+            throw std::logic_error("Invalid index vector!\n");
 
         // idx is a subset of dummy indices, which need to be
         // converted to real indices.  we just need to build the map
-        // from dummy to real indices. First, form full list of dummy
-        // indices
-        arma::uvec dummy_idx(arma::linspace<arma::uvec>(0,Ndummy()-1,Ndummy()));
-        // This is the corresponding list of real indices
-        arma::uvec real_idx(dummy_idx(pure_indices()));
+        // from dummy to real indices. pure_indices() is the list of
+        // real (dummy) indices, in real-index order.
+        const std::vector<Eigen::Index> real_idx(pure_indices());
         // Now the list has all the info needed to construct the
         // mapping between the two
-        std::map<arma::uword, arma::uword> mapping;
-        for(arma::uword i=0;i<real_idx.n_elem;i++) {
-          mapping[real_idx[i]] = i;
+        std::map<Eigen::Index, Eigen::Index> mapping;
+        for(size_t i=0;i<real_idx.size();i++) {
+          mapping[real_idx[i]] = (Eigen::Index) i;
         }
 
         // Mapped indices
-        std::vector<arma::uword> mapidx;
-        for(size_t i=0;i<idx.n_elem;i++) {
+        std::vector<Eigen::Index> mapidx;
+        for(size_t i=0;i<idx.size();i++) {
           // Try to find the function
-          std::map<arma::uword, arma::uword>::const_iterator pos(mapping.find(idx(i)));
+          std::map<Eigen::Index, Eigen::Index>::const_iterator pos(mapping.find(idx[i]));
           // Dummy functions are not on the map
           if(pos == mapping.end())
             continue;
           // If we are here, the function is real
-          mapidx.push_back(mapping.at(idx(i)));
+          mapidx.push_back(pos->second);
         }
-        return arma::conv_to<arma::uvec>::from(mapidx);
+        return mapidx;
       }
 
-      arma::uvec TwoDBasis::bf_list_dummy(size_t iel) const {
+      std::vector<Eigen::Index> TwoDBasis::bf_list_dummy(size_t iel) const {
         // Radial functions in element
         size_t ifirst, ilast;
         radial.get_idx(iel,ifirst,ilast);
@@ -1911,22 +1866,19 @@ namespace helfem {
         size_t Nrad(radial.Nbf());
 
         // List of functions in the element
-        arma::uvec idx(Nr*lval.n_elem);
-        for(size_t iam=0;iam<lval.n_elem;iam++)
+        std::vector<Eigen::Index> idx(Nr*lval.size());
+        for(size_t iam=0;iam<(size_t) lval.size();iam++)
           for(size_t j=0;j<Nr;j++)
-            idx(iam*Nr+j)=Nrad*iam+ifirst+j;
-
-        //printf("Basis function in element %i\n",(int) iel);
-        //idx.print();
+            idx[iam*Nr+j]=(Eigen::Index) (Nrad*iam+ifirst+j);
 
         return idx;
       }
 
-      arma::uvec TwoDBasis::bf_list(size_t iel) const {
+      std::vector<Eigen::Index> TwoDBasis::bf_list(size_t iel) const {
         return dummy_idx_to_real_idx(bf_list_dummy(iel));
       }
 
-      arma::uvec TwoDBasis::bf_list_dummy(size_t iel, int m) const {
+      std::vector<Eigen::Index> TwoDBasis::bf_list_dummy(size_t iel, int m) const {
         // Radial functions in element
         size_t ifirst, ilast;
         radial.get_idx(iel,ifirst,ilast);
@@ -1937,13 +1889,13 @@ namespace helfem {
         size_t Nrad(radial.Nbf());
 
         // List of functions in the element
-        std::vector<arma::uword> idx;
-        for(size_t iam=0;iam<lval.n_elem;iam++)
+        std::vector<Eigen::Index> idx;
+        for(size_t iam=0;iam<(size_t) lval.size();iam++)
           if(mval(iam)==m)
             for(size_t j=0;j<Nr;j++)
-              idx.push_back(Nrad*iam+ifirst+j);
+              idx.push_back((Eigen::Index) (Nrad*iam+ifirst+j));
 
-        return arma::conv_to<arma::uvec>::from(idx);
+        return idx;
       }
 
       size_t TwoDBasis::get_rad_Nel() const {
@@ -1962,12 +1914,12 @@ namespace helfem {
         return radial.get_d2f(iel);
       }
 
-      arma::vec TwoDBasis::get_wrad(size_t iel) const {
-        return helfem::to_arma(radial.get_wrad(iel));
+      helfem::Vector TwoDBasis::get_wrad(size_t iel) const {
+        return radial.get_wrad(iel);
       }
 
-      arma::vec TwoDBasis::get_r(size_t iel) const {
-        return helfem::to_arma(radial.get_r(iel));
+      helfem::Vector TwoDBasis::get_r(size_t iel) const {
+        return radial.get_r(iel);
       }
 
     }

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -127,9 +127,9 @@ namespace helfem {
         /// Radial basis set
         RadialBasis radial;
         /// Angular basis set: function l values
-        arma::ivec lval;
+        Eigen::VectorXi lval;
         /// Angular basis set: function m values
-        arma::ivec mval;
+        Eigen::VectorXi mval;
 
         /// Gaunt coefficient table
         gaunt::Gaunt gaunt;
@@ -214,14 +214,14 @@ namespace helfem {
         double get_Rhalf() const;
 
         /// Get l values
-        arma::ivec get_lval() const;
+        Eigen::VectorXi get_lval() const;
         /// Get m values
-        arma::ivec get_mval() const;
+        Eigen::VectorXi get_mval() const;
 
         /// Get number of quadrature points
         int get_nquad() const;
         /// Get boundary values
-        arma::vec get_bval() const;
+        helfem::Vector get_bval() const;
 	/// Get maximum mu value
 	double get_mumax() const;
         /// Get polynomial basis identifier
@@ -230,11 +230,7 @@ namespace helfem {
         int get_poly_nnodes() const;
 
         /// Get indices of real basis functions
-        arma::uvec pure_indices() const;
-        /// Expand boundary conditions
-        arma::mat expand_boundaries(const arma::mat & H) const;
-        /// Remove boundary conditions
-        arma::mat remove_boundaries(const arma::mat & H) const;
+        std::vector<Eigen::Index> pure_indices() const;
 
         /// Eigen-native boundary expansion / removal.
         ///
@@ -379,20 +375,20 @@ namespace helfem {
         ///                        - ( l(l+1) + m^2/sinh^2(mu) ) R ] Y_l^m.
         void eval_lf(size_t iel, size_t irad, double cth, int m, helfem::Matrix & lf) const;
         /// Translate dummy indices to real indices
-        arma::uvec dummy_idx_to_real_idx(const arma::uvec & idx) const;
+        std::vector<Eigen::Index> dummy_idx_to_real_idx(const std::vector<Eigen::Index> & idx) const;
         /// Get list of basis function dummy indices in element
-        arma::uvec bf_list_dummy(size_t iel) const;
+        std::vector<Eigen::Index> bf_list_dummy(size_t iel) const;
         /// Get list of basis function dummy indices in element with m=m
-        arma::uvec bf_list_dummy(size_t iel, int m) const;
+        std::vector<Eigen::Index> bf_list_dummy(size_t iel, int m) const;
         /// Get list of basis function indices in element
-        arma::uvec bf_list(size_t iel) const;
+        std::vector<Eigen::Index> bf_list(size_t iel) const;
 
         /// Get number of radial elements
         size_t get_rad_Nel() const;
         /// Get radial quadrature weights
-        arma::vec get_wrad(size_t iel) const;
+        helfem::Vector get_wrad(size_t iel) const;
         /// Get r values
-        arma::vec get_r(size_t iel) const;
+        helfem::Vector get_r(size_t iel) const;
         /// Get radial basis functions at the quadrature points of element iel
         /// (rows = radial points, cols = element primitives)
         helfem::Matrix get_rad_bf(size_t iel) const;

--- a/src/diatomic/completeness.cpp
+++ b/src/diatomic/completeness.cpp
@@ -19,6 +19,7 @@
 #include "../general/lcao.h"
 #include "basis.h"
 #include "twodquadrature.h"
+#include <ArmaEigen.h>
 #include <cfloat>
 #include <climits>
 
@@ -69,13 +70,14 @@ int main(int argc, char **argv) {
   loadchk.read("Z2",Z2);
 
   // Completeness probe
-  int lquad = (ldft>0) ? ldft : 4*arma::max(basis.get_lval())+12;
+  int lquad = (ldft>0) ? ldft : 4*basis.get_lval().maxCoeff()+12;
   helfem::diatomic::twodquad::TwoDGrid qgrid;
   qgrid=helfem::diatomic::twodquad::TwoDGrid(&basis,lquad);
   qgrid.compute_atoms(Z1,Z2);
 
-  // Unique m values
-  arma::ivec muni(basis.get_mval());
+  // Unique m values (get_mval is Eigen-typed; bridge to arma for this
+  // out-of-scope analysis path).
+  arma::ivec muni(helfem::to_arma(basis.get_mval()));
   muni=arma::sort(muni(arma::find_unique(muni)),"ascend");
 
   // Exponents
@@ -93,7 +95,7 @@ int main(int argc, char **argv) {
     {
       std::vector<arma::mat> minimal_basis;
       for(int l=std::abs(m);l<=completeness;l++) {
-        arma::mat proj = qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_LEFT);
+        arma::mat proj = helfem::to_arma(qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_LEFT));
         if(proj.n_elem) {
           minimal_basis.push_back(proj);
           nminimal += proj.n_rows;
@@ -102,7 +104,7 @@ int main(int argc, char **argv) {
         }
       }
       for(int l=std::abs(m);l<=completeness;l++) {
-        arma::mat proj = qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_RIGHT);
+        arma::mat proj = helfem::to_arma(qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_RIGHT));
         if(proj.n_elem) {
           minimal_basis.push_back(proj);
           nminimal += proj.n_rows;
@@ -196,9 +198,9 @@ int main(int argc, char **argv) {
           // LCAO projection <\alpha|FEM>
           arma::mat Plcao;
           if(iprobe==0) {
-            Plcao=qgrid.gto_projection(l, m, expbatch, probes[icen]);
+            Plcao=helfem::to_arma(qgrid.gto_projection(l, m, helfem::to_eigen(expbatch), probes[icen]));
           } else if(iprobe==1) {
-            Plcao=qgrid.sto_projection(l, m, expbatch, probes[icen]);
+            Plcao=helfem::to_arma(qgrid.sto_projection(l, m, helfem::to_eigen(expbatch), probes[icen]));
           } else
             throw std::logic_error("Unknown probe\n");
 

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -61,9 +61,9 @@ int main(int argc, char **argv) {
   if(nquad<=0)
     nquad=5*basis.get_poly_nnodes();
   if(lang<=0)
-    lang=4*arma::max(basis.get_lval())+12;
+    lang=4*basis.get_lval().maxCoeff()+12;
   if(mang<=0)
-    mang=4*arma::max(arma::abs(basis.get_mval()))+5;
+    mang=4*basis.get_mval().cwiseAbs().maxCoeff()+5;
 
   arma::vec cth, phi, wang;
   helfem::angular::angular_chebyshev(lang,mang,cth,phi,wang);
@@ -84,9 +84,10 @@ int main(int argc, char **argv) {
 
   // mu array
   std::vector<arma::vec> mu(basis.get_rad_Nel()), wmu(basis.get_rad_Nel());
+  // get_r / get_wrad are Eigen-typed; bridge for this arma-native analysis path.
   for(size_t iel=0;iel<mu.size();iel++) {
-    mu[iel]=basis.get_r(iel);
-    wmu[iel]=basis.get_wrad(iel);
+    mu[iel]=helfem::to_arma(basis.get_r(iel));
+    wmu[iel]=helfem::to_arma(basis.get_wrad(iel));
   }
 
   size_t Nradpts=mu.size()*mu[0].n_elem;
@@ -96,8 +97,8 @@ int main(int argc, char **argv) {
   size_t Ngrid = Nradpts*wang.n_elem;
 
   // Pretabulate basis function data
-  arma::ivec lval(basis.get_lval());
-  arma::ivec mval(basis.get_mval());
+  arma::ivec lval(helfem::to_arma(basis.get_lval()));
+  arma::ivec mval(helfem::to_arma(basis.get_mval()));
   arma::cx_mat sph(wang.n_elem,lval.n_elem);
   for(size_t il=0;il<lval.n_elem;il++)
     for(size_t iang=0;iang<wang.n_elem;iang++)
@@ -140,8 +141,11 @@ int main(int argc, char **argv) {
   // Loop over radial elements
   for(size_t iel=0;iel<mu.size();iel++) {
     // Get the list of basis functions in the element in the dummy
-    // indexing
-    arma::uvec bidx=basis.bf_list(iel);
+    // indexing (bf_list is Eigen-typed; bridge to arma::uvec here).
+    std::vector<Eigen::Index> bidx_v=basis.bf_list(iel);
+    arma::uvec bidx(bidx_v.size());
+    for(size_t i=0;i<bidx_v.size();i++)
+      bidx(i)=(arma::uword) bidx_v[i];
 
     // Orbital submatrices
     arma::mat Casub(Ca.cols(0,nela-1));
@@ -270,7 +274,7 @@ int main(int argc, char **argv) {
   savechk.write("Rh",basis.get_Rhalf());
   savechk.write("Z1",basis.get_Z1());
   savechk.write("Z2",basis.get_Z2());
-  int mmax = arma::max(basis.get_mval());
+  int mmax = basis.get_mval().maxCoeff();
   savechk.write("mmax",mmax);
 
   printf("Saved density to file %s\n",output.c_str());

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -132,9 +132,9 @@ namespace helfem {
         // Polarized calculation.
         polarized=true;
 
-        // Update density vector (expand_boundaries stays arma; bridge locally).
-        arma::mat Paexp(basp->expand_boundaries(helfem::to_arma(Pa0)));
-        arma::mat Pbexp(basp->expand_boundaries(helfem::to_arma(Pb0)));
+        // Update density vector.
+        helfem::Matrix Paexp(basp->expand_boundaries(Pa0));
+        helfem::Matrix Pbexp(basp->expand_boundaries(Pb0));
         helfem::Matrix Pa(bf_ind.size(), bf_ind.size());
         helfem::Matrix Pb(bf_ind.size(), bf_ind.size());
         for(size_t i=0;i<bf_ind.size();i++)
@@ -413,15 +413,11 @@ namespace helfem {
       // inherited from DFTGridWorkerBase.
 
       void DFTGridWorker::compute_bf(size_t iel, size_t irad) {
-        // Update function list (bf_list_dummy stays arma; bridge to indices).
-        arma::uvec bf_ind_arma(basp->bf_list_dummy(iel));
-        bf_ind.assign(bf_ind_arma.n_elem, 0);
-        for(size_t k=0;k<bf_ind_arma.n_elem;k++)
-          bf_ind[k]=(Eigen::Index) bf_ind_arma(k);
+        // Update function list
+        bf_ind=basp->bf_list_dummy(iel);
 
         // Get radial weights. Only do one radial quadrature point at a
         // time, since this is an easy way to save a lot of memory.
-        // (get_wrad / get_r return arma vectors; read the single point.)
         helfem::Vector wrad(1), r(1);
         wrad(0)=basp->get_wrad(iel)(irad);
         r(0)=basp->get_r(iel)(irad);
@@ -524,8 +520,7 @@ namespace helfem {
       }
 
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
-        // Eigen flows straight through the worker; only remove_boundaries at
-        // exit still bridges to arma.
+        // Eigen flows straight through the worker and remove_boundaries.
         helfem::Matrix H = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
 
         double exc=0.0;
@@ -536,7 +531,7 @@ namespace helfem {
           grid.check_grad_tau_lapl(x_func,c_func);
 
           for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
+            for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
               grid.compute_bf(iel,irad);
               grid.update_density(P_e);
               nel+=grid.compute_Nel();
@@ -563,8 +558,7 @@ namespace helfem {
       }
 
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, helfem::Matrix & Ha_e, helfem::Matrix & Hb_e, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {
-        // Eigen flows straight through the worker; only remove_boundaries at
-        // exit still bridges to arma.
+        // Eigen flows straight through the worker and remove_boundaries.
         helfem::Matrix Ha = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
         helfem::Matrix Hb = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
 
@@ -576,7 +570,7 @@ namespace helfem {
           grid.check_grad_tau_lapl(x_func,c_func);
 
           for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
+            for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
               grid.compute_bf(iel,irad);
               grid.update_density(Pa_e,Pb_e);
               nel+=grid.compute_Nel();

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -38,8 +38,8 @@ namespace helfem {
         wang = helfem::to_eigen(wang_a);
 
         // Distinct m values present in the basis
-        const arma::ivec mv(basp->get_mval());
-        for (size_t i = 0; i < mv.n_elem; i++) {
+        const Eigen::VectorXi mv(basp->get_mval());
+        for (size_t i = 0; i < (size_t) mv.size(); i++) {
           const int m = (int) mv(i);
           if (std::find(mlist.begin(), mlist.end(), m) == mlist.end())
             mlist.push_back(m);
@@ -48,7 +48,7 @@ namespace helfem {
 
         // Angular factors depend only on (l, m, nu) -- not on the radial point
         // -- so build them once here rather than per element / per radial point.
-        const arma::ivec lv(basp->get_lval());
+        const Eigen::VectorXi lv(basp->get_lval());
         const Eigen::Index nang = cth.size();
         lval_m.assign(mlist.size(), std::vector<int>());
         sph_m.assign(mlist.size(), std::vector<helfem::Vector>());
@@ -56,7 +56,7 @@ namespace helfem {
         for (size_t im = 0; im < mlist.size(); im++) {
           const int m = mlist[im];
           // Shells of this m block, in the order bf_list_dummy lists them
-          for (size_t i = 0; i < mv.n_elem; i++) {
+          for (size_t i = 0; i < (size_t) mv.size(); i++) {
             if ((int) mv(i) != m) continue;
             const int l = (int) lv(i);
             lval_m[im].push_back(l);
@@ -149,11 +149,8 @@ namespace helfem {
 
         for (size_t im = 0; im < nm; im++) {
           const int m = mlist[im];
-          const arma::uvec ind(basp->bf_list_dummy(iel, m));
-          bf_ind_m[im].resize(ind.n_elem);
-          for (size_t k = 0; k < ind.n_elem; k++)
-            bf_ind_m[im][k] = (Eigen::Index) ind(k);
-          const Eigen::Index nbf = (Eigen::Index) ind.n_elem;
+          bf_ind_m[im] = basp->bf_list_dummy(iel, m);
+          const Eigen::Index nbf = (Eigen::Index) bf_ind_m[im].size();
           if (!nbf) continue;
 
           bf_m[im] = helfem::Matrix::Zero(nbf, nang);
@@ -602,7 +599,7 @@ namespace helfem {
           grid.check_grad_tau_lapl(x_func, c_func);
 
           for (size_t iel = 0; iel < basp->get_rad_Nel(); iel++) {
-            for (size_t irad = 0; irad < basp->get_r(iel).n_elem; irad++) {
+            for (size_t irad = 0; irad < (size_t) basp->get_r(iel).size(); irad++) {
               grid.compute_bf(iel, irad);
               grid.update_density(P);
               nel  += grid.compute_Nel();
@@ -633,7 +630,7 @@ namespace helfem {
           grid.check_grad_tau_lapl(x_func, c_func);
 
           for (size_t iel = 0; iel < basp->get_rad_Nel(); iel++) {
-            for (size_t irad = 0; irad < basp->get_r(iel).n_elem; irad++) {
+            for (size_t irad = 0; irad < (size_t) basp->get_r(iel).size(); irad++) {
               grid.compute_bf(iel, irad);
               grid.update_density(Pa, Pb);
               nel  += grid.compute_Nel();

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
   // src/diatomic/main.cpp lines 318..328.
   std::vector<std::vector<std::vector<Eigen::Index>>> mavg_idx;
   if (maverage) {
-    const int mmax_bf = arma::max(arma::abs(basis.get_mval()));
+    const int mmax_bf = basis.get_mval().cwiseAbs().maxCoeff();
     for (int m = 0; m <= mmax_bf; ++m) {
       std::vector<std::vector<Eigen::Index>> entry;
       entry.push_back(basis.m_indices(m));

--- a/src/diatomic/purem_test.cpp
+++ b/src/diatomic/purem_test.cpp
@@ -173,22 +173,22 @@ int main(int argc, char **argv) {
     // shell, whose psi(mu=0,nu) function the boundary condition drops. So map
     // dummy -> real explicitly, and skip the dropped functions, which have no
     // real-basis counterpart to difference.
-    const arma::uvec pure(basis.pure_indices());
-    std::map<arma::uword, arma::uword> dummy2real;
-    for (size_t r = 0; r < pure.n_elem; r++)
-      dummy2real[pure(r)] = r;
+    const std::vector<Eigen::Index> pure(basis.pure_indices());
+    std::map<Eigen::Index, size_t> dummy2real;
+    for (size_t r = 0; r < pure.size(); r++)
+      dummy2real[pure[r]] = r;
 
     for (int m = 0; m <= std::min(mmax, 2); m++) {
       // A radial point comfortably inside the second element, and a few nu
       const size_t iel = std::min<size_t>(1, basis.get_rad_Nel() - 1);
-      const arma::vec rr(basis.get_r(iel));
+      const helfem::Vector rr(basis.get_r(iel));
       // The FEM basis is only C0 across element boundaries -- the second
       // derivative jumps -- so a finite-difference stencil must not step out
       // of the element. Gauss-Lobatto points cluster at the edges, so skip
       // any radial point within `edge` of a boundary.
-      const arma::vec bv(basis.get_bval());
+      const helfem::Vector bv(basis.get_bval());
       const double edge = 100.0 * 1e-4;
-      for (size_t irad = 0; irad < rr.n_elem; irad += 7) {
+      for (size_t irad = 0; irad < (size_t) rr.size(); irad += 7) {
         const double mu = rr(irad);
         if (mu - bv(iel) < edge || bv(iel + 1) - mu < edge) continue;
         nchecked++;
@@ -198,10 +198,10 @@ int main(int argc, char **argv) {
 
           // Map the m-block columns back to dummy indices so the same
           // function can be evaluated by eval_bf(mu, cth, phi).
-          const arma::uvec dummy(basis.bf_list_dummy(iel, m));
+          const std::vector<Eigen::Index> dummy(basis.bf_list_dummy(iel, m));
           const double d = 1e-4;
-          for (size_t k = 0; k < dummy.n_elem; k++) {
-            auto it = dummy2real.find(dummy(k));
+          for (size_t k = 0; k < dummy.size(); k++) {
+            auto it = dummy2real.find(dummy[k]);
             if (it == dummy2real.end()) continue;   // dropped by the m != 0 BC
             const double ana = lf(0, k);
             const double num = fd_laplacian(basis, it->second, m, mu, nu, Rhalf, d);

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -23,17 +23,6 @@
 #include <algorithm>
 #include <cmath>
 
-namespace {
-  // Convert an arma index list (from the still-arma TwoDBasis accessors)
-  // into the std::vector<Eigen::Index> form used by Eigen's indexed views.
-  static std::vector<Eigen::Index> to_index_vector(const arma::uvec & idx) {
-    std::vector<Eigen::Index> out(idx.n_elem);
-    for(size_t i=0;i<idx.n_elem;i++)
-      out[i]=static_cast<Eigen::Index>(idx(i));
-    return out;
-  }
-}
-
 // PBE ground states determined with 10 radial elements
 int pbe_ground_states[118][4] = {
   { 1, 0, 0, 0},     //   1  H
@@ -177,7 +166,7 @@ namespace helfem {
         // Store m
         m=m_;
         // Update function list
-        bf_ind=to_index_vector(basp->bf_list_dummy(iel,m));
+        bf_ind=basp->bf_list_dummy(iel,m);
 
         // Get radial weights. Only do one radial quadrature point at a
         // time, since this is an easy way to save a lot of memory.
@@ -335,20 +324,20 @@ namespace helfem {
         }
       }
 
-      void TwoDGridWorker::gto(int l, const arma::vec & expn, probe_t p) {
+      void TwoDGridWorker::gto(int l, const helfem::Vector & expn, probe_t p) {
         std::function<helfem::Vector(double r)> compute_gto = [expn, l](double r) {
-          helfem::Vector f(expn.n_elem);
-          for(size_t ix=0;ix<expn.n_elem;ix++)
+          helfem::Vector f(expn.size());
+          for(size_t ix=0;ix<(size_t) expn.size();ix++)
             f(ix)=lcao::radial_GTO(r,l,expn(ix));
           return f;
         };
         ao_projection(compute_gto, p);
       }
 
-      void TwoDGridWorker::sto(int l, const arma::vec & expn, probe_t p) {
+      void TwoDGridWorker::sto(int l, const helfem::Vector & expn, probe_t p) {
         std::function<helfem::Vector(double r)> compute_sto = [expn, l](double r) {
-          helfem::Vector f(expn.n_elem);
-          for(size_t ix=0;ix<expn.n_elem;ix++)
+          helfem::Vector f(expn.size());
+          for(size_t ix=0;ix<(size_t) expn.size();ix++)
             f(ix)=lcao::radial_STO(r,l,expn(ix));
           return f;
         };
@@ -384,16 +373,21 @@ namespace helfem {
       helfem::Matrix TwoDGrid::model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2) {
         helfem::Matrix H = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
 
-        // Get unique m values in basis set (get_mval is still arma-typed).
-        arma::ivec muni(basp->get_mval());
-        muni=muni(arma::find_unique(muni));
+        // Get unique m values in basis set. eval_pot accumulates into H
+        // additively per m, so the iteration order does not affect the result.
+        const Eigen::VectorXi mvals(basp->get_mval());
+        std::vector<int> muni;
+        for(Eigen::Index i=0;i<mvals.size();i++)
+          if(std::find(muni.begin(),muni.end(),mvals(i))==muni.end())
+            muni.push_back(mvals(i));
+        std::sort(muni.begin(),muni.end());
         {
           TwoDGridWorker grid(basp,lang);
 
-          for(size_t im=0;im<muni.n_elem;im++) {
+          for(size_t im=0;im<muni.size();im++) {
             for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-              for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
-                grid.compute_bf(iel,irad,muni(im));
+              for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+                grid.compute_bf(iel,irad,muni[im]);
                 grid.model_potential(p1, p2);
                 grid.eval_pot(H);
               }
@@ -406,12 +400,12 @@ namespace helfem {
         return basp->remove_boundaries(H);
       }
 
-      arma::mat TwoDGrid::gto_projection(int l, int m, const arma::vec & expn, probe_t p) {
-        helfem::Matrix S = helfem::Matrix::Zero(expn.n_elem,basp->Ndummy());
+      helfem::Matrix TwoDGrid::gto_projection(int l, int m, const helfem::Vector & expn, probe_t p) {
+        helfem::Matrix S = helfem::Matrix::Zero(expn.size(),basp->Ndummy());
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
+          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.gto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -419,15 +413,15 @@ namespace helfem {
           }
         }
 
-        return helfem::to_arma(helfem::Matrix(S(Eigen::all,to_index_vector(basp->pure_indices()))));
+        return S(Eigen::all,basp->pure_indices());
       }
 
-      arma::mat TwoDGrid::gto_overlap(int l, int m, const arma::vec & expn, probe_t p) {
-        helfem::Matrix S = helfem::Matrix::Zero(expn.n_elem,expn.n_elem);
+      helfem::Matrix TwoDGrid::gto_overlap(int l, int m, const helfem::Vector & expn, probe_t p) {
+        helfem::Matrix S = helfem::Matrix::Zero(expn.size(),expn.size());
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
+          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.gto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -435,15 +429,15 @@ namespace helfem {
           }
         }
 
-        return helfem::to_arma(S);
+        return S;
       }
 
-      arma::mat TwoDGrid::sto_projection(int l, int m, const arma::vec & expn, probe_t p) {
-        helfem::Matrix S = helfem::Matrix::Zero(expn.n_elem,basp->Ndummy());
+      helfem::Matrix TwoDGrid::sto_projection(int l, int m, const helfem::Vector & expn, probe_t p) {
+        helfem::Matrix S = helfem::Matrix::Zero(expn.size(),basp->Ndummy());
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
+          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.sto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -451,15 +445,15 @@ namespace helfem {
           }
         }
 
-        return helfem::to_arma(helfem::Matrix(S(Eigen::all,to_index_vector(basp->pure_indices()))));
+        return S(Eigen::all,basp->pure_indices());
       }
 
-      arma::mat TwoDGrid::sto_overlap(int l, int m, const arma::vec & expn, probe_t p) {
-        helfem::Matrix S = helfem::Matrix::Zero(expn.n_elem,expn.n_elem);
+      helfem::Matrix TwoDGrid::sto_overlap(int l, int m, const helfem::Vector & expn, probe_t p) {
+        helfem::Matrix S = helfem::Matrix::Zero(expn.size(),expn.size());
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
+          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.sto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -467,28 +461,28 @@ namespace helfem {
           }
         }
 
-        return helfem::to_arma(S);
+        return S;
       }
 
-      arma::mat TwoDGrid::atomic_projection(int l, int m, probe_t p) {
+      helfem::Matrix TwoDGrid::atomic_projection(int l, int m, probe_t p) {
         helfem::Matrix C;
         sadatom::basis::TwoDBasis basis;
         if(p == PROBE_LEFT) {
           if((size_t) l>=(size_t) lh_occs.size())
-            return arma::mat();
+            return helfem::Matrix();
           int nocc = std::ceil(lh_occs(l)/(2.0*(2.0*l+1.0)));
           if(nocc==0)
             // empty matrix
-            return arma::mat();
+            return helfem::Matrix();
           C = lh_orbs[l].leftCols(nocc);
           basis = lh_basis;
         } else if(p == PROBE_RIGHT) {
           if((size_t) l>=(size_t) rh_occs.size())
-            return arma::mat();
+            return helfem::Matrix();
           int nocc = std::ceil(rh_occs(l)/(2.0*(2.0*l+1.0)));
           if(nocc==0)
             // empty matrix
-            return arma::mat();
+            return helfem::Matrix();
           C = rh_orbs[l].leftCols(nocc);
           basis = rh_basis;
         } else
@@ -503,7 +497,7 @@ namespace helfem {
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<basp->get_r(iel).n_elem;irad++) {
+          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.ao_projection(eval_ao, p);
             grid.multiply_Plm(l, m, p);
@@ -511,7 +505,7 @@ namespace helfem {
           }
         }
 
-        return helfem::to_arma(helfem::Matrix(S(Eigen::all,to_index_vector(basp->pure_indices()))));
+        return S(Eigen::all,basp->pure_indices());
       }
 
       void TwoDGrid::compute_atoms(int Zl, int Zr) {

--- a/src/diatomic/twodquadrature.h
+++ b/src/diatomic/twodquadrature.h
@@ -75,9 +75,9 @@ namespace helfem {
         /// Compute AO projection
         void ao_projection(const std::function<helfem::Vector(double r)> & compute_ao, probe_t p);
         /// Compute GTO projection
-        void gto(int l, const arma::vec & expn, probe_t p);
+        void gto(int l, const helfem::Vector & expn, probe_t p);
         /// Compute STO projection
-        void sto(int l, const arma::vec & expn, probe_t p);
+        void sto(int l, const helfem::Vector & expn, probe_t p);
         /// Multiply in the Legendre polynomial
         void multiply_Plm(int l, int m, probe_t p);
 
@@ -116,16 +116,16 @@ namespace helfem {
         helfem::Matrix model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2);
 
         /// Compute GTO projection
-        arma::mat gto_projection(int l, int m, const arma::vec & expn, probe_t p);
+        helfem::Matrix gto_projection(int l, int m, const helfem::Vector & expn, probe_t p);
         /// Compute GTO projection
-        arma::mat gto_overlap(int l, int m, const arma::vec & expn, probe_t p);
+        helfem::Matrix gto_overlap(int l, int m, const helfem::Vector & expn, probe_t p);
         /// Compute STO projection
-        arma::mat sto_projection(int l, int m, const arma::vec & expn, probe_t p);
+        helfem::Matrix sto_projection(int l, int m, const helfem::Vector & expn, probe_t p);
         /// Compute STO overlap
-        arma::mat sto_overlap(int l, int m, const arma::vec & expn, probe_t p);
+        helfem::Matrix sto_overlap(int l, int m, const helfem::Vector & expn, probe_t p);
 
         /// Compute atomic orbital projection
-        arma::mat atomic_projection(int l, int m, probe_t p);
+        helfem::Matrix atomic_projection(int l, int m, probe_t p);
 
         /// Compute atoms
         void compute_atoms(int Zl, int Zr);

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -500,8 +500,9 @@ void Checkpoint::write(const helfem::atomic::basis::TwoDBasis & basis) {
   write("poly_nnodes",basis.get_poly_nnodes());
   write("zeroder",basis.get_zeroder());
 
-  write("lval",basis.get_lval());
-  write("mval",basis.get_mval());
+  // get_lval/get_mval are Eigen::VectorXi; bridge to arma for HDF5.
+  write("lval",helfem::to_arma(basis.get_lval()));
+  write("mval",helfem::to_arma(basis.get_mval()));
 
   if(cl) close();
 }
@@ -575,8 +576,9 @@ void Checkpoint::write(const helfem::diatomic::basis::TwoDBasis & basis) {
   write("poly_id",basis.get_poly_id());
   write("poly_nnodes",basis.get_poly_nnodes());
 
-  write("lval",basis.get_lval());
-  write("mval",basis.get_mval());
+  // get_lval/get_mval are Eigen::VectorXi; bridge to arma for HDF5.
+  write("lval",helfem::to_arma(basis.get_lval()));
+  write("mval",helfem::to_arma(basis.get_mval()));
 
   if(cl) close();
 }


### PR DESCRIPTION
Wave 2 of eliminating Armadillo from HelFEM (#24 / the "no arma left" campaign). Converts the **interior integer/vector storage and accessors** of the basis classes.

## Converted
* **`diatomic/basis.{h,cpp}`** — the interior `arma::ivec lval, mval` -> `Eigen::VectorXi`; `get_lval`/`get_mval` -> `Eigen::VectorXi`, `get_bval`/`get_r`/`get_wrad` -> `helfem::Vector`. All the Fock-path internal reads (`lval(i)`, `.n_elem`, `arma::max`) updated. arma count 39 -> 3.
* **`diatomic/twodquadrature.{h,cpp}`** — projection-helper boundaries to Eigen; 16 -> 2.
* Partial reduction in the atomic files (`TwoDBasis`, `basis`, `dftgrid`) for the pieces feeding the above.

Integer index vectors are precision-free, so this is pure container-type swapping -- no numeric algorithm touched.

## Correctness -- bit-exact
`gate_energy.sh` -> ALL PASS (atomic HF restricted+unrestricted, N2 LDA/GGA/mGGA symmetry=2, unrestricted O2 symmetry=2, gensap core-guess per-iteration -- all bit-identical to a master build). Diff audit: no self-aliasing `X=X.transpose()`, no non-`::Zero` matrix decls.

## Remaining (next waves)
The atomic **complex analysis evaluators** (`eval_bf`/`eval_df`/`eval_lf` -> `arma::cx_mat`) and the atomic grid helpers (`concatenate_grid`, `finite_nuclear_grid`) are the atomic counterpart of the diatomic analysis path -- a separate coherent wave. Bridges left where a genuinely out-of-scope consumer (Checkpoint HDF5) needs one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
