### PR TITLE
docs: retire stale armadillo comment, re-document --nquad

### DIFF
--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -134,9 +134,7 @@ namespace helfem {
       public:
         TwoDBasisT();
         /// Constructor
-        // Phase 5.19: bval/lval/mval accepted as Eigen at the public
-        // boundary so a consumer does not need to include <armadillo>
-        // to instantiate the basis.
+        // bval/lval/mval are accepted as Eigen types at the public boundary.
         TwoDBasisT(int Z, modelpotential::nuclear_model_t model, T Rrms,
                    const std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> &poly,
                    bool zeroder, int n_quad,

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
   parser.add<int>("nelem", 0, "number of elements", true);
   parser.add<int>("nelem0", 0, "number of elements between center and off-center nuclei", false, 0);
   parser.add<int>("nnodes", 0, "number of nodes per element", false, 15);
-  parser.add<int>("nquad", 0, "number of quadrature points", false, 0);
+  parser.add<int>("nquad", 0, "radial quadrature points: DFT grid + auto-convergence seed (no longer sets HF/2e integral accuracy, which now converges automatically; still sets the erfc/range-separated rule)", false, 0);
   parser.add<std::string>("method", 0, "DFT method to use", false, "lda_x");
   parser.add<int>("ldft", 0, "theta rule for dft quadrature (0 for auto)", false, 0);
   parser.add<int>("mdft", 0, "phi rule for dft quadrature (0 for auto)", false, 0);

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
   parser.add<double>("zexp", 0, "parameter in radial grid", false, 1.0);
   parser.add<int>("nelem", 0, "number of elements", true);
   parser.add<int>("nnodes", 0, "number of nodes per element", false, 15);
-  parser.add<int>("nquad", 0, "number of quadrature points", false, 0);
+  parser.add<int>("nquad", 0, "radial quadrature points: DFT grid + auto-convergence seed (no longer sets integral accuracy, which now converges automatically)", false, 0);
   parser.add<std::string>("method", 0, "DFT method to use", false, "lda_x");
   parser.add<int>("ldft", 0, "theta rule for dft quadrature (0 for auto)", false, 0);
   parser.add<int>("mdft", 0, "phi rule for dft quadrature (0 for auto; unused by the pure-m path)", false, 0);


### PR DESCRIPTION
Doc-only follow-up to the auto-convergence work (#257/#260 atomic, #261 diatomic). No functional change.

- **`src/atomic/TwoDBasis.h`** — drop the stale "so a consumer does not need to include `<armadillo>`" clause from the constructor comment. Armadillo is fully removed from the tree (this was the last textual reference); the substantive note that `bval/lval/mval` are Eigen types at the public boundary is kept.
- **`src/atomic/main.cpp`, `src/diatomic/main.cpp`** — the `--nquad` help text still read "number of quadrature points" as though it set integral accuracy. That is no longer true: the analytic radial integrals auto-converge to `eps` of the scalar type. Re-documented to say `--nquad` now (1) seeds the auto-convergence and (2) sets the radial DFT integration grid. The atomic string additionally notes it still sets the erfc/range-separated rule (the one integral not yet auto-converged — tracked separately); the diatomic string omits that, since the diatomic has no range-separated path.