### PR TITLE
libhelfem: switch the 2e refinement to Gauss-Lobatto

### DIFF
--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -17,6 +17,7 @@
 #include "quadrature.h"
 #include "utils.h"
 #include <chebyshev.h>
+#include <lobatto.h>
 #include <limits>
 // Scalar formatter that prints a T value at its own precision (no truncation
 // to double). Header-only, needs only Matrix.h + std; see src/general/eigen_io.h.
@@ -49,8 +50,30 @@ namespace helfem {
       // between consecutive outer nodes -- one rule drives both the outer
       // nodes and the inner segments, so plain order-refinement converges.
       //
-      // The rule family stays Gauss-Chebyshev to match the existing scheme;
-      // switching families would perturb the results more than necessary.
+      // The rule family is Gauss-Lobatto, NOT the modified Gauss-Chebyshev
+      // rule used elsewhere. This matters: despite its name, the modified
+      // Gauss-Chebyshev rule (chebyshev.h) is not a Gaussian rule but the
+      // equispaced trapezoid rule pushed through the variable transformation
+      // x(t) with Jacobian ~ sin^4(t). Its error is governed by the Euler-
+      // Maclaurin expansion of the transformed integrand g(t) = f(x(t))
+      // sin^4(t): near the endpoints sin^4 contributes only even powers
+      // t^4, t^6, t^8 and x(t)-x(0) ~ t^5, so the first odd derivative of g
+      // that survives at the boundary is g^(9), leaving a FIXED algebraic
+      // error O(n^-10) for every smooth integrand (measured: the block diff
+      // shrinks by 2^-10 per order doubling, at any n). That is ample for
+      // double -- n ~ 300 reaches 1e-16 -- but it can never follow eps(T)
+      // for wide types: reaching 1e-33 in _Float128 would take n ~ 10^4.
+      //
+      // Gauss-Lobatto is polynomial-exact (degree 2n-3), and the 2e radial
+      // primitives are polynomial-friendly: the accumulated inner integral
+      // is G(r) * r^(-L-1) with G(r) = int_rmin^r B_k B_l r'^L dr' a
+      // polynomial, so on the innermost element (rmin = 0) the outer
+      // integrand B_i B_j G / r^(L+1) is itself a POLYNOMIAL of degree
+      // <= 4(nbf-1), integrated exactly once 2n-3 covers it, and on outer
+      // elements it is a rational function whose only pole (r = 0) lies
+      // outside the element, so the rule converges geometrically. Either
+      // way the refinement loop terminates at modest n for every T instead
+      // of grinding the Chebyshev rule's order-10 wall to the cap.
       // --------------------------------------------------------------------
       namespace {
         /// Order cap for the refinement loop.
@@ -58,7 +81,7 @@ namespace helfem {
         /// Warn at most once per process if a primitive hits the order cap.
         bool twoe_cap_warned = false;
 
-        /// Refine `eval(n)` -- which must build its own n-point Chebyshev
+        /// Refine `eval(n)` -- which must build its own n-point Lobatto
         /// rule -- by doubling n from nstart until the returned block is
         /// stable. The 2e blocks are (nbf^2 x nbf^2), i.e. their shape is
         /// independent of n, so the block-difference comparison is well
@@ -69,21 +92,22 @@ namespace helfem {
         ///
         ///   1. True eps convergence: the block stops changing to 8*eps(T),
         ///      exactly the criterion the one-electron matrix_element uses
-        ///      (FiniteElementBasis.cpp converge_panel). Low-degree bases /
-        ///      small elements hit this.
+        ///      (FiniteElementBasis.cpp converge_panel). This is the common
+        ///      exit: the innermost element's Coulomb block is polynomial
+        ///      and hence EXACT once 2n-3 covers its degree, and the outer
+        ///      elements' rational integrands converge geometrically.
         ///
-        ///   2. Roundoff-floor stall: unlike the one-electron path -- whose
-        ///      polynomial weight makes the Gauss-Lobatto block exact at a
-        ///      finite order, so its difference collapses to true zero -- the
-        ///      2e Coulomb/Yukawa kernel is NOT polynomial-exact, so the
-        ///      block difference converges geometrically only down to the
-        ///      roundoff floor of the (nbf^2 x nbf^2) assembly (a small
-        ///      multiple of eps above 8*eps*scale) and then wobbles. Once the
-        ///      difference is deep in the asymptotic regime (well below
-        ///      sqrt(eps)*scale) and a doubling of the order no longer at
-        ///      least halves it, further refinement only chases roundoff:
-        ///      the block has converged to T's precision. This is a normal
-        ///      outcome, not a failure, so it returns quietly.
+        ///   2. Roundoff-floor stall: for the branches that are not
+        ///      polynomial (Yukawa's Bessel kernels, weighted cross-basis
+        ///      projections) the block difference converges geometrically
+        ///      only down to the roundoff floor of the (nbf^2 x nbf^2)
+        ///      assembly (a small multiple of eps above 8*eps*scale) and
+        ///      then wobbles. Once the difference is deep in the asymptotic
+        ///      regime (well below sqrt(eps)*scale) and a doubling of the
+        ///      order no longer at least halves it, further refinement only
+        ///      chases roundoff: the block has converged to T's precision.
+        ///      This is a normal outcome, not a failure, so it returns
+        ///      quietly.
         ///
         /// The nmax cap + one-shot warning is thus a genuine backstop for
         /// pathological non-convergence, not the common high-degree case.
@@ -117,7 +141,7 @@ namespace helfem {
             if (n >= twoe_nmax) {
               if (!twoe_cap_warned) {
                 twoe_cap_warned = true;
-                printf("Warning: FEMRadialBasis::%s hit the Gauss-Chebyshev order"
+                printf("Warning: FEMRadialBasis::%s hit the Gauss-Lobatto order"
                        " cap (n=%d) without converging to eps(T); using best"
                        " estimate.\n", what, twoe_nmax);
                 fflush(stdout);
@@ -345,7 +369,7 @@ namespace helfem {
         return converge_rule<T>(
             [&](int n) {
               helfem::Vec<T> xproj, wproj;
-              helfem::chebyshev::chebyshev<T>(n, xproj, wproj);
+              helfem::lobatto::lobatto_compute<T>(n, xproj, wproj);
 
               helfem::Mat<T> S = helfem::Mat<T>::Zero(Nbf(), rh.Nbf());
               for (size_t iel = 0; iel < fem.get_nelem(); ++iel) {
@@ -357,8 +381,14 @@ namespace helfem {
                   const T intmid   = T(0.5) * (intend + intstart);
                   const T intlen   = T(0.5) * (intend - intstart);
 
+                  // The Lobatto rule includes x = +-1, whose mapped image
+                  // intmid +- intlen can round a few ulps past the exact
+                  // interval ends and trip eval_prim's bounds check; clamp
+                  // to the interval, whose ends are exact element
+                  // boundaries of one basis and interior to the other.
                   const helfem::Vec<T> r =
-                      helfem::Vec<T>::Constant(xproj.size(), intmid) + intlen * xproj;
+                      (helfem::Vec<T>::Constant(xproj.size(), intmid) + intlen * xproj)
+                          .cwiseMax(intstart).cwiseMin(intend);
 
                   const helfem::Vec<T> xi = fem.eval_prim(r, iel);
                   const helfem::Vec<T> xj = rh.fem.eval_prim(r, jel);
@@ -609,7 +639,7 @@ namespace helfem {
         helfem::Mat<T> tei = converge_rule<T>(
             [&](int n) {
               helfem::Vec<T> x, w;
-              helfem::chebyshev::chebyshev<T>(n, x, w);
+              helfem::lobatto::lobatto_compute<T>(n, x, w);
               // Phase 5.7: quadrature::twoe_integral is now Eigen.
               return quadrature::twoe_integral<T>(Rmin, Rmax, x, w, p, L);
             },
@@ -690,7 +720,7 @@ namespace helfem {
         return converge_rule<T>(
             [&](int n) {
               helfem::Vec<T> x, w;
-              helfem::chebyshev::chebyshev<T>(n, x, w);
+              helfem::lobatto::lobatto_compute<T>(n, x, w);
               return quadrature::yukawa_integral<T>(Rmin, Rmax, x, w, p, L, lambda);
             },
             twoe_nstart(), "yukawa_integral");

--- a/libhelfem/src/quadrature.cpp
+++ b/libhelfem/src/quadrature.cpp
@@ -85,15 +85,27 @@ namespace helfem {
 
       const int nbf = poly->get_nbf();
       Mat<T> inner(x.size(), nbf * nbf);
-      // Row 0: integral from rmin to r(0)
-      inner.row(0) = twoe_inner_integral_wrk<T>(rmin, r(0), rmin, rmax, x, wx, poly, fsmallbig, fbig).transpose();
+      // Row 0: integral from rmin to r(0). With an endpoint-including rule
+      // (Gauss-Lobatto) r(0) == rmin and the segment is empty; skip the
+      // kernel evaluation, which on the innermost element (rmin = 0) would
+      // otherwise hit fsmallbig(0, 0) and poison the row with NaN.
+      const bool empty_first = (r(0) == rmin);
+      if (empty_first)
+        inner.row(0).setZero();
+      else
+        inner.row(0) = twoe_inner_integral_wrk<T>(rmin, r(0), rmin, rmax, x, wx, poly, fsmallbig, fbig).transpose();
       for (Eigen::Index ip = 1; ip < x.size(); ++ip)
         inner.row(ip) = twoe_inner_integral_wrk<T>(r(ip - 1), r(ip), rmin, rmax, x, wx, poly, fsmallbig, fbig).transpose();
 
       // Rescale: undo the per-segment R^(-L-1) factor we applied for
-      // numerical stability.
-      for (Eigen::Index ip = 1; ip < x.size(); ++ip)
+      // numerical stability. When row 0 is an empty segment it carries
+      // nothing, and skipping it also avoids evaluating fbig(0) = inf on
+      // the innermost element.
+      for (Eigen::Index ip = 1; ip < x.size(); ++ip) {
+        if (ip == 1 && empty_first)
+          continue;
         inner.row(ip) += inner.row(ip - 1) * (fbig(r(ip)) / fbig(r(ip - 1)));
+      }
 
       return inner;
     }


### PR DESCRIPTION
The auto-converging two-electron primitives stopped ~4 digits short of quad precision: on the helium `_Float128` ladder the energies floored at ~3e-26 sitting *below* the HF limit, and every `converge_rule` call ran to the n=512 order cap with neither stopping criterion ever firing.

**Root cause — the rule family, not the integrand or the stopping logic.** Despite its name, the modified Gauss-Chebyshev rule (`chebyshev.h`) is not a Gaussian rule: it is the equispaced trapezoid rule under the Pérez-Jordá transformation, whose Jacobian ~ sin⁴(t) leaves the first surviving Euler–Maclaurin boundary term at h¹⁰. Its error is **O(n⁻¹⁰) for every smooth integrand, at any order** (measured: block diff shrinks by 2⁻¹⁰ per doubling up to n=1200). Ample for double; a wall for `_Float128` (1e-33 would need n ~ 10⁴).

The 2e integrands are as good as integrands get: the accumulated inner integral makes the outer integrand a *polynomial* of degree ≤ 4(nbf−1) on the innermost element and a rational function with its only pole outside the element elsewhere. Building the refinement rules with `lobatto_compute` (polynomial-exact to degree 2n−3) makes the innermost block exact at finite order and the rest geometric: every call now takes the true-eps exit on its **first doubling**, at the assembly roundoff floor (~1e-35 relative in quad).

Two mechanical consequences of Lobatto's endpoint nodes:
- `twoe_inner_integral`'s first row is now an empty segment; skip it (otherwise fsmallbig(0,0)/fbig(0) NaN-poison the innermost element);
- the cross-basis projection's mapped ±1 nodes can round ulps past the interval ends and trip `eval_prim`'s bounds check (aborted e.g. `gensap --load` onto a different grid); clamp to the intersection interval.

`erfc_integral`, the DFT grids, and the semi-infinite `radial_chebyshev` maps deliberately stay on the Chebyshev rule — for cusped/endpoint-singular integrands its sin⁴ endpoint clustering is the right treatment.

**Validation** — He RHF in `_Float128` vs the 30-digit HF limit (Yamamoto & Hatano; reference resolution ±5e-30):

| 15-node dof | before | after | | 25-node dof | before | after |
|---|---|---|---|---|---|---|
| 223 | 4.7e-26 | 1.10e-27 | | 191 | 1.8e-25 | 4.44e-30 |
| 279 | 3.1e-26 | **6.7e-31** | | 239 | 1.2e-25 | **1.23e-30** |

All after-errors are variational (above the reference), monotone, and reach the reference's own resolution; 25-node now beats 15-node at matched dof as spectral convergence demands. Double/long double: accuracy unaffected, slightly *faster* (Kr HF lmax=3 nelem=8: 39.3s vs 42.1s) since refinement ends on the first doubling. Spot checks reproduce every printed digit vs the pre-change build: Be HF + lda_x_yukawa (atomic), Ar (gensap, incl. save/load across grids — crashed before the clamp fix), H2 (diatomic), atomic_itest, and the atomic_precision story is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01713v3a7XrUHrPRWtYy3XKy