### PR TITLE
Template the erfc range-separated integral special functions on the scalar type

### DIFF
--- a/libhelfem/src/erfc_expn.cpp
+++ b/libhelfem/src/erfc_expn.cpp
@@ -14,164 +14,191 @@
  */
 
 #include "erfc_expn.h"
+#include "utils.h"
 #include <algorithm>
 #include <cmath>
-#include <cfloat>
+#include <limits>
+#include <vector>
 #include <stdexcept>
 #include <sstream>
+
+// The Ángyán-Gerber-Marsman erfc/Legendre expansion, templated on the
+// scalar type T and explicitly instantiated for double, long double and
+// (under HELFEM_HAVE_FLOAT128) _Float128 at the bottom of the namespace.
+//
+// The algorithm is byte-for-byte the same one as the original double-only
+// implementation: the Fn recursion (eq. 22), the Hn tail (eq. 24), the
+// general expansion (eq. 21), the Dnk damping coefficients (eqs. 28/29) and
+// the short-range Taylor series (eq. 30). Precision-capping constants have
+// been replaced by their T-aware equivalents:
+//   * M_PI            -> helfem::utils::pi<T>() (arithmetic order preserved,
+//                        so the double instantiation is bit-identical: the
+//                        long-double pi literal rounds to exactly M_PI at
+//                        T = double, and 2/sqrt(pi) is still spelled as the
+//                        same T(2)/std::sqrt(pi<T>()) division as before).
+//   * DBL_EPSILON     -> std::numeric_limits<T>::epsilon(), so the short-range
+//                        Taylor series runs to T's precision, not double's.
+// The short-range convergence loop cap was raised from 30 to 200 so that the
+// series still reaches the (now much tighter) eps(T) tolerance at long double
+// and _Float128. At T = double the eps break fires well before k = 30, so the
+// double results are unchanged.
 
 namespace helfem {
   namespace atomic {
     namespace erfc_expn {
-      inline static double double_factorial(unsigned int n) {
-        double v = 1.0;
+      template <typename T> static T double_factorial(unsigned int n) {
+        T v = T(1);
         for(unsigned int k=n; k>=2; k-=2)
-          v *= static_cast<double>(k);
+          v *= T(k);
         return v;
       }
 
-      inline static double factorial(unsigned int n) {
-        double v = 1.0;
+      template <typename T> static T factorial(unsigned int n) {
+        T v = T(1);
         for(unsigned int k=2; k<=n; ++k)
-          v *= static_cast<double>(k);
+          v *= T(k);
         return v;
       }
 
-      inline static double choose(int n, int m) {
+      template <typename T> static T choose(int n, int m) {
         // Special cases
         if(n==-1)
           // choose(-1,m) = (-1)^m
-          return std::pow(-1.0,m);
+          return std::pow(T(-1),m);
         if(n==0)
           // choose(0,m) = 0 except for choose(0,0) = 1
-          return m==0 ? 1.0 : 0.0;
+          return m==0 ? T(1) : T(0);
         if(m==0)
           // choose(n,0) = 1 for all n
-          return 1.0;
+          return T(1);
         if(m==1)
           // choose(n,1) = n for all n
-          return n;
+          return T(n);
         if(n>0 && m>0 && m>n)
           // choose(n,m) = 0 for m>n positive
-          return 0.0;
+          return T(0);
 
         // Negative binomials
         if(n<0) {
-          return choose(n+m-1,m)*std::pow(-1,m);
+          return choose<T>(n+m-1,m)*std::pow(T(-1),m);
         } else {
-          // Multiplicative formula keeps the running value as a double
+          // Multiplicative formula keeps the running value as a T
           // and avoids any factorial overflow for large n.
-          double v = 1.0;
+          T v = T(1);
           const int k = std::min(m, n - m);
           for(int i=0; i<k; ++i)
-            v *= static_cast<double>(n - i) / static_cast<double>(i + 1);
+            v *= T(n - i) / T(i + 1);
           return v;
         }
       }
 
       // Angyan et al, equation (22)
-      inline static double Fn(unsigned int n, double Xi, double xi) {
+      template <typename T> static T Fn(unsigned int n, T Xi, T xi) {
         // Exponential factors
-        double explus(std::exp(-std::pow(Xi+xi,2)));
-        double exminus(std::exp(-std::pow(Xi-xi,2)));
+        T explus(std::exp(-std::pow(Xi+xi,2)));
+        T exminus(std::exp(-std::pow(Xi-xi,2)));
 
         // Prefactor
-        double prefac(-1.0/(4.0*Xi*xi));
+        T prefac(T(-1)/(T(4)*Xi*xi));
 
-        double F=0.0;
+        T F=T(0);
         // Looks like there's a typo in the equation: I can't make the
         // function match the equations in the appendix unless the
         // lower limit is 0 instead of 1.
         for(unsigned int p=0;p<=n;p++) {
-          F += std::pow(prefac,p+1) * (factorial(n+p)/(factorial(p)*factorial(n-p))) * (std::pow(-1,n-p) * explus - exminus);
+          F += std::pow(prefac,(int)(p+1)) * (factorial<T>(n+p)/(factorial<T>(p)*factorial<T>(n-p))) * (std::pow(T(-1),(int)(n-p)) * explus - exminus);
         }
         // Apply prefactor
-        return 2.0/sqrt(M_PI)*F;
+        return T(2)/std::sqrt(utils::pi<T>())*F;
       }
 
       // Angyan et al, equation (24)
-      inline static double Hn(unsigned int n, double Xi, double xi) {
+      template <typename T> static T Hn(unsigned int n, T Xi, T xi) {
         if(Xi<xi)
           throw std::logic_error("Xi < xi");
 
-        double Xi2np1=std::pow(Xi,2*n+1);
-        double xi2np1=std::pow(xi,2*n+1);
+        T Xi2np1=std::pow(Xi,(int)(2*n+1));
+        T xi2np1=std::pow(xi,(int)(2*n+1));
 
-        double Hn = (Xi2np1+xi2np1)*erfc(Xi+xi) - (Xi2np1-xi2np1)*erfc(Xi-xi);
-        return Hn/(2.0*std::pow(xi*Xi,n+1));
+        T Hn = (Xi2np1+xi2np1)*std::erfc(Xi+xi) - (Xi2np1-xi2np1)*std::erfc(Xi-xi);
+        return Hn/(T(2)*std::pow(xi*Xi,(int)(n+1)));
       }
 
       // Angyan et al, equation (21)
-      double Phi_general(unsigned int n, double Xi, double xi) {
+      template <typename T> static T Phi_general(unsigned int n, T Xi, T xi) {
         // Make sure arguments are in the correct order
         if(Xi < xi)
           std::swap(Xi,xi);
 
-        double Fnarr[n];
+        std::vector<T> Fnarr(n);
         for(unsigned int i=0;i<n;i++)
-          Fnarr[i]=Fn(i,Xi,xi);
+          Fnarr[i]=Fn<T>(i,Xi,xi);
 
-        double sum = 0.0;
+        T sum = T(0);
         for(unsigned int m=1;m<=n;m++) {
-          double Xim(std::pow(Xi,m));
-          double xim(std::pow(xi,m));
+          T Xim(std::pow(Xi,(int)m));
+          T xim(std::pow(xi,(int)m));
           sum += Fnarr[n-m]*((Xim*Xim + xim*xim)/(Xim*xim));
         }
 
-        return Fn(n,Xi,xi) + sum + Hn(n,Xi,xi);
+        return Fn<T>(n,Xi,xi) + sum + Hn<T>(n,Xi,xi);
       }
 
       // Angyan et al, equations 28 and 29
-      double Dnk(int n, int k, double Xi) {
+      template <typename T> static T Dnk(int n, int k, T Xi) {
         // Prefactor
-        double prefac = std::exp(-std::pow(Xi,2))/sqrt(M_PI)*std::pow(2,n+1)*std::pow(Xi,2*n+1);
+        T prefac = std::exp(-std::pow(Xi,2))/std::sqrt(utils::pi<T>())*std::pow(T(2),n+1)*std::pow(Xi,2*n+1);
 
-        double D = 0.0;
+        T D = T(0);
         if(k==0) {
           // Compute the sum
-          double sum = 0.0;
+          T sum = T(0);
           for(int m=1;m<=n;m++)
-            sum += 1.0/(double_factorial(2*(n-m)+1)*std::pow(2*Xi*Xi,m));
+            sum += T(1)/(double_factorial<T>(2*(n-m)+1)*std::pow(T(2)*Xi*Xi,m));
 
-          D = erfc(Xi) + prefac*sum;
+          D = std::erfc(Xi) + prefac*sum;
         } else {
           // Compute the sum
-          double sum = 0.0;
+          T sum = T(0);
           for(int m=1;m<=k;m++)
-            sum += choose(m-k-1,m-1)*std::pow(2*Xi*Xi,k-m)/double_factorial(2*(n+k-m)+1);
+            sum += choose<T>(m-k-1,m-1)*std::pow(T(2)*Xi*Xi,k-m)/double_factorial<T>(2*(n+k-m)+1);
 
-          D = prefac * (2.0*n+1.0)/(factorial(k)*(2.0*(n+k)+1.0)) * sum;
+          D = prefac * (T(2)*T(n)+T(1))/(factorial<T>(k)*(T(2)*T(n+k)+T(1))) * sum;
         }
 
         return D;
       }
 
       // Angyan et al, equation (30), evaluated to full numerical precision
-      double Phi_short(unsigned int n, double Xi, double xi) {
+      template <typename T> static T Phi_short(unsigned int n, T Xi, T xi) {
         // Make sure arguments are in the correct order
         if(Xi < xi)
           std::swap(Xi,xi);
         // this is a power series in xi
-        if(xi == 0.0 && n>0)
-          return 0.0;
-        else if(n == 0 && xi == 0.0 && Xi == 0.0)
+        if(xi == T(0) && n>0)
+          return T(0);
+        else if(n == 0 && xi == T(0) && Xi == T(0))
           // This is an edge case and I think this should be the right value
-          return 1.0;
+          return T(1);
 
-        double Phi = 0.0;
-        double dPhi = 0.0;
+        T Phi = T(0);
+        T dPhi = T(0);
         unsigned int k;
-        const double tol = DBL_EPSILON;
+        const T tol = std::numeric_limits<T>::epsilon();
         // Convergence is tested against max(|Phi|, 1.0): the relative test
         // alone fails when alternating-sign cancellation drives |Phi| toward
         // zero, even though the increment is genuinely below numerical noise.
+        // The cap is 200 (was 30): at long double / _Float128 the eps(T)
+        // tolerance is far tighter, so the series needs more terms before the
+        // increment falls under noise. At T = double the eps break still fires
+        // by k ~ 30, leaving the double results untouched.
         bool converged = false;
-        for(k=0; k<=30; k+=2) {
+        for(k=0; k<=200; k+=2) {
           // Unroll odd values so that we don't truncate too soon by accident
-          dPhi = Dnk(n,k  ,Xi)*std::pow(xi,n+2*k)
-            +    Dnk(n,k+1,Xi)*std::pow(xi,n+2*(k+1));
+          dPhi = Dnk<T>(n,k  ,Xi)*std::pow(xi,(int)(n+2*k))
+            +    Dnk<T>(n,k+1,Xi)*std::pow(xi,(int)(n+2*(k+1)));
           Phi += dPhi;
-          if(std::abs(dPhi) < tol*std::max(std::abs(Phi), 1.0)) {
+          if(std::abs(dPhi) < tol*std::max(std::abs(Phi), T(1))) {
             converged = true;
             break;
           }
@@ -179,30 +206,37 @@ namespace helfem {
         if(!converged) {
           std::ostringstream oss;
           oss << "Phi_short Taylor series failed to converge: n=" << n
-              << " Xi=" << Xi << " xi=" << xi
-              << " dPhi=" << dPhi << " Phi=" << Phi << "\n";
+              << " Xi=" << static_cast<double>(Xi) << " xi=" << static_cast<double>(xi)
+              << " dPhi=" << static_cast<double>(dPhi) << " Phi=" << static_cast<double>(Phi) << "\n";
           throw std::runtime_error(oss.str());
         }
 
-        return Phi/std::pow(Xi,n+1);
+        return Phi/std::pow(Xi,(int)(n+1));
       }
 
       // Wrapper
-      double Phi(unsigned int n, double Xi, double xi) {
+      template <typename T> T Phi(unsigned int n, T Xi, T xi) {
         // Make sure arguments are in the correct order
         if(Xi < xi)
           std::swap(Xi,xi);
 
         // See text on top of page 8624 of Angyan et al
-        if(xi < 0.4 || (Xi < 0.5 && xi < 2*Xi)) {
+        if(xi < T(0.4) || (Xi < T(0.5) && xi < T(2)*Xi)) {
           // Short-range Taylor polynomial
-          return Phi_short(n,Xi,xi);
+          return Phi_short<T>(n,Xi,xi);
         } else {
           // General expansion, susceptible to numerical noise for
           // small arguments
-          return Phi_general(n,Xi,xi);
+          return Phi_general<T>(n,Xi,xi);
         }
       }
+
+      // Explicit instantiations.
+      template double      Phi<double>     (unsigned int, double, double);
+      template long double Phi<long double>(unsigned int, long double, long double);
+#ifdef HELFEM_HAVE_FLOAT128
+      template _Float128   Phi<_Float128>  (unsigned int, _Float128, _Float128);
+#endif
     }
   }
 }

--- a/libhelfem/src/erfc_expn.h
+++ b/libhelfem/src/erfc_expn.h
@@ -18,20 +18,19 @@
 namespace helfem {
   namespace atomic {
     namespace erfc_expn {
-      /// Damping functions
-      double Dnk(int n, int k, double Xi);
-      /// Short-range helper
-      double Phi_short(unsigned int n, unsigned int k, double Xi, double xi);
-      /// General expansion, unstable in short range
-      double Phi_general(unsigned int n, double Xi, double xi);
-
       /**
        * Computes the complementary error function expansion as
        * described in J. G. Ángyán, I. Gerber and M. Marsman, "Spherical
        * harmonic expansion of short-range screened Coulomb
        * interactions", J. Phys. A: Math. Gen. 39, 8613 (2006).
+       *
+       * Templated on the scalar type T and explicitly instantiated for
+       * double, long double and (under HELFEM_HAVE_FLOAT128) _Float128.
+       * The whole erfc/Legendre special-function chain runs at T, so the
+       * range-separated (erfc) two-electron integrals carry T's precision
+       * rather than being capped at double.
        */
-      double Phi(unsigned int n, double Xi, double xi);
+      template <typename T> T Phi(unsigned int n, T Xi, T xi);
     }
   }
 }

--- a/libhelfem/src/quadrature.cpp
+++ b/libhelfem/src/quadrature.cpp
@@ -214,18 +214,14 @@ namespace helfem {
 
       // Green's function matrix Fn(i, k) = Phi(L, mu*ri(i), mu*rk(k)).
       //
-      // erfc_expn::Phi is the one piece of the radial layer that is still
-      // double-only: it is a long series of double-precision special-function
-      // evaluations (erfc, Boys-like damping functions) with hard-coded
-      // double tolerances. This is the single double boundary in the
-      // templated radial code -- the range-separated (erfc) two-electron
-      // integrals are therefore computed at double accuracy even at
-      // T = long double. Everything else in the chain is at T.
+      // erfc_expn::Phi is now templated on the scalar type, so the whole
+      // range-separated (erfc) special-function chain runs at T: the erfc
+      // two-electron integrals carry T's precision instead of being capped
+      // at double.
       Mat<T> Fn(ri.size(), rk.size());
       for (Eigen::Index i = 0; i < ri.size(); ++i)
         for (Eigen::Index k = 0; k < rk.size(); ++k)
-          Fn(i, k) = static_cast<T>(atomic::erfc_expn::Phi(
-              L, static_cast<double>(mu * ri(i)), static_cast<double>(mu * rk(k))));
+          Fn(i, k) = atomic::erfc_expn::Phi<T>(L, mu * ri(i), mu * rk(k));
 
       Mat<T> bfprodij = make_bfprod<T>(bfi);
       Mat<T> bfprodkl = make_bfprod<T>(bfk);


### PR DESCRIPTION
Follow-up in the arbitrary-precision arc: template the erfc (range-separated /
Yukawa-screened) two-electron integral special-function chain on the scalar type,
so range-separated integrals stop being capped at `double` when the calculation
runs at `long double` / `_Float128`.

## The cap
`atomic::erfc_expn::Phi` (and helpers `Fn`, `double_factorial`, `factorial`,
`choose`) was double-only, and `quadrature.cpp`'s `erfc_integral<T>` cast its
arguments to `double`, evaluated `Phi` at double, and cast the result back to T
— so the whole erfc integral was double even at higher T. (There was a comment
calling this out as "the one piece of the radial layer still double".)

## Change
- `erfc_expn.{cpp,h}`: `Phi<T>` and its helpers are now templated on the scalar
  type. `M_PI` -> `helfem::utils::pi<T>()` (arithmetic order preserved; the
  long-double pi literal rounds to exactly `M_PI` at double, so double is
  unchanged); `DBL_EPSILON` -> `std::numeric_limits<T>::epsilon()` so the
  short-range Taylor series runs to T's precision, not double's.
- `quadrature.cpp`: `erfc_integral<T>` calls `Phi<T>(L, mu*ri, mu*rk)` directly —
  the `static_cast<double>` on the args and `static_cast<T>` on the result are gone.

## Verification
- DOUBLE REGRESSION (bit-exact): `Phi<double>` on an (L, Xi, xi) grid is
  max|Δ|==0 vs the original, and a range-separated **LC-ωPBE** Ne atomic energy
  is bit-for-bit identical to master (`-123.6558596441`, independently confirmed).
- QUAD GAINS DIGITS: for the same (L,Xi,xi), `|Phi<quad> - Phi<double>|` and
  `|Phi<long double> - Phi<double>|` are strictly ordered (double < long double
  < quad, residuals ~1e-17..1e-25) — the series carries genuine digits beyond
  double rather than recomputing the same double value.
- No arma, no direct BLAS; full build clean.

Advances task #37; the range-separated integral path is now precision-generic.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
