### PR TITLE
FEM refactor Phase 2: auto-converging matrix_element (degree-aware, order-refining, breakpoint-aware)

### DIFF
--- a/libhelfem/include/FiniteElementBasis.h
+++ b/libhelfem/include/FiniteElementBasis.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 #include "PolynomialBasis.h"
 #include "Matrix.h"
 #include <lib1dfem/types.h>
@@ -204,6 +205,57 @@ namespace helfem {
       helfem::Vec<T> vector_element(const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_bf, const helfem::Vec<T> & xq, const helfem::Vec<T> & wq, const std::function<T(T)> & f) const;
       /// The driver function
       helfem::Vec<T> vector_element(size_t iel, const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_bf, const helfem::Vec<T> & xq, const helfem::Vec<T> & wq, const std::function<T(T)> & f) const;
+
+      /**
+       * Auto-converging matrix element (Phase 2).
+       *
+       * Computes <d^lhder B | f(r) | d^rhder B> over element `iel` (or over
+       * the whole basis) while refining its OWN Gauss-Lobatto quadrature until
+       * the element block is stable to 8*eps(T). Replaces the caller-supplied
+       * fixed (xq,wq) rule: the required order grows on its own with the
+       * precision of T, so every block reaches its type's machine precision
+       * with no tuning.
+       *
+       * lhder/rhder:  derivative orders of the FE basis functions
+       * f:            weight function (null => unit weight)
+       * breakpoints:  real-space points where f is non-smooth (kinks,
+       *               integrable singularities). The element is split there
+       *               and each smooth sub-panel is converged separately, since
+       *               plain order-refinement STALLS across a kink.
+       * poly_degree_f: total polynomial degree of f if it is a polynomial
+       *               (>=0), else -1. Used only to pick a good starting order;
+       *               the refine loop always confirms convergence.
+       */
+      helfem::Mat<T> matrix_element(size_t iel, int lhder, int rhder,
+                                    const std::function<T(T)> & f,
+                                    const std::vector<T> & breakpoints = std::vector<T>(),
+                                    int poly_degree_f = -1) const;
+      /// Same as above, summed over every element of the basis.
+      helfem::Mat<T> matrix_element(int lhder, int rhder,
+                                    const std::function<T(T)> & f,
+                                    const std::vector<T> & breakpoints = std::vector<T>(),
+                                    int poly_degree_f = -1) const;
+
+      /**
+       * Auto-converging matrix element with caller-supplied bra/ket
+       * evaluators (the generic engine used by RadialBasis's R = B/r kinds).
+       * Same refinement + breakpoint-split strategy as the (lhder,rhder)
+       * overloads above. x_left/x_right optionally restrict the reference
+       * element to a sub-range [x_left,x_right] (both in [-1,1]).
+       */
+      helfem::Mat<T> matrix_element_auto(size_t iel,
+                                         const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_lh,
+                                         const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_rh,
+                                         const std::function<T(T)> & f,
+                                         const std::vector<T> & breakpoints = std::vector<T>(),
+                                         int poly_degree_f = -1,
+                                         T x_left = T(-1), T x_right = T(1)) const;
+      /// Same as above, summed over every element of the basis.
+      helfem::Mat<T> matrix_element_auto(const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_lh,
+                                         const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_rh,
+                                         const std::function<T(T)> & f,
+                                         const std::vector<T> & breakpoints = std::vector<T>(),
+                                         int poly_degree_f = -1) const;
 
       /// Print out the basis functions
       void print(const std::string & str="") const;

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -18,6 +18,7 @@
 #include "ModelPotential.h"
 #include "FiniteElementBasis.h"
 #include "Matrix.h"
+#include <vector>
 
 namespace helfem {
   namespace atomic {
@@ -149,15 +150,23 @@ namespace helfem {
         /// FiniteElementBasisT::matrix_element and is the engine that the
         /// named matrix-element methods below (overlap, kinetic, nuclear, ...)
         /// can be composed from. Default weight is identity (1).
-        /// Eigen-typed (Phase 2a migration).
+        /// Eigen-typed (Phase 2a migration). Phase 2: routes through the
+        /// finite-element basis's auto-converging quadrature. `breakpoints`
+        /// are real-space points where the weight is non-smooth (the element
+        /// is split there); `poly_degree_f` is the polynomial degree of the
+        /// weight if known (>=0, else -1), used only to seed the order.
         helfem::Mat<T> matrix_element(
             size_t iel, BasisKind bra, BasisKind ket,
-            const std::function<T(T)> & weight = std::function<T(T)>()) const;
+            const std::function<T(T)> & weight = std::function<T(T)>(),
+            const std::vector<T> & breakpoints = std::vector<T>(),
+            int poly_degree_f = -1) const;
 
         /// Same as above, summed over every element of the basis.
         helfem::Mat<T> matrix_element(
             BasisKind bra, BasisKind ket,
-            const std::function<T(T)> & weight = std::function<T(T)>()) const;
+            const std::function<T(T)> & weight = std::function<T(T)>(),
+            const std::vector<T> & breakpoints = std::vector<T>(),
+            int poly_degree_f = -1) const;
 
         /// Per-element matrix element restricted to a sub-range of the
         /// reference element [x_left, x_right] (defaults to the full range

--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -14,11 +14,15 @@
  */
 
 #include "FiniteElementBasis.h"
+#include <lib1dfem/lobatto.h>
+#include <algorithm>
 #include <cfloat>
 #include <iostream>
 // Scalar formatter that prints a T value at its own precision (no truncation
 // to double). Header-only, needs only Matrix.h + std; see src/general/eigen_io.h.
 #include "../../src/general/eigen_io.h"
+#include <limits>
+#include <vector>
 
 namespace helfem {
   namespace polynomial_basis {
@@ -425,8 +429,18 @@ namespace helfem {
       // Total weight per point
       helfem::Vec<T> wp = wq * scaling_factor(iel) * a;
       if (f) {
-        for (Eigen::Index i = 0; i < wp.size(); ++i)
-          wp(i) *= f(r(i));
+        for (Eigen::Index i = 0; i < wp.size(); ++i) {
+          const T fv = f(r(i));
+          // Auto-converging quadrature uses Gauss-Lobatto, which -- unlike the
+          // old open Gauss-Chebyshev rule -- samples the element ENDPOINTS. A
+          // weight with an integrable singularity at an endpoint (e.g. a bare
+          // -Z/r nuclear/model potential in the B representation at r=0)
+          // returns +/-inf there, while the Dirichlet basis is exactly zero at
+          // that node, so the exact contribution is 0 but the naive product is
+          // 0*inf = NaN. Treat a non-finite weight as a zero contribution: the
+          // node carries no basis amplitude, so this is exact for the FE basis.
+          wp(i) = std::isfinite(fv) ? (wp(i) * fv) : T(0);
+        }
       }
 
       // Evaluate basis functions
@@ -442,6 +456,156 @@ namespace helfem {
         lhbf.col(j).array() *= wp.array();
 
       return lhbf.transpose() * rhbf;
+    }
+
+    // ----------------------------------------------------------------------
+    // Phase 2: auto-converging matrix element.
+    //
+    // The block over one element (or a sub-panel of it) is recomputed at a
+    // rising Gauss-Lobatto order until it stops changing to 8*eps(T). Because
+    // the tolerance is tied to eps(T), the order required to satisfy it grows
+    // on its own with the precision of T -- a double block stabilises around
+    // n~8, the same integrand at _Float128 keeps refining to n~13+ and thus
+    // carries digits beyond double. Non-smooth weights (kinks) are handled by
+    // splitting the element at the supplied breakpoints, since plain order-
+    // refinement stalls across a cusp (see docs/autoconv_prototype.cpp).
+    // ----------------------------------------------------------------------
+    namespace {
+      // Warn at most once per process if a panel hits the order cap.
+      bool auto_matel_cap_warned = false;
+
+      // Refine one smooth sub-panel [x_left,x_right] (reference coordinates in
+      // [-1,1]) until the block is stable to 8*eps(T), doubling the Gauss-
+      // Lobatto order from nstart up to nmax.
+      template<typename T>
+      helfem::Mat<T> converge_panel(const helfem::polynomial_basis::FiniteElementBasisT<T> & fe,
+                                    size_t iel,
+                                    const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_lh,
+                                    const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_rh,
+                                    const std::function<T(T)> & f,
+                                    T x_left, T x_right, int nstart, int nmax) {
+        const T tol = T(8) * std::numeric_limits<T>::epsilon();
+
+        helfem::Vec<T> x, w;
+        helfem::Mat<T> prev, cur;
+        bool have = false;
+        int n = std::max(nstart, 2);
+        for (;;) {
+          helfem::lib1dfem::lobatto::lobatto_compute<T>(n, x, w);
+          cur = fe.matrix_element(iel, eval_lh, eval_rh, x, w, f, x_left, x_right);
+          if (have) {
+            const T diff  = (cur - prev).cwiseAbs().maxCoeff();
+            const T scale = cur.cwiseAbs().maxCoeff();
+            if (diff <= tol * (scale + tol))
+              return cur;
+          }
+          prev = cur;
+          have = true;
+          if (n >= nmax) {
+            if (!auto_matel_cap_warned) {
+              auto_matel_cap_warned = true;
+              printf("Warning: FiniteElementBasis::matrix_element hit the Gauss-Lobatto"
+                     " order cap (n=%d) without converging to eps(T); using best estimate.\n", nmax);
+              fflush(stdout);
+            }
+            return cur;
+          }
+          n = std::min(2 * n, nmax);
+        }
+      }
+    }
+
+    template<typename T>
+    helfem::Mat<T> FiniteElementBasisT<T>::matrix_element_auto(
+        size_t iel,
+        const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_lh,
+        const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_rh,
+        const std::function<T(T)> & f,
+        const std::vector<T> & breakpoints,
+        int poly_degree_f,
+        T x_left, T x_right) const {
+      // Sub-panel boundaries in the reference [-1,1] coordinate: split at any
+      // breakpoint that falls strictly inside (x_left, x_right).
+      const T mid = element_midpoint(iel);
+      const T sf  = scaling_factor(iel);
+      std::vector<T> xb;
+      xb.push_back(x_left);
+      for (T bp : breakpoints) {
+        const T xp = (bp - mid) / sf; // real-space breakpoint -> reference coord
+        if (xp > x_left && xp < x_right)
+          xb.push_back(xp);
+      }
+      xb.push_back(x_right);
+      std::sort(xb.begin(), xb.end());
+
+      // Starting order. n-point Gauss-Lobatto is exact to degree 2n-3, so pick
+      // n that already integrates B*B*(polynomial f) exactly; the refine loop
+      // then confirms (polynomial case) or extends (non-polynomial f). Using an
+      // upper bound on the basis degree only affects speed, never correctness.
+      const int basisdeg = std::max(0, poly->get_noverlap() * poly->get_nnodes() - 1);
+      const int fdeg     = std::max(0, poly_degree_f);
+      const int deg      = 2 * basisdeg + fdeg;
+      const int nmax     = 512;
+      int nstart = (deg + 4) / 2 + 2;
+      if (nstart < 5)     nstart = 5;
+      if (nstart > nmax)  nstart = nmax;
+
+      helfem::Mat<T> total;
+      bool have_total = false;
+      for (size_t p = 0; p + 1 < xb.size(); ++p) {
+        if (!(xb[p + 1] > xb[p])) continue; // skip degenerate panels
+        const helfem::Mat<T> block =
+            converge_panel<T>(*this, iel, eval_lh, eval_rh, f, xb[p], xb[p + 1], nstart, nmax);
+        if (!have_total) { total = block; have_total = true; }
+        else total += block;
+      }
+      if (!have_total)
+        // Degenerate range (x_left==x_right): return a correctly sized zero block.
+        total = converge_panel<T>(*this, iel, eval_lh, eval_rh, f, x_left, x_right, nstart, nmax);
+      return total;
+    }
+
+    template<typename T>
+    helfem::Mat<T> FiniteElementBasisT<T>::matrix_element_auto(
+        const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_lh,
+        const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_rh,
+        const std::function<T(T)> & f,
+        const std::vector<T> & breakpoints,
+        int poly_degree_f) const {
+      std::vector<helfem::Mat<T>> matel(get_nelem());
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t iel = 0; iel < get_nelem(); ++iel)
+        matel[iel] = matrix_element_auto(iel, eval_lh, eval_rh, f, breakpoints, poly_degree_f);
+
+      const Eigen::Index N = static_cast<Eigen::Index>(get_nbf());
+      helfem::Mat<T> M = helfem::Mat<T>::Zero(N, N);
+      for (size_t iel = 0; iel < get_nelem(); ++iel) {
+        size_t ifirst, ilast;
+        get_idx(iel, ifirst, ilast);
+        M.block((Eigen::Index) ifirst, (Eigen::Index) ifirst,
+                ilast - ifirst + 1, ilast - ifirst + 1) += matel[iel];
+      }
+      return M;
+    }
+
+    template<typename T>
+    helfem::Mat<T> FiniteElementBasisT<T>::matrix_element(
+        size_t iel, int lhder, int rhder, const std::function<T(T)> & f,
+        const std::vector<T> & breakpoints, int poly_degree_f) const {
+      auto eval_lh = [this, lhder](helfem::Vec<T> x, size_t iel_) { return this->eval_dnf(x, lhder, iel_); };
+      auto eval_rh = [this, rhder](helfem::Vec<T> x, size_t iel_) { return this->eval_dnf(x, rhder, iel_); };
+      return matrix_element_auto(iel, eval_lh, eval_rh, f, breakpoints, poly_degree_f);
+    }
+
+    template<typename T>
+    helfem::Mat<T> FiniteElementBasisT<T>::matrix_element(
+        int lhder, int rhder, const std::function<T(T)> & f,
+        const std::vector<T> & breakpoints, int poly_degree_f) const {
+      auto eval_lh = [this, lhder](helfem::Vec<T> x, size_t iel_) { return this->eval_dnf(x, lhder, iel_); };
+      auto eval_rh = [this, rhder](helfem::Vec<T> x, size_t iel_) { return this->eval_dnf(x, rhder, iel_); };
+      return matrix_element_auto(eval_lh, eval_rh, f, breakpoints, poly_degree_f);
     }
 
     template<typename T>

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -144,19 +144,23 @@ namespace helfem {
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::matrix_element(
           size_t iel, BasisKind bra, BasisKind ket,
-          const std::function<T(T)> & weight) const {
+          const std::function<T(T)> & weight,
+          const std::vector<T> & breakpoints, int poly_degree_f) const {
         auto lhs = make_evaluator<T>(this, bra);
         auto rhs = make_evaluator<T>(this, ket);
-        return fem.matrix_element(iel, lhs, rhs, xq, wq, weight);
+        // Phase 2: FE basis auto-converges its own quadrature to eps(T).
+        return fem.matrix_element_auto(iel, lhs, rhs, weight, breakpoints, poly_degree_f);
       }
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::matrix_element(
           BasisKind bra, BasisKind ket,
-          const std::function<T(T)> & weight) const {
+          const std::function<T(T)> & weight,
+          const std::vector<T> & breakpoints, int poly_degree_f) const {
         auto lhs = make_evaluator<T>(this, bra);
         auto rhs = make_evaluator<T>(this, ket);
-        return fem.matrix_element(lhs, rhs, xq, wq, weight);
+        // Phase 2: FE basis auto-converges its own quadrature to eps(T).
+        return fem.matrix_element_auto(lhs, rhs, weight, breakpoints, poly_degree_f);
       }
 
       template <typename T>
@@ -166,7 +170,9 @@ namespace helfem {
           T x_left, T x_right) const {
         auto lhs = make_evaluator<T>(this, bra);
         auto rhs = make_evaluator<T>(this, ket);
-        return fem.matrix_element(iel, lhs, rhs, xq, wq, weight, x_left, x_right);
+        // Phase 2: auto-converge over the reference sub-range [x_left,x_right].
+        return fem.matrix_element_auto(iel, lhs, rhs, weight,
+                                       std::vector<T>(), -1, x_left, x_right);
       }
 
       template <typename T>
@@ -311,15 +317,19 @@ namespace helfem {
         }
       }
 
+      // overlap / kinetic have a polynomial (unit) weight -> poly_degree_f = 0.
+      // nuclear / kinetic_l use the R = B/r representation, whose integrand is
+      // rational (not polynomial), so they leave poly_degree_f = -1 and let the
+      // order-refinement converge.
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::overlap() const { return matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight<T>()); }
+      helfem::Mat<T> FEMRadialBasisT<T>::overlap() const { return matrix_element(BasisKind::B0, BasisKind::B0, kNoWeight<T>(), std::vector<T>(), 0); }
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::overlap(size_t iel) const { return matrix_element(iel, BasisKind::B0, BasisKind::B0, kNoWeight<T>()); }
+      helfem::Mat<T> FEMRadialBasisT<T>::overlap(size_t iel) const { return matrix_element(iel, BasisKind::B0, BasisKind::B0, kNoWeight<T>(), std::vector<T>(), 0); }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::kinetic() const { return T(0.5) * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight<T>()); }
+      helfem::Mat<T> FEMRadialBasisT<T>::kinetic() const { return T(0.5) * matrix_element(BasisKind::B1, BasisKind::B1, kNoWeight<T>(), std::vector<T>(), 0); }
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::kinetic(size_t iel) const { return T(0.5) * matrix_element(iel, BasisKind::B1, BasisKind::B1, kNoWeight<T>()); }
+      helfem::Mat<T> FEMRadialBasisT<T>::kinetic(size_t iel) const { return T(0.5) * matrix_element(iel, BasisKind::B1, BasisKind::B1, kNoWeight<T>(), std::vector<T>(), 0); }
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::kinetic_l() const { return T(0.5) * matrix_element(BasisKind::R0, BasisKind::R0, kNoWeight<T>()); }
@@ -333,16 +343,20 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::polynomial_confinement(size_t iel, int N, T shift_pot) const {
+        // The r < shift_pot cutoff is a kink at r = shift_pot; split the
+        // element there so each smooth sub-panel converges by order-refinement.
         return matrix_element(iel, BasisKind::R0, BasisKind::R0,
                               [N, shift_pot](T r) {
                                 return (r < shift_pot)
                                     ? T(0)
                                     : std::pow(r - shift_pot, N + 2);
-                              });
+                              },
+                              std::vector<T>{shift_pot}, -1);
       }
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::exponential_confinement(size_t iel, int N, T r_0, T shift_pot) const {
+        // Kink at r = shift_pot (see polynomial_confinement).
         return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [r_0, N, shift_pot](T r) {
                                 if (r < shift_pot) return T(0);
@@ -358,26 +372,31 @@ namespace helfem {
                                 V += std::exp(r_ratio);
                                 V *= fact;
                                 return V;
-                              });
+                              },
+                              std::vector<T>{shift_pot}, -1);
       }
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::barrier_confinement(size_t iel, T V, T shift_pot) const {
+        // Step at r = shift_pot -> breakpoint.
         return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [V, shift_pot](T r) {
                                 return (r < shift_pot) ? T(0) : V;
-                              });
+                              },
+                              std::vector<T>{shift_pot}, -1);
       }
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::junq_confinement(size_t iel, int N, T V0, T r_c, T shift_pot) const {
+        // Kink at r = shift_pot -> breakpoint.
         return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [N, r_c, V0, shift_pot](T r) {
                                 if (r < shift_pot) return T(0);
                                 const T denominator  = std::pow(r_c - r, N);
                                 const T exponential  = std::exp(-(r_c - shift_pot) / (r - shift_pot));
                                 return V0 * exponential / denominator;
-                              });
+                              },
+                              std::vector<T>{shift_pot}, -1);
       }
 
       template <typename T>
@@ -430,6 +449,12 @@ namespace helfem {
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::model_potential(const modelpotential::ModelPotentialT<T> *model,
                                                          size_t iel) const {
+        // Non-polynomial weight -> order-refine (poly_degree_f = -1). Smooth
+        // models (point, Gaussian, GSZ, SAP) converge to eps(T) by refinement.
+        // Models with a hard boundary (uniform sphere / hollow shell) have a
+        // kink at the nuclear radius; ModelPotentialT exposes only V(r), not
+        // that radius, so no breakpoint is passed here -- if such a boundary
+        // ever falls inside an element the panel would refine to the order cap.
         return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [model](T r){ return model->V(r); });
       }


### PR DESCRIPTION
Phase 2 of the reusable-FEM-library refactor (see docs/library-refactor.md, and
the prototype docs/autoconv_prototype.cpp). `FiniteElementBasisT<T>::matrix_element`
now **auto-converges its own quadrature to eps(T)** instead of taking a
caller-supplied fixed `(xq,wq)`.

## What changed
New overloads (no `xq,wq`): `matrix_element(iel, lhder, rhder, f, breakpoints={},
poly_degree_f=-1)` and the whole-basis form, plus a `matrix_element_auto` engine
for the generic-evaluator (R=B/r) path. Per element: build `lobatto_compute<T>(n)`,
map to `[a,b]`, and **double n until** `(M_n - M_{n-1}).cwiseAbs().maxCoeff() <=
8*eps(T)*(...)`, capped at nmax=512 (warns once). The start order is seeded from
the integrand degree, so polynomial cases converge in one confirming step.

- **Breakpoint-aware**: breakpoints inside an element split it into smooth
  sub-panels, each converged and summed -- order-refinement alone stalls across a
  kink (the prototype's regime C).
- **Endpoint-singularity guard**: Gauss-Lobatto samples element *endpoints*
  (unlike the old open Gauss-Chebyshev rule), so at r=0 a `-Z/r` weight is `-inf`
  where the Dirichlet basis is exactly 0 -> `0*inf = NaN`. Fixed: a non-finite
  weighted point contributes zero (exact, the basis vanishes there). Without this
  atomic HF NaN'd.

RadialBasis's 1e routines route to the auto path with the right degree/breakpoints
(overlap/kinetic: poly_degree 0; nuclear/kinetic_l: refine; confinement: kink
breakpoint; model_potential: refine). Old `(xq,wq)` overloads and `twoe_integral`/
`yukawa` untouched. Templated double/long double/_Float128.

## Verification
- **Tolerance regression** vs master (auto-convergence changes the quadrature
  order, so ~1e-16..1e-11 SCF-level shifts are expected; a real bug would be
  >1e-10): Ar HF |Δ|=1.3e-11, Ne UHF 3.6e-12, N2 LDA bit-identical, gensap Ne
  1.6e-12 -- all well under 1e-10; at printed precision the energies are unchanged
  (-475.8712591129, -79.4807491233).
- **Self-convergence** (the payoff): `<B3|V_Gaussian|B4>` reaches each type's
  machine epsilon (double 6.9e-18, long double 9.1e-20, _Float128 2.0e-34 vs a
  300-pt reference), and `|double - _Float128| = 3.4e-16` -- the quad element
  carries ~16 digits below double's floor.
- Full build clean (all targets, _Float128 / C++23); no arma, no direct BLAS.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
