### PR TITLE
Precision-aware diagnostic printouts (no double truncation at long double/_Float128)

### DIFF
--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -16,6 +16,9 @@
 #include "FiniteElementBasis.h"
 #include <cfloat>
 #include <iostream>
+// Scalar formatter that prints a T value at its own precision (no truncation
+// to double). Header-only, needs only Matrix.h + std; see src/general/eigen_io.h.
+#include "../../src/general/eigen_io.h"
 
 namespace helfem {
   namespace polynomial_basis {
@@ -114,15 +117,13 @@ namespace helfem {
           std::cout << "lh values:\n" << lh.template cast<double>()   << "\n";
           std::cout << "rh values:\n" << rh.template cast<double>()   << "\n";
           std::cout << "difference:\n" << diff.template cast<double>() << "\n";
-          // printf is a double-only boundary: %e consumes a double, so a
-          // T = long double argument is undefined behaviour (it printed
-          // garbage denormals). Cast here and nowhere else.
-          printf("Difference norm %e\n", (double) dnorm(iel));
+          // Format the T norm at its own precision (no truncation to double).
+          printf("Difference norm %s\n", helfem::io::fmt_sci(dnorm(iel)).c_str());
         }
       }
       Eigen::Index imax;
       dnorm.maxCoeff(&imax);
-      printf("Finite element basis set max discontinuity %e between elements %i and %i\n",(double) dnorm(imax),(int) imax,(int) imax+1);
+      printf("Finite element basis set max discontinuity %s between elements %i and %i\n",helfem::io::fmt_sci(dnorm(imax)).c_str(),(int) imax,(int) imax+1);
       fflush(stdout);
       if(dnorm(imax) > sqrt(DBL_EPSILON)) {
         throw std::logic_error("Finite element basis set is not continuous\n");

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -18,6 +18,9 @@
 #include "utils.h"
 #include <lib1dfem/chebyshev.h>
 #include <limits>
+// Scalar formatter that prints a T value at its own precision (no truncation
+// to double). Header-only, needs only Matrix.h + std; see src/general/eigen_io.h.
+#include "../../src/general/eigen_io.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -34,11 +37,11 @@ namespace helfem {
       FEMRadialBasisT<T>::FEMRadialBasisT(const polynomial_basis::FiniteElementBasisT<T> & fem_, int n_quad) : fem(fem_) {
         helfem::lib1dfem::chebyshev::chebyshev<T>(n_quad, xq, wq);
         for (Eigen::Index i = 0; i < xq.size(); ++i) {
-          // printf is a double-only boundary; cast there and nowhere else.
+          // Format the T value at its own precision (no truncation to double).
           if (!std::isfinite(xq(i)))
-            printf("xq[%lld]=%e\n", (long long) i, (double) xq(i));
+            printf("xq[%lld]=%s\n", (long long) i, helfem::io::fmt_sci(xq(i)).c_str());
           if (!std::isfinite(wq(i)))
-            printf("wq[%lld]=%e\n", (long long) i, (double) wq(i));
+            printf("wq[%lld]=%s\n", (long long) i, helfem::io::fmt_sci(wq(i)).c_str());
         }
       }
 
@@ -386,7 +389,7 @@ namespace helfem {
 	r_0 = std::abs(r_0);
 
 	if(iconf==1) {
-          printf("Polynomial confinement, r_0 = %e N = %i shift = %e \n",(double) r_0,N,(double) shift_pot);
+          printf("Polynomial confinement, r_0 = %s N = %i shift = %s \n",helfem::io::fmt_sci(r_0).c_str(),N,helfem::io::fmt_sci(shift_pot).c_str());
 	  if(N<0) {
 	    if(shift_pot != T(0))
 	      throw std::logic_error("Cannot have a divergent potential with a shift!\n");
@@ -396,7 +399,7 @@ namespace helfem {
 	  }
 
 	} else if(iconf==2) {
-          printf("Exponential confinement, r_0 = %e N = %i shift = %e \n",(double) r_0,N,(double) shift_pot);
+          printf("Exponential confinement, r_0 = %s N = %i shift = %s \n",helfem::io::fmt_sci(r_0).c_str(),N,helfem::io::fmt_sci(shift_pot).c_str());
 
 	  if(N<0)
 	    throw std::logic_error("Exponential confinement potential does not make sense with negative N!\n");
@@ -409,11 +412,11 @@ namespace helfem {
 	  if(V<0)
 	    throw std::logic_error("Cannot have attractive barrier!\n");
 
-          printf("Barrier confinement, V = %e shift = %e \n",(double) V,(double) shift_pot);
+          printf("Barrier confinement, V = %s shift = %s \n",helfem::io::fmt_sci(V).c_str(),helfem::io::fmt_sci(shift_pot).c_str());
 	  return barrier_confinement(iel, V, shift_pot);
 
 	} else if(iconf==4) {
-          printf("Junquera-type confinement, r_0 = %e N = %i V = %e shift = %e \n",(double) r_0,N,(double) V,(double) shift_pot);
+          printf("Junquera-type confinement, r_0 = %s N = %i V = %s shift = %s \n",helfem::io::fmt_sci(r_0).c_str(),N,helfem::io::fmt_sci(V).c_str(),helfem::io::fmt_sci(shift_pot).c_str());
 	  if(N<=0)
 	    throw std::logic_error("Junquera confinement potential requires N >= 1!");
 	  if(V<=0)

--- a/libhelfem/src/RegularizedNucleus.cpp
+++ b/libhelfem/src/RegularizedNucleus.cpp
@@ -15,6 +15,9 @@
 #include "RegularizedNucleus.h"
 #include "Matrix.h"
 #include "utils.h"
+// Scalar formatter that prints a T value at its own precision (no truncation
+// to double). Header-only, needs only Matrix.h + std; see src/general/eigen_io.h.
+#include "../../src/general/eigen_io.h"
 #include <lib1dfem/chebyshev.h>
 #include <cmath>
 #include <functional>
@@ -229,8 +232,8 @@ namespace helfem {
       // Number of quadrature points
       int N = 100;
       b = find_b<T>(a,N);
-      // printf is a double-only boundary; cast there and nowhere else.
-      printf("a = %.15e yields b = %.15e\n",(double) a,(double) b);
+      // Format the T values at their own precision (no truncation to double).
+      printf("a = %s yields b = %s\n",helfem::io::fmt_sci(a).c_str(),helfem::io::fmt_sci(b).c_str());
     }
 
     template class RegularizedNucleusT<double>;

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -14,6 +14,9 @@
  */
 #include "utils.h"
 #include <lib1dfem/math.h>
+// Scalar formatter that prints a T value at its own precision (no truncation
+// to double). Header-only, needs only Matrix.h + std; see src/general/eigen_io.h.
+#include "../../src/general/eigen_io.h"
 #include <Eigen/Cholesky>
 #include <Eigen/Eigenvalues>
 #include <Eigen/LU>
@@ -139,10 +142,13 @@ namespace helfem {
           throw std::logic_error("Diagonalization of overlap matrix failed\n");
         const helfem::Vec<T> Sval = es.eigenvalues();
         const helfem::Mat<T> Svec = es.eigenvectors();
-        // printf has no conversion for T; go through double at the I/O
-        // boundary only (the arithmetic above stays in T).
-        printf("Smallest eigenvalue of overlap matrix is % e, condition number %e\n",
-               (double) Sval(0), (double) (Sval(Sval.size() - 1) / Sval(0)));
+        // Format the T eigenvalues at their own precision (no truncation to
+        // double). Sval(0) is the smallest eigenvalue of the (SPD) overlap
+        // matrix and hence positive, so the leading " " reproduces the old
+        // "% e" space flag exactly.
+        printf("Smallest eigenvalue of overlap matrix is %s, condition number %s\n",
+               (" " + helfem::io::fmt_sci(Sval(0))).c_str(),
+               helfem::io::fmt_sci(Sval(Sval.size() - 1) / Sval(0)).c_str());
         Sinvh = Svec * inv_sqrt<T>(Sval).asDiagonal() * Svec.transpose();
       }
 

--- a/src/general/eigen_io.h
+++ b/src/general/eigen_io.h
@@ -16,6 +16,7 @@
 #define HELFEM_EIGEN_IO_H
 
 #include "Matrix.h"
+#include <charconv>
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -31,6 +32,36 @@
 
 namespace helfem {
   namespace io {
+
+    /// Format a single scalar of type T in scientific notation, with the
+    /// precision that follows the scalar type -- exactly the max_digits10(T)-1
+    /// policy of write_raw_ascii / print_matrix below. std::to_chars with
+    /// chars_format::scientific and precision p prints p+1 significant figures,
+    /// and max_digits10 is the count needed to round-trip T, so
+    /// precision = max_digits10(T)-1 shows exactly enough digits to reconstruct
+    /// the value and no more: 16 for double, ~20 for long double, ~35 for
+    /// _Float128.
+    ///
+    /// The value is converted AT ITS OWN precision -- there is NO cast to
+    /// double, so a long double / _Float128 diagnostic actually displays its
+    /// extra digits instead of being truncated by printf("%e",(double)x).
+    ///
+    /// std::to_chars is used rather than an ostringstream because libstdc++'s
+    /// operator<< is ambiguous for _Float128 (it converts equally well to
+    /// float/double/long double); the matrix dumpers below stream T directly
+    /// only because they are never instantiated at _Float128. to_chars is pure
+    /// standard library (C++17 for double/long double, C++23 for float128),
+    /// so no extra dependency, and it round-trips all three types exactly.
+    template <typename T>
+    std::string fmt_sci(const T & x) {
+      constexpr int prec = std::numeric_limits<T>::max_digits10 - 1;
+      // Longest output is "-d.<prec digits>e-NNNN": sign + digit + '.' + prec +
+      // 'e' + sign + up-to-4-digit exponent. max_digits10 + 16 is ample.
+      char buf[std::numeric_limits<T>::max_digits10 + 16];
+      const auto res = std::to_chars(buf, buf + sizeof(buf), x,
+                                     std::chars_format::scientific, prec);
+      return std::string(buf, res.ptr);
+    }
 
     namespace detail {
       /// One matrix row, as arma::raw_ascii writes it: each entry

--- a/src/general/model_potential.cpp
+++ b/src/general/model_potential.cpp
@@ -1,12 +1,14 @@
 #include "model_potential.h"
 #include "sap.h"
 #include "gsz.h"
+#include "eigen_io.h"
 #include <cfloat>
 
 namespace helfem {
   namespace modelpotential {
-    // printf has no conversion for a general T, so the diagnostics go through
-    // double at the I/O boundary only; the potential itself is built in T.
+    // printf has no conversion for a general T, so the T-typed radius is
+    // formatted with helfem::io::fmt_sci (scientific, at T's own precision)
+    // and spliced in as %s -- no truncation to double at the I/O boundary.
     template <typename T>
     ModelPotentialT<T> * get_nuclear_model(nuclear_model_t model, int Z, T Rrms) {
       switch(model) {
@@ -14,16 +16,16 @@ namespace helfem {
         printf("Getting point nucleus with Z=%i\n",Z);
         return new PointNucleusT<T>(Z);
       case(GAUSSIAN_NUCLEUS):
-        printf("Getting Gaussian nucleus with Z=%i Rrms=%e\n",Z,(double) Rrms);
+        printf("Getting Gaussian nucleus with Z=%i Rrms=%s\n",Z,helfem::io::fmt_sci(Rrms).c_str());
         return new GaussianNucleusT<T>(Z,Rrms);
       case(HOLLOW_NUCLEUS):
-        printf("Getting hollow spherical nucleus with Z=%i Rrms=%e\n",Z,(double) Rrms);
+        printf("Getting hollow spherical nucleus with Z=%i Rrms=%s\n",Z,helfem::io::fmt_sci(Rrms).c_str());
         return new HollowNucleusT<T>(Z,Rrms);
       case(SPHERICAL_NUCLEUS):
-        printf("Getting uniformly charged spherical nucleus with Z=%i Rrms=%e\n",Z,(double) Rrms);
+        printf("Getting uniformly charged spherical nucleus with Z=%i Rrms=%s\n",Z,helfem::io::fmt_sci(Rrms).c_str());
         return new SphericalNucleusT<T>(Z,Rrms);
       case(REGULARIZED_NUCLEUS):
-        printf("Getting regularized nucleus with Z=%i a=%e\n",Z,(double) Rrms);
+        printf("Getting regularized nucleus with Z=%i a=%s\n",Z,helfem::io::fmt_sci(Rrms).c_str());
         return new RegularizedNucleusT<T>(Z,Rrms);
       case(NOSUCH_NUCLEUS):
         throw std::logic_error("No such nucleus!\n");


### PR DESCRIPTION
Follow-up in the arbitrary-precision arc: make the diagnostic printouts
precision-aware, so a `long double` / `_Float128` run can DISPLAY its extra
digits instead of `printf("%e",(double)x)` truncating every T-typed value to
double for display. Display only — no numeric behavior change.

## Change
- New `helfem::io::fmt_sci<T>(x)` in `src/general/eigen_io.h`: scientific notation
  with precision `max_digits10(T)-1` (16 double / ~20 long double / ~35
  _Float128), NO cast to double. Uses `std::to_chars` (chars_format::scientific)
  rather than an ostringstream because libstdc++'s `operator<<` is ambiguous for
  `_Float128` (converts equally to float/double/long double); `to_chars`
  round-trips all three exactly and adds no dependency. (The matrix dumpers keep
  `operator<<` — they are never instantiated at `_Float128`.)
- Converted the ~12 `printf("...%e...",(double)<T value>...)` diagnostic sites in
  the templated core (`FiniteElementBasis.cpp`, `RadialBasis.cpp`,
  `RegularizedNucleus.cpp`, `utils.cpp`, `model_potential.cpp`) to
  `%s` + `helfem::io::fmt_sci(x).c_str()`. Labels unchanged; libxc/HDF5/timing/
  integer prints untouched.

## Verification
- Build clean; atomic Ar HF still `-475.8712591129` (value is display-independent).
- QUAD DISPLAY payoff: in `atomic_precision`, a converted diagnostic line prints
  its full precision — `2.01383400001228435833062116315933341e+00` (35 sig figs)
  at `_Float128`, `2.01383400001228435512e+00` (20) at `long double` — vs the ~16
  the old `(double)` cast allowed.

No libfmt dependency (it can't format `_Float128` natively anyway). Advances #37.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
