### PR TITLE
Eliminate arma, wave 5a: atomic complex evaluators + grid helpers

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -40,7 +40,7 @@ namespace helfem {
     namespace basis {
 
       // The routines that evaluate basis functions on a grid
-      // (eval_bf / eval_df / eval_lf) return arma::cx_mat and go through the
+      // (eval_bf / eval_df / eval_lf) return Eigen::MatrixXcd and go through the
       // double-only ::spherical_harmonics. They serve the DFT grid and the
       // analysis binaries, neither of which can run above double anyway (libxc
       // is a double-only C library), and none is on the Fock path. Rather than
@@ -53,8 +53,8 @@ namespace helfem {
         [[noreturn]] void double_only(const char *what) {
           throw std::logic_error(std::string(what) +
                                  " is only available at T = double "
-                                 "(it returns arma types / uses the "
-                                 "double-only spherical harmonics).\n");
+                                 "(it uses the double-only spherical "
+                                 "harmonics).\n");
         }
       }
 
@@ -1094,20 +1094,20 @@ namespace helfem {
       }
 
       template <typename T>
-      arma::cx_mat TwoDBasisT<T>::eval_bf(size_t iel, double cth, double phi) const {
+      Eigen::MatrixXcd TwoDBasisT<T>::eval_bf(size_t iel, double cth, double phi) const {
         if constexpr (std::is_same_v<T, double>) {
           // Evaluate spherical harmonics
-          arma::cx_vec sph(lval.size());
+          Eigen::VectorXcd sph(lval.size());
           for(size_t i=0;i<(size_t) lval.size();i++)
             sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
           // Evaluate radial functions
-          arma::mat rad(helfem::to_arma(radial.get_bf(iel)));
+          helfem::Matrix rad(radial.get_bf(iel));
 
           // Form supermatrix
-          arma::cx_mat bf(rad.n_rows,lval.size()*rad.n_cols);
+          Eigen::MatrixXcd bf(rad.rows(),lval.size()*rad.cols());
           for(size_t i=0;i<(size_t) lval.size();i++)
-            bf.cols(i*rad.n_cols,(i+1)*rad.n_cols-1)=sph(i)*rad;
+            bf.middleCols(i*rad.cols(),rad.cols())=sph(i)*rad.cast<std::complex<double>>();
 
           return bf;
         } else {
@@ -1117,28 +1117,28 @@ namespace helfem {
       }
 
       template <typename T>
-      void TwoDBasisT<T>::eval_df(size_t iel, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const {
+      void TwoDBasisT<T>::eval_df(size_t iel, double cth, double phi, Eigen::MatrixXcd & dr, Eigen::MatrixXcd & dth, Eigen::MatrixXcd & dphi) const {
         if constexpr (std::is_same_v<T, double>) {
           // Evaluate spherical harmonics
-          arma::cx_vec sph(lval.size());
+          Eigen::VectorXcd sph(lval.size());
           for(size_t i=0;i<(size_t) lval.size();i++)
             sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
           // Evaluate radial functions
-          arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
-          arma::mat drad(helfem::to_arma(radial.get_df(iel)));
+          helfem::Matrix frad(radial.get_bf(iel));
+          helfem::Matrix drad(radial.get_df(iel));
 
           // Form supermatrices
-          dr.zeros(frad.n_rows,lval.size()*frad.n_cols);
-          dth.zeros(frad.n_rows,lval.size()*frad.n_cols);
-          dphi.zeros(frad.n_rows,lval.size()*frad.n_cols);
+          dr=Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*frad.cols());
+          dth=Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*frad.cols());
+          dphi=Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*frad.cols());
 
           // Radial one is easy
           for(size_t i=0;i<(size_t) lval.size();i++)
-            dr.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=sph(i)*drad;
+            dr.middleCols(i*frad.cols(),frad.cols())=sph(i)*drad.cast<std::complex<double>>();
           // and so is phi
           for(size_t i=0;i<(size_t) lval.size();i++)
-            dphi.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=std::complex<double>(0.0,mval(i))*sph(i)*frad;
+            dphi.middleCols(i*frad.cols(),frad.cols())=(std::complex<double>(0.0,mval(i))*sph(i))*frad.cast<std::complex<double>>();
           // sin^2(theta) = (1 - cth)(1 + cth) is algebraically identical to
           // 1 - cth*cth but avoids the catastrophic cancellation when cth is
           // close to +/- 1. The std::max(..., 0.0) is a paranoia floor for
@@ -1159,7 +1159,7 @@ namespace helfem {
             if(mval(i)<lval(i))
               angfac+=sqrt((l-m)*(l+m+1))*std::exp(std::complex<double>(0,-phi))*::spherical_harmonics(lval(i),mval(i)+1,cth,phi);
 
-            dth.cols(i*frad.n_cols,(i+1)*frad.n_cols-1)=angfac*frad;
+            dth.middleCols(i*frad.cols(),frad.cols())=angfac*frad.cast<std::complex<double>>();
           }
         } else {
           (void) iel; (void) cth; (void) phi; (void) dr; (void) dth; (void) dphi;
@@ -1168,27 +1168,27 @@ namespace helfem {
       }
 
       template <typename T>
-      arma::cx_mat TwoDBasisT<T>::eval_lf(size_t iel, double cth, double phi) const {
+      Eigen::MatrixXcd TwoDBasisT<T>::eval_lf(size_t iel, double cth, double phi) const {
         if constexpr (std::is_same_v<T, double>) {
           // Evaluate spherical harmonics
-          arma::cx_vec sph(lval.size());
+          Eigen::VectorXcd sph(lval.size());
           for(size_t i=0;i<(size_t) lval.size();i++)
             sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
           // Evaluate radial functions
-          arma::vec r(helfem::to_arma(radial.get_r(iel)));
-          arma::mat frad(helfem::to_arma(radial.get_bf(iel)));
-          arma::mat drad(helfem::to_arma(radial.get_df(iel)));
-          arma::mat lrad(helfem::to_arma(radial.get_lf(iel)));
+          helfem::Vector r(radial.get_r(iel));
+          helfem::Matrix frad(radial.get_bf(iel));
+          helfem::Matrix drad(radial.get_df(iel));
+          helfem::Matrix lrad(radial.get_lf(iel));
 
           // Form supermatrix
-          arma::cx_mat lf(frad.n_rows,lval.size()*frad.n_cols,arma::fill::zeros);
+          Eigen::MatrixXcd lf(Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*frad.cols()));
           // Loop over basis function indices
           for(size_t iang=0;iang<(size_t) lval.size();iang++)
-            for(size_t irad=0;irad<frad.n_cols;irad++)
+            for(Eigen::Index irad=0;irad<frad.cols();irad++)
               // Loop over grid-point indices
-              for(size_t igrid=0;igrid<frad.n_rows;igrid++)
-                lf(igrid,iang*frad.n_cols+irad) = (lrad(igrid,irad) + 2*drad(igrid,irad)/r(igrid) - lval(iang)*(lval(iang)+1)*frad(igrid,irad)/(r(igrid)*r(igrid)))*sph(iang);
+              for(Eigen::Index igrid=0;igrid<frad.rows();igrid++)
+                lf(igrid,iang*frad.cols()+irad) = (lrad(igrid,irad) + 2*drad(igrid,irad)/r(igrid) - lval(iang)*(lval(iang)+1)*frad(igrid,irad)/(r(igrid)*r(igrid)))*sph(iang);
 
           return lf;
         } else {

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -42,7 +42,7 @@ namespace helfem {
       ///     TwoDBasis (= TwoDBasisT<double>) as before.
       ///   * the basis-function EVALUATION routines used by that grid and by
       ///     the analysis binaries -- eval_bf / eval_df / eval_lf (which return
-      ///     arma::cx_mat and go through the double-only ::spherical_harmonics).
+      ///     Eigen::MatrixXcd and go through the double-only ::spherical_harmonics).
       ///     These are compiled for every T but THROW unless T = double; they
       ///     are not on the Fock path. (The quadrature-point accessors get_bval
       ///     / get_wrad / get_r are precision-generic helfem::Vec<T>.)
@@ -258,11 +258,11 @@ namespace helfem {
         std::vector<std::vector<Eigen::Index>> get_sym_idx(int isym) const;
 
         /// Evaluate basis functions (T = double only)
-        arma::cx_mat eval_bf(size_t iel, double cth, double phi) const;
+        Eigen::MatrixXcd eval_bf(size_t iel, double cth, double phi) const;
         /// Evaluate basis functions derivatives (T = double only)
-        void eval_df(size_t iel, double cth, double phi, arma::cx_mat & dr, arma::cx_mat & dth, arma::cx_mat & dphi) const;
+        void eval_df(size_t iel, double cth, double phi, Eigen::MatrixXcd & dr, Eigen::MatrixXcd & dth, Eigen::MatrixXcd & dphi) const;
         /// Evaluate Laplacian of basis functions (T = double only)
-        arma::cx_mat eval_lf(size_t iel, double cth, double phi) const;
+        Eigen::MatrixXcd eval_lf(size_t iel, double cth, double phi) const;
         /// Get list of basis function indices in element
         std::vector<Eigen::Index> bf_list(size_t iel) const;
 

--- a/src/atomic/basis.cpp
+++ b/src/atomic/basis.cpp
@@ -19,6 +19,8 @@
 #include "../general/gaunt.h"
 #include "utils.h"
 #include "../general/scf_helpers.h"
+#include "../general/eigen_io.h"
+#include <algorithm>
 #include <cassert>
 #include <cfloat>
 #include <helfem.h>
@@ -31,10 +33,10 @@
 namespace helfem {
   namespace atomic {
     namespace basis {
-      static arma::vec concatenate_grid(const arma::vec & left, const arma::vec & right) {
-        if(!left.n_elem)
+      static helfem::Vector concatenate_grid(const helfem::Vector & left, const helfem::Vector & right) {
+        if(!left.size())
           return right;
-        if(!right.n_elem)
+        if(!right.size())
           return left;
 
         if(left(0) != 0.0)
@@ -43,9 +45,9 @@ namespace helfem {
           throw std::logic_error("right vector doesn't start from zero");
 
         // Concatenated vector
-        arma::vec ret(left.n_elem + right.n_elem - 1);
-        ret.subvec(0,left.n_elem-1)=left;
-        ret.subvec(left.n_elem,ret.n_elem-1)=right.subvec(1,right.n_elem-1) + left(left.n_elem-1)*arma::ones<arma::vec>(right.n_elem-1);
+        helfem::Vector ret(left.size() + right.size() - 1);
+        ret.segment(0,left.size())=left;
+        ret.segment(left.size(),right.size()-1)=(right.segment(1,right.size()-1).array() + left(left.size()-1)).matrix();
         return ret;
       }
 
@@ -53,21 +55,21 @@ namespace helfem {
         return utils::get_grid(rmax,num_el,igrid,zexp);
       }
 
-      arma::vec finite_nuclear_grid(int num_el, double rmax, int igrid, double zexp, int num_el_nuc, double rnuc, int igrid_nuc, double zexp_nuc) {
+      helfem::Vector finite_nuclear_grid(int num_el, double rmax, int igrid, double zexp, int num_el_nuc, double rnuc, int igrid_nuc, double zexp_nuc) {
         if(num_el_nuc) {
           // Grid for the finite nucleus
-          arma::vec bnuc(helfem::to_arma(utils::get_grid(rnuc,num_el_nuc,igrid_nuc,zexp_nuc)));
+          helfem::Vector bnuc(utils::get_grid(rnuc,num_el_nuc,igrid_nuc,zexp_nuc));
           // and the one for the electrons
-          arma::vec belec(helfem::to_arma(utils::get_grid(rmax-rnuc,num_el,igrid,zexp)));
+          helfem::Vector belec(utils::get_grid(rmax-rnuc,num_el,igrid,zexp));
 
-          arma::vec bnucel(concatenate_grid(bnuc,bnuc));
+          helfem::Vector bnucel(concatenate_grid(bnuc,bnuc));
           return concatenate_grid(bnucel,belec);
         } else {
-          return helfem::to_arma(utils::get_grid(rmax,num_el,igrid,zexp));
+          return utils::get_grid(rmax,num_el,igrid,zexp);
         }
       }
 
-      arma::vec offcenter_nuclear_grid(int num_el0, int Zm, int Zlr, double Rhalf, int num_el, double rmax, int igrid, double zexp) {
+      helfem::Vector offcenter_nuclear_grid(int num_el0, int Zm, int Zlr, double Rhalf, int num_el, double rmax, int igrid, double zexp) {
         // First boundary at
         int b0used = (Zm != 0);
         double b0=Zm*Rhalf/(Zm+Zlr);
@@ -82,24 +84,25 @@ namespace helfem {
         printf("b2 = %e\n",b2);
 
         // Get grids
-        arma::vec bval0, bval1;
+        helfem::Vector bval0, bval1;
         if(b0used) {
           // 0 to b0
-          bval0=helfem::to_arma(utils::get_grid(b0,num_el0,igrid,zexp));
+          bval0=utils::get_grid(b0,num_el0,igrid,zexp);
         }
         if(b1used) {
           // b0 to b1
 
           // Reverse grid to get tighter spacing around nucleus
-          bval1=-arma::reverse(helfem::to_arma(utils::get_grid(b1-b0,num_el0,igrid,zexp)));
-          bval1+=arma::ones<arma::vec>(bval1.n_elem)*(b1-b0);
+          helfem::Vector b1grid(utils::get_grid(b1-b0,num_el0,igrid,zexp));
+          bval1=-b1grid.reverse();
+          bval1.array()+=(b1-b0);
           // Assert numerical exactness
           bval1(0)=0.0;
-          bval1(bval1.n_elem-1)=b1-b0;
+          bval1(bval1.size()-1)=b1-b0;
         }
-        arma::vec bval2=helfem::to_arma(utils::get_grid(b2-b1,num_el,igrid,zexp));
+        helfem::Vector bval2=utils::get_grid(b2-b1,num_el,igrid,zexp);
 
-        arma::vec bval;
+        helfem::Vector bval;
         if(b0used && b1used) {
           bval=concatenate_grid(bval0,bval1);
         } else if(b0used) {
@@ -116,13 +119,13 @@ namespace helfem {
         return bval;
       }
 
-      arma::vec form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf) {
+      helfem::Vector form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf) {
 	return form_grid(model, Rrms, Nelem, Rmax, igrid, zexp, Nelem0, igrid0, zexp0, Z, Zl, Zr, Rhalf, false, 0.0);
       }
 
-      arma::vec form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf, bool add_el, double shift_conf) {
+      helfem::Vector form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf, bool add_el, double shift_conf) {
         // Construct the radial basis
-        arma::vec bval;
+        helfem::Vector bval;
         if(model != modelpotential::POINT_NUCLEUS && model != modelpotential::REGULARIZED_NUCLEUS) {
           printf("Finite-nucleus grid\n");
 
@@ -146,28 +149,28 @@ namespace helfem {
           bval=atomic::basis::offcenter_nuclear_grid(Nelem0,Z,std::max(Zl,Zr),Rhalf,Nelem,Rmax,igrid,zexp);
         } else {
           printf("Normal grid\n");
-          // normal_grid returns Eigen; form_grid is still arma-native.
-          bval=helfem::to_arma(atomic::basis::normal_grid(Nelem,Rmax,igrid,zexp));
+          bval=atomic::basis::normal_grid(Nelem,Rmax,igrid,zexp);
         }
 
 	if(add_el) {
 	  // Check that r is not in bval
 	  bool in_bval = false;
-	  for (size_t i = 0; i < bval.n_elem; i++)
+	  for (Eigen::Index i = 0; i < bval.size(); i++)
 	    if (bval(i) == shift_conf)
 	      in_bval = true;
 
 	  // Add
 	  if (!in_bval) {
-	    arma::vec newbval(bval.n_elem + 1);
-	    newbval.subvec(0, bval.n_elem - 1) = bval;
-	    newbval(bval.n_elem) = shift_conf;
-	    bval = arma::sort(newbval, "ascend");
+	    helfem::Vector newbval(bval.size() + 1);
+	    newbval.segment(0, bval.size()) = bval;
+	    newbval(bval.size()) = shift_conf;
+	    std::sort(newbval.data(), newbval.data() + newbval.size());
+	    bval = newbval;
 	  }
 
 	}
 
-        bval.print("Grid");
+        helfem::io::print_matrix("Grid", helfem::Matrix(bval));
 
         return bval;
       }

--- a/src/atomic/basis.h
+++ b/src/atomic/basis.h
@@ -27,14 +27,14 @@ namespace helfem {
       /// Get the element grid for a normal calculation
       helfem::Vector normal_grid(int num_el, double rmax, int igrid, double zexp);
       /// Get the element grid for a finite nucleus
-      arma::vec finite_nuclear_grid(int num_el, double rmax, int igrid, double zexp, int num_el_nuc, double rnuc, int igrid_nuc, double zexp_nuc);
+      helfem::Vector finite_nuclear_grid(int num_el, double rmax, int igrid, double zexp, int num_el_nuc, double rnuc, int igrid_nuc, double zexp_nuc);
       /// Get the element grid in the case of off-center nuclei
-      arma::vec offcenter_nuclear_grid(int num_el0, int Zm, int Zlr, double Rhalf, int num_el, double rmax, int igrid, double zexp);
+      helfem::Vector offcenter_nuclear_grid(int num_el0, int Zm, int Zlr, double Rhalf, int num_el, double rmax, int igrid, double zexp);
       /// Form the grid in the general case, using the above routines
-      arma::vec form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf);
+      helfem::Vector form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf);
 
       /// Form the grid in case of added boundary due to confinement
-      arma::vec form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf, bool add_el, double r);
+      helfem::Vector form_grid(modelpotential::nuclear_model_t model, double Rrms, int Nelem, double Rmax, int igrid, double zexp, int Nelem0, int igrid0, double zexp0, int Z, int Zl, int Zr, double Rhalf, bool add_el, double r);
 
       /// Constructs an angular basis
       void angular_basis(int lmax, int mmax, Eigen::VectorXi & lval, Eigen::VectorXi & mval);

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -515,50 +515,35 @@ namespace helfem {
         bf=Eigen::MatrixXcd::Zero(nbf,wtot.size());
         // Loop over angular grid
         for(Eigen::Index ia=0;ia<cth.size();ia++) {
-          // Evaluate basis functions at angular point (arma::cx_mat --
-          // bridge to Eigen).
-          arma::cx_mat abf(basp->eval_bf(iel, cth(ia), phi(ia)));
-          if((Eigen::Index) abf.n_cols != nbf) {
+          // Evaluate basis functions at angular point.
+          Eigen::MatrixXcd abf(basp->eval_bf(iel, cth(ia), phi(ia)));
+          if(abf.cols() != nbf) {
             std::ostringstream oss;
-            oss << "Mismatch! Have " << nbf << " basis function indices but " << abf.n_cols << " basis functions!\n";
+            oss << "Mismatch! Have " << nbf << " basis function indices but " << abf.cols() << " basis functions!\n";
             throw std::logic_error(oss.str());
           }
-          Eigen::MatrixXcd abf_e(abf.n_rows, abf.n_cols);
-          for(arma::uword c=0;c<abf.n_cols;c++)
-            for(arma::uword rr=0;rr<abf.n_rows;rr++)
-              abf_e(rr,c)=abf(rr,c);
-          // Store functions (arma::trans on complex is the conjugate
-          // transpose -> .adjoint()).
-          bf.block(0,ia*nrad,nbf,nrad)=abf_e.adjoint();
+          // Store functions (conjugate transpose on complex -> .adjoint()).
+          bf.block(0,ia*nrad,nbf,nrad)=abf.adjoint();
         }
 
         if(do_grad) {
           bf_rho=Eigen::MatrixXcd::Zero(nbf,wtot.size());
           bf_theta=Eigen::MatrixXcd::Zero(nbf,wtot.size());
           bf_phi=Eigen::MatrixXcd::Zero(nbf,wtot.size());
-          arma::cx_mat dr, dth, dphi;
+          Eigen::MatrixXcd dr, dth, dphi;
 
           for(Eigen::Index ia=0;ia<cth.size();ia++) {
             // Evaluate basis functions at angular point
             basp->eval_df(iel, cth(ia), phi(ia), dr, dth, dphi);
-            if((Eigen::Index) dr.n_cols != nbf) {
+            if(dr.cols() != nbf) {
               std::ostringstream oss;
-              oss << "Mismatch! Have " << nbf << " basis function indices but " << dr.n_cols << " basis functions!\n";
+              oss << "Mismatch! Have " << nbf << " basis function indices but " << dr.cols() << " basis functions!\n";
               throw std::logic_error(oss.str());
             }
-            Eigen::MatrixXcd dr_e(dr.n_rows, dr.n_cols);
-            Eigen::MatrixXcd dth_e(dth.n_rows, dth.n_cols);
-            Eigen::MatrixXcd dphi_e(dphi.n_rows, dphi.n_cols);
-            for(arma::uword c=0;c<dr.n_cols;c++)
-              for(arma::uword rr=0;rr<dr.n_rows;rr++) {
-                dr_e(rr,c)=dr(rr,c);
-                dth_e(rr,c)=dth(rr,c);
-                dphi_e(rr,c)=dphi(rr,c);
-              }
-            // Store functions
-            bf_rho.block(0,ia*nrad,nbf,nrad)=dr_e.adjoint();
-            bf_theta.block(0,ia*nrad,nbf,nrad)=dth_e.adjoint();
-            bf_phi.block(0,ia*nrad,nbf,nrad)=dphi_e.adjoint();
+            // Store functions (conjugate transpose on complex -> .adjoint()).
+            bf_rho.block(0,ia*nrad,nbf,nrad)=dr.adjoint();
+            bf_theta.block(0,ia*nrad,nbf,nrad)=dth.adjoint();
+            bf_phi.block(0,ia*nrad,nbf,nrad)=dphi.adjoint();
           }
         }
 
@@ -567,18 +552,14 @@ namespace helfem {
           // Loop over angular grid
           for(Eigen::Index ia=0;ia<cth.size();ia++) {
             // Evaluate basis functions at angular point
-            arma::cx_mat alf(basp->eval_lf(iel, cth(ia), phi(ia)));
-            if((Eigen::Index) alf.n_cols != nbf) {
+            Eigen::MatrixXcd alf(basp->eval_lf(iel, cth(ia), phi(ia)));
+            if(alf.cols() != nbf) {
               std::ostringstream oss;
-              oss << "Mismatch! Have " << nbf << " basis function indices but " << alf.n_cols << " basis functions!\n";
+              oss << "Mismatch! Have " << nbf << " basis function indices but " << alf.cols() << " basis functions!\n";
               throw std::logic_error(oss.str());
             }
-            Eigen::MatrixXcd alf_e(alf.n_rows, alf.n_cols);
-            for(arma::uword c=0;c<alf.n_cols;c++)
-              for(arma::uword rr=0;rr<alf.n_rows;rr++)
-                alf_e(rr,c)=alf(rr,c);
-            // Store functions
-            bf_lapl.block(0,ia*nrad,nbf,nrad)=alf_e.adjoint();
+            // Store functions (conjugate transpose on complex -> .adjoint()).
+            bf_lapl.block(0,ia*nrad,nbf,nrad)=alf.adjoint();
           }
         }
       }

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -256,15 +256,14 @@ int main(int argc, char **argv) {
 
   Eigen::VectorXi lval, mval;
   atomic::basis::angular_basis(lmax, mmax, lval, mval);
-  // form_grid is still arma-native; bridge once.
-  arma::vec bval = atomic::basis::form_grid(
+  const helfem::Vector bval = atomic::basis::form_grid(
       (modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax,
       igrid, zexp, Nelem0, igrid0, zexp0, Z, Zl, Zr, Rhalf,
       iconf ? add_conf : false, shift_conf);
 
   atomic::basis::TwoDBasis basis(Z, (modelpotential::nuclear_model_t) finitenuc,
                                   Rrms, poly, zeroder, Nquad,
-                                  helfem::to_eigen(bval),
+                                  bval,
                                   lval,
                                   mval,
                                   Zl, Zr, Rhalf);

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -550,10 +550,9 @@ namespace helfem {
           opts.lmax           = lmax;
           opts.poly           = poly;
           opts.Nquad          = Nquad;
-          // atomic::basis::form_grid still returns arma::vec; bridge once.
-          opts.bval           = helfem::to_eigen(atomic::basis::form_grid(
+          opts.bval           = atomic::basis::form_grid(
               modelpotential::POINT_NUCLEUS, 0.0, Nelem, Rmax, igrid, zexp,
-              0, 0, 0.0, Z, 0, 0, 0.0));
+              0, 0, 0.0, Z, 0, 0, 0.0);
           opts.nela           = Ntot / 2;  // restricted closed-shell (PBE ground occs
           opts.nelb           = Ntot / 2;  // are always even totals per l).
           opts.restricted     = true;

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -91,12 +91,10 @@ int main(int argc, char **argv) {
   // Order of quadrature rule
   printf("Using %i point quadrature rule.\n",Nquad);
 
-  // Radial basis. atomic::basis::form_grid still returns arma::vec
-  // (atomic basis layer, migrated in a later wave); bridge its result to
-  // Eigen once at the FiniteElementBasis constructor.
-  const helfem::Vector bval = helfem::to_eigen(atomic::basis::form_grid(
+  // Radial basis.
+  const helfem::Vector bval = atomic::basis::form_grid(
       (modelpotential::nuclear_model_t) finitenuc, Rrms, Nelem, Rmax,
-      igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0));
+      igrid, zexp, Nelem0, igrid0, zexp0, Z, 0, 0, 0.0);
 
   const bool zero_func_left  = true;
   const bool zero_deriv_left = false;

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -30,9 +30,6 @@
 #include "../atomic/basis.h"
 #include "scf.h"
 #include "../general/eigen_io.h"
-// ArmaEigen.h is included only for the helfem::to_eigen bridge on the
-// return value of atomic::basis::form_grid, which is still arma-typed.
-#include <ArmaEigen.h>
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -317,11 +314,10 @@ int main(int argc, char **argv) {
   if (!is_supported(c_func))
     throw std::logic_error("The specified correlation functional is not currently supported in HelFEM.\n");
 
-  // atomic::basis::form_grid still returns arma::vec; bridge once here.
-  const helfem::Vector bval = helfem::to_eigen(atomic::basis::form_grid(
+  const helfem::Vector bval = atomic::basis::form_grid(
       modelpotential::POINT_NUCLEUS, 0.0, Nelem, Rmax, igrid, zexp,
       0, 0, 0.0, Z, 0, 0, 0.0,
-      iconf ? add_conf : false, shift_conf));
+      iconf ? add_conf : false, shift_conf);
 
   sadatom::scf::AtomicSCFOptions opts;
   opts.Z            = Z;


### PR DESCRIPTION
Wave 5a of the campaign to eliminate Armadillo (task #36), stacked on #246.
Takes the atomic interior off `arma::`: the complex analysis evaluators
`eval_bf`/`eval_df`/`eval_lf` (`arma::cx_mat` -> `Eigen::MatrixXcd`) and the
`concatenate_grid`/`finite_nuclear_grid` helpers (`arma::vec` -> `helfem::Vector`).

The complex evaluators turned out to carry NO conjugation/transpose/dot -- they
are built purely from `scalar * matrix` products -- so the conversion is a
container/type change plus `.cast<std::complex<double>>()` promotion of the real
radial blocks; associativity preserved. The one place with conjugation semantics
(`dftgrid.cpp`'s `.adjoint()` store and non-conjugating density contraction) was
already Eigen from an earlier wave and is untouched.

Because `form_grid` / `radial.get_*` already return Eigen, the old code
round-tripped needlessly through arma; those bridges are gone, and the
`helfem::to_eigen(form_grid(...))` wrappers at the callers
(`atomic/main.cpp`, `diatomic/twodquadrature.cpp`, `sadatom/1e.cpp`,
`sadatom/main.cpp`) drop out too. Net to_arma/to_eigen bridges in touched files: 0.

No direct BLAS/LAPACK (grep-clean). Verified bit-identical to master: atomic
Ar/Ne HF, Ar LDA, Ne PBE all converge to the same energies, and `atomic_itest`
matches to the last digit. `eval_lf` (laplacian-mGGA only) has no practical
converging test case; its conversion is mechanical index/type translation with
no conjugation semantics, audited by inspection.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
