### PR TITLE
model potentials: report where they are not smooth

### DIFF
--- a/libhelfem/include/ModelPotential.h
+++ b/libhelfem/include/ModelPotential.h
@@ -15,6 +15,8 @@
 #ifndef MODELPOTENTIAL_MODELPOTENTIAL_H
 #define MODELPOTENTIAL_MODELPOTENTIAL_H
 
+#include <vector>
+
 namespace helfem {
   namespace modelpotential {
     /// Model potential.
@@ -33,6 +35,22 @@ namespace helfem {
 
       /// Potential at a single radial point.
       virtual T V(T r) const = 0;
+
+      /// Radii in [a, b] at which V is not smooth -- a hard nuclear
+      /// boundary, a tabulation knot, the edge of a charge distribution.
+      /// The quadrature splits the element there, because plain
+      /// order-refinement stalls across a kink: it converges only
+      /// algebraically and grinds to the order cap without ever reaching
+      /// eps(T).
+      ///
+      /// Default: none, i.e. the potential is smooth everywhere. A model
+      /// that overrides this must return only the points strictly inside
+      /// (a, b); boundaries coinciding with the element ends are already
+      /// handled by the element decomposition itself.
+      virtual std::vector<T> breakpoints(T a, T b) const {
+        (void) a; (void) b;
+        return std::vector<T>();
+      }
     };
 
     /// The double instantiation, which every existing caller uses.

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -605,13 +605,17 @@ namespace helfem {
       helfem::Mat<T> FEMRadialBasisT<T>::model_potential(const modelpotential::ModelPotentialT<T> *model,
                                                          size_t iel) const {
         // Non-polynomial weight -> order-refine (poly_degree_f = -1). Smooth
-        // models (point, Gaussian, GSZ, SAP) converge to eps(T) by refinement.
-        // Models with a hard boundary (uniform sphere / hollow shell) have a
-        // kink at the nuclear radius; ModelPotentialT exposes only V(r), not
-        // that radius, so no breakpoint is passed here -- if such a boundary
-        // ever falls inside an element the panel would refine to the order cap.
+        // models (point, Gaussian, GSZ) converge to eps(T) by refinement.
+        // Models with a hard boundary -- the uniform sphere and hollow shell
+        // have a kink at the nuclear radius, a tabulated potential has one at
+        // every knot -- report those radii through
+        // ModelPotentialT::breakpoints(), and the element is split there.
+        // Without the split a kink inside an element refines only
+        // algebraically and grinds to the order cap.
         return matrix_element(iel, BasisKind::B0, BasisKind::B0,
-                              [model](T r){ return model->V(r); });
+                              [model](T r){ return model->V(r); },
+                              model->breakpoints(fem.element_begin(iel),
+                                                 fem.element_end(iel)));
       }
 
       template <typename T>

--- a/libhelfemqc/include/HollowNucleus.h
+++ b/libhelfemqc/include/HollowNucleus.h
@@ -33,6 +33,12 @@ namespace helfem {
       ~HollowNucleusT();
       /// Potential
       T V(T r) const override;
+      /// All the charge sits on the shell r = R, so the potential is
+      /// constant inside and -Z/r outside, with a kink at R.
+      std::vector<T> breakpoints(T a, T b) const override {
+        if (R > a && R < b) return std::vector<T>{R};
+        return std::vector<T>();
+      }
       /// Get R
       T get_R() const;
       /// Set R

--- a/libhelfemqc/include/SphericalNucleus.h
+++ b/libhelfemqc/include/SphericalNucleus.h
@@ -33,6 +33,13 @@ namespace helfem {
       ~SphericalNucleusT();
       /// Potential
       T V(T r) const override;
+      /// The potential is piecewise: the interior of the uniformly
+      /// charged ball joins the exterior -Z/r at R0 with a discontinuous
+      /// second derivative, so the quadrature must split there.
+      std::vector<T> breakpoints(T a, T b) const override {
+        if (R0 > a && R0 < b) return std::vector<T>{R0};
+        return std::vector<T>();
+      }
       /// Get R0
       T get_R0() const;
       /// Set R0


### PR DESCRIPTION
A model potential with a kink inside an element cannot be integrated to eps(T) by order refinement — the panel converges only algebraically and grinds to the Gauss-Lobatto order cap, printing a warning and wasting the refinement.

The quadrature already knows how to split an element at supplied breakpoints; it just had no way to learn where they are, since `ModelPotentialT` exposed only `V(r)`. The existing comment at `FEMRadialBasisT::model_potential` said exactly this:

> Models with a hard boundary (uniform sphere / hollow shell) have a kink at the nuclear radius; ModelPotentialT exposes only V(r), not that radius, so no breakpoint is passed here — if such a boundary ever falls inside an element the panel would refine to the order cap.

This adds a virtual `breakpoints(a, b)`, defaulting to none, and has the uniformly charged sphere and the hollow shell report their nuclear radius. `FEMRadialBasisT::model_potential` forwards the result to `matrix_element`, which splits the element there.

## Verification

Ne with a deliberately oversized nucleus (`--Rrms=3.0`, so the boundary lands inside an element) and `--iguess=0` to keep the SAP guess out of the picture:

| finitenuc | before | after |
|---|---|---|
| 0 point | clean | clean, −127.4907408299 |
| 1 Gaussian | clean | clean, −15.5635416801 |
| 2 uniform sphere | **order cap** | clean, −14.8166074208 |
| 3 hollow shell | **order cap** | clean, −14.6747332153 |

The smooth models are unaffected — they warned neither before nor after. (The large energies for models 1–3 are the oversized test nucleus, not a defect.)

`SAPAtom` is deliberately left for later: its 751 tabulation knots live in a function-local `static` inside a generated 30k-line file, and rebuilding SAP from tabulated wave functions replaces that table with the 8 boundaries of the atomic FEM grid — so plumbing the old knots through would be churn against code on its way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)