### PR TITLE
sadatom: do not save numerically empty orbitals

### DIFF
--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -29,7 +29,15 @@ namespace helfem {
 
       /// Occupation below which a saved orbital is treated as
       /// unoccupied and dropped from the checkpoint.
-      static const double occ_save_threshold = 1e-12;
+      ///
+      /// 1e-6 rather than something closer to eps: OpenOrbitalOptimizer
+      /// leaves a long tail of numerically empty virtuals when it
+      /// optimizes fractional occupations, and storing them dominates
+      /// the record. Over Z = 1..118 a 1e-12 cutoff keeps 3049 orbitals
+      /// where 1e-6 keeps 1376 -- less than half the data for the same
+      /// physics, since the largest occupation dropped at 1e-6 is
+      /// 9.9e-7, a millionth of an electron.
+      static const double occ_save_threshold = 1e-6;
 
       AtomicSCFResult run_atomic_scf(const AtomicSCFOptions & opts) {
         using OOO_Real = double;


### PR DESCRIPTION
The checkpoint kept every orbital whose occupation exceeded 1e-12. OpenOrbitalOptimizer leaves a long tail of numerically empty virtuals when it optimizes fractional occupations, so that cutoff stored far more than the state.

Measured over Z = 1..118, spin-restricted LDA exchange on the standard database grid:

| threshold | orbitals | doubles | vs sap.cpp table |
|---|---|---|---|
| 1e-12 (old) | 3049 | 402 468 | 4.5× |
| 1e-8 | 1539 | 203 148 | 2.3× |
| **1e-6 (new)** | **1376** | **181 632** | **2.0×** |

The largest occupation discarded at 1e-6 is **9.9e-7** — a millionth of an electron — so this is less than half the data for the same physics.

Regenerating the whole database at 1e-6 gives 1380 orbitals, 182 160 doubles (1.46 MB). All 39 elements whose spherically averaged ground states carry genuinely fractional occupations keep them (Fe 4s^1.1885 3d^6.8115, Ru 5s^0.0516 4d^7.9484, La 5d^0.1737 4f^0.8263, …).

This matters for the plan to ship wave functions in a distributable SAP file: data size is the main objection to shipping orbitals rather than a Zeff table, and 2× is a very different proposition from 4.5×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)