### PR TITLE
Restore spin-restricted calculations on open-shell systems

### DIFF
--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -166,16 +166,20 @@ namespace helfem {
     ///   when both are zero on entry;
     /// * restr = -1 means "auto": closed shell -> 1 restricted,
     ///   otherwise 0 unrestricted;
-    /// * restricted mode requires nela == nelb, else throws.
+    /// * restricted mode requires nela == nelb, else throws -- unless
+    ///   allow_open_shell_restricted is set, for solvers whose
+    ///   restricted mode is a spin-averaged single density channel
+    ///   (sadatom) where an odd electron count is meaningful.
     /// Returns the derived (restricted, Ntot = nela + nelb) pair via
     /// out-refs so both drivers can use them directly below.
     inline void derive_nela_nelb_restricted(
         int & nela, int & nelb, int & restr, int Q, int M, int Ztotal,
-        bool & restricted, int & Ntot) {
+        bool & restricted, int & Ntot,
+        bool allow_open_shell_restricted = false) {
       scf::parse_nela_nelb(nela, nelb, Q, M, Ztotal);
       if (restr == -1) restr = (nela == nelb) ? 1 : 0;
       restricted = (restr != 0);
-      if (restricted && nela != nelb)
+      if (restricted && nela != nelb && !allow_open_shell_restricted)
         throw std::logic_error("Restricted mode requires nela == nelb (closed shell). "
                                 "Use --restricted=0 (or leave -1 for auto) for open-shell.");
       Ntot = nela + nelb;

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -164,24 +164,38 @@ namespace helfem {
     /// CLI-input normalisation shared by both drivers:
     /// * scf::parse_nela_nelb fills in nela/nelb from --Q and --M
     ///   when both are zero on entry;
+    /// * M = 0 with no explicit nela/nelb runs spin-restricted
+    ///   straight from the total electron count Ztotal - Q: the
+    ///   restricted SCF sees a single density channel where only
+    ///   Ntot matters (and may be odd), so no multiplicity is
+    ///   needed. An explicit --restricted=0 with M=0 is an error
+    ///   since the alpha/beta split is then undefined.
     /// * restr = -1 means "auto": closed shell -> 1 restricted,
-    ///   otherwise 0 unrestricted;
-    /// * restricted mode requires nela == nelb, else throws -- unless
-    ///   allow_open_shell_restricted is set, for solvers whose
-    ///   restricted mode is a spin-averaged single density channel
-    ///   (sadatom) where an odd electron count is meaningful.
+    ///   otherwise 0 unrestricted. Restricted mode with an open
+    ///   shell (nela != nelb) is allowed when requested explicitly:
+    ///   only Ntot enters the restricted SCF, which distributes any
+    ///   unpaired electrons over the frontier orbitals.
     /// Returns the derived (restricted, Ntot = nela + nelb) pair via
-    /// out-refs so both drivers can use them directly below.
+    /// out-refs so the drivers can use them directly below.
     inline void derive_nela_nelb_restricted(
         int & nela, int & nelb, int & restr, int Q, int M, int Ztotal,
-        bool & restricted, int & Ntot,
-        bool allow_open_shell_restricted = false) {
+        bool & restricted, int & Ntot) {
+      if (M == 0 && nela == 0 && nelb == 0) {
+        if (restr == 0)
+          throw std::logic_error("Unrestricted mode needs a multiplicity (--M) or "
+                                 "explicit nela/nelb.\n");
+        Ntot = Ztotal - Q;
+        if (Ntot <= 0)
+          throw std::logic_error("No electrons: Z - Q <= 0.\n");
+        nela = (Ntot + 1) / 2;
+        nelb = Ntot / 2;
+        restr = 1;
+        restricted = true;
+        return;
+      }
       scf::parse_nela_nelb(nela, nelb, Q, M, Ztotal);
       if (restr == -1) restr = (nela == nelb) ? 1 : 0;
       restricted = (restr != 0);
-      if (restricted && nela != nelb && !allow_open_shell_restricted)
-        throw std::logic_error("Restricted mode requires nela == nelb (closed shell). "
-                                "Use --restricted=0 (or leave -1 for auto) for open-shell.");
       Ntot = nela + nelb;
     }
 

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -283,8 +283,25 @@ int main(int argc, char **argv) {
 
   bool restricted;
   int Ntot;
-  helfem::scf_driver::derive_nela_nelb_restricted(
-      nela, nelb, restr, Q, M, Z, restricted, Ntot);
+  if (M == 0 && nela == 0 && nelb == 0 && restr != 0) {
+    // Spin-restricted, spin-averaged calculation: the SCF sees a
+    // single density channel and only the total electron count
+    // matters, so no multiplicity is needed and the count may be
+    // odd. This is the sadatom default (and matches the aij
+    // convention, where M=0 runs spin-restricted).
+    Ntot = Z - Q;
+    if (Ntot <= 0)
+      throw std::logic_error("No electrons to correlate: Z - Q <= 0.\n");
+    nela = (Ntot + 1) / 2;
+    nelb = Ntot / 2;
+    restricted = true;
+  } else {
+    // Restricted here means spin-averaged, so an open shell
+    // (nela != nelb) is fine: the SCF only consults Ntot.
+    helfem::scf_driver::derive_nela_nelb_restricted(
+        nela, nelb, restr, Q, M, Z, restricted, Ntot,
+        /*allow_open_shell_restricted=*/true);
+  }
   (void) Ntot;  // sadatom SCF driver does its own per-l particle counting.
 
   helfem::Vector x_pars, c_pars;

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -283,25 +283,8 @@ int main(int argc, char **argv) {
 
   bool restricted;
   int Ntot;
-  if (M == 0 && nela == 0 && nelb == 0 && restr != 0) {
-    // Spin-restricted, spin-averaged calculation: the SCF sees a
-    // single density channel and only the total electron count
-    // matters, so no multiplicity is needed and the count may be
-    // odd. This is the sadatom default (and matches the aij
-    // convention, where M=0 runs spin-restricted).
-    Ntot = Z - Q;
-    if (Ntot <= 0)
-      throw std::logic_error("No electrons to correlate: Z - Q <= 0.\n");
-    nela = (Ntot + 1) / 2;
-    nelb = Ntot / 2;
-    restricted = true;
-  } else {
-    // Restricted here means spin-averaged, so an open shell
-    // (nela != nelb) is fine: the SCF only consults Ntot.
-    helfem::scf_driver::derive_nela_nelb_restricted(
-        nela, nelb, restr, Q, M, Z, restricted, Ntot,
-        /*allow_open_shell_restricted=*/true);
-  }
+  helfem::scf_driver::derive_nela_nelb_restricted(
+      nela, nelb, restr, Q, M, Z, restricted, Ntot);
   (void) Ntot;  // sadatom SCF driver does its own per-l particle counting.
 
   helfem::Vector x_pars, c_pars;


### PR DESCRIPTION
The OOO migration's shared nela/nelb helper rejected `--restricted=1` whenever nela != nelb, and all drivers demanded a multiplicity. Spin-restricted open-shell calculations used to work in the bespoke drivers.

This restores them uniformly across **gensap, atomic, and diatomic**, with the whole derivation living in the shared `derive_nela_nelb_restricted` helper:

- `--M=0` with no explicit nela/nelb (the default) runs a spin-restricted calculation straight from the total electron count Z − Q, which may be odd — no multiplicity needed. This matches the old gensap and the aij convention (M=0 → restricted, M ≥ 1 → unrestricted). An explicit `--restricted=0` with M=0 errors out, since the alpha/beta split is then undefined.
- An explicit `--restricted=1` together with a multiplicity is also allowed for open shells: only Ntot enters the restricted SCF, which distributes the unpaired electrons over the frontier orbitals.

Verification:
- `gensap` N: −53.5679031015 identically via `--M=0` and `--M=4 --restricted=1` (only Ntot enters).
- `atomic` N: −53.5679031011 identically via both routes, matching sadatom's spin-averaged result to 1e-9 — as expected for a spherically symmetric restricted density.
- `diatomic` NO (15 electrons): runs restricted at `--M=0`, converges to −86.8132386266.
- Regressions unchanged: unrestricted N −53.7092762871, Ar lda_x −524.5174255706 (with and without `--M=1`), Be HF −14.5730231683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)