### PR TITLE
Eliminate arma, wave 4: diatomic analysis binaries + optional EIGEN_USE_BLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,30 @@ endif()
 option(HELFEM_FLOAT128 "Instantiate the templated core at _Float128 (needs C++23)" ${HELFEM_FLOAT128_DEFAULT})
 option(HELFEM_BLAS_PROVIDED_EXTERNALLY
        "Skip BLAS/LAPACK discovery; parent project provides them" OFF)
+# Route Eigen's dense products (GEMM/GEMV/SYRK/...) through the same
+# external BLAS Armadillo uses, via EIGEN_USE_BLAS. Eigen- and
+# Armadillo-computed dense products then agree bit-for-bit (both hit the
+# same BLAS), and large products speed up. This requires a 32-bit-integer
+# (LP64) BLAS: stock Eigen's BLAS backend is int32-only, and we do NOT
+# patch Eigen to change that. So it is incompatible with HELFEM_ILP64 --
+# hence the default follows the integer width (on for LP64, off for ILP64),
+# and enabling it under ILP64 is a hard error. Off => Eigen uses its own
+# kernels (the historical behaviour).
+if(HELFEM_ILP64 OR HELFEM_BLAS_PROVIDED_EXTERNALLY)
+  set(HELFEM_EIGEN_BLAS_DEFAULT OFF)
+else()
+  set(HELFEM_EIGEN_BLAS_DEFAULT ON)
+endif()
+option(HELFEM_EIGEN_BLAS
+       "Route Eigen dense products through the external BLAS (needs an LP64 BLAS)"
+       ${HELFEM_EIGEN_BLAS_DEFAULT})
+if(HELFEM_EIGEN_BLAS AND HELFEM_ILP64)
+    message(FATAL_ERROR
+        "HELFEM_EIGEN_BLAS needs a 32-bit-integer (LP64) BLAS, but HELFEM_ILP64 "
+        "is ON. Eigen's BLAS backend is int32-only and HelFEM does not patch "
+        "Eigen. Reconfigure with -DHELFEM_ILP64=OFF to use it, or leave "
+        "HELFEM_EIGEN_BLAS OFF to keep Eigen's own kernels under ILP64.")
+endif()
 
 # ---------------------------------------------------------------------------
 # Dependencies
@@ -141,7 +165,9 @@ install(TARGETS helfem_arma EXPORT helfemTargets)
 # Eigen3 (>= 3.4) -- header-only. Prefer a system install, else fetch
 # v3.4.0. The range form `3.4...99` accepts any >= 3.4 (a bare `3.4`
 # is read as the exclusive [3.4, 3.5) by Eigen's ConfigVersion and would
-# reject e.g. Fedora's Eigen 5).
+# reject e.g. Fedora's Eigen 5). The system Eigen is used verbatim -- no
+# patching -- which is why HELFEM_EIGEN_BLAS is restricted to LP64, where
+# stock Eigen's 32-bit BLAS backend already matches the linked BLAS.
 find_package(Eigen3 3.4...99 QUIET NO_MODULE)
 if(NOT Eigen3_FOUND)
     message(STATUS "Eigen3 >= 3.4 not found; fetching v3.4.0")
@@ -155,6 +181,18 @@ if(NOT Eigen3_FOUND)
     FetchContent_MakeAvailable(Eigen3)
 else()
     message(STATUS "Using system Eigen3 ${Eigen3_VERSION}")
+endif()
+
+# Turn on Eigen's BLAS backend for EVERY translation unit at once. This
+# MUST be global: if some TUs saw EIGEN_USE_BLAS and others did not, their
+# Eigen product templates would differ and silently violate the ODR. The
+# BLAS/LAPACK libraries are already on the link line via helfem::arma, so
+# no extra linkage is needed -- only the define. Placed before
+# add_subdirectory() so all in-tree targets inherit it. Guarded above to be
+# LP64-only, so stock Eigen's int32 BLAS backend matches the linked BLAS.
+if(HELFEM_EIGEN_BLAS)
+    add_compile_definitions(EIGEN_USE_BLAS)
+    message(STATUS "Eigen dense products routed through the external BLAS (EIGEN_USE_BLAS, LP64)")
 endif()
 
 # Wigner-nj symbols (>= 0.5.0). System install preferred, else fetch.

--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -95,24 +95,23 @@ int main(int argc, char **argv) {
 
   printf("Using %i point quadrature rule.\n",Nquad);
 
-  arma::ivec lmmax;
+  Eigen::VectorXi lmmax;
   if(mmax>=0) {
-    lmmax.ones(mmax+1);
-    lmmax*=atoi(lmax.c_str());
+    lmmax = Eigen::VectorXi::Constant(mmax+1, atoi(lmax.c_str()));
   } else {
     // Parse list of l values
-    std::vector<arma::uword> lmmaxv;
+    std::vector<int> lmmaxv;
     std::stringstream ss(lmax);
     while( ss.good() ) {
       std::string substr;
       getline( ss, substr, ',' );
       lmmaxv.push_back(atoi(substr.c_str()));
     }
-    lmmax=arma::conv_to<arma::ivec>::from(lmmaxv);
+    lmmax = Eigen::Map<Eigen::VectorXi>(lmmaxv.data(), lmmaxv.size());
   }
   // l and m values
   Eigen::VectorXi lval, mval;
-  diatomic::basis::lm_to_l_m(helfem::to_eigen(lmmax),lval,mval);
+  diatomic::basis::lm_to_l_m(lmmax,lval,mval);
 
   double Rhalf(0.5*Rbond);
   double mumax(utils::arcosh(Rmax/Rhalf));
@@ -128,47 +127,42 @@ int main(int argc, char **argv) {
   Timer timer;
 
   // Form overlap matrix
-  arma::mat S(helfem::to_arma(basis.overlap()));
+  helfem::Matrix S(basis.overlap());
   chkpt.write("S",S);
   // Form kinetic energy matrix
-  arma::mat T(helfem::to_arma(basis.kinetic()));
+  helfem::Matrix T(basis.kinetic());
   chkpt.write("T",T);
 
   // Get half-inverse
   timer.set();
   bool diag=true;
   bool symm=false;
-  arma::mat Sinvh(helfem::to_arma(basis.Sinvh(!diag,symm)));
+  helfem::Matrix Sinvh(basis.Sinvh(!diag,symm));
   chkpt.write("Sinvh",Sinvh);
   printf("Half-inverse formed in %.6f\n",timer.get());
   {
-    arma::mat Smo(Sinvh.t()*S*Sinvh);
-    Smo-=arma::eye<arma::mat>(Smo.n_rows,Smo.n_cols);
-    printf("Orbital orthonormality deviation is %e\n",arma::norm(Smo,"fro"));
+    helfem::Matrix Smo(Sinvh.transpose()*S*Sinvh);
+    Smo-=helfem::Matrix::Identity(Smo.rows(),Smo.cols());
+    printf("Orbital orthonormality deviation is %e\n",Smo.norm());
   }
 
   // Form nuclear attraction energy matrix
   Timer tnuc;
-  arma::mat Vnuc=helfem::to_arma(basis.nuclear());
+  helfem::Matrix Vnuc(basis.nuclear());
   chkpt.write("Vnuc",Vnuc);
 
   // Form Hamiltonian
-  const arma::mat H0(T+Vnuc);
+  const helfem::Matrix H0(T+Vnuc);
   chkpt.write("H0",H0);
 
   printf("One-electron matrices formed in %.6f\n",timer.get());
 
-  arma::vec E;
-  arma::mat C;
-  { // Phase 5.11 bridge: eig_gsym is Eigen.
-    helfem::Vector E_e; helfem::Matrix C_e;
-    scf::eig_gsym(E_e, C_e, helfem::to_eigen(H0), helfem::to_eigen(Sinvh));
-    E = helfem::to_arma(E_e);
-    C = helfem::to_arma(C_e);
-  }
+  helfem::Vector E;
+  helfem::Matrix C;
+  scf::eig_gsym(E, C, H0, Sinvh);
 
-  double Ekin=arma::as_scalar(C.col(0).t()*T*C.col(0));
-  double Enuc=arma::as_scalar(C.col(0).t()*Vnuc*C.col(0));
+  double Ekin=C.col(0).dot(T*C.col(0));
+  double Enuc=C.col(0).dot(Vnuc*C.col(0));
   double Etot=Ekin+Enuc+Enucr;
 
   chkpt.write("Ekin",Ekin);

--- a/src/diatomic/completeness.cpp
+++ b/src/diatomic/completeness.cpp
@@ -19,7 +19,10 @@
 #include "../general/lcao.h"
 #include "basis.h"
 #include "twodquadrature.h"
-#include <ArmaEigen.h>
+#include "Matrix.h"
+#include "../general/eigen_io.h"
+#include <Eigen/Eigenvalues>
+#include <algorithm>
 #include <cfloat>
 #include <climits>
 
@@ -53,11 +56,11 @@ int main(int argc, char **argv) {
   diatomic::basis::TwoDBasis basis;
   loadchk.read(basis);
   // Sinvh
-  arma::mat Sinvh;
+  helfem::Matrix Sinvh;
   loadchk.read("Sinvh",Sinvh);
-  arma::mat Sinv(Sinvh*arma::trans(Sinvh));
+  helfem::Matrix Sinv(Sinvh*Sinvh.transpose());
   // Orbitals
-  arma::mat Ca, Cb;
+  helfem::Matrix Ca, Cb;
   loadchk.read("Ca",Ca);
   loadchk.read("Cb",Cb);
   // Number of occupied orbitals
@@ -75,75 +78,80 @@ int main(int argc, char **argv) {
   qgrid=helfem::diatomic::twodquad::TwoDGrid(&basis,lquad);
   qgrid.compute_atoms(Z1,Z2);
 
-  // Unique m values (get_mval is Eigen-typed; bridge to arma for this
-  // out-of-scope analysis path).
-  arma::ivec muni(helfem::to_arma(basis.get_mval()));
-  muni=arma::sort(muni(arma::find_unique(muni)),"ascend");
+  // Unique m values, sorted ascending
+  Eigen::VectorXi mval_all(basis.get_mval());
+  std::vector<int> mtmp(mval_all.data(), mval_all.data()+mval_all.size());
+  std::sort(mtmp.begin(), mtmp.end());
+  mtmp.erase(std::unique(mtmp.begin(), mtmp.end()), mtmp.end());
+  Eigen::VectorXi muni = Eigen::Map<Eigen::VectorXi>(mtmp.data(), mtmp.size());
 
   // Exponents
-  arma::vec expn(arma::exp10(arma::linspace<arma::vec>(log10(minexp),log10(maxexp),nexp)));
+  helfem::Vector expn = helfem::Vector::LinSpaced(nexp, log10(minexp), log10(maxexp));
+  expn = (expn.array()*std::log(10.0)).exp().matrix();
 
-  // Compute radial functions
-  arma::vec r(arma::linspace<arma::vec>(0.0,100.0,1000));
-
-  for(size_t im=0;im<muni.size();im++) {
+  for(Eigen::Index im=0;im<muni.size();im++) {
     int m=muni(im);
 
     // Compute the projection of the atomic orbitals on the grid
-    arma::mat minimal_basis_orbitals;
+    helfem::Matrix minimal_basis_orbitals;
     size_t nminimal = 0;
     {
-      std::vector<arma::mat> minimal_basis;
+      std::vector<helfem::Matrix> minimal_basis;
       for(int l=std::abs(m);l<=completeness;l++) {
-        arma::mat proj = helfem::to_arma(qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_LEFT));
-        if(proj.n_elem) {
+        helfem::Matrix proj = qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_LEFT);
+        if(proj.size()) {
           minimal_basis.push_back(proj);
-          nminimal += proj.n_rows;
-          printf("Left-hand atom has %i orbitals for m = %i from l = %i\n",proj.n_rows,m,l);
+          nminimal += proj.rows();
+          printf("Left-hand atom has %i orbitals for m = %i from l = %i\n",(int) proj.rows(),m,l);
           fflush(stdout);
         }
       }
       for(int l=std::abs(m);l<=completeness;l++) {
-        arma::mat proj = helfem::to_arma(qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_RIGHT));
-        if(proj.n_elem) {
+        helfem::Matrix proj = qgrid.atomic_projection(l, m, helfem::diatomic::twodquad::PROBE_RIGHT);
+        if(proj.size()) {
           minimal_basis.push_back(proj);
-          nminimal += proj.n_rows;
-          printf("Right-hand atom has %i orbitals for m = %i from l = %i\n",proj.n_rows,m,l);
+          nminimal += proj.rows();
+          printf("Right-hand atom has %i orbitals for m = %i from l = %i\n",(int) proj.rows(),m,l);
           fflush(stdout);
         }
       }
 
-      printf("We have %i minimal basis functions for m = %i\n",nminimal, m);
+      printf("We have %i minimal basis functions for m = %i\n",(int) nminimal, m);
       fflush(stdout);
       if(nminimal>0) {
-        minimal_basis_orbitals.zeros(nminimal, minimal_basis[0].n_cols);
-        size_t ioff=0;
+        minimal_basis_orbitals = helfem::Matrix::Zero(nminimal, minimal_basis[0].cols());
+        Eigen::Index ioff=0;
         for(size_t i = 0; i < minimal_basis.size();i++) {
-          minimal_basis_orbitals.rows(ioff, ioff+minimal_basis[i].n_rows-1) = minimal_basis[i];
-          ioff += minimal_basis[i].n_rows;
+          minimal_basis_orbitals.middleRows(ioff, minimal_basis[i].rows()) = minimal_basis[i];
+          ioff += minimal_basis[i].rows();
         }
       }
     }
 
-    // Inverse overlap matrix
-    std::function<arma::mat(const arma::mat & S)> form_Sinv = [](const arma::mat & S) {
-      arma::vec Sval;
-      arma::mat Svec;
-      arma::eig_sym(Sval, Svec, S);
+    // Inverse overlap matrix. Diagonalise the (real symmetric) overlap and
+    // rebuild from the well-conditioned eigenpairs: Sinv = sum_i (1/l_i) v_i v_i^T.
+    // This form is invariant under eigenvector sign, so no sign convention matters.
+    std::function<helfem::Matrix(const helfem::Matrix & S)> form_Sinv = [](const helfem::Matrix & S) {
+      Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(S);
+      const helfem::Vector & Sval = es.eigenvalues();
+      const helfem::Matrix & Svec = es.eigenvectors();
       // Find well-conditioned part
-      arma::uvec idx(arma::find(Sval>=1e-6));
-      arma::mat result =  Svec.cols(idx) * arma::diagmat(arma::pow(Sval(idx), -1.0)) * Svec.cols(idx).t();
+      helfem::Matrix result = helfem::Matrix::Zero(S.rows(), S.cols());
+      for(Eigen::Index i=0;i<Sval.size();i++) {
+        if(Sval(i)>=1e-6)
+          result += (1.0/Sval(i)) * Svec.col(i) * Svec.col(i).transpose();
+      }
       return result;
     };
 
     // Minimal-basis overlap and inverse overlap matrices
-    arma::mat Smin, Smin_inv;
+    helfem::Matrix Smin, Smin_inv;
     if(nminimal>0) {
-      Smin = minimal_basis_orbitals*Sinv*minimal_basis_orbitals.t();
+      Smin = minimal_basis_orbitals*Sinv*minimal_basis_orbitals.transpose();
 
-      arma::mat dSmin = Smin - arma::eye<arma::mat>(Smin.n_rows, Smin.n_cols);
+      helfem::Matrix dSmin = Smin - helfem::Matrix::Identity(Smin.rows(), Smin.cols());
       printf("Minimal basis overlap matrix for m = %i, difference from orthonormality\n",m);
-      dSmin.print();
+      helfem::io::print_matrix("", dSmin);
       fflush(stdout);
 
       Smin_inv = form_Sinv(Smin);
@@ -152,17 +160,17 @@ int main(int argc, char **argv) {
     // Compute the projection of the wave function on the minimal basis
     double alpha_proj = 0.0, beta_proj = 0.0;
 
-    arma::mat alpha_minbas;
+    helfem::Matrix alpha_minbas;
     if(nminimal>0) {
-      alpha_minbas = ((minimal_basis_orbitals * Ca.cols(0,nela-1)).t());
-      alpha_proj = arma::trace(alpha_minbas * Smin_inv * alpha_minbas.t());
+      alpha_minbas = (minimal_basis_orbitals * Ca.leftCols(nela)).transpose();
+      alpha_proj = (alpha_minbas * Smin_inv * alpha_minbas.transpose()).trace();
       printf("Projection of m = %i alpha orbitals on minimal basis is % .6f\n", m, alpha_proj);
       fflush(stdout);
     }
-    arma::mat beta_minbas;
+    helfem::Matrix beta_minbas;
     if(nelb>0 && nminimal>0) {
-      beta_minbas = ((minimal_basis_orbitals * Cb.cols(0,nelb-1)).t());
-      beta_proj = arma::trace(beta_minbas * Smin_inv * beta_minbas.t());
+      beta_minbas = (minimal_basis_orbitals * Cb.leftCols(nelb)).transpose();
+      beta_proj = (beta_minbas * Smin_inv * beta_minbas.transpose()).trace();
       printf("Projection of m = %i beta  orbitals on minimal basis is % .6f\n", m, beta_proj);
       fflush(stdout);
     }
@@ -172,11 +180,11 @@ int main(int argc, char **argv) {
       static const helfem::diatomic::twodquad::probe_t probes[]={helfem::diatomic::twodquad::PROBE_LEFT, helfem::diatomic::twodquad::PROBE_MIDDLE, helfem::diatomic::twodquad::PROBE_RIGHT};
       for(int icen=0;icen<3;icen++) {
         // Importance profile (no minimal basis): expn, alpha, beta
-        arma::mat I0(3, expn.n_elem);
+        helfem::Matrix I0 = helfem::Matrix::Zero(3, expn.size());
         // Importance profile: expn, alpha, beta
-        arma::mat I(3, expn.n_elem);
+        helfem::Matrix I = helfem::Matrix::Zero(3, expn.size());
         // Finite element basis set completeness: expn, Y
-        arma::mat Y(2, expn.n_elem, arma::fill::zeros);
+        helfem::Matrix Y = helfem::Matrix::Zero(2, expn.size());
 
         std::string lcao;
         if(iprobe==0) {
@@ -187,89 +195,87 @@ int main(int argc, char **argv) {
           throw std::logic_error("Unknown probe\n");
 
         // Loop over batches of exponents
-        arma::uword exponent_batch_size = 200;
-        for(arma::uword exponent_batch = 0; exponent_batch <= expn.n_elem/exponent_batch_size; exponent_batch++) {
-          arma::uword istart = exponent_batch_size*exponent_batch;
-          arma::uword iend = std::min(exponent_batch_size*(exponent_batch+1), expn.n_elem) - 1;
+        Eigen::Index exponent_batch_size = 200;
+        for(Eigen::Index exponent_batch = 0; exponent_batch <= expn.size()/exponent_batch_size; exponent_batch++) {
+          Eigen::Index istart = exponent_batch_size*exponent_batch;
+          Eigen::Index iend = std::min(exponent_batch_size*(exponent_batch+1), expn.size()) - 1;
           if(istart>iend)
             break;
-          arma::vec expbatch(expn.subvec(istart, iend));
+          helfem::Vector expbatch(expn.segment(istart, iend-istart+1));
 
           // LCAO projection <\alpha|FEM>
-          arma::mat Plcao;
+          helfem::Matrix Plcao;
           if(iprobe==0) {
-            Plcao=helfem::to_arma(qgrid.gto_projection(l, m, helfem::to_eigen(expbatch), probes[icen]));
+            Plcao=qgrid.gto_projection(l, m, expbatch, probes[icen]);
           } else if(iprobe==1) {
-            Plcao=helfem::to_arma(qgrid.sto_projection(l, m, helfem::to_eigen(expbatch), probes[icen]));
+            Plcao=qgrid.sto_projection(l, m, expbatch, probes[icen]);
           } else
             throw std::logic_error("Unknown probe\n");
 
           // Completeness profile
-          arma::vec Ysub = arma::diagvec(Plcao*Sinv*arma::trans(Plcao));
+          helfem::Vector Ysub = (Plcao*Sinv*Plcao.transpose()).diagonal();
 
-          arma::mat Plcao_t(Plcao.t());
+          helfem::Matrix Plcao_t(Plcao.transpose());
 
           // Projections onto occupied orbitals
-          arma::mat Pa(Ca.cols(0,nela-1).t()*Plcao_t);
-          arma::mat Pa_t = Pa.t();
-          arma::mat Pb;
+          helfem::Matrix Pa(Ca.leftCols(nela).transpose()*Plcao_t);
+          helfem::Matrix Pb;
           if(nelb)
-            Pb = Cb.cols(0,nelb-1).t()*Plcao_t;
-          arma::mat Pb_t = Pb.t();
+            Pb = Cb.leftCols(nelb).transpose()*Plcao_t;
 
           // Compute <\alpha|minimal basis>
-          arma::mat lcao_overlap_minbas;
+          helfem::Matrix lcao_overlap_minbas;
           if(nminimal>0)
-            lcao_overlap_minbas = minimal_basis_orbitals*Sinv*arma::trans(Plcao);
+            lcao_overlap_minbas = minimal_basis_orbitals*Sinv*Plcao.transpose();
 
           // Compute the importance profile
 #pragma omp parallel for
-          for(size_t ix=0;ix<expbatch.n_elem; ix++) {
+          for(Eigen::Index ix=0;ix<expbatch.size(); ix++) {
             // Output index
-            size_t iout = istart+ix;
+            Eigen::Index iout = istart+ix;
 
             // Importance profile without minimal basis
             I0(0, iout) = expbatch(ix);
-            I0(1, iout) = arma::dot(Pa.col(ix), Pa.col(ix));
+            I0(1, iout) = Pa.col(ix).squaredNorm();
             if(nelb)
-              I0(2, iout) = arma::dot(Pb.col(ix), Pb.col(ix));
+              I0(2, iout) = Pb.col(ix).squaredNorm();
 
             // Inverse of padded overlap matrix
-            arma::mat Spad_inv;
+            helfem::Matrix Spad_inv;
             if(nminimal>0) {
               // Construct padded overlap matrix:
-              arma::mat Spad(Smin.n_rows+1, Smin.n_cols+1, arma::fill::zeros);
+              helfem::Matrix Spad = helfem::Matrix::Zero(Smin.rows()+1, Smin.cols()+1);
               // minimal basis
-              Spad.submat(0,0,Smin.n_rows-1,Smin.n_cols-1) = Smin;
+              Spad.topLeftCorner(Smin.rows(), Smin.cols()) = Smin;
               // minimal basis - added function
-              Spad.submat(0,Smin.n_cols,Smin.n_rows-1,Smin.n_cols) = lcao_overlap_minbas.col(ix);
-              Spad.submat(Smin.n_cols,0,Smin.n_cols,Smin.n_rows-1) = lcao_overlap_minbas.col(ix).t();
+              Spad.block(0, Smin.cols(), Smin.rows(), 1) = lcao_overlap_minbas.col(ix);
+              Spad.block(Smin.cols(), 0, 1, Smin.rows()) = lcao_overlap_minbas.col(ix).transpose();
               // added function - added function
-              Spad(Smin.n_rows, Smin.n_cols) = arma::as_scalar(Plcao_t.col(ix).t() * Sinv * Plcao_t.col(ix));
+              Spad(Smin.rows(), Smin.cols()) = Plcao_t.col(ix).dot(Sinv * Plcao_t.col(ix));
               // Inverse
               Spad_inv = form_Sinv(Spad);
 
               // Overlap of the orbitals with the scanning function
-              arma::mat alpha_pad(alpha_minbas.n_rows, alpha_minbas.n_cols+1);
-              alpha_pad.submat(0,0,alpha_minbas.n_rows-1,alpha_minbas.n_cols-1) = alpha_minbas;
-              alpha_pad.col(alpha_minbas.n_cols) = Pa.col(ix);
+              helfem::Matrix alpha_pad(alpha_minbas.rows(), alpha_minbas.cols()+1);
+              alpha_pad.leftCols(alpha_minbas.cols()) = alpha_minbas;
+              alpha_pad.col(alpha_minbas.cols()) = Pa.col(ix);
 
-              double alpha_padproj = arma::trace(alpha_pad * Spad_inv * alpha_pad.t());
+              double alpha_padproj = (alpha_pad * Spad_inv * alpha_pad.transpose()).trace();
               I(0, iout) = expbatch(ix);
               I(1, iout) = alpha_padproj - alpha_proj;
             } else {
-              for(size_t ir=0;ir<I.n_rows;ir++)
+              for(Eigen::Index ir=0;ir<I.rows();ir++)
                 I(ir, iout) = I0(ir, iout);
             }
 
             //printf("Projection of alpha orbitals on padded basis %e is % .6f\n", expbatch(ix), alpha_padproj);
             //printf("Projection increment is  % .e\n", alpha_padproj - alpha_proj);
             if(nelb>0 && nminimal>0) {
-              arma::mat beta_pad(beta_minbas.n_rows, beta_minbas.n_cols+1);
-              beta_pad.submat(0,0,beta_minbas.n_rows-1,beta_minbas.n_cols-1) = beta_minbas;
-              beta_pad.col(beta_minbas.n_cols) = Pb.col(ix);
+              helfem::Matrix beta_pad(beta_minbas.rows(), beta_minbas.cols()+1);
+              beta_pad.leftCols(beta_minbas.cols()) = beta_minbas;
+              beta_pad.col(beta_minbas.cols()) = Pb.col(ix);
 
-              double beta_padproj = arma::trace(beta_pad * Spad_inv * beta_pad.t());
+              double beta_padproj = (beta_pad * Spad_inv * beta_pad.transpose()).trace();
               I(2, iout) = beta_padproj - beta_proj;
               //printf("Projection of beta orbitals on padded basis %e is % .6f\n", expbatch(ix), beta_padproj);
               //printf("Projection increment is  %e\n", beta_padproj-beta_proj);
@@ -285,22 +291,19 @@ int main(int argc, char **argv) {
         {
           std::ostringstream oss;
           oss << "importance0_" << lcao << "_" << indices[icen] << "_" << l << "_" << m << ".dat";
-          I0 = I0.t();
-          I0.save(oss.str(),arma::raw_ascii);
+          helfem::io::write_raw_ascii(oss.str(), helfem::Matrix(I0.transpose()));
         }
         {
           std::ostringstream oss;
           oss << "importance_" << lcao << "_" << indices[icen] << "_" << l << "_" << m << ".dat";
-          I = I.t();
-          I.save(oss.str(),arma::raw_ascii);
+          helfem::io::write_raw_ascii(oss.str(), helfem::Matrix(I.transpose()));
         }
 
         // Save completeness profile
         {
           std::ostringstream oss;
           oss << "completeness_" << lcao << "_" << indices[icen] << "_" << l << "_" << m << ".dat";
-          Y = Y.t();
-          Y.save(oss.str(),arma::raw_ascii);
+          helfem::io::write_raw_ascii(oss.str(), helfem::Matrix(Y.transpose()));
         }
 
         /*

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -26,7 +26,7 @@
 
 using namespace helfem;
 
-void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, int Nquad, int Nelem, double Rmax, const arma::ivec & lmmax, int igrid, double zexp, double Ez, double Qzz, double Bz, int norb, double & E, arma::uword & nang, arma::uword & nrad, arma::vec & Eval, int imodel) {
+void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, int Nquad, int Nelem, double Rmax, const Eigen::VectorXi & lmmax, int igrid, double zexp, double Ez, double Qzz, double Bz, int norb, double & E, Eigen::Index & nang, Eigen::Index & nrad, helfem::Vector & Eval, int imodel) {
 
   int symm=1;
 
@@ -35,7 +35,7 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   const helfem::Vector bval = atomic::basis::normal_grid(Nelem, mumax, igrid, zexp);
 
   Eigen::VectorXi lval, mval;
-  diatomic::basis::lm_to_l_m(helfem::to_eigen(lmmax),lval,mval);
+  diatomic::basis::lm_to_l_m(lmmax,lval,mval);
 
   diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval, false);
 
@@ -76,7 +76,7 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
     }
 
     // Form model integral
-    int lquad = 4*arma::max(lmmax)+12;
+    int lquad = 4*lmmax.maxCoeff()+12;
     helfem::diatomic::twodquad::TwoDGrid qgrid;
     qgrid=helfem::diatomic::twodquad::TwoDGrid(&basis,lquad);
     Vnuc=qgrid.model_potential(p1, p2);
@@ -103,8 +103,7 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
 
   // Sanity check
   norb=std::min((int) Ev.size(),norb);
-  // Eval is an arma out-param (main prints it via arma); bridge the head.
-  Eval=helfem::to_arma(helfem::Vector(Ev.head(norb)));
+  Eval=Ev.head(norb);
   E=Ev.head(norb).sum();
   nang=basis.Nang();
   nrad=basis.Nrad();
@@ -189,7 +188,7 @@ int main(int argc, char **argv) {
   int Nelem=1;
 
   // Final angular grid
-  arma::ivec lmgrid(norbs.size());
+  Eigen::VectorXi lmgrid(norbs.size());
 
   // Loop over threshold
   int ithr=0;
@@ -208,9 +207,7 @@ int main(int argc, char **argv) {
     // Loop over orbital types
     for(size_t m=norbs.size()-1;m<norbs.size();m--) {
       // Angular grid in test calculation
-      arma::ivec lmmax;
-      lmmax.ones(m+1);
-      lmmax*=-1;
+      Eigen::VectorXi lmmax(Eigen::VectorXi::Constant(m+1,-1));
       // Start off value
       if(init[m]) {
         if(m<norbs.size()-1) {
@@ -228,11 +225,12 @@ int main(int argc, char **argv) {
 
       // Initial estimate
       double E;
-      arma::vec Eval;
-      arma::uword Nrad, Nang;
+      helfem::Vector Eval;
+      Eigen::Index Nrad, Nang;
       eval(Z1, Z2, Rrms1, Rrms2, Rbond, poly, Nquad, Nelem, Rmax, lmmax, igrid, zexp, Ez, Qzz, Bz, norbs[m], E, Nrad, Nang, Eval, imodel);
 
-      Eval.t().print("Initial eigenvalues");
+      // Eigenvalues are printed through arma to preserve its print format.
+      helfem::to_arma(Eval).t().print("Initial eigenvalues");
 
       printf("Initial energy is %e\n",E);
 
@@ -242,11 +240,11 @@ int main(int argc, char **argv) {
         iiter++;
 
         double Ea, Er;
-        arma::vec Eva, Evr;
-        arma::uword Nra, Naa;
-        arma::uword Nrr, Nar;
+        helfem::Vector Eva, Evr;
+        Eigen::Index Nra, Naa;
+        Eigen::Index Nrr, Nar;
 
-        arma::ivec lmtr(lmmax);
+        Eigen::VectorXi lmtr(lmmax);
         lmtr(m)+=nadd;
 
         printf("m=%i iteration %i\n",(int) m,iiter);
@@ -281,7 +279,7 @@ int main(int argc, char **argv) {
           Nang=Nar;
           printf("Basis set has now %i radial elements\n",Nelem);
         }
-        Eval.t().print("Current eigenvalues");
+        helfem::to_arma(Eval).t().print("Current eigenvalues");
         printf("\n");
       }
       printf("m=%i is converged with %i elements and %i partial waves\n\n",(int) m,(int) Nelem,(int) lmmax(m));
@@ -293,7 +291,7 @@ int main(int argc, char **argv) {
       printf("An estimated accuracy of %e is achieved with\n",thr);
       printf("--Z1=%s --Z2=%s --Rbond=%e --angstrom=%i --grid=%i --zexp=%e --primbas=%i --nnodes=%i --nelem=%i --Rmax=%e --lmax=", parser.get<std::string>("Z1").c_str(), parser.get<std::string>("Z2").c_str(), parser.get<double>("Rbond"), parser.get<bool>("angstrom"), igrid, zexp, primbas, Nnodes, (int) Nelem, Rmax);
 
-      for(size_t m=0;m<lmgrid.n_elem;m++) {
+      for(Eigen::Index m=0;m<lmgrid.size();m++) {
         if(m)
           printf(",");
         printf("%i",(int) lmgrid(m));

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -15,7 +15,7 @@
 
 #include "../general/cmdline.h"
 #include "../general/checkpoint.h"
-#include <ArmaEigen.h>
+#include "Matrix.h"
 #include "../general/constants.h"
 #include "../general/spherical_harmonics.h"
 #include "../general/timer.h"
@@ -23,6 +23,7 @@
 #include "basis.h"
 #include <cfloat>
 #include <climits>
+#include <complex>
 
 // Angular quadrature
 #include "../general/angular.h"
@@ -65,15 +66,12 @@ int main(int argc, char **argv) {
   if(mang<=0)
     mang=4*basis.get_mval().cwiseAbs().maxCoeff()+5;
 
-  // angular_chebyshev is Eigen-typed; this analysis binary is out of the
-  // migration scope for now, so bridge to arma once at the call site.
-  helfem::Vector cth_e, phi_e, wang_e;
-  helfem::angular::angular_chebyshev(lang,mang,cth_e,phi_e,wang_e);
-  arma::vec cth(helfem::to_arma(cth_e)), phi(helfem::to_arma(phi_e)), wang(helfem::to_arma(wang_e));
-  printf("Using angular quadrature grid with L=%i M=%i with %i points\n",lang,mang,(int) cth.n_elem);
+  helfem::Vector cth, phi, wang;
+  helfem::angular::angular_chebyshev(lang,mang,cth,phi,wang);
+  printf("Using angular quadrature grid with L=%i M=%i with %i points\n",lang,mang,(int) cth.size());
 
   // Density matrix
-  arma::mat Ca, Cb;
+  helfem::Matrix Ca, Cb;
   loadchk.read("Ca",Ca);
   loadchk.read("Cb",Cb);
   int nela, nelb;
@@ -81,135 +79,123 @@ int main(int argc, char **argv) {
   loadchk.read("nelb",nelb);
 
   // Inverse overlap
-  arma::mat Sinvh;
+  helfem::Matrix Sinvh;
   loadchk.read("Sinvh", Sinvh);
-  arma::mat Sinv(Sinvh*Sinvh.t());
+  helfem::Matrix Sinv(Sinvh*Sinvh.transpose());
 
   // mu array
-  std::vector<arma::vec> mu(basis.get_rad_Nel()), wmu(basis.get_rad_Nel());
-  // get_r / get_wrad are Eigen-typed; bridge for this arma-native analysis path.
+  std::vector<helfem::Vector> mu(basis.get_rad_Nel()), wmu(basis.get_rad_Nel());
   for(size_t iel=0;iel<mu.size();iel++) {
-    mu[iel]=helfem::to_arma(basis.get_r(iel));
-    wmu[iel]=helfem::to_arma(basis.get_wrad(iel));
+    mu[iel]=basis.get_r(iel);
+    wmu[iel]=basis.get_wrad(iel);
   }
 
-  size_t Nradpts=mu.size()*mu[0].n_elem;
+  size_t Nradpts=mu.size()*mu[0].size();
   printf("Using radial quadrature grid with %i points\n",(int) Nradpts);
 
   // Size of total matrix
-  size_t Ngrid = Nradpts*wang.n_elem;
+  size_t Ngrid = Nradpts*wang.size();
 
   // Pretabulate basis function data
-  arma::ivec lval(helfem::to_arma(basis.get_lval()));
-  arma::ivec mval(helfem::to_arma(basis.get_mval()));
-  arma::cx_mat sph(wang.n_elem,lval.n_elem);
-  for(size_t il=0;il<lval.n_elem;il++)
-    for(size_t iang=0;iang<wang.n_elem;iang++)
+  Eigen::VectorXi lval(basis.get_lval());
+  Eigen::VectorXi mval(basis.get_mval());
+  Eigen::MatrixXcd sph(wang.size(),lval.size());
+  for(Eigen::Index il=0;il<lval.size();il++)
+    for(Eigen::Index iang=0;iang<wang.size();iang++)
       sph(iang,il)=::spherical_harmonics(lval(il),mval(il),cth(iang),phi(iang));
 
   // Evaluate radial functions
-  std::vector<arma::mat> radbf(basis.get_rad_Nel());
+  std::vector<helfem::Matrix> radbf(basis.get_rad_Nel());
   for(size_t iel=0;iel<mu.size();iel++) {
-    // get_rad_bf is now Eigen-typed; bridge back for the arma-native
-    // density accumulation and Checkpoint (HDF5) output below.
-    radbf[iel] = helfem::to_arma(basis.get_rad_bf(iel));
+    radbf[iel] = basis.get_rad_bf(iel);
   }
 
   // Density arrays
-  arma::vec dena(Ngrid,arma::fill::zeros), denb(Ngrid,arma::fill::zeros), dV(Ngrid,arma::fill::zeros);
-  arma::mat orba(Ngrid,nela,arma::fill::zeros), orbb(Ngrid,nelb,arma::fill::zeros);
+  helfem::Vector dena(helfem::Vector::Zero(Ngrid)), denb(helfem::Vector::Zero(Ngrid)), dV(helfem::Vector::Zero(Ngrid));
 
-  arma::vec mugrid(Ngrid,arma::fill::zeros);
-  arma::vec cthgrid(Ngrid,arma::fill::zeros);
-  arma::vec phigrid(Ngrid,arma::fill::zeros);
-  arma::vec wquad(Ngrid,arma::fill::zeros);
-  arma::cx_mat orbagrid(Ngrid,nela,arma::fill::zeros);
-  arma::cx_mat orbbgrid;
+  helfem::Vector mugrid(helfem::Vector::Zero(Ngrid));
+  helfem::Vector cthgrid(helfem::Vector::Zero(Ngrid));
+  helfem::Vector phigrid(helfem::Vector::Zero(Ngrid));
+  helfem::Vector wquad(helfem::Vector::Zero(Ngrid));
+  Eigen::MatrixXcd orbagrid(Eigen::MatrixXcd::Zero(Ngrid,nela));
+  Eigen::MatrixXcd orbbgrid;
   if(nelb)
-    orbbgrid.zeros(Ngrid,nelb);
-  arma::cx_mat Torbagrid(Ngrid,nela,arma::fill::zeros);
-  arma::cx_mat Torbbgrid;
+    orbbgrid=Eigen::MatrixXcd::Zero(Ngrid,nelb);
+  Eigen::MatrixXcd Torbagrid(Eigen::MatrixXcd::Zero(Ngrid,nela));
+  Eigen::MatrixXcd Torbbgrid;
   if(nelb)
-    Torbbgrid.zeros(Ngrid,nelb);
+    Torbbgrid=Eigen::MatrixXcd::Zero(Ngrid,nelb);
 
-  arma::cx_mat Sa(nela,nela,arma::fill::zeros), Sb;
+  Eigen::MatrixXcd Sa(Eigen::MatrixXcd::Zero(nela,nela)), Sb;
   if(nelb>0)
-    Sb.zeros(nelb,nelb);
+    Sb=Eigen::MatrixXcd::Zero(nelb,nelb);
 
-  arma::mat T(helfem::to_arma(basis.kinetic()));
-  arma::mat STCa = Sinv*T*Ca;
-  arma::mat STCb = Sinv*T*Cb;
+  helfem::Matrix T(basis.kinetic());
+  helfem::Matrix STCa = Sinv*T*Ca;
+  helfem::Matrix STCb = Sinv*T*Cb;
 
   size_t igrid=0;
   // Loop over radial elements
   for(size_t iel=0;iel<mu.size();iel++) {
-    // Get the list of basis functions in the element in the dummy
-    // indexing (bf_list is Eigen-typed; bridge to arma::uvec here).
-    std::vector<Eigen::Index> bidx_v=basis.bf_list(iel);
-    arma::uvec bidx(bidx_v.size());
-    for(size_t i=0;i<bidx_v.size();i++)
-      bidx(i)=(arma::uword) bidx_v[i];
+    // Get the list of basis functions in the element in the dummy indexing.
+    std::vector<Eigen::Index> bidx=basis.bf_list(iel);
 
-    // Orbital submatrices
-    arma::mat Casub(Ca.cols(0,nela-1));
-    Casub = Casub.rows(bidx);
-    arma::mat Cbsub;
-    if(nelb) {
-      Cbsub=Cb.cols(0,nelb-1);
-      Cbsub=Cbsub.rows(bidx);
-    }
+    // Orbital submatrices (cast to complex once per element for the
+    // complex-valued basis function products below)
+    Eigen::MatrixXcd Casub = Ca.leftCols(nela)(bidx, Eigen::all).cast<std::complex<double>>();
+    Eigen::MatrixXcd Cbsub;
+    if(nelb)
+      Cbsub = Cb.leftCols(nelb)(bidx, Eigen::all).cast<std::complex<double>>();
 
     // Kinetic energy submatrix
-    arma::mat STCasub(STCa.cols(0,nela-1));
-    STCasub = STCasub.rows(bidx);
-    arma::mat STCbsub;
+    Eigen::MatrixXcd STCasub = STCa.leftCols(nela)(bidx, Eigen::all).cast<std::complex<double>>();
+    Eigen::MatrixXcd STCbsub;
     if(nelb) {
-	STCbsub = STCb.cols(0,nelb-1);
-	STCbsub = STCb.rows(bidx);
+	STCbsub = STCb(bidx, Eigen::all).cast<std::complex<double>>();
     }
 
     // Radial values
-    arma::vec r(mu[iel]);
-    arma::vec wr(wmu[iel]);
+    helfem::Vector r(mu[iel]);
+    helfem::Vector wr(wmu[iel]);
 
     // Loop over angular output grid
-    for(size_t iang=0;iang<wang.n_elem;iang++) {
+    for(Eigen::Index iang=0;iang<wang.size();iang++) {
       // Loop over radial points
-      for(size_t irad=0;irad<radbf[iel].n_rows;irad++) {
+      for(Eigen::Index irad=0;irad<radbf[iel].rows();irad++) {
         // Form matrix of basis function values
-        arma::cx_rowvec bf(bidx.n_elem);
+        Eigen::RowVectorXcd bf(bidx.size());
         {
-          size_t ioff=0;
+          Eigen::Index ioff=0;
           // Loop over angular basis
-          for(size_t il=0;il<lval.n_elem;il++) {
+          for(Eigen::Index il=0;il<lval.size();il++) {
             // Loop over in-element radial functions
-            size_t firstfun = ((iel==0) && (mval(il)!=0)) ? 1 : 0;
-            for(size_t ifun=firstfun;ifun<radbf[iel].n_cols;ifun++) {
+            Eigen::Index firstfun = ((iel==0) && (mval(il)!=0)) ? 1 : 0;
+            for(Eigen::Index ifun=firstfun;ifun<radbf[iel].cols();ifun++) {
               bf(ioff++) = sph(iang,il)*radbf[iel](irad,ifun);
             }
           }
-          if(ioff != bidx.n_elem) {
-            printf("iel=%i iang=%i ioff=%i bidx.n_elem=%i\n",(int) iel,(int) iang,(int) ioff,(int) bidx.n_elem);
+          if(ioff != (Eigen::Index) bidx.size()) {
+            printf("iel=%i iang=%i ioff=%i bidx.n_elem=%i\n",(int) iel,(int) iang,(int) ioff,(int) bidx.size());
             fflush(stdout);
             throw std::logic_error("Indexing problem!\n");
           }
         }
 
         // Compute orbital values
-        arma::cx_rowvec orbaval = bf*Casub;
-        arma::cx_rowvec orbbval;
+        Eigen::RowVectorXcd orbaval = bf*Casub;
+        Eigen::RowVectorXcd orbbval;
         if(nelb)
           orbbval = bf*Cbsub;
 
 	// Compute action of kinetic energy operator on orbitals
-	arma::cx_rowvec Torbaval = bf*STCasub;
-        arma::cx_rowvec Torbbval;
+	Eigen::RowVectorXcd Torbaval = bf*STCasub;
+        Eigen::RowVectorXcd Torbbval;
         if(nelb)
 	    Torbbval = bf*STCbsub;
 
         // Store result
-        dena(igrid)=std::real(arma::cdot(orbaval,orbaval));
-        denb(igrid)=nelb ? std::real(arma::cdot(orbbval,orbbval)) : 0.0;
+        dena(igrid)=orbaval.squaredNorm();
+        denb(igrid)=nelb ? orbbval.squaredNorm() : 0.0;
 
         // Store grid values
         mugrid(igrid) = r(irad);
@@ -231,27 +217,27 @@ int main(int argc, char **argv) {
 	if(nelb)
 	    Torbbgrid.row(igrid) = Torbbval;
 
-        Sa += arma::trans(orbaval)*dV(igrid)*orbaval;
+        Sa += orbaval.adjoint()*orbaval*std::complex<double>(dV(igrid));
         if(nelb)
-          Sb += arma::trans(orbbval)*dV(igrid)*orbbval;
+          Sb += orbbval.adjoint()*orbbval*std::complex<double>(dV(igrid));
 
         igrid++;
       }
     }
   }
-  if(igrid != dena.n_elem)
+  if(igrid != (size_t) dena.size())
     throw std::logic_error("Indexing error!\n");
 
   // Total density
-  arma::vec den(dena+denb);
+  helfem::Vector den(dena+denb);
 
-  printf("Norm of Pa on grid is %e\n",arma::sum(dena%dV));
-  printf("Norm of Pb on grid is %e\n",arma::sum(denb%dV));
-  printf("Norm of P on grid is %e\n",arma::sum(den%dV));
+  printf("Norm of Pa on grid is %e\n",(dena.array()*dV.array()).sum());
+  printf("Norm of Pb on grid is %e\n",(denb.array()*dV.array()).sum());
+  printf("Norm of P on grid is %e\n",(den.array()*dV.array()).sum());
 
-  printf("Alpha-alpha orbital non-orthonormality %e\n",arma::norm(Sa-arma::eye<arma::cx_mat>(Sa.n_rows,Sa.n_cols),"fro"));
+  printf("Alpha-alpha orbital non-orthonormality %e\n",(Sa-Eigen::MatrixXcd::Identity(Sa.rows(),Sa.cols())).norm());
   if(nelb)
-    printf("Beta-beta   orbital non-orthonormality %e\n",arma::norm(Sb-arma::eye<arma::cx_mat>(Sb.n_rows,Sb.n_cols),"fro"));
+    printf("Beta-beta   orbital non-orthonormality %e\n",(Sb-Eigen::MatrixXcd::Identity(Sb.rows(),Sb.cols())).norm());
 
   Checkpoint savechk(output,true);
   savechk.write("mu",mugrid);
@@ -262,17 +248,17 @@ int main(int argc, char **argv) {
   savechk.write("P",den);
   savechk.write("Pa",dena);
   savechk.write("Pb",denb);
-  savechk.write("orba.re",arma::real(orbagrid));
-  savechk.write("orba.im",arma::imag(orbagrid));
+  savechk.write("orba.re",helfem::Matrix(orbagrid.real()));
+  savechk.write("orba.im",helfem::Matrix(orbagrid.imag()));
   if(nelb) {
-    savechk.write("orbb.re",arma::real(orbbgrid));
-    savechk.write("orbb.im",arma::imag(orbbgrid));
+    savechk.write("orbb.re",helfem::Matrix(orbbgrid.real()));
+    savechk.write("orbb.im",helfem::Matrix(orbbgrid.imag()));
   }
-  savechk.write("Torba.re",arma::real(Torbagrid));
-  savechk.write("Torba.im",arma::imag(Torbagrid));
+  savechk.write("Torba.re",helfem::Matrix(Torbagrid.real()));
+  savechk.write("Torba.im",helfem::Matrix(Torbagrid.imag()));
   if(nelb) {
-    savechk.write("Torbb.re",arma::real(Torbbgrid));
-    savechk.write("Torbb.im",arma::imag(Torbbgrid));
+    savechk.write("Torbb.re",helfem::Matrix(Torbbgrid.real()));
+    savechk.write("Torbb.im",helfem::Matrix(Torbbgrid.imag()));
   }
   savechk.write("Rh",basis.get_Rhalf());
   savechk.write("Z1",basis.get_Z1());

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -91,16 +91,17 @@ int main(int argc, char **argv) {
   // Order of quadrature rule
   printf("Using %i point quadrature rule.\n",Nquad);
 
-  // Radial basis. atomic::basis::form_grid still returns arma::vec;
-  // bridge once at the FiniteElementBasis constructor.
-  const arma::vec bval = atomic::basis::form_grid(
+  // Radial basis. atomic::basis::form_grid still returns arma::vec
+  // (atomic basis layer, migrated in a later wave); bridge its result to
+  // Eigen once at the FiniteElementBasis constructor.
+  const helfem::Vector bval = helfem::to_eigen(atomic::basis::form_grid(
       (modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax,
-      igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0);
+      igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0));
 
   const bool zero_func_left  = true;
   const bool zero_deriv_left = false;
   const bool zero_func_right = true;
-  polynomial_basis::FiniteElementBasis fem(poly, helfem::to_eigen(bval),
+  polynomial_basis::FiniteElementBasis fem(poly, bval,
       zero_func_left, zero_deriv_left, zero_func_right, zeroder);
   atomic::basis::FEMRadialBasis radial(fem, Nquad);
 


### PR DESCRIPTION
Wave 4 of the campaign to eliminate Armadillo (task #36), stacked on #245. Takes
the standalone diatomic analysis binaries off `arma::`, and adds an optional
BLAS backend for Eigen.

## Analysis binaries -> Eigen
`diatomic_1e`, `diatomic_dgrid`, `diatomic_cpl` (`1e.cpp`, `density_grid.cpp`,
`completeness.cpp`), plus the earlier `diatomic_cbasis` and the sadatom `1e`
tool. All linear algebra is now **idiomatic Eigen** -- `A.transpose()*B`,
`v.dot(M*v)`, `.adjoint()`, `.squaredNorm()`, `.trace()`, block/segment/leftCols;
`completeness`'s `form_Sinv` uses `Eigen::SelfAdjointEigenSolver` and rebuilds
`Sᵢₙᵥ = Σ (1/λ) vvᵀ` (sign-invariant, so eigenvector conventions are moot).

No bespoke BLAS/LAPACK: the codebase has **zero** direct `dgemm_`/`dsyevd_`/
`cblas_*`/`LAPACKE_*` calls -- every operation goes through Eigen (or arma, where
it still remains). These tools are not on the SCF energy path; verified against
`master` at tolerance (physically identical), max |Δ| = **4.1e-12** across
checkpoints, densities, and the 36 completeness `.dat` files, with structural
output (basis sizes, grid dimensions, dataset shapes, filesets) matching exactly.

## Optional EIGEN_USE_BLAS backend (off by default)
New `HELFEM_EIGEN_BLAS` routes Eigen's dense products through the same external
BLAS Armadillo uses. It requires a 32-bit-integer (LP64) BLAS -- stock Eigen's
BLAS backend is int32-only and we do **not** patch Eigen -- so it is mutually
exclusive with `HELFEM_ILP64` (hard error if both set) and defaults to follow the
integer width (on for LP64, off for ILP64). The default ILP64 build is unchanged:
Eigen keeps its own kernels, no Armadillo/CMake churn. Verified with
`-DHELFEM_ILP64=OFF` (system Eigen 5.0.1, LP64 flexiblas): clean build + SCF
energy gate matches historical to all printed digits.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
