### PR TITLE
gensap: make the SAP table opt-in again, via --pot=none

### DIFF
--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -242,7 +242,7 @@ int main(int argc, char **argv) {
   // With a functional active, gensap tabulates the radial effective
   // charge Zeff(r) = Z - r*(V_Hartree + V_xc) to result_<El>.dat -- the
   // data used to build the SAP guess (see src/general/sap.cpp).
-  parser.add<std::string>("pot", 0, "functional for the effective/SAP potential (empty = use --method)", false, "");
+  parser.add<std::string>("pot", 0, "functional for the effective/SAP potential; 'none' writes no table", false, "none");
   parser.add<bool>("savepot", 0, "also save the xc screening potential to xcpot.dat?", false, false);
   parser.add<bool>("saveing", 0, "also save the density ingredients to xcing.dat?", false, false);
   parser.add<bool>("saveorb", 0, "save radial orbitals to orbs_<El>_<spin>_l<l>.dat?", false, false);
@@ -461,11 +461,15 @@ int main(int argc, char **argv) {
   const bool savepot = parser.get<bool>("savepot");
   const bool saveing = parser.get<bool>("saveing");
 
-  int xp_func = x_func, cp_func = c_func;
-  if (potmethod.size()) {
-    ::parse_xc_func(xp_func, cp_func, potmethod);
+  // The SAP table is OPT-IN, via --pot. It does NOT fall back to the
+  // SCF --method: with --method defaulting to lda_x that fallback made
+  // every gensap run write result_<El>.dat, whereas the potential is a
+  // deliberate product one asks for. --pot=none parses to (0, 0) and
+  // so skips the write, exactly as the pre-OOO driver did.
+  int xp_func = 0, cp_func = 0;
+  ::parse_xc_func(xp_func, cp_func, potmethod);
+  if (xp_func > 0 || cp_func > 0)
     ::print_info(xp_func, cp_func);
-  }
   // Meta-GGA / range-separated potentials are not implemented in the
   // spherically symmetric screening path (matches the old driver).
   {


### PR DESCRIPTION
Writing the effective-potential table used to require asking for it. The OOO rewrite made it unconditional, so every gensap run now drops a `result_<El>.dat` whether or not one was wanted.

The pre-OOO driver defaulted `--pot` to the string `"none"`, parsed *that* into the potential functional, and wrote the table only when the result was nonzero:

```cpp
parser.add<std::string>("pot", 0, "method to use to compute potential", false, "none");
::parse_xc_func(xp_func, cp_func, potmethod);   // "none" -> 0, 0
if(xp_func > 0 || cp_func > 0) { ...write result_<El>.dat... }
```

The rewrite changed the default to empty and made an empty value fall back to the SCF `--method`:

```cpp
parser.add<std::string>("pot", ..., false, "");
int xp_func = x_func, cp_func = c_func;          // <-- falls back to --method
if (potmethod.size()) { ::parse_xc_func(xp_func, cp_func, potmethod); }
```

Since `--method` defaults to `lda_x`, `xp_func` is always nonzero and the table is always written. (The comment asserting "As in the bespoke driver, the table is written whenever a functional is active" was true as stated but missed that the old `xp_func` was zero unless `--pot` was given.)

This restores the original behaviour: `--pot` defaults to `"none"` and there is no fallback to `--method`. The potential is a deliberate product, asked for explicitly.

Verified:
- no `--pot` → no "Saved effective potential" line, no `result_<El>.dat` on disk
- `--pot=lda_x` → table written exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)