### PR TITLE
gensap: add --maxiter

### DIFF
--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -237,6 +237,7 @@ int main(int argc, char **argv) {
   // SCF convergence algorithms handed to OOO's state machine: a '+'
   // separated subset of DIIS, ODA, CG and LBFGS.
   parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "DIIS + ODA + CG");
+  parser.add<int>("maxiter", 0, "maximum number of SCF iterations", false, 128);
 
   // SAP / effective-potential generation (parity with bespoke gensap).
   // With a functional active, gensap tabulates the radial effective
@@ -345,6 +346,7 @@ int main(int argc, char **argv) {
   opts.shift_conf   = shift_conf;
   opts.verbosity    = 5;
   opts.scf_methods  = parser.get<std::string>("scfmethods");
+  opts.maxiter      = parser.get<int>("maxiter");
   opts.iguess       = parser.get<int>("iguess");
   opts.load_file    = parser.get<std::string>("load");
   opts.save_file    = parser.get<std::string>("save");

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -269,6 +269,7 @@ namespace helfem {
             number_of_blocks_per_particle_type, maximum_occupation,
             number_of_particles, fock_builder, block_descriptions);
         scfsolver.set("verbosity", opts.verbosity);
+        scfsolver.set("maximum_iterations", opts.maxiter);
 
         // Frozen per-l occupation: hand OOO a per-block particle count
         // vector so Aufbau is bypassed. Same pattern as atomic_ooo /

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -73,6 +73,12 @@ namespace helfem {
         /// SCF convergence algorithms handed to OOO's state machine: a
         /// '+' separated subset of DIIS, ODA, CG and LBFGS.
         std::string scf_methods = "DIIS + ODA + CG";
+        /// Outer SCF iteration cap. Matches OOO's own default; raise it
+        /// for systems that converge steadily but slowly, such as the
+        /// partially filled 3d atoms, where the 4s/3d near-degeneracy
+        /// leaves the error decreasing by a fraction of a percent per
+        /// iteration.
+        int maxiter = 128;
         /// Load orbital guess from checkpoint. Empty = start from core-H
         /// guess as before. When non-empty, the old basis + per-l AO
         /// densities are read from the checkpoint, projected into the


### PR DESCRIPTION
gensap had no way to raise the SCF iteration cap, so it was stuck on OpenOrbitalOptimizer's default of 128. That is not enough for the partially filled d and f shells.

Found while generating the tabulated atomic wave function database: sweeping Z = 1..118 spin-restricted with LDA exchange, **32 of 118 elements failed** — Cr–Ni (3d), Mo–Ru (4d), Pm–Tm (4f), W–Re (5d), Ac–Fm (5f), Rf–Db (6d). That is exactly the open d/f block and nothing else.

They are not diverging. Fe decreases its DIIS error monotonically every single iteration over the last 16 before the cap:

```
Iteration 113 ... energy -1258.9186865002  DIIS error 7.651305e-08
...
Iteration 128 ... energy -1258.9186865062  DIIS error 7.526929e-08
```

The energy is stable to 1e-9 and the error is still falling; it simply runs out of iterations before reaching the 1e-7 threshold, because the 4s/3d near-degeneracy leaves it shrinking by a fraction of a percent per step.

Raising the cap is all that is needed, and no change of method mix is. At `--maxiter=1024` the default `DIIS + ODA + CG` converges Cr, Ni, Tc, Gd and U, and it reaches the same solution a DIIS-free mix does:

| | default, maxiter 1024 | ODA + CG, maxiter 128 |
|---|---|---|
| Ni | −1503.2111220932 | −1503.2111220932 |
| Cr | −1040.0436327103 | −1040.0436327274 |

(A separate failure mode does exist — Cr genuinely oscillates under DIIS at 128, its newest step sitting 0.024 Ha above the lowest entry with the occupations flip-flopping — but given enough iterations DIIS settles onto the same answer, so a single knob covers both.)

The flag mirrors aij's existing `--maxiter` and defaults to 128, so nothing changes unless asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
