### PR TITLE
Template HDF5 checkpoint float I/O on the scalar type (double/long double/_Float128)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,12 @@ target_link_libraries(over_r_test helfem-common legendre)
 add_executable(gaunt_test general/gaunt_test.cpp)
 target_link_libraries(gaunt_test helfem-common legendre)
 
+# Round-trips the templated HDF5 checkpoint float I/O at double / long double
+# / _Float128 and asserts bit-identical reloads (proves the per-T memory type,
+# not a double-capped path).
+add_executable(checkpoint_precision_test general/checkpoint_precision_test.cpp)
+target_link_libraries(checkpoint_precision_test helfem-common legendre)
+
 add_executable(sphtest general/sphtest.cpp)
 target_link_libraries(sphtest helfem-common legendre)
 

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -35,6 +35,39 @@ namespace {
     }
     return id;
   }
+
+  // HDF5 datatype selector for the templated floating-point I/O. Returns
+  // the HDF5 *native* (in-memory) datatype matching the C++ scalar T; the
+  // write path H5Tcopy()s this for the on-disk (file) datatype, so the
+  // on-disk representation matches the memory type exactly per T. In
+  // particular h5_native_float<double>() == H5T_NATIVE_DOUBLE, so double
+  // datasets stay byte-identical (H5T_IEEE_F64LE) to older .chk files.
+  //
+  // The returned hid_t is NOT owned by the caller: for double / long double
+  // it is a predefined HDF5 constant (must not be closed), and for _Float128
+  // it is a process-lifetime cached type (built once, never closed). Callers
+  // that need an owned copy must H5Tcopy() it (the write path does).
+  template <typename T> hid_t h5_native_float();
+  template <> hid_t h5_native_float<double>()      { return H5T_NATIVE_DOUBLE; }
+  template <> hid_t h5_native_float<long double>() { return H5T_NATIVE_LDOUBLE; }
+#ifdef HELFEM_HAVE_FLOAT128
+  // _Float128 has no predefined HDF5 native type, so describe IEEE
+  // binary128 explicitly: 1 sign + 15 exponent + 112 stored mantissa bits
+  // (113-bit significand with the implicit leading bit), size 16 bytes,
+  // exponent bias 16383. Built once and cached for the process lifetime.
+  template <> hid_t h5_native_float<_Float128>() {
+    static const hid_t t = []() {
+      hid_t t = H5Tcopy(H5T_IEEE_F64LE);
+      H5Tset_size(t, 16);          // 128 bits
+      H5Tset_precision(t, 128);    // full-width IEEE type (msize+esize+1)
+      H5Tset_fields(t, /*spos=*/127, /*epos=*/112, /*esize=*/15,
+                       /*mpos=*/0,   /*msize=*/112);
+      H5Tset_ebias(t, 16383);
+      return t;
+    }();
+    return t;
+  }
+#endif
 }
 
 Checkpoint::Checkpoint(const std::string & fname, bool writem, bool trunc) {
@@ -128,7 +161,8 @@ void Checkpoint::remove(const std::string & name) {
   if(cl) close();
 }
 
-void Checkpoint::write(const std::string & name, const helfem::Matrix & m) {
+template <typename T>
+void Checkpoint::write(const std::string & name, const helfem::Mat<T> & m) {
   CHECK_WRITE();
 
   bool cl=false;
@@ -140,7 +174,7 @@ void Checkpoint::write(const std::string & name, const helfem::Matrix & m) {
   // Remove possible existing entry
   remove(name);
 
-  // Dimensions of the matrix. helfem::Matrix is Eigen column-major
+  // Dimensions of the matrix. helfem::Mat<T> is Eigen column-major
   // (like arma::mat was); the column-major buffer is stored with
   // dims {n_cols, n_rows} so the on-disk bytes stay identical.
   hsize_t dims[2];
@@ -150,8 +184,9 @@ void Checkpoint::write(const std::string & name, const helfem::Matrix & m) {
   // Create a dataspace.
   hid_t dataspace=H5Screate_simple(2,dims,NULL);
 
-  // Create a datatype.
-  hid_t datatype=H5Tcopy(H5T_NATIVE_DOUBLE);
+  // Create a datatype. The file datatype matches the T memory type, so
+  // T=double stays H5T_IEEE_F64LE (byte-identical to older .chk files).
+  hid_t datatype=H5Tcopy(h5_native_float<T>());
 
   // Create the dataset using the defined dataspace and datatype, and
   // default dataset creation properties.
@@ -167,7 +202,8 @@ void Checkpoint::write(const std::string & name, const helfem::Matrix & m) {
   if(cl) close();
 }
 
-void Checkpoint::read(const std::string & name, helfem::Matrix & m) {
+template <typename T>
+void Checkpoint::read(const std::string & name, helfem::Mat<T> & m) {
   bool cl=false;
   if(!opend) {
     open();
@@ -206,9 +242,11 @@ void Checkpoint::read(const std::string & name, helfem::Matrix & m) {
 
   // Allocate memory. dims are {n_cols, n_rows} (see write), so the
   // matrix is (dims[1], dims[0]) and the column-major buffer is read
-  // straight into .data().
-  m=helfem::Matrix::Zero(dims[1],dims[0]);
-  H5Dread(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, m.data());
+  // straight into .data(). The H5T_FLOAT guard above admits any
+  // float-on-disk; HDF5 converts the disk type to the T memory type on
+  // read, so a double .chk loads into a long double / _Float128 run.
+  m=helfem::Mat<T>::Zero(dims[1],dims[0]);
+  H5Dread(dataset, h5_native_float<T>(), H5S_ALL, H5S_ALL, H5P_DEFAULT, m.data());
 
   // Close dataspace
   H5Sclose(dataspace);
@@ -220,17 +258,19 @@ void Checkpoint::read(const std::string & name, helfem::Matrix & m) {
   if(cl) close();
 }
 
-void Checkpoint::write(const std::string & name, const helfem::Vector & v) {
+template <typename T>
+void Checkpoint::write(const std::string & name, const helfem::Vec<T> & v) {
   // Store as an N x 1 matrix.
-  write(name, helfem::Matrix(v));
+  write(name, helfem::Mat<T>(v));
 }
 
-void Checkpoint::read(const std::string & name, helfem::Vector & v) {
-  helfem::Matrix m;
+template <typename T>
+void Checkpoint::read(const std::string & name, helfem::Vec<T> & v) {
+  helfem::Mat<T> m;
   read(name, m);
   if (m.cols() != 1) {
     std::ostringstream oss;
-    oss << "Cannot read \"" << name << "\" as a helfem::Vector: "
+    oss << "Cannot read \"" << name << "\" as a helfem::Vec: "
         << "expected 1 column, got " << m.cols() << "\n";
     throw std::runtime_error(oss.str());
   }
@@ -320,7 +360,8 @@ void Checkpoint::read(const std::string & name, Eigen::MatrixXi & m) {
 }
 
 
-void Checkpoint::write(const std::string & name, const std::vector<double> & v) {
+template <typename T>
+void Checkpoint::write(const std::string & name, const std::vector<T> & v) {
   CHECK_WRITE();
   bool cl=false;
   if(!opend) {
@@ -338,8 +379,9 @@ void Checkpoint::write(const std::string & name, const std::vector<double> & v) 
   // Create a dataspace.
   hid_t dataspace=H5Screate_simple(1,dims,NULL);
 
-  // Create a datatype.
-  hid_t datatype=H5Tcopy(H5T_NATIVE_DOUBLE);
+  // Create a datatype. File type matches the T memory type, so T=double
+  // stays byte-identical (H5T_IEEE_F64LE) to older .chk files.
+  hid_t datatype=H5Tcopy(h5_native_float<T>());
 
   // Create the dataset using the defined dataspace and datatype, and
   // default dataset creation properties.
@@ -355,7 +397,8 @@ void Checkpoint::write(const std::string & name, const std::vector<double> & v) 
   if(cl) close();
 }
 
-void Checkpoint::read(const std::string & name, std::vector<double> & v) {
+template <typename T>
+void Checkpoint::read(const std::string & name, std::vector<T> & v) {
   bool cl=false;
   if(!opend) {
     open();
@@ -392,9 +435,10 @@ void Checkpoint::read(const std::string & name, std::vector<double> & v) {
   hsize_t dims[ndim];
   H5Sget_simple_extent_dims(dataspace,dims,NULL);
 
-  // Allocate memory
+  // Allocate memory. HDF5 converts the disk float type to the T memory
+  // type on read, so a double-on-disk array loads into any T.
   v.resize(dims[0]);
-  H5Dread(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &(v[0]));
+  H5Dread(dataset, h5_native_float<T>(), H5S_ALL, H5S_ALL, H5P_DEFAULT, &(v[0]));
 
   // Close dataspace
   H5Sclose(dataspace);
@@ -641,7 +685,8 @@ void Checkpoint::read(helfem::diatomic::basis::TwoDBasis & basis) {
   if(cl) close();
 }
 
-void Checkpoint::write(const std::string & name, double val) {
+template <typename T>
+void Checkpoint::write(const std::string & name, T val) {
   CHECK_WRITE();
   bool cl=false;
   if(!opend) {
@@ -655,8 +700,9 @@ void Checkpoint::write(const std::string & name, double val) {
   // Create a dataspace.
   hid_t dataspace=H5Screate(H5S_SCALAR);
 
-  // Create a datatype.
-  hid_t datatype=H5Tcopy(H5T_NATIVE_DOUBLE);
+  // Create a datatype. File type matches the T memory type, so T=double
+  // stays byte-identical (H5T_IEEE_F64LE) to older .chk files.
+  hid_t datatype=H5Tcopy(h5_native_float<T>());
 
   // Create the dataset using the defined dataspace and datatype, and
   // default dataset creation properties.
@@ -672,7 +718,8 @@ void Checkpoint::write(const std::string & name, double val) {
   if(cl) close();
 }
 
-void Checkpoint::read(const std::string & name, double & v) {
+template <typename T>
+void Checkpoint::read(const std::string & name, T & v) {
   bool cl=false;
   if(!opend) {
     open();
@@ -702,8 +749,9 @@ void Checkpoint::read(const std::string & name, double & v) {
   if(type!=H5S_SCALAR)
     throw std::runtime_error("Error - dataspace is not of scalar type!\n");
 
-  // Read
-  H5Dread(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &v);
+  // Read. HDF5 converts the disk float type to the T memory type, so a
+  // double-on-disk scalar loads into any T.
+  H5Dread(dataset, h5_native_float<T>(), H5S_ALL, H5S_ALL, H5P_DEFAULT, &v);
 
   // Close dataspace
   H5Sclose(dataspace);
@@ -1019,6 +1067,28 @@ void Checkpoint::read(const std::string & name, std::string & val) {
   H5Dclose(dataset);
   if(cl) close();
 }
+
+// Explicit instantiations of the templated floating-point I/O. The
+// definitions live here (not in the header) because they depend on the
+// HDF5 C API; instantiating for each supported scalar type keeps every
+// existing helfem::Matrix / helfem::Vector / std::vector<double> / double
+// caller linking via the T=double instantiation, unchanged.
+#define HELFEM_INSTANTIATE_CHECKPOINT_FLOAT(T)                                \
+  template void Checkpoint::write(const std::string &, const helfem::Mat<T> &); \
+  template void Checkpoint::read (const std::string &, helfem::Mat<T> &);      \
+  template void Checkpoint::write(const std::string &, const helfem::Vec<T> &); \
+  template void Checkpoint::read (const std::string &, helfem::Vec<T> &);      \
+  template void Checkpoint::write(const std::string &, const std::vector<T> &); \
+  template void Checkpoint::read (const std::string &, std::vector<T> &);      \
+  template void Checkpoint::write(const std::string &, T);                     \
+  template void Checkpoint::read (const std::string &, T &);
+
+HELFEM_INSTANTIATE_CHECKPOINT_FLOAT(double)
+HELFEM_INSTANTIATE_CHECKPOINT_FLOAT(long double)
+#ifdef HELFEM_HAVE_FLOAT128
+HELFEM_INSTANTIATE_CHECKPOINT_FLOAT(_Float128)
+#endif
+#undef HELFEM_INSTANTIATE_CHECKPOINT_FLOAT
 
 bool file_exists(const std::string & name) {
   std::ifstream file(name.c_str());

--- a/src/general/checkpoint.h
+++ b/src/general/checkpoint.h
@@ -79,17 +79,28 @@ class Checkpoint {
    * An open file will be left open, a closed file will be left closed.
    */
 
-  /// Save matrix. helfem::Matrix is Eigen column-major; the HDF5
+  /// Save matrix. helfem::MatT<T> is Eigen column-major; the HDF5
   /// dataset stores the raw column-major buffer with dims
   /// {n_rows, n_cols}, byte-identical to the old arma::mat layout.
-  void write(const std::string & name, const helfem::Matrix & mat);
+  ///
+  /// Templated on the scalar type T so a long double / _Float128 SCF
+  /// can round-trip its matrices at full precision. The on-disk (file)
+  /// datatype matches the memory type per T, so T=double stays exactly
+  /// H5T_IEEE_F64LE and existing .chk files remain byte-identical.
+  /// Definitions live in checkpoint.cpp with explicit instantiations
+  /// for double, long double and (guarded) _Float128.
+  template <typename T>
+  void write(const std::string & name, const helfem::Mat<T> & mat);
   /// Read matrix
-  void read(const std::string & name, helfem::Matrix & mat);
+  template <typename T>
+  void read(const std::string & name, helfem::Mat<T> & mat);
 
-  /// helfem::Vector convenience: writes as a single-column matrix and
+  /// helfem::Vec<T> convenience: writes as a single-column matrix and
   /// reads back the first column.
-  void write(const std::string & name, const helfem::Vector & v);
-  void read(const std::string & name, helfem::Vector & v);
+  template <typename T>
+  void write(const std::string & name, const helfem::Vec<T> & v);
+  template <typename T>
+  void read(const std::string & name, helfem::Vec<T> & v);
 
   /// Save integer matrix. 32-bit int elements matching the on-disk
   /// H5T_NATIVE_INT type (the old arma::Mat<int> storage).
@@ -97,10 +108,13 @@ class Checkpoint {
   /// Read integer matrix
   void read(const std::string & name, Eigen::MatrixXi & mat);
 
-  /// Save array
-  void write(const std::string & name, const std::vector<double> & v);
+  /// Save array. Templated on the scalar type T (double, long double,
+  /// _Float128); T=double stays byte-identical on disk.
+  template <typename T>
+  void write(const std::string & name, const std::vector<T> & v);
   /// Load array
-  void read(const std::string & name, std::vector<double> & v);
+  template <typename T>
+  void read(const std::string & name, std::vector<T> & v);
 
   /// Save array
   void write(const std::string & name, const std::vector<hsize_t> & v);
@@ -116,10 +130,15 @@ class Checkpoint {
   /// Save basis set
   void read(helfem::diatomic::basis::TwoDBasis & basis);
 
-  /// Save value
-  void write(const std::string & name, double val);
+  /// Save value. Templated on the scalar type T (double, long double,
+  /// _Float128); T=double stays byte-identical on disk. The non-template
+  /// int / hsize_t / bool overloads below are exact matches for their
+  /// argument types and so are still preferred over this template.
+  template <typename T>
+  void write(const std::string & name, T val);
   /// Read value
-  void read(const std::string & name, double & val);
+  template <typename T>
+  void read(const std::string & name, T & val);
 
   /// Save value
   void write(const std::string & name, int val);

--- a/src/general/checkpoint_precision_test.cpp
+++ b/src/general/checkpoint_precision_test.cpp
@@ -1,0 +1,161 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+
+// Round-trip test for the precision-generic HDF5 checkpoint I/O.
+//
+// For every supported scalar type T (double, long double, and _Float128
+// when built with HELFEM_HAVE_FLOAT128) it writes a MatT<T> and a Vec<T>
+// filled with values that need MORE than double precision to represent
+// (1/3, sqrt(2), pi), reads them back into fresh MatT<T>/Vec<T>, and
+// requires the reload to be BIT-IDENTICAL to the original (max|Δ| == 0).
+//
+// A double-capped I/O path (memory type stuck at H5T_NATIVE_DOUBLE) would
+// truncate long double / _Float128 to 53 significant bits and show a
+// ~1e-16..1e-19 error at those types; a genuine per-T path shows exactly 0.
+//
+// It additionally checks that a value written through the DOUBLE path
+// (on-disk H5T_IEEE_F64LE) loads correctly through the _Float128 memory
+// type -- i.e. HDF5's F64LE -> binary128 conversion is exact -- which is
+// what pins down the binary128 field parameters in h5_native_float.
+
+#include "checkpoint.h"
+#include "Matrix.h"
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+// High-precision reference constants, evaluated at the scalar type T so the
+// low-order bits genuinely differ between double / long double / _Float128.
+template <typename T> T one_third() { return T(1) / T(3); }
+template <typename T> T root_two()  { return std::sqrt(T(2)); }
+template <typename T>
+T my_pi() {
+  // 4*atan(1) evaluated at T.
+  return T(4) * std::atan(T(1));
+}
+
+// Print a scalar difference as long double; exact-zero prints as 0.
+long double as_ld(double v)      { return (long double) v; }
+long double as_ld(long double v) { return v; }
+#ifdef HELFEM_HAVE_FLOAT128
+long double as_ld(_Float128 v)   { return (long double) v; }
+#endif
+
+template <typename T>
+int roundtrip(const char * tname) {
+  const int n = 5;
+
+  // Build a matrix and a vector whose entries need >double precision.
+  helfem::Mat<T> M(n, n);
+  helfem::Vec<T> v(n);
+  for (int j = 0; j < n; j++) {
+    v(j) = one_third<T>() + T(j) * root_two<T>();
+    for (int i = 0; i < n; i++)
+      M(i, j) = my_pi<T>() * T(i + 1) + root_two<T>() / T(j + 1) + one_third<T>();
+  }
+
+  // Round-trip through a temporary checkpoint.
+  std::string fname = tempname();
+  {
+    Checkpoint chk(fname, /*write=*/true);
+    chk.write("M", M);
+    chk.write("v", v);
+    chk.write("s", one_third<T>());
+  }
+
+  helfem::Mat<T> M2;
+  helfem::Vec<T> v2;
+  T s2;
+  {
+    Checkpoint chk(fname, /*write=*/false);
+    chk.read("M", M2);
+    chk.read("v", v2);
+    chk.read("s", s2);
+  }
+  remove(fname.c_str());
+
+  // Bit-identity: max|Δ| must be exactly 0, and the raw buffers must match.
+  const T sref = one_third<T>();
+  T dM = (M2 - M).cwiseAbs().maxCoeff();
+  T dv = (v2 - v).cwiseAbs().maxCoeff();
+  T ds = (s2 > sref) ? (s2 - sref) : (sref - s2);
+
+  bool bits_ok =
+      (M2.rows() == M.rows() && M2.cols() == M.cols() &&
+       std::memcmp(M2.data(), M.data(), sizeof(T) * n * n) == 0) &&
+      (v2.size() == v.size() &&
+       std::memcmp(v2.data(), v.data(), sizeof(T) * n) == 0) &&
+      (std::memcmp(&s2, &sref, sizeof(T)) == 0);
+
+  long double maxd = as_ld(dM);
+  if (as_ld(dv) > maxd) maxd = as_ld(dv);
+  if (as_ld(ds) > maxd) maxd = as_ld(ds);
+
+  bool ok = (dM == T(0)) && (dv == T(0)) && (ds == T(0)) && bits_ok;
+  printf("  %-12s sizeof=%2zu  max|delta| = %.3Le   %s\n",
+         tname, sizeof(T), maxd, ok ? "OK" : "FAIL");
+  return ok ? 0 : 1;
+}
+
+#ifdef HELFEM_HAVE_FLOAT128
+// Cross-type conversion: a value written through the DOUBLE path (F64LE on
+// disk) must reload exactly through the _Float128 memory type. Verifies the
+// binary128 field parameters -- a wrong exponent bias / field layout would
+// corrupt the converted value.
+int cross_double_to_quad() {
+  double d = 1.0 / 3.0;             // exact double bit pattern
+  std::string fname = tempname();
+  {
+    Checkpoint chk(fname, /*write=*/true);
+    chk.write("d", d);             // T=double -> on-disk H5T_IEEE_F64LE
+  }
+  _Float128 q;
+  {
+    Checkpoint chk(fname, /*write=*/false);
+    chk.read("d", q);             // T=_Float128 memory type; HDF5 converts
+  }
+  remove(fname.c_str());
+
+  _Float128 expect = (_Float128) d; // exact widening of the double value
+  _Float128 diff = (q > expect) ? (q - expect) : (expect - q);
+  bool ok = (diff == (_Float128) 0);
+  printf("  %-12s               F64LE->binary128 delta = %.3Le   %s\n",
+         "double->quad", (long double) diff, ok ? "OK" : "FAIL");
+  return ok ? 0 : 1;
+}
+#endif
+
+} // namespace
+
+int main() {
+  printf("checkpoint precision round-trip:\n");
+  int fail = 0;
+  fail += roundtrip<double>("double");
+  fail += roundtrip<long double>("long double");
+#ifdef HELFEM_HAVE_FLOAT128
+  fail += roundtrip<_Float128>("_Float128");
+  fail += cross_double_to_quad();
+#endif
+  if (fail) {
+    printf("FAILED: %d check(s) did not round-trip bit-identically.\n", fail);
+    return 1;
+  }
+  printf("All checkpoint precision round-trips are bit-identical.\n");
+  return 0;
+}


### PR DESCRIPTION
Follow-up to the arma removal: make the HDF5 checkpoint **float** I/O
precision-generic, so a `long double` / `_Float128` SCF can save and reload its
matrices. Previously the float side was pinned to `double` (`H5T_NATIVE_DOUBLE`,
`helfem::Matrix`), so an arbitrary-precision run could not round-trip.

## What changed
- `checkpoint.{cpp,h}`: the four float overload pairs — `write/read` for
  `Mat<T>`, `Vec<T>`, `std::vector<T>`, and scalar `T` — are now templated on the
  scalar type, defined in the .cpp with explicit instantiation at `double`,
  `long double`, and (under `HELFEM_HAVE_FLOAT128`) `_Float128`. Existing
  `helfem::Matrix`/`Vector` callers are unchanged (they pick the `double`
  instantiation). The integer (`Eigen::MatrixXi`) and metadata (`hsize_t`,
  `bool`, `char`, `string`) overloads are untouched.
- New `h5_native_float<T>()` datatype selector: `NATIVE_DOUBLE` /
  `NATIVE_LDOUBLE` / a self-describing IEEE **binary128** type for `_Float128`
  (HDF5 has no native quad type). The binary128 type is built once from
  `H5T_IEEE_F64LE` with `size=16, precision=128, fields(spos=127, epos=112,
  esize=15, mpos=0, msize=112), ebias=16383` and cached for the process.
- The read path keeps the existing `H5Tget_class==H5T_FLOAT` guard, so any
  float-on-disk is converted to the requested `T` on read (a `double` `.chk`
  loads into a quad run and vice-versa).

## Back-compat
The `double` specialization keeps `H5T_NATIVE_DOUBLE` and the exact
column-major `{n_cols,n_rows}` byte layout, so **existing `.chk` files are
byte-identical and load unchanged** (verified: `h5diff` shows zero differences
vs a master-written checkpoint; on-disk `/Pa` datatype stays `H5T_IEEE_F64LE`;
reloading a master checkpoint gives the same energy).

## Verification
New permanent test `checkpoint_precision_test`: writes `Mat<T>`/`Vec<T>` filled
with `T(1)/T(3)`, `pi<T>()`, `sqrt(T(2))`, reads them back, asserts
**max|Δ| == 0** for `double`, `long double`, and `_Float128` (a double-capped
path would show ~1e-16 at quad). Also checks an F64LE→binary128 on-read
conversion is exact. All pass. Atomic Ar HF `--save`/`--load` round-trips to the
same energy; full build clean.

Advances the arbitrary-precision arc (task #37).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
