### PR TITLE
build: fetch latest stable Eigen (5.0.1) instead of 3.4.0 when absent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,19 +111,20 @@ endif()
 
 install(TARGETS helfem_blas EXPORT helfemTargets)
 
-# Eigen3 (>= 3.4) -- header-only. Prefer a system install, else fetch
-# v3.4.0. The range form `3.4...99` accepts any >= 3.4 (a bare `3.4`
-# is read as the exclusive [3.4, 3.5) by Eigen's ConfigVersion and would
-# reject e.g. Fedora's Eigen 5). The system Eigen is used verbatim -- no
-# patching -- which is why HELFEM_EIGEN_BLAS is restricted to LP64, where
-# stock Eigen's 32-bit BLAS backend already matches the linked BLAS.
+# Eigen3 (>= 3.4) -- header-only. Prefer a system install, else fetch the
+# latest stable release (5.0.1). The range form `3.4...99` accepts any
+# >= 3.4 (a bare `3.4` is read as the exclusive [3.4, 3.5) by Eigen's
+# ConfigVersion and would reject e.g. Fedora's Eigen 5). The system Eigen
+# is used verbatim -- no patching -- which is why HELFEM_EIGEN_BLAS is
+# restricted to LP64, where stock Eigen's 32-bit BLAS backend already
+# matches the linked BLAS.
 find_package(Eigen3 3.4...99 QUIET NO_MODULE)
 if(NOT Eigen3_FOUND)
-    message(STATUS "Eigen3 >= 3.4 not found; fetching v3.4.0")
+    message(STATUS "Eigen3 >= 3.4 not found; fetching v5.0.1")
     include(FetchContent)
     FetchContent_Declare(Eigen3
         GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-        GIT_TAG        3.4.0)
+        GIT_TAG        5.0.1)
     set(EIGEN_BUILD_DOC       OFF CACHE INTERNAL "")
     set(EIGEN_BUILD_PKGCONFIG OFF CACHE INTERNAL "")
     set(BUILD_TESTING         OFF CACHE INTERNAL "")


### PR DESCRIPTION
When no system Eigen is found, the FetchContent fallback now pulls the latest stable release **5.0.1** (was 3.4.0). The accepted-version range (`find_package(Eigen3 3.4...99)`) is unchanged, so a system Eigen >= 3.4 is still used as-is; only the from-source fallback moves. Verified the v5.0.1 tag fetches and still provides the `Eigen3::Eigen` alias target HelFEM links; the code already builds against system Eigen 5.0.1.