### PR TITLE
build: enable wignernj quadmath under its 0.8.0 option name (fixes fetched-wignernj gaunt_q link)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ if(NOT wignernj_FOUND)
     FetchContent_Declare(wignernj
         GIT_REPOSITORY https://github.com/susilehtola/wignernj.git
         GIT_TAG        v0.8.0)
+    # gaunt.cpp calls the __float128 C entry point ::gaunt_q, which wignernj
+    # only compiles when its quadmath build is enabled. In wignernj 0.8.0 that
+    # option was renamed BUILD_QUADMATH -> WIGNERNJ_BUILD_QUADMATH and defaults
+    # OFF, so it must be set explicitly here or ::gaunt_q fails to link.
+    set(WIGNERNJ_BUILD_QUADMATH ON CACHE INTERNAL "")
     FetchContent_MakeAvailable(wignernj)
     if(NOT TARGET wignernj::wignernj)
         add_library(wignernj::wignernj ALIAS wignernj)


### PR DESCRIPTION
The FetchContent fallback pins wignernj v0.8.0, which renamed `BUILD_QUADMATH` -> `WIGNERNJ_BUILD_QUADMATH` (defaulting OFF). HelFEM set neither, so the fetched wignernj built without `gaunt_q` and `gaunt.cpp`'s `::gaunt_q` (the __float128 quad-Gaunt entry point) failed to link for anyone without a system wignernj >= 0.7.0. Fix: set `WIGNERNJ_BUILD_QUADMATH=ON` before `FetchContent_MakeAvailable(wignernj)`.

Verified: standalone v0.8.0 build shows old option name FATAL-errors / 0 `gaunt_q` symbols vs new name -> 1; and a forced HelFEM fetch now links `gaunt_test` with `::gaunt_q` resolved (0 errors). System-0.7.0 path unaffected.

Diagnosis credit: the wignernj author (option rename in wignernj PR #44 / commit 74c3857).