### PR TITLE
Migrate to OpenOrbitalOptimizer's settings facade

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -658,6 +658,8 @@ int main(int argc, char **argv) {
   }
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
+  scfsolver.print_citation();
+  scfsolver.print_settings();
   scfsolver.run();
 
   // --save: reconstruct the AO densities from the converged per-block

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -657,7 +657,8 @@ int main(int argc, char **argv) {
     scfsolver.initialize_with_fock(CoreH);
   }
 
-  scfsolver.run(parser.get<std::string>("scfmethods"));
+  scfsolver.set("methods", parser.get<std::string>("scfmethods"));
+  scfsolver.run();
 
   // --save: reconstruct the AO densities from the converged per-block
   // orbitals + occupations and write them plus the basis to a

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -659,7 +659,6 @@ int main(int argc, char **argv) {
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
   scfsolver.print_citation();
-  scfsolver.print_settings();
   scfsolver.run();
 
   // --save: reconstruct the AO densities from the converged per-block

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -610,6 +610,8 @@ int main(int argc, char **argv) {
   }
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
+  scfsolver.print_citation();
+  scfsolver.print_settings();
   scfsolver.run();
 
   if (savefile.size()) {

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -609,7 +609,8 @@ int main(int argc, char **argv) {
     scfsolver.initialize_with_fock(CoreH);
   }
 
-  scfsolver.run(parser.get<std::string>("scfmethods"));
+  scfsolver.set("methods", parser.get<std::string>("scfmethods"));
+  scfsolver.run();
 
   if (savefile.size()) {
     Checkpoint savechk(savefile, /*writemode=*/true);

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -611,7 +611,6 @@ int main(int argc, char **argv) {
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
   scfsolver.print_citation();
-  scfsolver.print_settings();
   scfsolver.run();
 
   if (savefile.size()) {

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -414,6 +414,10 @@ namespace helfem {
           scfsolver.initialize_with_fock(CoreH);
         }
         scfsolver.set("methods", opts.scf_methods);
+        if (opts.verbosity > 0) {
+          scfsolver.print_citation();
+          scfsolver.print_settings();
+        }
         scfsolver.run();
 
         // Extract results. Convert OOO's per-block orbital matrices

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -264,7 +264,7 @@ namespace helfem {
         OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
             number_of_blocks_per_particle_type, maximum_occupation,
             number_of_particles, fock_builder, block_descriptions);
-        scfsolver.verbosity(opts.verbosity);
+        scfsolver.set("verbosity", opts.verbosity);
 
         // Frozen per-l occupation: hand OOO a per-block particle count
         // vector so Aufbau is bypassed. Same pattern as atomic_ooo /
@@ -413,7 +413,8 @@ namespace helfem {
         } else {
           scfsolver.initialize_with_fock(CoreH);
         }
-        scfsolver.run(opts.scf_methods);
+        scfsolver.set("methods", opts.scf_methods);
+        scfsolver.run();
 
         // Extract results. Convert OOO's per-block orbital matrices
         // (in the Sinvh-orthonormal basis) back to AO coefficients

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -414,10 +414,8 @@ namespace helfem {
           scfsolver.initialize_with_fock(CoreH);
         }
         scfsolver.set("methods", opts.scf_methods);
-        if (opts.verbosity > 0) {
+        if (opts.verbosity > 0)
           scfsolver.print_citation();
-          scfsolver.print_settings();
-        }
         scfsolver.run();
 
         // Extract results. Convert OOO's per-block orbital matrices


### PR DESCRIPTION
Upstream OpenOrbitalOptimizer replaced the named setter methods with a string-keyed settings façade (`set` / `get_*` / `options()`), and `run()` no longer takes the method string. Since HelFEM fetches OOO at `master`, a fresh configure now picks up the new API and the old calls fail to compile.

This migrates the four call sites:
- `scfsolver.verbosity(n)` → `scfsolver.set("verbosity", n)` (sadatom)
- `scfsolver.run(methods)` → `scfsolver.set("methods", methods); scfsolver.run()` (sadatom, atomic, diatomic)

Everything else HelFEM uses (`initialize_with_fock/orbitals`, `fixed_number_of_particles_per_block`, `get_orbitals`, `get_orbital_occupations`) is unchanged upstream.

In addition, all three drivers now print the OpenOrbitalOptimizer citation (`print_citation()`) before running the SCF, mirroring the Libxc reference banner the drivers already emit. (The solver settings themselves are dumped by OOO's own `run()` at verbosity ≥ 10, so no explicit settings printout is needed.) In sadatom the citation is gated on the verbosity option like the rest of the OOO output.

No behavior change in the numbers — regression energies match the previous references to all printed digits:
- `atomic` Be HF: -14.5730231683
- `gensap` Ar lda_x: -524.5174255706
- `diatomic` H2 HF: -1.1336051422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
