### PR TITLE
docs: reusable-FEM-library restructuring plan + auto-converging evaluator prototype

### DIFF
--- a/docs/autoconv_prototype.cpp
+++ b/docs/autoconv_prototype.cpp
@@ -1,0 +1,111 @@
+// Prototype: auto-converging FEM matrix-element evaluator.
+//
+// Demonstrates <d^k B | f(x) | d^l B> quadrature that refines its own Gauss-
+// Lobatto order until the value is stable to eps(T), across double / long
+// double / _Float128, on the three integrand regimes that matter for HelFEM:
+//   A) polynomial       (overlap / kinetic / POINT-nucleus after the r^2 measure)
+//   B) smooth non-poly  (finite nuclei, model potentials, erfc/Yukawa)
+//   C) a kink at x0     (the radial 2e Green's function r<^L / r>^(L+1) at r=r')
+//
+// Uses lib1dfem's templated Gauss-Lobatto rule -- the real machinery.
+#include <lib1dfem/types.h>
+#include <lib1dfem/lobatto.h>
+#include <functional>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+using helfem::lib1dfem::Vec;
+
+// One Gauss-Lobatto panel of order n on [a,b].
+template <typename T>
+T panel(T a, T b, int n, const std::function<T(T)> & g) {
+  Vec<T> x, w;
+  helfem::lib1dfem::lobatto::lobatto_compute<T>(n, x, w);   // nodes/weights on [-1,1]
+  const T half = (b - a) / T(2), mid = (a + b) / T(2);
+  T I = T(0);
+  for (int k = 0; k < n; ++k) I += w(k) * g(mid + half * x(k));
+  return I * half;
+}
+
+// Auto-converge the order on a single panel until |I_n - I_{n-1}| <= tol*|I_n|.
+// Returns {value, order, converged}.
+template <typename T>
+struct Res { T val; int order; bool ok; };
+
+template <typename T>
+Res<T> integrate(T a, T b, const std::function<T(T)> & g, int nmax = 400) {
+  const T tol = T(8) * std::numeric_limits<T>::epsilon();
+  T prev = T(0);
+  bool have = false;
+  for (int n = 2; n <= nmax; ++n) {
+    T I = panel<T>(a, b, n, g);
+    if (have && std::abs(I - prev) <= tol * (std::abs(I) + tol))
+      return {I, n, true};
+    prev = I; have = true;
+  }
+  return {prev, nmax, false};
+}
+
+// Subdivision-aware: same, but split at the breakpoints (e.g. the kink) so each
+// sub-panel sees a smooth integrand. Sums the per-panel auto-converged values.
+template <typename T>
+Res<T> integrate_split(T a, T b, const std::vector<T> & brk,
+                       const std::function<T(T)> & g) {
+  std::vector<T> pts; pts.push_back(a);
+  for (T p : brk) if (p > a && p < b) pts.push_back(p);
+  pts.push_back(b);
+  T tot = T(0); int maxord = 0; bool ok = true;
+  for (size_t i = 0; i + 1 < pts.size(); ++i) {
+    Res<T> r = integrate<T>(pts[i], pts[i + 1], g);
+    tot += r.val; maxord = std::max(maxord, r.order); ok = ok && r.ok;
+  }
+  return {tot, maxord, ok};
+}
+
+template <typename T>
+const char * name();
+template <> const char * name<double>()      { return "double     "; }
+template <> const char * name<long double>() { return "long double"; }
+template <> const char * name<_Float128>()   { return "_Float128  "; }
+
+template <typename T>
+void run() {
+  const int P = std::numeric_limits<T>::max_digits10;
+  // Case A: g = x^2 on [0,1]  (polynomial; exact ref 1/3).
+  {
+    auto g = [](T x){ return x * x; };
+    Res<T> r = integrate<T>(T(0), T(1), g);
+    T err = std::abs(r.val - T(1) / T(3));
+    printf("  A poly x^2      %s  n=%3d  err=%.*Le\n", name<T>(), r.order, 3, (long double)err);
+  }
+  // Case B: g = exp(-x) on [0,1]  (smooth non-poly; ref 1 - 1/e at precision T).
+  {
+    auto g = [](T x){ return std::exp(-x); };
+    Res<T> r = integrate<T>(T(0), T(1), g);
+    T err = std::abs(r.val - (T(1) - std::exp(T(-1))));
+    printf("  B exp(-x)       %s  n=%3d  err=%.*Le\n", name<T>(), r.order, 3, (long double)err);
+  }
+  // Case C: g = |x - 1/2| on [0,1]  (kink; ref 1/4). Naive vs split-at-kink.
+  {
+    T x0 = T(1) / T(2);
+    auto g = [x0](T x){ return std::abs(x - x0); };
+    Res<T> naive = integrate<T>(T(0), T(1), g);
+    Res<T> split = integrate_split<T>(T(0), T(1), {x0}, g);
+    T en = std::abs(naive.val - T(1) / T(4));
+    T es = std::abs(split.val - T(1) / T(4));
+    printf("  C kink |x-.5|   %s  naive: n=%3d err=%.*Le %s | split@kink: n=%3d err=%.*Le\n",
+           name<T>(), naive.order, 3, (long double)en, naive.ok ? "conv" : "STALL",
+           split.order, 3, (long double)es);
+  }
+  (void)P;
+}
+
+int main() {
+  printf("auto-converging matrix element (tol = 8*eps(T)); n = Gauss-Lobatto order reached\n\n");
+  run<double>();
+  run<long double>();
+  run<_Float128>();
+  return 0;
+}

--- a/docs/library-refactor.md
+++ b/docs/library-refactor.md
@@ -1,0 +1,134 @@
+# Library restructuring plan: a reusable FEM core
+
+Status: proposal for discussion. Prototype in `docs/autoconv_prototype.cpp`.
+
+## Goal
+
+Turn `libhelfem` into a **proper, reusable, domain-agnostic finite-element
+library**, and keep the atomic / diatomic quantum chemistry as *applications*
+on top of it. Concretely, a two-library stack:
+
+```
+libhelfem     FEM discretization + matrix-element / 2e-Green's-function
+              evaluators.  Templated on the scalar type, auto-converging to
+              eps(T).  Knows nothing about electrons.
+   |
+libhelfemqc   Radial quantum chemistry: potentials (nucleus models, model
+              potentials), Coulomb/exchange kernels + angular coupling,
+              GTO/STO/NAO.  Supplies "f(x)" and its breakpoints to libhelfem.
+   |
+HelFEM        Applications: atomic/, diatomic/, sadatom/, SCF, DFT.
+```
+
+## Where we start from (better than a blank slate)
+
+The codebase already leans this way:
+
+- **The unifying primitive already exists.** `FiniteElementBasis::matrix_element(
+  lhder, rhder, xq, wq, f)` is exactly `<d^k B | f(x) | d^l B>`: left/right
+  derivative orders and an arbitrary weight `f` (`std::function<T(T)>`, null =
+  unit). There is a matching `vector_element` and generic-callable overloads.
+- **`RadialBasis` already keeps physics out.** Its `kinetic()` *excludes* the
+  centrifugal term — "caller adds `l(l+1)*kinetic_l()`". Angular momentum is
+  already the caller's business.
+- **The r^2 measure tames the obvious singularity.** The point-nucleus element
+  is `-<R| r |R>` (the `1/r` is cancelled by the spherical Jacobian) — a
+  *polynomial* weight, the *easy* case, not a hard one.
+
+So this is ~60% a consolidation, not a rewrite.
+
+## Component classification
+
+| Component | Today | Target | Note |
+|---|---|---|---|
+| polynomial bases (LIP/HIP/HIP2/HIP3/Legendre), quadrature, grid | lib1dfem | **libhelfem** | fold lib1dfem in — no separate customer for "bases" vs "assembly" |
+| `FiniteElementBasis` (+ `matrix_element`) | libhelfem | **libhelfem** | the general assembly + the unifying evaluator |
+| `RadialBasis` | libhelfem | **libhelfem** | radial/spherical FEM is domain-neutral; already physics-free once `f` is injected |
+| radial 2e primitives (`twoe_integral`, `yukawa_integral` per multipole L) | libhelfem | **libhelfem** | the `r<^L/r>^(L+1)` Green's function is math, not chemistry |
+| nucleus models, `ModelPotential`/`RadialPotential` | libhelfem | **libhelfemqc** | these are just `f(r)` |
+| `CoulombExchangeFE`, `erfc_expn` | libhelfem | **libhelfemqc** | kernel choice + angular coupling + Fock assembly is chemistry |
+| `NAORadialBasis`, `GTO`, `STO` | libhelfem | **libhelfemqc** | atomic orbitals |
+| gaunt, SCF, DFT, checkpoint, atomic/diatomic bases | helfem-common | **HelFEM app** | unchanged |
+
+## The auto-converging matrix-element evaluator
+
+Replace the caller-supplied `(xq, wq)` with an evaluator that refines its own
+quadrature until the element is stable to `eps(T)`. The prototype
+(`docs/autoconv_prototype.cpp`, run below) establishes the strategy empirically:
+
+```
+  A poly x^2    double  n=4  err=0         | _Float128 n=4  err=0
+  B exp(-x)     double  n=8  err=0         | _Float128 n=13 err=0
+  C kink |x-.5| double  naive n=400 err=1.3e-6 STALL | split@kink n=3 err=0
+```
+
+Design that follows from it:
+
+1. **Polynomial / unit `f`: no iteration.** Compute the exact Gauss-Lobatto
+   order from the integrand degree (`deg(B_k)+deg(B_l)+deg(f)`), evaluate once.
+   Covers overlap, kinetic, point-nucleus, polynomial confinement — the bulk.
+2. **Smooth non-polynomial `f`: order-refine.** Double the order until
+   `|I_n - I_{n-1}| <= eps(T)*|I_n|`. Converges geometrically and, crucially,
+   the required order grows with `T` on its own (8 at double, 13 at quad) — the
+   element reaches *its type's* machine precision with no tuning. Covers finite
+   nuclei, model potentials, erfc/Yukawa weights.
+3. **Non-smooth `f` (kinks, integrable singularities): subdivide, don't
+   over-quadrature.** Across a cusp, order-refinement *stalls* — at ~1.3e-6 for
+   the 2e Green's function, and quad buys nothing. The evaluator must take the
+   breakpoint locations and split there; each smooth sub-panel then converges by
+   rule (2). **The QC layer supplies `f` together with its breakpoints** (e.g.
+   `r=r'` for the Coulomb kernel, the nuclear boundary for a finite nucleus).
+
+Proposed general interface (schematic):
+
+```cpp
+// libhelfem
+Mat<T> matrix_element(int lhder, int rhder,
+                      const std::function<T(T)>& f,           // null = unit
+                      const std::vector<T>& breakpoints = {}, // non-smooth points of f
+                      int poly_degree_of_f = -1);             // >=0 => exact order, no refine
+```
+
+Chemistry side becomes declarative: `overlap = matrix_element(0,0, r^2)`,
+`nuclear = -matrix_element(0,0, r)`, `finite_nuclear =
+matrix_element(0,0, r^2*V(r), {R_nuc})`, etc.
+
+## Two-electron integrals
+
+`twoe_integral(L, iel)` (the `r<^L/r>^(L+1)` radial Green's function per
+multipole) stays a **libhelfem** primitive — it's the 2-coordinate analogue of
+the matrix element, and its cusp on the diagonal is exactly a breakpoint case.
+What is chemistry and moves to **libhelfemqc**: which multipoles couple, the
+Gaunt angular factors, Coulomb-vs-exchange pairing, the erfc/Yukawa kernel
+choice, and the Fock build.
+
+## Phasing (one PR each)
+
+1. **Make `matrix_element` the single 1e assembly path.** Rewrite
+   `RadialBasis`'s `overlap/kinetic/nuclear/potential/...` as thin `(k,l,f)`
+   callers; delete the duplicates. Bit-exactness gate against master.
+2. **Auto-convergence.** Add the degree-aware / order-refining / breakpoint-aware
+   evaluator; make the QC callers pass breakpoints. Gate: existing energies
+   bit-identical at double (exact-order path), and a known-hard element
+   (finite-nucleus, 2e cusp) converges to eps(T) at double **and** gains digits
+   at quad.
+3. **Split `libhelfemqc`.** Move nucleus models, `ModelPotential`/
+   `RadialPotential`, `CoulombExchangeFE`, `erfc_expn`, `NAO`/`GTO`/`STO` up into
+   a new `libhelfemqc` target; `libhelfem` keeps only FEM + evaluators. Update
+   `helfem-common` to link `libhelfemqc`. Downstream `find_package` consumer test.
+4. **Fold `lib1dfem` into `libhelfem`.** Collapse the base-primitive library into
+   the FEM library; one general target.
+
+## Open questions / risks
+
+- **Breakpoint plumbing.** Every non-smooth `f` must carry its breakpoints. Are
+  they always known analytically (nucleus radius, `r=r'`)? Yes for the current
+  set; a general library should still allow a fallback adaptive bisection when
+  they are not.
+- **Naming.** `libhelfem` (general) + `libhelfemqc` (chemistry) as agreed. The
+  `helfem::` C++ namespace is shared; the QC pieces likely want a
+  `helfem::qc::` sub-namespace to mirror the target split.
+- **Performance.** The exact-order short-circuit must cover the SCF hot path so
+  auto-convergence never adds cost where the integrand is polynomial.
+- **`erfc_expn` still lives in `atomic::`.** Rename its namespace as part of the
+  QC move.


### PR DESCRIPTION
Design proposal (for discussion, not a code change): make libhelfem a reusable domain-agnostic FEM library with a libhelfemqc chemistry layer on top. Includes component classification, four-PR phasing, the auto-converging `<d^k B|f|d^l B>` evaluator design, and a runnable prototype (`docs/autoconv_prototype.cpp`) that establishes the breakpoint-aware convergence strategy across double/long double/_Float128. See docs/library-refactor.md.