### PR TITLE
sadatom: cache the grid basis values, and build Fock matrices in batches

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -84,6 +84,16 @@ namespace helfem {
         /// Finite element basis
         polynomial_basis::FiniteElementBasisT<T> fem;
 
+        /// Quadrature-node values of the basis functions and of their
+        /// first two derivatives, indexed by element. Filled on demand by
+        /// fill_quadrature_cache(); an empty entry means "not cached", so
+        /// the get_*(iel) overloads fall back to evaluating. Mutable
+        /// because filling them changes nothing an observer can see --
+        /// the values are a pure function of the element index.
+        mutable std::vector<helfem::Mat<T>> bfq_cache;
+        mutable std::vector<helfem::Mat<T>> dfq_cache;
+        mutable std::vector<helfem::Mat<T>> lfq_cache;
+
         /// Starting Gauss-Chebyshev order for the auto-converging
         /// two-electron primitives. Seeded from the requested n_quad so the
         /// common case converges in 1-2 refinement steps; the refinement
@@ -291,6 +301,22 @@ namespace helfem {
                                        bool lhder = false, bool rhder = false) const;
         /// Compute projection (Eigen; Phase 2a).
         helfem::Mat<T> overlap(const FEMRadialBasisT &rh) const;
+
+        /// Precompute the quadrature-node values of the basis functions
+        /// (and, on request, of their first and second derivatives) for
+        /// every element, so that the get_*(iel) overloads below become
+        /// table lookups.
+        ///
+        /// The values depend only on the element index -- the nodes are
+        /// the fixed rule `xq` -- so recomputing them, as the DFT grid
+        /// did on every Fock build, is pure repetition: it cost ~11% of
+        /// an atom-in-jellium run. Nel * Nquad * (nnodes+1) doubles per
+        /// requested order, a few MB even for a large grid.
+        ///
+        /// Call this from serial code. The cache is only *read* once
+        /// filled, so the parallel DFT-grid loops are safe afterwards,
+        /// but filling it concurrently is not.
+        void fill_quadrature_cache(bool need_df = false, bool need_lf = false) const;
 
         /// Evaluate basis functions at quadrature points (Eigen return).
         helfem::Mat<T> get_bf(size_t iel) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -821,7 +821,22 @@ namespace helfem {
       }
 
       template <typename T>
+      void FEMRadialBasisT<T>::fill_quadrature_cache(bool need_df, bool need_lf) const {
+        const size_t Nel = fem.get_nelem();
+        if (bfq_cache.size() != Nel) bfq_cache.assign(Nel, helfem::Mat<T>());
+        if (dfq_cache.size() != Nel) dfq_cache.assign(Nel, helfem::Mat<T>());
+        if (lfq_cache.size() != Nel) lfq_cache.assign(Nel, helfem::Mat<T>());
+        for (size_t iel = 0; iel < Nel; ++iel) {
+          if (!bfq_cache[iel].size()) bfq_cache[iel] = get_bf(xq, iel);
+          if (need_df && !dfq_cache[iel].size()) dfq_cache[iel] = get_df(xq, iel);
+          if (need_lf && !lfq_cache[iel].size()) lfq_cache[iel] = get_lf(xq, iel);
+        }
+      }
+
+      template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::get_bf(size_t iel) const {
+        if (iel < bfq_cache.size() && bfq_cache[iel].size())
+          return bfq_cache[iel];
         return get_bf(xq, iel);
       }
 
@@ -864,6 +879,8 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::get_df(size_t iel) const {
+        if (iel < dfq_cache.size() && dfq_cache[iel].size())
+          return dfq_cache[iel];
         return get_df(xq, iel);
       }
 
@@ -885,6 +902,8 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::get_lf(size_t iel) const {
+        if (iel < lfq_cache.size() && lfq_cache[iel].size())
+          return lfq_cache[iel];
         return get_lf(xq, iel);
       }
 

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -87,6 +87,13 @@ namespace helfem {
       /// Explicit override of the do_grad / do_tau / do_lapl flags
       void set_grad_tau_lapl(bool grad, bool tau, bool lapl);
 
+      /// Which orders of the basis functions the current functional
+      /// actually needs. Lets a caller prime a basis-value cache for the
+      /// right orders before entering the parallel grid loop, instead of
+      /// guessing or computing derivatives an LDA will never look at.
+      bool needs_grad() const { return do_grad; }
+      bool needs_lapl() const { return do_lapl; }
+
       /// Initialise vxc / vsigma / vtau / vlapl buffers with the
       /// correct shape and zero exc.
       void init_xc();

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -429,6 +429,10 @@ namespace helfem {
       }
 
 
+      void TwoDBasis::fill_quadrature_cache(bool need_df, bool need_lf) const {
+        radial.fill_quadrature_cache(need_df, need_lf);
+      }
+
       helfem::Matrix TwoDBasis::eval_bf(size_t iel) const {
         return radial.get_bf(iel);
       }

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -122,6 +122,12 @@ namespace helfem {
         /// Get list of basis function indices in element
         std::vector<Eigen::Index> bf_list(size_t iel) const;
 
+        /// Precompute the quadrature-node basis values behind eval_bf /
+        /// eval_df / eval_lf, so that repeated Fock builds look them up
+        /// rather than re-evaluating the polynomials. Serial: call it
+        /// before entering a parallel grid loop.
+        void fill_quadrature_cache(bool need_df, bool need_lf) const;
+
         /// Evaluate orbitals
         helfem::Vector eval_orbs(const helfem::Matrix & C, double r) const;
 

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -494,6 +494,14 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
+      void DFTGrid::prime_quadrature_cache(int x_func, int c_func) const {
+        // A throwaway worker is the cheapest way to ask the functionals
+        // which orders they need; it allocates nothing beyond the flags.
+        DFTGridWorker probe(basp);
+        probe.check_grad_tau_lapl(x_func, c_func);
+        basp->fill_quadrature_cache(probe.needs_grad(), probe.needs_lapl());
+      }
+
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Cube & P, helfem::Cube & H, double & Exc, double & Nel, double thr) {
         const Eigen::Index Nrad = P[0].rows();
 
@@ -507,6 +515,12 @@ namespace helfem {
 
         double exc=0.0;
         double nel=0.0;
+
+        // The basis values at the quadrature nodes are a pure function of
+        // the element index, but every Fock build used to re-evaluate
+        // them -- ~11% of an atom-in-jellium run. Fill the cache once,
+        // here, while we are still serial; the loop below only reads it.
+        prime_quadrature_cache(x_func,c_func);
 
 #ifdef _OPENMP
 #pragma omp parallel reduction(+:exc,nel)
@@ -577,6 +591,11 @@ namespace helfem {
 
         double exc=0.0;
         double nel=0.0;
+
+        // Same as in the restricted overload: fill the basis-value cache
+        // while we are still serial.
+        prime_quadrature_cache(x_func,c_func);
+
 #ifdef _OPENMP
 #pragma omp parallel reduction(+:exc,nel)
 #endif

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -99,6 +99,16 @@ namespace helfem {
         const helfem::sadatom::basis::TwoDBasis * basp;
 
       public:
+        /// Fill the basis set's quadrature-value cache for the orders the
+        /// given functionals need, so the grid loops become table lookups
+        /// rather than a polynomial evaluation per element per Fock
+        /// build. eval_Fxc calls this itself; it is public so that a
+        /// caller about to evaluate several Fock matrices concurrently
+        /// can fill the cache once, serially, first -- filling it from
+        /// several threads at once would be a data race, reading it from
+        /// several threads is fine.
+        void prime_quadrature_cache(int x_func, int c_func) const;
+
         /// Dummy constructor
         DFTGrid();
         /// Constructor

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -134,8 +134,15 @@ namespace helfem {
             Ekin_out += l * (l + 1) * (P_l * Tl).trace();
         };
 
-        OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
-            [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+        // Shared implementation of the Fock build. `log_line`, when
+        // non-null, collects the energy breakdown instead of it going
+        // straight to stdout: a batched build evaluates its entries
+        // concurrently, and interleaved printf from several threads
+        // would be unreadable and out of order. Everything else here is
+        // either a local or a const capture, so the body is safe to run
+        // from several threads at once.
+        auto build_fock = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm,
+                              std::string * log_line) {
           const auto & orbitals    = dm.first;
           const auto & occupations = dm.second;
 
@@ -218,11 +225,18 @@ namespace helfem {
           const double Etot = Ekin + Enuc + Econf + Ecoul + Exc + Exx;
 
           if (opts.verbosity > 0) {
-            printf("Ekin %.10f  Enuc %.10f  Ecoul %.10f  Exc %.10f  Exx %.10f",
-                    Ekin, Enuc, Ecoul, Exc, Exx);
-            if (have_conf) printf("  Econf %.10f", Econf);
-            printf("  Etot %.10f\n", Etot);
-            fflush(stdout);
+            std::ostringstream line;
+            line << std::fixed << std::setprecision(10)
+                 << "Ekin " << Ekin << "  Enuc " << Enuc << "  Ecoul " << Ecoul
+                 << "  Exc " << Exc << "  Exx " << Exx;
+            if (have_conf) line << "  Econf " << Econf;
+            line << "  Etot " << Etot << "\n";
+            if (log_line) {
+              *log_line = line.str();
+            } else {
+              fputs(line.str().c_str(), stdout);
+              fflush(stdout);
+            }
           }
 
           auto build_fock_block = [&](size_t l, const helfem::Cube & XC_cube,
@@ -249,6 +263,54 @@ namespace helfem {
             }
           }
           return std::make_pair(Etot, fock);
+        };
+
+        OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
+            [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+          return build_fock(dm, nullptr);
+        };
+
+        // Batched Fock build. The solver hands us every density it wants
+        // evaluated at once -- the ODA polytope's axis vertices, which
+        // share a set of orbitals and differ only in their occupations --
+        // and they are independent, so evaluate them concurrently.
+        //
+        // Going parallel across the batch rather than inside each build
+        // is deliberate. The per-build parallelism is over radial
+        // elements and over output angular momenta, and it scales badly:
+        // measured on atom-in-jellium, six threads bought 1.15x. The
+        // batch entries are perfectly independent, so this is the level
+        // that actually has parallelism in it. Nested OpenMP is off by
+        // default, so the inner regions collapse to serial and no
+        // oversubscription results.
+        OpenOrbitalOptimizer::BatchedFockBuilder<OOO_Real, OOO_Real> batched_fock_builder =
+            [&](const std::vector<OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real>> & dms) {
+          const size_t n = dms.size();
+          std::vector<OpenOrbitalOptimizer::FockBuilderReturn<OOO_Real, OOO_Real>> out(n);
+          std::vector<std::string> lines(n);
+
+          // Fill any lazily-built caches while still serial: the builds
+          // below only read them, but filling concurrently would race.
+          if (have_xc)
+            grid.prime_quadrature_cache(opts.x_func, opts.c_func);
+
+          if (n > 1) {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+            for (long i = 0; i < (long) n; ++i)
+              out[i] = build_fock(dms[i], &lines[i]);
+          } else {
+            for (size_t i = 0; i < n; ++i)
+              out[i] = build_fock(dms[i], &lines[i]);
+          }
+
+          // Report in batch order, so the log reads the same whether or
+          // not the entries were evaluated concurrently.
+          for (const auto & line : lines)
+            if (line.size()) fputs(line.c_str(), stdout);
+          fflush(stdout);
+          return out;
         };
 
         // Initial-guess electron-nuclear potential. iguess 0 uses the
@@ -284,6 +346,7 @@ namespace helfem {
         OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
             number_of_blocks_per_particle_type, maximum_occupation,
             number_of_particles, fock_builder, block_descriptions);
+        scfsolver.set_batched_fock_builder(batched_fock_builder);
         scfsolver.set("verbosity", opts.verbosity);
         scfsolver.set("maximum_iterations", opts.maxiter);
         scfsolver.set("convergence_threshold", opts.convthr);


### PR DESCRIPTION
Two optimisations for atom-in-jellium, measured on Al with 100 jellium
electrons, `nelem=15`, six cores: **280.5 s -> 211.3 s (1.33x)**, converged
total energy unchanged at -236.0511138576 and the same 21 iterations.

### The DFT grid re-evaluated the basis on every Fock build

Those values are a pure function of the element index -- the nodes are the
fixed quadrature rule -- so this was pure repetition, worth ~11% of the
run. `FEMRadialBasisT` now carries an optional cache of the
quadrature-node values, `DFTGrid` fills it once before entering its
parallel loop, and `get_bf`/`get_df`/`get_lf` become table lookups.
Filling is serial and reading is not, so the grid loops stay safe. Worth
280.5 s -> 222.7 s on its own. The cache lives in libhelfem, so the atomic
and diatomic grids can take it up the same way.

### HelFEM never registered a batched Fock builder

`OpenOrbitalOptimizer::evaluate_batch_` was falling through to a serial
loop over densities. The ODA polytope hands over its axis vertices
together -- they share a set of orbitals and differ only in occupations --
and they are independent, so they are now evaluated concurrently.

Parallelising across the batch rather than inside each build is
deliberate: the per-build parallelism is over radial elements and output
angular momenta and scales badly (six threads bought 1.15x on this
system), while the batch entries are perfectly independent. Nested OpenMP
is off by default, so the inner regions collapse to serial rather than
oversubscribing.

The Fock build's energy report is collected per entry and printed in batch
order, so the log reads the same however the entries were scheduled.

### Verification

`gensap` reproduces the shipped database energies: O to every digit, Fe to
3e-11 (reduction-order noise).