### PR TITLE
cmake: don't install the fetched OpenOrbitalOptimizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,10 +175,22 @@ find_package(OpenOrbitalOptimizer QUIET)
 if(NOT OpenOrbitalOptimizer_FOUND)
     message(STATUS "OpenOrbitalOptimizer not found; fetching from GitHub")
     include(FetchContent)
+    # EXCLUDE_FROM_ALL keeps the fetched copy's install() rules out of our
+    # install tree. Without it `cmake --install` deposits OOO in
+    # CMAKE_INSTALL_PREFIX, which the next configure's find_package then
+    # picks up -- freezing the dependency at that snapshot and making
+    # ./compile.sh non-idempotent. Only honoured from CMake 3.28; we
+    # require 3.20, so apply it conditionally.
+    set(_ooo_exclude "")
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+        set(_ooo_exclude EXCLUDE_FROM_ALL)
+    endif()
     FetchContent_Declare(OpenOrbitalOptimizer
         GIT_REPOSITORY https://github.com/susilehtola/OpenOrbitalOptimizer.git
-        GIT_TAG        master)
+        GIT_TAG        master
+        ${_ooo_exclude})
     FetchContent_MakeAvailable(OpenOrbitalOptimizer)
+    unset(_ooo_exclude)
 else()
     message(STATUS "Using system OpenOrbitalOptimizer")
 endif()


### PR DESCRIPTION
Replaces #265, cut down to just the part that prevents the problem. **+13 −1** instead of ~60 lines.

`FetchContent_MakeAvailable` brings in OOO's `install()` rules along with its targets, so `cmake --install` deposited OOO into HelFEM's own `CMAKE_INSTALL_PREFIX`. CMake's config-mode search includes that prefix, so the next configure found the copy, set `OpenOrbitalOptimizer_FOUND`, and skipped the fetch — freezing the dependency at whatever `master` was on the day of the first build.

`./compile.sh` was therefore not idempotent: run it twice and the second build used a stale OOO, failing deep into the build with

```
sadatom/scf.cpp: no matching function for call to
  SCFSolver<double,double>::run(const std::string&)
```

`EXCLUDE_FROM_ALL` keeps those install rules out of our install tree, which prevents the loop forming. Only honoured from CMake 3.28 and the project requires 3.20, so it's applied conditionally.

### Scope — deliberately limited

This stops **new** trees from being poisoned. It does **not**:

- clean up an already-poisoned prefix — delete the stale `<prefix>/lib*/cmake/OpenOrbitalOptimizer`, or configure once with `-DCMAKE_DISABLE_FIND_PACKAGE_OpenOrbitalOptimizer=ON`
- do anything on CMake < 3.28

#265 covered both with a compile-time feature check on the found package, which was judged more machinery than this is worth. Recording the tradeoff here so it's a conscious choice rather than an oversight.

### Verification

After `cmake --install`: no OOO anywhere under the install prefix, while HelFEM's own headers still install as before (checked, since a misapplied `EXCLUDE_FROM_ALL` could have suppressed our own install rules too).

`wignernj` and `Eigen3` just above use the same fetch pattern and have the same exposure — left alone to keep this minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01713v3a7XrUHrPRWtYy3XKy