### PR TITLE
sadatom: allow fractional per-l occupations in --occs

### DIFF
--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -558,7 +558,9 @@ namespace helfem {
           opts.x_func         = x_func;
           opts.c_func         = c_func;
           opts.dftthr         = dftthr;
-          opts.fixed_per_l_a  = occ;
+          // fixed_per_l_* are real-valued (fractional occupations are
+          // allowed); the tabulated PBE ground-state config is integral.
+          opts.fixed_per_l_a  = occ.cast<double>();
           opts.verbosity      = 0;
           auto res = sadatom::scf::run_atomic_scf(opts);
           basis_out = res.basis;

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -30,6 +30,8 @@
 #include "../atomic/basis.h"
 #include "scf.h"
 #include "../general/eigen_io.h"
+// std::abs / std::round / std::lround for the --occs integrality check.
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -228,7 +230,7 @@ int main(int argc, char **argv) {
   parser.add<bool>  ("add_conf",     0, "Add element boundary at shifted confinement radius?", false, true);
 
   parser.add<int>("iguess", 0, "initial guess: 0 core Hamiltonian, 1 GSZ, 2 SAP, 3 Thomas-Fermi", false, 2);
-  parser.add<std::string>("occs", 0, "occupations: 'auto' (Aufbau), or space-separated per-l counts (lmax+1 totals; unrestricted also accepts 2*(lmax+1) as alpha then beta)", false, "auto");
+  parser.add<std::string>("occs", 0, "occupations: 'auto' (Aufbau), or space-separated per-l counts (lmax+1 integer totals; unrestricted also accepts 2*(lmax+1) as alpha then beta, which may be fractional)", false, "auto");
 
   parser.add<std::string>("load", 0, "load orbital guess from checkpoint file", false, "");
   parser.add<std::string>("save", 0, "save results to checkpoint file",       false, "");
@@ -348,34 +350,42 @@ int main(int argc, char **argv) {
   opts.save_file    = parser.get<std::string>("save");
 
   // Explicit occupations. "auto" leaves OOO to fill by Aufbau. Otherwise
-  // parse space-separated per-l integer counts and pin them via the
+  // parse space-separated per-l counts and pin them via the
   // frozen-occupation API (opts.fixed_per_l_*). Restricted expects
   // lmax+1 per-l totals; unrestricted accepts lmax+1 totals (Hund
   // high-spin split into alpha/beta) or 2*(lmax+1) explicit alpha-then-
-  // beta counts.
+  // beta counts.  The explicit alpha/beta form accepts fractional
+  // counts; the Hund-split form does not, since the shell-filling
+  // arithmetic is integral.
   {
     const std::string occstr = parser.get<std::string>("occs");
     if (occstr != "auto" && occstr != "AUTO" && occstr != "Auto") {
       std::istringstream iss(occstr);
-      std::vector<int> vals; int v;
+      std::vector<double> vals; double v;
       while (iss >> v) vals.push_back(v);
       const int nl = lmax + 1;
-      auto to_ivec = [](const std::vector<int> & x) {
-        Eigen::VectorXi o(x.size());
+      auto to_dvec = [](const std::vector<double> & x) {
+        Eigen::VectorXd o(x.size());
         for (size_t i = 0; i < x.size(); ++i) o(i) = x[i];
         return o;
       };
       if (restricted) {
         if ((int) vals.size() != nl)
           throw std::logic_error("Restricted --occs needs lmax+1 per-l totals.\n");
-        opts.fixed_per_l_a = to_ivec(vals);
+        opts.fixed_per_l_a = to_dvec(vals);
       } else if ((int) vals.size() == nl) {
         // Hund high-spin split of each per-l total across n-shells: fill
         // shells of capacity 2*(2l+1), putting up to (2l+1) per shell in
         // alpha before beta (matches the bespoke driver's hund_rule).
-        Eigen::VectorXi a = Eigen::VectorXi::Zero(nl), b = Eigen::VectorXi::Zero(nl);
+        // Integral only: the fill is defined shell by shell.
+        for (int l = 0; l < nl; ++l)
+          if (std::abs(vals[l] - std::round(vals[l])) > 1e-10)
+            throw std::logic_error("Fractional --occs requires the explicit "
+                                   "2*(lmax+1) alpha-then-beta form; the "
+                                   "lmax+1 Hund-split form takes integers.\n");
+        Eigen::VectorXd a = Eigen::VectorXd::Zero(nl), b = Eigen::VectorXd::Zero(nl);
         for (int l = 0; l < nl; ++l) {
-          int numel = vals[l];
+          int numel = static_cast<int>(std::lround(vals[l]));
           while (numel > 0) {
             const int numsh = std::min(numel, 2 * (2 * l + 1));
             const int na    = std::min(numsh, 2 * l + 1);
@@ -387,8 +397,8 @@ int main(int argc, char **argv) {
         opts.fixed_per_l_a = a;
         opts.fixed_per_l_b = b;
       } else if ((int) vals.size() == 2 * nl) {
-        opts.fixed_per_l_a = to_ivec(std::vector<int>(vals.begin(), vals.begin() + nl));
-        opts.fixed_per_l_b = to_ivec(std::vector<int>(vals.begin() + nl, vals.end()));
+        opts.fixed_per_l_a = to_dvec(std::vector<double>(vals.begin(), vals.begin() + nl));
+        opts.fixed_per_l_b = to_dvec(std::vector<double>(vals.begin() + nl, vals.end()));
       } else {
         throw std::logic_error("Unrestricted --occs needs lmax+1 totals or 2*(lmax+1) alpha/beta counts.\n");
       }

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -63,8 +63,11 @@ namespace helfem {
         // 2*(2l+1)) and leave fixed_per_l_b empty.
         // Unrestricted: pass both; each entry is the alpha or beta
         // count in that l (up to 2l+1).
-        Eigen::VectorXi fixed_per_l_a;
-        Eigen::VectorXi fixed_per_l_b;
+        // Counts may be fractional: OOO's frozen-occupation API takes
+        // reals, so a partially filled l shell can be pinned at any
+        // occupation in [0, 2l+1] (or [0, 2*(2l+1)] when restricted).
+        Eigen::VectorXd fixed_per_l_a;
+        Eigen::VectorXd fixed_per_l_b;
         /// OOO verbosity; 0 for silent, higher for per-iteration prints.
         int verbosity = 5;
         /// SCF convergence algorithms handed to OOO's state machine: a


### PR DESCRIPTION
`--occs` parsed into `std::vector<int>` and stored `Eigen::VectorXi`, so only integral per-l counts could be pinned. That prevents scanning E(n) along a fractional 4s/3d split — the direct way to locate the minimum and measure the curvature of the energy along the occupation coordinate.

The downstream consumer already works in real arithmetic: `scf.cpp` casts each entry to `OOO_Real` and hands it to OOO's `fixed_number_of_particles_per_block`, which takes reals. So only the storage type and the parser change; **`scf.cpp` needs no edit**.

The Hund auto-split branch (lmax+1 totals for an unrestricted run) distributes electrons over n-shells with integer arithmetic and has no meaningful fractional generalisation, so it keeps requiring integers and now says so explicitly rather than silently truncating.

One addition beyond the storage/parser change: `src/diatomic/twodquadrature.cpp:561` assigns the tabulated PBE ground-state config to `fixed_per_l_a`. Eigen has no implicit scalar conversion, so `VectorXd = VectorXi` does not compile — that assignment needs an explicit `.cast<double>()`.

### Verification

- Integer Hund-split form unchanged: `--occs="8 12 6"` runs as before.
- Guard fires correctly: `--occs="4 6 5.5"` → *"Fractional --occs requires the explicit 2\*(lmax+1) alpha-then-beta form; the lmax+1 Hund-split form takes integers."*
- Fractional counts are genuinely applied rather than rounded — shown by the energy varying smoothly along the occupation coordinate.

Fe M=5, lmax=2, PBE, alpha=(4,6,5), beta=(3+x, 6, 2−x):

| x | 3d_β | E |
|---|---|---|
| 0.50 | 1.50 | −1263.4355431953 |
| 0.55 | 1.45 | −1263.4359642259 |
| 0.60 | 1.40 | −1263.4362275486 |
| 0.65 | 1.35 | −1263.4363287455 |
| 0.70 | 1.30 | −1263.4362633631 |
| 0.75 | 1.25 | −1263.4360269248 |
| 0.80 | 1.20 | −1263.4356149421 |

Parabola fit (max residual 4.5e-6 Ha): minimum at **x = 0.65404, i.e. 3d_β = 1.34596**, with **d²E/dx² = 0.0666 Ha**.

That curvature means a ±0.0035 displacement in occupation costs only **4.1e-7 Ha** — which is why chained restarts of the free-occupation run scatter over 3d_β = 1.336–1.343 while the energy barely moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01713v3a7XrUHrPRWtYy3XKy