### PR TITLE
gensap: add --convthr

### DIFF
--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -238,6 +238,7 @@ int main(int argc, char **argv) {
   // separated subset of DIIS, ODA, CG and LBFGS.
   parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "DIIS + ODA + CG");
   parser.add<int>("maxiter", 0, "maximum number of SCF iterations", false, 128);
+  parser.add<double>("convthr", 0, "SCF convergence threshold", false, 1e-7);
 
   // SAP / effective-potential generation (parity with bespoke gensap).
   // With a functional active, gensap tabulates the radial effective
@@ -347,6 +348,7 @@ int main(int argc, char **argv) {
   opts.verbosity    = 5;
   opts.scf_methods  = parser.get<std::string>("scfmethods");
   opts.maxiter      = parser.get<int>("maxiter");
+  opts.convthr      = parser.get<double>("convthr");
   opts.iguess       = parser.get<int>("iguess");
   opts.load_file    = parser.get<std::string>("load");
   opts.save_file    = parser.get<std::string>("save");

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -270,6 +270,7 @@ namespace helfem {
             number_of_particles, fock_builder, block_descriptions);
         scfsolver.set("verbosity", opts.verbosity);
         scfsolver.set("maximum_iterations", opts.maxiter);
+        scfsolver.set("convergence_threshold", opts.convthr);
 
         // Frozen per-l occupation: hand OOO a per-block particle count
         // vector so Aufbau is bypassed. Same pattern as atomic_ooo /

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -79,6 +79,11 @@ namespace helfem {
         /// leaves the error decreasing by a fraction of a percent per
         /// iteration.
         int maxiter = 128;
+        /// SCF convergence threshold on the DIIS error. Matches OOO's
+        /// own default. Some systems have an arithmetic noise floor
+        /// above it -- their energy is stable to 1e-11 while the error
+        /// sits frozen just above the target -- and need it relaxed.
+        double convthr = 1e-7;
         /// Load orbital guess from checkpoint. Empty = start from core-H
         /// guess as before. When non-empty, the old basis + per-l AO
         /// densities are read from the checkpoint, projected into the


### PR DESCRIPTION
gensap could not relax the SCF convergence threshold, so it was pinned to OpenOrbitalOptimizer's default of 1e-7 on the DIIS error. aij has had `--convthr` all along; this is the same gap `--maxiter` had.

Some systems have an arithmetic noise floor above that target, and no amount of iterating or switching method mix reaches it.

Found while building the spin-restricted LDA-exchange wave function database over Z = 1..118. Es (Z=99) was the single element no recipe could converge:

- with `DIIS + ODA + CG` it ran 29 minutes to the iteration cap;
- with `ODA+LBFGS`, even seeded from the already-converged Cf (Z=98) record, it froze at a DIIS error of **1.818135e-07** — *identical* between successive iterations — with the energy stable at −30528.4639904987 to 1e-11 and zero change per step.

That is a converged answer that cannot be certified, not a failing SCF. At `--convthr=1e-6` it converges to −30528.4639905122, agreeing with the stalled value to **1.4e-8 Ha**, and the database completes at 118/118.

Defaults to 1e-7, so nothing changes unless asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)