### PR TITLE
diatomic: auto-converging one- and two-electron radial integrals

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -28,7 +28,9 @@
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
+#include <cmath>
 #include <complex>
+#include <limits>
 #include <map>
 
 #ifdef _OPENMP
@@ -38,6 +40,139 @@
 namespace helfem {
   namespace diatomic {
     namespace basis {
+
+      // --------------------------------------------------------------------
+      // Auto-converging quadrature for the in-element two-electron kernel.
+      //
+      // Mirrors the atomic Stage-1 helper (libhelfem/src/RadialBasis.cpp,
+      // converge_rule): recompute a probe block at a rising Gauss-Chebyshev
+      // order until it stops changing, so the accuracy of the two-electron
+      // radial integrals is set by the floating-point type (here double's eps)
+      // instead of a user-supplied --nquad. The diatomic path is double-only,
+      // so this is a plain double specialization rather than a template.
+      //
+      // TWO stopping conditions, both meaning "all of double's precision has
+      // been extracted":
+      //   (1) True eps convergence: the block stops changing to 8*eps, the
+      //       same criterion FiniteElementBasis's 1e matrix_element uses.
+      //   (2) Roundoff-floor stall: the 2e Coulomb P_L(cosh mu_<)Q_L(cosh mu_>)
+      //       Green's function is NOT polynomial-exact, so (unlike the 1e
+      //       Gauss-Lobatto block) the block difference converges only down to
+      //       the assembly roundoff floor and then wobbles rather than
+      //       collapsing to zero. Once it is deep in the asymptotic regime
+      //       (diff <= sqrt(eps)*(scale+tol)) and a doubling no longer at least
+      //       halves it (diff > 0.5*prevdiff), it has converged: return
+      //       quietly. Without this every production element would grind to the
+      //       cap and print a spurious warning.
+      //
+      // nmax cap = 512 with a one-shot warning is a genuine backstop, not the
+      // common path; the start order is seeded from --nquad so the common case
+      // converges in 1-2 steps.
+      // --------------------------------------------------------------------
+      namespace {
+        /// Order cap for the refinement loop.
+        const int twoe_nmax = 512;
+        /// Warn at most once per process if the refinement hits the order cap.
+        bool twoe_cap_warned = false;
+
+        /// Refine `probe(n)` -- which must rebuild its block using its own
+        /// n-point Gauss-Chebyshev rule -- by doubling n from nstart until the
+        /// block is stable, and return the converged block. If `nconv` is
+        /// non-null it receives the (finer) converged order, so a caller can
+        /// rebuild a heavier object (e.g. a TwoElectronElement) once at that
+        /// order. The block's shape is independent of n, so the
+        /// block-difference comparison is well defined.
+        ///
+        /// `seed_fallback` selects what happens if the order cap is reached
+        /// without convergence. The disjoint Q_L integral over the element that
+        /// touches mu=0 is genuinely NON-convergent for |M| >= 2 -- there
+        /// Q_{L,|M|}(cosh mu) ~ mu^{-|M|}, so the bare integral (without the
+        /// companion P_{L,|M|} ~ mu^{|M|} that regularizes it inside the
+        /// in-element kernel) diverges. That block is never actually used (the
+        /// innermost element is never the OUTER element of a disjoint pair), so
+        /// forcing it is pointless. With seed_fallback the routine then returns
+        /// the block at the seed order -- exactly the fixed --nquad value the
+        /// pre-auto-convergence code produced -- quietly. Without it (the
+        /// in-element kernel, which IS convergent) a cap is a real anomaly and
+        /// gets the one-shot warning + best estimate.
+        template <typename Fn>
+        helfem::Matrix converge_block(const Fn & probe, int nstart,
+                                      const char * what, int * nconv = nullptr,
+                                      bool seed_fallback = false) {
+          const double eps     = std::numeric_limits<double>::epsilon();
+          const double tol     = 8.0 * eps;
+          const double sqrteps = std::sqrt(eps);
+          // Machine-precision floor. These blocks are not polynomial-exact and
+          // the LIP assembly carries a roundoff floor of a small multiple of
+          // eps (empirically ~1e-15 relative), so the block difference
+          // plateaus there rather than collapsing to 8*eps. 256*eps ~ 5.7e-14
+          // is comfortably above that floor yet far below both the cd_thresh
+          // (1e-12) the kernel is later factorized to and the 1e-10 total-
+          // energy tolerance: once the difference reaches it, all of double's
+          // precision has been extracted.
+          const double floor_rel = 256.0 * eps;
+
+          helfem::Matrix prev, cur, seed;
+          bool have = false;
+          double prevdiff = -1.0;
+          int n = std::max(nstart, 2);
+          for(;;) {
+            cur = probe(n);
+            if(!have)
+              seed = cur;   // the fixed --nquad value, for seed_fallback
+            if(have) {
+              const double diff  = (cur - prev).cwiseAbs().maxCoeff();
+              const double scale = cur.cwiseAbs().maxCoeff();
+              // (1) true eps convergence (well-conditioned, polynomial-exact
+              // blocks reach this).
+              if(diff <= tol * (scale + tol)) {
+                if(nconv) *nconv = n;
+                return cur;
+              }
+              // (2) roundoff-floor stall: the Coulomb P_L(cosh mu_<)Q_L(cosh
+              // mu_>) Green's function is not polynomial-exact, and over the
+              // element that touches mu=0 the Q_L weight is only C^0 (a
+              // mu*ln(mu) endpoint kink, Q_L(1)=+inf). So the block difference
+              // converges only down to the assembly roundoff floor and then
+              // wobbles. Once it is deep in the asymptotic regime
+              // (diff <= sqrt(eps)*scale) AND it has either reached the
+              // machine-precision floor (diff <= floor_rel*scale) or a doubling
+              // no longer at least halves it, all of double's precision has
+              // been extracted: stop quietly. The floor test makes this robust
+              // when only a couple of doublings separate the seed from the cap.
+              if(diff <= sqrteps * (scale + tol) &&
+                 (diff <= floor_rel * (scale + tol) ||
+                  (prevdiff >= 0.0 && diff > 0.5 * prevdiff))) {
+                if(nconv) *nconv = n;
+                return cur;
+              }
+              prevdiff = diff;
+            }
+            prev = cur;
+            have = true;
+            if(n >= twoe_nmax) {
+              if(seed_fallback) {
+                // Non-convergent integrand (the divergent innermost-element Q_L
+                // for |M| >= 2). Fall back to the requested --nquad order
+                // quietly -- the same value the fixed-order code produced.
+                if(nconv) *nconv = std::max(nstart, 2);
+                return seed;
+              }
+              if(!twoe_cap_warned) {
+                twoe_cap_warned = true;
+                printf("Warning: diatomic %s hit the Gauss-Chebyshev order cap"
+                       " (n=%d) without converging to eps(double); using best"
+                       " estimate.\n", what, twoe_nmax);
+                fflush(stdout);
+              }
+              if(nconv) *nconv = n;
+              return cur;
+            }
+            n = std::min(2 * n, twoe_nmax);
+          }
+        }
+      }
+
       RadialBasis::RadialBasis() {
       }
 
@@ -169,7 +304,22 @@ namespace helfem {
         } else {
           Plm = [legtab, L, M](double mu) { return std::sinh(mu)*legtab.get_Plm(L,M,cosh(mu)); };
         }
-        return fem.matrix_element(iel, false, false, xq, wq, Plm);
+        // Auto-converging disjoint (cross-element) 2e integral. The Gauss-
+        // Chebyshev order is refined until the block is stable, so the accuracy
+        // follows the FP type instead of the caller's --nquad. We keep the
+        // Gauss-Chebyshev rule (not the FE's Gauss-Lobatto auto-overload)
+        // deliberately: over the element that touches mu=0 the companion Q_L
+        // weight is singular there (Q_L(1)=+inf), and Chebyshev's endpoint
+        // clustering handles that far better than Lobatto's endpoint nodes.
+        // converge_block carries the roundoff-floor stall that lets that
+        // element converge quietly rather than grind to the order cap.
+        return converge_block(
+            [&](int n) {
+              helfem::Vector x, w;
+              chebyshev::chebyshev<double>(n, x, w);
+              return fem.matrix_element(iel, false, false, x, w, Plm);
+            },
+            std::max((int) xq.size(), 5), "Plm_integral", nullptr, true);
       }
 
       helfem::Matrix RadialBasis::Qlm_integral(int k, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const {
@@ -179,7 +329,16 @@ namespace helfem {
         } else {
           Qlm = [legtab, L, M](double mu) { return std::sinh(mu)*legtab.get_Qlm(L,M,cosh(mu)); };
         }
-        return fem.matrix_element(iel, false, false, xq, wq, Qlm);
+        // Auto-converging disjoint 2e integral (see Plm_integral above). This
+        // is the branch whose weight Q_L(cosh mu) is singular on the mu=0
+        // element -- the Chebyshev rule + roundoff-floor stall handle it.
+        return converge_block(
+            [&](int n) {
+              helfem::Vector x, w;
+              chebyshev::chebyshev<double>(n, x, w);
+              return fem.matrix_element(iel, false, false, x, w, Qlm);
+            },
+            std::max((int) xq.size(), 5), "Qlm_integral", nullptr, true);
       }
 
       helfem::Matrix RadialBasis::kinetic() const {
@@ -199,8 +358,19 @@ namespace helfem {
       }
 
       quadrature::TwoElectronElement RadialBasis::twoe_element(size_t iel) const {
+        // Build at the stored quadrature order.
+        return twoe_element(iel, (int) xq.size());
+      }
+
+      quadrature::TwoElectronElement RadialBasis::twoe_element(size_t iel, int n) const {
+        // Build at a specified Gauss-Chebyshev order: a fresh n-point rule
+        // instead of the stored (xq, wq). This is what lets compute_tei refine
+        // the in-element two-electron kernel until it is converged to
+        // eps(double).
+        helfem::Vector x, w;
+        chebyshev::chebyshev<double>(n, x, w);
         std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
-        return quadrature::twoe_element(fem.element_begin(iel), fem.element_end(iel), xq, wq, p);
+        return quadrature::twoe_element(fem.element_begin(iel), fem.element_end(iel), x, w, p);
       }
 
       helfem::Matrix RadialBasis::twoe_integral(int alpha, int beta, const quadrature::TwoElectronElement & el, int L, int M, const legendretable::LegendreTable & legtab) const {
@@ -502,7 +672,9 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::in_element_kernel(size_t iel, int L, int M) const {
-        const quadrature::TwoElectronElement el(radial.twoe_element(iel));
+        // Use the same auto-converged order as compute_tei so this diagnostic
+        // reflects the kernel that was actually factorized.
+        const quadrature::TwoElectronElement el(radial.twoe_element(iel, converged_twoe_order(iel)));
         const helfem::Matrix T00(quadrature::twoe_integral(el, 0, 0, L, M, legtab));
         const helfem::Matrix T02(quadrature::twoe_integral(el, 0, 2, L, M, legtab));
         const helfem::Matrix T22(quadrature::twoe_integral(el, 2, 2, L, M, legtab));
@@ -518,7 +690,7 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::in_element_kernel_exchange(size_t iel, int L, int M) const {
-        const quadrature::TwoElectronElement el(radial.twoe_element(iel));
+        const quadrature::TwoElectronElement el(radial.twoe_element(iel, converged_twoe_order(iel)));
         const size_t Ni(radial.Nprim(iel));
 
         const helfem::Matrix T00(quadrature::twoe_integral(el, 0, 0, L, M, legtab));
@@ -545,8 +717,11 @@ namespace helfem {
         const size_t ilm(lmind(L,M));
         const size_t Nel(radial.Nel());
 
-        // Exact kernel and the exact exchange-ordered tensors
-        const quadrature::TwoElectronElement el(radial.twoe_element(iel));
+        // Exact kernel and the exact exchange-ordered tensors. Build at the
+        // same auto-converged order compute_tei used, so the reference W here
+        // matches the one that produced cd_B / cd_sigma (otherwise kerr would
+        // pick up the order mismatch rather than the factorization error).
+        const quadrature::TwoElectronElement el(radial.twoe_element(iel, converged_twoe_order(iel)));
         const helfem::Matrix T00(quadrature::twoe_integral(el,0,0,L,M,legtab));
         const helfem::Matrix T02(quadrature::twoe_integral(el,0,2,L,M,legtab));
         const helfem::Matrix T20(quadrature::twoe_integral(el,2,0,L,M,legtab));
@@ -993,6 +1168,46 @@ namespace helfem {
         return (lh.first == rh.first) && (lh.second == rh.second);
       }
 
+      int TwoDBasis::converged_twoe_order(size_t iel) const {
+        // Seed the refinement from the requested --nquad so the common case
+        // converges in 1-2 steps; the loop, not the seed, sets the accuracy.
+        int nstart = radial.get_nquad();
+        if(nstart < 5) nstart = 5;
+        if(nstart > twoe_nmax) nstart = twoe_nmax;
+
+        // Nothing to probe: no multipoles requested. Fall back to the seed.
+        if(lm_map.empty())
+          return nstart;
+
+        // Probe the HARDEST multipole. lm_map is sorted ascending by (L, |M|)
+        // (see operator< on lmidx_t), so its back() is the largest L and, for
+        // that L, the largest |M| -- the sharpest Green's function and hence
+        // the one that needs the most quadrature points. Converging it
+        // converges every lower multipole.
+        const int L = lm_map.back().first;
+        const int M = lm_map.back().second;
+
+        int nconv = nstart;
+        converge_block(
+            [&](int n) {
+              const quadrature::TwoElectronElement el(radial.twoe_element(iel, n));
+              const helfem::Matrix T00(quadrature::twoe_integral(el, 0, 0, L, M, legtab));
+              const helfem::Matrix T02(quadrature::twoe_integral(el, 0, 2, L, M, legtab));
+              const helfem::Matrix T22(quadrature::twoe_integral(el, 2, 2, L, M, legtab));
+              // Assemble the 2-channel kernel W exactly as compute_tei does, so
+              // the probe measures the quantity that is actually factorized.
+              const Eigen::Index nn = T00.rows();
+              helfem::Matrix W(2*nn, 2*nn);
+              W.topLeftCorner(nn,nn)     =  T00;
+              W.topRightCorner(nn,nn)    = -T02;
+              W.bottomLeftCorner(nn,nn)  = -T02.transpose();
+              W.bottomRightCorner(nn,nn) =  T22;
+              return helfem::Matrix(0.5*(W + W.transpose()));
+            },
+            nstart, "in-element two-electron kernel", &nconv);
+        return nconv;
+      }
+
       void TwoDBasis::compute_tei(bool exchange) {
         // Number of distinct L values is
         size_t Nel(radial.Nel());
@@ -1040,7 +1255,12 @@ namespace helfem {
 #pragma omp parallel for
 #endif
         for(size_t iel=0;iel<Nel;iel++) {
-          const quadrature::TwoElectronElement eldata(radial.twoe_element(iel));
+          // Auto-convergence: refine the Gauss-Chebyshev order on the hardest
+          // multipole, then build the element ONCE at the converged order and
+          // reuse it across all (L, |M|). The order is set by double's eps, not
+          // by --nquad.
+          const int nconv = converged_twoe_order(iel);
+          const quadrature::TwoElectronElement eldata(radial.twoe_element(iel, nconv));
 
           for(size_t ilm=0;ilm<lm_map.size();ilm++) {
             int L(lm_map[ilm].first);

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -237,18 +237,24 @@ namespace helfem {
         } else if(m==0 && n!=0) {
           chsh = [n](double mu) { return std::pow(std::cosh(mu), n); };
         }
-        return fem.matrix_element(false, false, xq, wq, chsh);
+        // Auto-converging: refine the Gauss-Chebyshev order until the block is
+        // stable to eps(double), so accuracy follows the FP type instead of the
+        // caller's --nquad. Same Chebyshev family + converge_block the two-
+        // electron and Plm/Qlm integrals use, so at production nquad (the seed)
+        // this reproduces the old fixed-order result. The sinh/cosh weight is
+        // smooth and non-singular here, so no seed fallback is needed.
+        return converge_block(
+            [&](int nq) {
+              helfem::Vector x, w;
+              chebyshev::chebyshev<double>(nq, x, w);
+              return fem.matrix_element(false, false, x, w, chsh);
+            },
+            std::max((int) xq.size(), 5), "radial_integral");
       }
 
       helfem::Matrix RadialBasis::overlap(const RadialBasis & rh, int n) const {
-        // Use the larger number of quadrature points to make sure the
-        // projection is computed correctly.
-        size_t n_quad(std::max(xq.size(), rh.xq.size()));
-
-        helfem::Vector xproj, wproj;
-        chebyshev::chebyshev<double>(n_quad, xproj, wproj);
-
-        // Find element pairs that share any mu range.
+        // Find element pairs that share any mu range (independent of the
+        // quadrature order).
         std::vector<std::vector<size_t>> overlap(fem.get_nelem());
         for(size_t iel=0;iel<fem.get_nelem();iel++) {
           double istart(fem.element_begin(iel));
@@ -261,40 +267,51 @@ namespace helfem {
           }
         }
 
-        helfem::Matrix S(helfem::Matrix::Zero(Nbf(), rh.Nbf()));
-        for(size_t iel=0;iel<fem.get_nelem();iel++) {
-          for(size_t jj=0;jj<overlap[iel].size();jj++) {
-            size_t jel=overlap[iel][jj];
-            // FE-side element ranges.
-            double imin(fem.element_begin(iel));
-            double imax(fem.element_end(iel));
-            double jmin(rh.fem.element_begin(jel));
-            double jmax(rh.fem.element_end(jel));
-            // Shared range.
-            double intstart(std::max(imin, jmin));
-            double intend(std::min(imax, jmax));
-            double intmid(0.5*(intend+intstart));
-            double intlen(0.5*(intend-intstart));
+        // Auto-converging projection: refine the Gauss-Chebyshev order until the
+        // whole (Nbf x rh.Nbf) block is stable to eps(double), so the accuracy
+        // follows the FP type rather than either basis's --nquad. Seeded from
+        // the finer of the two bases.
+        return converge_block(
+            [&](int nq) {
+              helfem::Vector xproj, wproj;
+              chebyshev::chebyshev<double>(nq, xproj, wproj);
 
-            helfem::Vector mu(intmid*helfem::Vector::Ones(xproj.size())+intlen*xproj);
-            helfem::Vector xi(fem.eval_prim(mu, iel));
-            helfem::Vector xj(rh.fem.eval_prim(mu, jel));
+              helfem::Matrix S(helfem::Matrix::Zero(Nbf(), rh.Nbf()));
+              for(size_t iel=0;iel<fem.get_nelem();iel++) {
+                for(size_t jj=0;jj<overlap[iel].size();jj++) {
+                  size_t jel=overlap[iel][jj];
+                  // FE-side element ranges.
+                  double imin(fem.element_begin(iel));
+                  double imax(fem.element_end(iel));
+                  double jmin(rh.fem.element_begin(jel));
+                  double jmax(rh.fem.element_end(jel));
+                  // Shared range.
+                  double intstart(std::max(imin, jmin));
+                  double intend(std::min(imax, jmax));
+                  double intmid(0.5*(intend+intstart));
+                  double intlen(0.5*(intend-intstart));
 
-            size_t ifirst, ilast;
-            get_idx(iel, ifirst, ilast);
-            size_t jfirst, jlast;
-            rh.get_idx(jel, jfirst, jlast);
+                  helfem::Vector mu(intmid*helfem::Vector::Ones(xproj.size())+intlen*xproj);
+                  helfem::Vector xi(fem.eval_prim(mu, iel));
+                  helfem::Vector xj(rh.fem.eval_prim(mu, jel));
 
-            helfem::Vector wtot(wproj*intlen);
-            wtot.array() *= mu.array().sinh();
-            if(n!=0) wtot.array() *= mu.array().cosh().pow((double) n);
-            helfem::Matrix ibf(fem.eval_dnf(xi, 0, iel));
-            helfem::Matrix jbf(rh.fem.eval_dnf(xj, 0, jel));
-            helfem::Matrix s(ibf.transpose()*wtot.asDiagonal()*jbf);
-            S.block(ifirst, jfirst, ilast-ifirst+1, jlast-jfirst+1) += s;
-          }
-        }
-        return S;
+                  size_t ifirst, ilast;
+                  get_idx(iel, ifirst, ilast);
+                  size_t jfirst, jlast;
+                  rh.get_idx(jel, jfirst, jlast);
+
+                  helfem::Vector wtot(wproj*intlen);
+                  wtot.array() *= mu.array().sinh();
+                  if(n!=0) wtot.array() *= mu.array().cosh().pow((double) n);
+                  helfem::Matrix ibf(fem.eval_dnf(xi, 0, iel));
+                  helfem::Matrix jbf(rh.fem.eval_dnf(xj, 0, jel));
+                  helfem::Matrix s(ibf.transpose()*wtot.asDiagonal()*jbf);
+                  S.block(ifirst, jfirst, ilast-ifirst+1, jlast-jfirst+1) += s;
+                }
+              }
+              return S;
+            },
+            std::max({(int) xq.size(), (int) rh.xq.size(), 5}), "overlap");
       }
 
       helfem::Matrix RadialBasis::Plm_integral(int k, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const {
@@ -343,7 +360,15 @@ namespace helfem {
 
       helfem::Matrix RadialBasis::kinetic() const {
         std::function<double(double)> sinhmu = [](double mu) {return std::sinh(mu);};
-        return fem.matrix_element(true, true, xq, wq, sinhmu);
+        // Auto-converging (see radial_integral): refine the Gauss-Chebyshev
+        // order until the derivative block is stable to eps(double).
+        return converge_block(
+            [&](int nq) {
+              helfem::Vector x, w;
+              chebyshev::chebyshev<double>(nq, x, w);
+              return fem.matrix_element(true, true, x, w, sinhmu);
+            },
+            std::max((int) xq.size(), 5), "kinetic");
       }
 
       helfem::Matrix RadialBasis::twoe_integral(int alpha, int beta, size_t iel, int L, int M, const legendretable::LegendreTable & legtab) const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -87,6 +87,12 @@ namespace helfem {
         /// table, subinterval geometry). Independent of (alpha, beta, L, M), so
         /// compute_tei builds it once per element and reuses it across them.
         quadrature::TwoElectronElement twoe_element(size_t iel) const;
+        /// Build the element-only two-electron data at a SPECIFIED
+        /// Gauss-Chebyshev order n, using a fresh n-point rule instead of the
+        /// stored (xq, wq). Used by compute_tei's auto-convergence refinement,
+        /// which rebuilds the element at rising n until the in-element kernel
+        /// stops changing to eps(double).
+        quadrature::TwoElectronElement twoe_element(size_t iel, int n) const;
         /// Primitive two-electron integral from precomputed element data
         helfem::Matrix twoe_integral(int alpha, int beta, const quadrature::TwoElectronElement & el, int L, int M, const legendretable::LegendreTable & legtab) const;
 
@@ -196,6 +202,16 @@ namespace helfem {
         /// iterates LM_map with signed M) and exchange (which derives M
         /// from mj - mi at use-time).
         std::vector<double> build_LMfac_abs() const;
+
+        /// Auto-convergence: return the Gauss-Chebyshev order at which the
+        /// in-element two-electron kernel of element iel is converged to
+        /// eps(double). The order is found by refining (order-doubling) the
+        /// HARDEST multipole present in lm_map -- the largest L (and its |M|),
+        /// which has the sharpest P_L(cosh mu_<) Q_L(cosh mu_>) Green's
+        /// function and therefore needs the most points; converging it
+        /// converges every lower multipole. compute_tei then builds the
+        /// element ONCE at this order and runs the full (L, |M|) loop on it.
+        int converged_twoe_order(size_t iel) const;
 
       public:
         // Dummy constructor

--- a/src/general/legendretable.cpp
+++ b/src/general/legendretable.cpp
@@ -22,6 +22,61 @@ namespace helfem {
       return lh.xi < rh.xi;
     }
 
+    // Compute the P_{l,m} / Q_{l,m} block at a single argument xi. This is the
+    // shared kernel behind both compute() (which caches the result) and the
+    // on-miss path of the getters (which computes it directly for arguments
+    // that were never tabulated -- e.g. the auto-converging two-electron
+    // quadrature evaluates the Legendre functions at points chosen at a
+    // quadrature order OTHER than the one the table was built for). Keeping it
+    // in one place guarantees the direct and cached values are bit-identical.
+    static legendre_table_t compute_entry(int Lmax, int Mmax, double xi) {
+      legendre_table_t entry;
+      entry.xi=xi;
+      entry.Plm=helfem::Matrix::Zero(Lmax+1,Mmax+1);
+      entry.Qlm=helfem::Matrix::Zero(Lmax+1,Mmax+1);
+
+      // Q is singular at xi == 1; the table treats that case as zero
+      // everywhere via the ::Zero above.
+      if(xi!=1.0) {
+        ::helfem::legendre::plm(entry.Plm.data(),Lmax,Mmax,xi);
+        ::helfem::legendre::qlm(entry.Qlm.data(),Lmax,Mmax,xi);
+      }
+
+      // Drop any non-normal entries (zero is fine, denormals/NaN/Inf get
+      // forced to zero so that downstream code doesn't propagate them).
+      for(int L=0;L<=Lmax;L++)
+        for(int M=0;M<=Mmax;M++) {
+          if(entry.Plm(L,M) != 0.0 && !std::isnormal(entry.Plm(L,M)))
+            entry.Plm(L,M)=0.0;
+          if(entry.Qlm(L,M) != 0.0 && !std::isnormal(entry.Qlm(L,M)))
+            entry.Qlm(L,M)=0.0;
+        }
+
+      return entry;
+    }
+
+    // Single-value version of the above, for the getters' on-miss path: compute
+    // just the requested function (P if wantP, else Q) at xi, bit-identically
+    // to what compute_entry / compute() would cache -- same plm/qlm arguments,
+    // same (Lmax+1)-row column-major layout, same xi==1 and isnormal handling.
+    // Avoids allocating the two Eigen blocks and computing the unused sibling
+    // function on every miss.
+    static double compute_one(bool wantP, int l, int m, int Lmax, int Mmax, double xi) {
+      // Q is singular at xi == 1; the table treats that case as zero.
+      if(xi==1.0)
+        return 0.0;
+      std::vector<double> buf((size_t) (Lmax+1)*(Mmax+1), 0.0);
+      if(wantP)
+        ::helfem::legendre::plm(buf.data(),Lmax,Mmax,xi);
+      else
+        ::helfem::legendre::qlm(buf.data(),Lmax,Mmax,xi);
+      // Column-major (Lmax+1) x (Mmax+1): element (l,m) is at l + m*(Lmax+1).
+      double v = buf[(size_t) l + (size_t) m*(Lmax+1)];
+      if(v!=0.0 && !std::isnormal(v))
+        v=0.0;
+      return v;
+    }
+
     LegendreTable::LegendreTable() {
       Lmax=-1;
       Mmax=-1;
@@ -67,28 +122,7 @@ namespace helfem {
 #pragma omp critical
 #endif
       {
-        legendre_table_t entry;
-
-        entry.xi=xi;
-        entry.Plm=helfem::Matrix::Zero(Lmax+1,Mmax+1);
-        entry.Qlm=helfem::Matrix::Zero(Lmax+1,Mmax+1);
-
-        // Q is singular at xi == 1; the table treats that case as zero
-        // everywhere via the ::Zero above.
-        if(xi!=1.0) {
-          ::helfem::legendre::plm(entry.Plm.data(),Lmax,Mmax,xi);
-          ::helfem::legendre::qlm(entry.Qlm.data(),Lmax,Mmax,xi);
-        }
-
-        // Drop any non-normal entries (zero is fine, denormals/NaN/Inf get
-        // forced to zero so that downstream code doesn't propagate them).
-        for(int L=0;L<=Lmax;L++)
-          for(int M=0;M<=Mmax;M++) {
-            if(entry.Plm(L,M) != 0.0 && !std::isnormal(entry.Plm(L,M)))
-              entry.Plm(L,M)=0.0;
-            if(entry.Qlm(L,M) != 0.0 && !std::isnormal(entry.Qlm(L,M)))
-              entry.Qlm(L,M)=0.0;
-          }
+        legendre_table_t entry(compute_entry(Lmax, Mmax, xi));
 
         if(!stor.size())
           stor.push_back(entry);
@@ -99,21 +133,24 @@ namespace helfem {
     }
 
     double LegendreTable::get_Plm(int l, int m, double xi) const {
-      if(get_index(xi)>stor.size()) {
-        std::ostringstream oss;
-        oss << "Error in get_Plm(" << l << "," << m << "," << xi << "): index " << get_index(xi) << " greater than array size " << stor.size() << "!\n";
-        throw std::logic_error(oss.str());
-      }
-      return stor[get_index(xi)].Plm(l,m);
+      // Fast path: the argument was tabulated (the stored-order quadrature
+      // points the table was built for). get_index(check=false) returns the
+      // lower-bound slot without throwing; a hit is an exact xi match.
+      const size_t idx(get_index(xi, false));
+      if(idx < stor.size() && stor[idx].xi == xi)
+        return stor[idx].Plm(l,m);
+      // Miss: an argument at some other quadrature order (the auto-converging
+      // two-electron refinement). Compute it directly -- bit-identical to what
+      // the table would hold -- instead of forcing the caller onto a fixed
+      // --nquad grid.
+      return compute_one(true, l, m, Lmax, Mmax, xi);
     }
 
     double LegendreTable::get_Qlm(int l, int m, double xi) const {
-      if(get_index(xi)>stor.size()) {
-        std::ostringstream oss;
-        oss << "Error in get_Qlm(" << l << "," << m << "," << xi << "): index " << get_index(xi) << " greater than array size " << stor.size() << "!\n";
-        throw std::logic_error(oss.str());
-      }
-      return stor[get_index(xi)].Qlm(l,m);
+      const size_t idx(get_index(xi, false));
+      if(idx < stor.size() && stor[idx].xi == xi)
+        return stor[idx].Qlm(l,m);
+      return compute_one(false, l, m, Lmax, Mmax, xi);
     }
 
     helfem::Vector LegendreTable::get_Plm(int l, int m, const helfem::Vector & xi) const {


### PR DESCRIPTION
Extends the auto-convergence guarantee (public #260, atomic) to the **diatomic**
driver: its two- **and** one-electron radial integrals now refine their own
Gauss-Chebyshev order until each block is stable to `eps(double)`, so a diatomic
calculation's accuracy follows the floating-point type instead of a user-supplied
`--nquad`. Two commits:

1. **Two-electron integrals.** The in-element kernel (`TwoElectronElement` →
   T00/T02/T22 → the 2-channel `W`, then the sign-aware Cholesky/RI factors) and
   the disjoint (cross-element) `Plm`/`Qlm` integrals refine internally via a
   local `converge_block` helper mirroring #260's `converge_rule`. The element is
   refined **once per element** by probing the hardest multipole — the largest
   `L`/`|M|` in `lm_map`, whose `P_L(cosh μ_<)Q_L(cosh μ_>)` Green's function is
   sharpest and whose convergence implies every lower multipole's — then built
   once at that order and fed to the existing factorization unchanged.
2. **One-electron integrals.** `radial_integral`, `kinetic`, and the cross-basis
   `overlap` projection get the same `converge_block` treatment, closing the last
   `--nquad` dependence in the diatomic energy.

## Design notes
- **Gauss-Chebyshev kept deliberately** (not the FE Gauss-Lobatto auto-overload):
  over the element touching μ=0 the companion `Q_{L,|M|}(cosh μ)` weight is
  singular (`Q_L(1)=+∞`); Chebyshev's endpoint clustering plus `converge_block`'s
  **roundoff-floor stall** converge there where Lobatto's endpoint nodes + an
  eps-only criterion would grind to the order cap. The bare disjoint `Q_L` over
  the innermost element is genuinely non-convergent for `|M|≥2`, but it is never
  used as the outer element of a disjoint pair, so that branch falls back quietly
  to the seed order (the pre-change fixed-order value).
- **No erfc path exists in the diatomic** (range-separated hybrids throw in the
  driver), so — unlike the atomic case — there is no fixed-rule exception.
- Double-only (`helfem::Matrix`); templating the diatomic on `T` is separate.
- **`LegendreTable` computes on a table miss** instead of throwing: the memoized
  table is keyed on the fixed-nquad points, but auto-convergence evaluates at
  other orders. A shared `compute_entry` kernel keeps the on-miss value
  bit-identical to what the cache holds; the getters stay `const`/read-only, so
  they remain thread-safe under the OpenMP `compute_tei` loop.
- DFT-grid accessors (`get_bf`/`get_df`/`get_chmu_quad`, …) keep the stored
  `xq`/`wq` — they define the DFT integration grid, not a matrix-element rule.

## Verification (independently reproduced)
**Tolerance vs master (default nquad, all Δ = 0):**

| case | branch | master |
|------|--------|--------|
| H2 HF | −1.1336295702 | −1.1336295702 |
| LiH HF | −7.8960967093 | −7.8960967093 |
| LiH LDA | −7.6149373618 | −7.6149373618 |

**nquad-independence** (deliberately under-resolved single maximally-wide element,
H2, `--nelem=1`) — the branch is now **flat**, master degrades at low nquad:

| nquad | branch | master |
|-------|--------|--------|
| 30 | −1.1336288259 | −1.1336288175 (8.4e-9 off) |
| 60 | −1.1336288259 | −1.1336288258 |
| 200 | −1.1336288259 | −1.1336288259 |

The in-element kernel block self-converges to ~`eps` as the order refines
(≈5e-14 on the μ=0 element, 1.6e-15 on a smooth interior element).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01713v3a7XrUHrPRWtYy3XKy
