### PR TITLE
atomic: keep the density and Fock build in real arithmetic (LDA, GGA, mGGA)

### DIFF
--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -329,7 +329,7 @@ namespace helfem {
             gr(i,2)*=2.0*wtot(i)*vs(i)/scale_phi(i);
           }
           // Increment matrix
-          increment_gga< std::complex<double> >(H,gr,bf,bf_rho,bf_theta,bf_phi);
+          increment_gga_split(H,gr,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
         }
 
         if(do_mgga_t || do_mgga_l) {
@@ -349,7 +349,7 @@ namespace helfem {
         }
         if(do_mgga_l) {
           helfem::Vector vl=vlapl.row(0).transpose().array()*wtot.array();
-          helfem::dftgrid_common::increment_mgga_lapl< std::complex<double> >(H,vl,bf,bf_lapl);
+          helfem::dftgrid_common::increment_mgga_lapl_split(H,vl,bf_re,bf_im,bf_lapl_re,bf_lapl_im);
         }
 
         for(size_t i=0;i<bf_ind.size();i++)
@@ -402,7 +402,7 @@ namespace helfem {
             gr_a(i,2)=wtot(i)*(2.0*vs_aa(i)*gr_a0(i,2) + vs_ab(i)*gr_b0(i,2))/scale_phi(i);
           }
           // Increment matrix
-          increment_gga< std::complex<double> >(Ha,gr_a,bf,bf_rho,bf_theta,bf_phi);
+          increment_gga_split(Ha,gr_a,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
 
           if(beta) {
             helfem::Vector vs_bb=vsigma.row(2).transpose();
@@ -412,7 +412,7 @@ namespace helfem {
               gr_b(i,1)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,1) + vs_ab(i)*gr_a0(i,1))/scale_theta(i);
               gr_b(i,2)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,2) + vs_ab(i)*gr_a0(i,2))/scale_phi(i);
             }
-            increment_gga< std::complex<double> >(Hb,gr_b,bf,bf_rho,bf_theta,bf_phi);
+            increment_gga_split(Hb,gr_b,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
           }
         }
 
@@ -450,8 +450,8 @@ namespace helfem {
         if(do_mgga_l) {
           helfem::Vector vl_a=vlapl.row(0).transpose().array()*wtot.array();
           helfem::Vector vl_b=vlapl.row(1).transpose().array()*wtot.array();
-          helfem::dftgrid_common::increment_mgga_lapl< std::complex<double> >(Ha,vl_a,bf,bf_lapl);
-          helfem::dftgrid_common::increment_mgga_lapl< std::complex<double> >(Hb,vl_b,bf,bf_lapl);
+          helfem::dftgrid_common::increment_mgga_lapl_split(Ha,vl_a,bf_re,bf_im,bf_lapl_re,bf_lapl_im);
+          helfem::dftgrid_common::increment_mgga_lapl_split(Hb,vl_b,bf_re,bf_im,bf_lapl_re,bf_lapl_im);
         }
 
         for(size_t i=0;i<bf_ind.size();i++)

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -63,12 +63,12 @@ namespace helfem {
         polarized=false;
 
         // Update density vector (real P * complex conj(bf)).
-        Pv=P.cast<std::complex<double> >()*bf.conjugate();
+        PvA.noalias()=P*bf_re;  PvB.noalias()=P*bf_im;
 
         // Calculate density (arma::dot does not conjugate).
         rho=helfem::Matrix::Zero(1,wtot.size());
         for(Eigen::Index ip=0;ip<wtot.size();ip++)
-          rho(0,ip)=std::real((Pv.col(ip).array()*bf.col(ip).array()).sum());
+          rho(0,ip)=PvA.col(ip).dot(bf_re.col(ip))+PvB.col(ip).dot(bf_im.col(ip));
 
         // Calculate gradient
         if(do_grad) {
@@ -76,9 +76,9 @@ namespace helfem {
           sigma=helfem::Matrix::Zero(1,wtot.size());
           for(Eigen::Index ip=0;ip<wtot.size();ip++) {
             // Calculate values
-            double g_rad=grho(0,ip)=2.0*std::real((Pv.col(ip).array()*bf_rho.col(ip).array()).sum())/scale_r(ip);
-            double g_th=grho(1,ip)=2.0*std::real((Pv.col(ip).array()*bf_theta.col(ip).array()).sum())/scale_theta(ip);
-            double g_phi=grho(2,ip)=2.0*std::real((Pv.col(ip).array()*bf_phi.col(ip).array()).sum())/scale_phi(ip);
+            double g_rad=grho(0,ip)=2.0*(PvA.col(ip).dot(bf_rho_re.col(ip))+PvB.col(ip).dot(bf_rho_im.col(ip)))/scale_r(ip);
+            double g_th=grho(1,ip)=2.0*(PvA.col(ip).dot(bf_theta_re.col(ip))+PvB.col(ip).dot(bf_theta_im.col(ip)))/scale_theta(ip);
+            double g_phi=grho(2,ip)=2.0*(PvA.col(ip).dot(bf_phi_re.col(ip))+PvB.col(ip).dot(bf_phi_im.col(ip)))/scale_phi(ip);
             // Compute sigma as well
             sigma(0,ip)=g_rad*g_rad + g_th*g_th + g_phi*g_phi;
           }
@@ -90,16 +90,16 @@ namespace helfem {
           tau=helfem::Matrix::Zero(1,wtot.size());
 
           // Update helpers
-          Pv_rho=P.cast<std::complex<double> >()*bf_rho.conjugate();
-          Pv_theta=P.cast<std::complex<double> >()*bf_theta.conjugate();
-          Pv_phi=P.cast<std::complex<double> >()*bf_phi.conjugate();
+          PvA_rho.noalias()=P*bf_rho_re;      PvB_rho.noalias()=P*bf_rho_im;
+          PvA_theta.noalias()=P*bf_theta_re;  PvB_theta.noalias()=P*bf_theta_im;
+          PvA_phi.noalias()=P*bf_phi_re;      PvB_phi.noalias()=P*bf_phi_im;
 
           // Calculate values
           for(Eigen::Index ip=0;ip<wtot.size();ip++) {
             // Gradient term
-            double kinrho(std::real((Pv_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2));
-            double kintheta(std::real((Pv_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2));
-            double kinphi(std::real((Pv_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2));
+            double kinrho((PvA_rho.col(ip).dot(bf_rho_re.col(ip))+PvB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2));
+            double kintheta((PvA_theta.col(ip).dot(bf_theta_re.col(ip))+PvB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2));
+            double kinphi((PvA_phi.col(ip).dot(bf_phi_re.col(ip))+PvB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2));
             double kin(kinrho + kintheta + kinphi);
 
             // Store values
@@ -112,12 +112,12 @@ namespace helfem {
             // Calculate values
             for(Eigen::Index ip=0;ip<wtot.size();ip++) {
               // Gradient term
-              double kinrho(std::real((Pv_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2));
-              double kintheta(std::real((Pv_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2));
-              double kinphi(std::real((Pv_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2));
+              double kinrho((PvA_rho.col(ip).dot(bf_rho_re.col(ip))+PvB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2));
+              double kintheta((PvA_theta.col(ip).dot(bf_theta_re.col(ip))+PvB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2));
+              double kinphi((PvA_phi.col(ip).dot(bf_phi_re.col(ip))+PvB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2));
               double kin(kinrho + kintheta + kinphi);
               // Laplacian term
-              double lap(std::real((Pv.col(ip).array()*bf_lapl.col(ip).array()).sum()));
+              double lap(PvA.col(ip).dot(bf_lapl_re.col(ip))+PvB.col(ip).dot(bf_lapl_im.col(ip)));
 
               // Store values
               lapl(0,ip)=2.0*(kin + lap);
@@ -143,14 +143,14 @@ namespace helfem {
             Pb(i,j)=Pb0(bf_ind[i],bf_ind[j]);
           }
 
-        Pav=Pa.cast<std::complex<double> >()*bf.conjugate();
-        Pbv=Pb.cast<std::complex<double> >()*bf.conjugate();
+        PavA.noalias()=Pa*bf_re;  PavB.noalias()=Pa*bf_im;
+        PbvA.noalias()=Pb*bf_re;  PbvB.noalias()=Pb*bf_im;
 
         // Calculate density (arma::dot does not conjugate).
         rho=helfem::Matrix::Zero(2,wtot.size());
         for(Eigen::Index ip=0;ip<wtot.size();ip++) {
-          rho(0,ip)=std::real((Pav.col(ip).array()*bf.col(ip).array()).sum());
-          rho(1,ip)=std::real((Pbv.col(ip).array()*bf.col(ip).array()).sum());
+          rho(0,ip)=PavA.col(ip).dot(bf_re.col(ip))+PavB.col(ip).dot(bf_im.col(ip));
+          rho(1,ip)=PbvA.col(ip).dot(bf_re.col(ip))+PbvB.col(ip).dot(bf_im.col(ip));
 
           /*
             double na=compute_density(Pa0,*basp,grid[ip].r);
@@ -166,13 +166,13 @@ namespace helfem {
           grho=helfem::Matrix::Zero(6,wtot.size());
           sigma=helfem::Matrix::Zero(3,wtot.size());
           for(Eigen::Index ip=0;ip<wtot.size();ip++) {
-            double ga_rad=grho(0,ip)=2.0*std::real((Pav.col(ip).array()*bf_rho.col(ip).array()).sum())/scale_r(ip);
-            double ga_th=grho(1,ip)=2.0*std::real((Pav.col(ip).array()*bf_theta.col(ip).array()).sum())/scale_theta(ip);
-            double ga_phi=grho(2,ip)=2.0*std::real((Pav.col(ip).array()*bf_phi.col(ip).array()).sum())/scale_phi(ip);
+            double ga_rad=grho(0,ip)=2.0*(PavA.col(ip).dot(bf_rho_re.col(ip))+PavB.col(ip).dot(bf_rho_im.col(ip)))/scale_r(ip);
+            double ga_th=grho(1,ip)=2.0*(PavA.col(ip).dot(bf_theta_re.col(ip))+PavB.col(ip).dot(bf_theta_im.col(ip)))/scale_theta(ip);
+            double ga_phi=grho(2,ip)=2.0*(PavA.col(ip).dot(bf_phi_re.col(ip))+PavB.col(ip).dot(bf_phi_im.col(ip)))/scale_phi(ip);
 
-            double gb_rad=grho(3,ip)=2.0*std::real((Pbv.col(ip).array()*bf_rho.col(ip).array()).sum())/scale_r(ip);
-            double gb_th=grho(4,ip)=2.0*std::real((Pbv.col(ip).array()*bf_theta.col(ip).array()).sum())/scale_theta(ip);
-            double gb_phi=grho(5,ip)=2.0*std::real((Pbv.col(ip).array()*bf_phi.col(ip).array()).sum())/scale_phi(ip);
+            double gb_rad=grho(3,ip)=2.0*(PbvA.col(ip).dot(bf_rho_re.col(ip))+PbvB.col(ip).dot(bf_rho_im.col(ip)))/scale_r(ip);
+            double gb_th=grho(4,ip)=2.0*(PbvA.col(ip).dot(bf_theta_re.col(ip))+PbvB.col(ip).dot(bf_theta_im.col(ip)))/scale_theta(ip);
+            double gb_phi=grho(5,ip)=2.0*(PbvA.col(ip).dot(bf_phi_re.col(ip))+PbvB.col(ip).dot(bf_phi_im.col(ip)))/scale_phi(ip);
 
             // Compute sigma as well
             sigma(0,ip)=ga_rad*ga_rad + ga_th*ga_th + ga_phi*ga_phi;
@@ -187,25 +187,25 @@ namespace helfem {
           tau.resize(2,wtot.size());
 
           // Update helpers
-          Pav_rho=Pa.cast<std::complex<double> >()*bf_rho.conjugate();
-          Pav_theta=Pa.cast<std::complex<double> >()*bf_theta.conjugate();
-          Pav_phi=Pa.cast<std::complex<double> >()*bf_phi.conjugate();
+          PavA_rho.noalias()=Pa*bf_rho_re;      PavB_rho.noalias()=Pa*bf_rho_im;
+          PavA_theta.noalias()=Pa*bf_theta_re;  PavB_theta.noalias()=Pa*bf_theta_im;
+          PavA_phi.noalias()=Pa*bf_phi_re;      PavB_phi.noalias()=Pa*bf_phi_im;
 
-          Pbv_rho=Pb.cast<std::complex<double> >()*bf_rho.conjugate();
-          Pbv_theta=Pb.cast<std::complex<double> >()*bf_theta.conjugate();
-          Pbv_phi=Pb.cast<std::complex<double> >()*bf_phi.conjugate();
+          PbvA_rho.noalias()=Pb*bf_rho_re;      PbvB_rho.noalias()=Pb*bf_rho_im;
+          PbvA_theta.noalias()=Pb*bf_theta_re;  PbvB_theta.noalias()=Pb*bf_theta_im;
+          PbvA_phi.noalias()=Pb*bf_phi_re;      PbvB_phi.noalias()=Pb*bf_phi_im;
 
           // Calculate values
           for(Eigen::Index ip=0;ip<wtot.size();ip++) {
             // Gradient term
-            double kinar=std::real((Pav_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2);
-            double kinath=std::real((Pav_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2);
-            double kinaphi=std::real((Pav_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2);
+            double kinar=(PavA_rho.col(ip).dot(bf_rho_re.col(ip))+PavB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2);
+            double kinath=(PavA_theta.col(ip).dot(bf_theta_re.col(ip))+PavB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2);
+            double kinaphi=(PavA_phi.col(ip).dot(bf_phi_re.col(ip))+PavB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2);
             double kina(kinar + kinath + kinaphi);
 
-            double kinbr=std::real((Pbv_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2);
-            double kinbth=std::real((Pbv_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2);
-            double kinbphi=std::real((Pbv_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2);
+            double kinbr=(PbvA_rho.col(ip).dot(bf_rho_re.col(ip))+PbvB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2);
+            double kinbth=(PbvA_theta.col(ip).dot(bf_theta_re.col(ip))+PbvB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2);
+            double kinbphi=(PbvA_phi.col(ip).dot(bf_phi_re.col(ip))+PbvB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2);
             double kinb(kinbr + kinbth + kinbphi);
 
             // Store values
@@ -218,19 +218,19 @@ namespace helfem {
             // Calculate values
             for(Eigen::Index ip=0;ip<wtot.size();ip++) {
               // Gradient term
-              double kinar=std::real((Pav_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2);
-              double kinath=std::real((Pav_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2);
-              double kinaphi=std::real((Pav_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2);
+              double kinar=(PavA_rho.col(ip).dot(bf_rho_re.col(ip))+PavB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2);
+              double kinath=(PavA_theta.col(ip).dot(bf_theta_re.col(ip))+PavB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2);
+              double kinaphi=(PavA_phi.col(ip).dot(bf_phi_re.col(ip))+PavB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2);
               double kina(kinar + kinath + kinaphi);
 
-              double kinbr=std::real((Pbv_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2);
-              double kinbth=std::real((Pbv_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2);
-              double kinbphi=std::real((Pbv_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2);
+              double kinbr=(PbvA_rho.col(ip).dot(bf_rho_re.col(ip))+PbvB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2);
+              double kinbth=(PbvA_theta.col(ip).dot(bf_theta_re.col(ip))+PbvB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2);
+              double kinbphi=(PbvA_phi.col(ip).dot(bf_phi_re.col(ip))+PbvB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2);
               double kinb(kinbr + kinbth + kinbphi);
 
               // Laplacian term
-              double lapa(std::real((Pav.col(ip).array()*bf_lapl.col(ip).array()).sum()));
-              double lapb(std::real((Pbv.col(ip).array()*bf_lapl.col(ip).array()).sum()));
+              double lapa(PavA.col(ip).dot(bf_lapl_re.col(ip))+PavB.col(ip).dot(bf_lapl_im.col(ip)));
+              double lapb(PbvA.col(ip).dot(bf_lapl_re.col(ip))+PbvB.col(ip).dot(bf_lapl_im.col(ip)));
 
               // Store values
               lapl(0,ip)=2.0*(kina + lapa);
@@ -314,7 +314,7 @@ namespace helfem {
           // Multiply weights into potential
           vrho=vrho.array()*wtot.array();
           // Increment matrix
-          increment_lda< std::complex<double> >(H,vrho,bf);
+          helfem::dftgrid_common::increment_lda_split(H,vrho,bf_re,bf_im);
         }
 
         if(do_gga) {
@@ -343,9 +343,9 @@ namespace helfem {
           helfem::Vector vtl_r=vtl.array()*inv_scale_r2.array();
           helfem::Vector vtl_th=vtl.array()*inv_scale_theta2.array();
           helfem::Vector vtl_phi=vtl.array()*inv_scale_phi2.array();
-          increment_lda< std::complex<double> >(H,vtl_r,bf_rho);
-          increment_lda< std::complex<double> >(H,vtl_th,bf_theta);
-          increment_lda< std::complex<double> >(H,vtl_phi,bf_phi);
+          helfem::dftgrid_common::increment_lda_split(H,vtl_r,bf_rho_re,bf_rho_im);
+          helfem::dftgrid_common::increment_lda_split(H,vtl_th,bf_theta_re,bf_theta_im);
+          helfem::dftgrid_common::increment_lda_split(H,vtl_phi,bf_phi_re,bf_phi_im);
         }
         if(do_mgga_l) {
           helfem::Vector vl=vlapl.row(0).transpose().array()*wtot.array();
@@ -373,12 +373,12 @@ namespace helfem {
           // Multiply weights into potential
           vrhoa=vrhoa.array()*wtot.array();
           // Increment matrix
-          increment_lda< std::complex<double> >(Ha,vrhoa,bf);
+          helfem::dftgrid_common::increment_lda_split(Ha,vrhoa,bf_re,bf_im);
 
           if(beta) {
             helfem::Vector vrhob=vxc.row(1).transpose();
             vrhob=vrhob.array()*wtot.array();
-            increment_lda< std::complex<double> >(Hb,vrhob,bf);
+            helfem::dftgrid_common::increment_lda_split(Hb,vrhob,bf_re,bf_im);
           }
         }
         if(!Ha.allFinite() || (beta && !Hb.allFinite()))
@@ -560,6 +560,17 @@ namespace helfem {
             // Store functions (conjugate transpose on complex -> .adjoint()).
             bf_lapl.block(0,ia*nrad,nbf,nrad)=alf.adjoint();
           }
+        }
+        // Split once per element: the density and Fock contractions below
+        // are real, so they consume these rather than the complex forms.
+        bf_re = bf.real();  bf_im = bf.imag();
+        if(do_grad) {
+          bf_rho_re   = bf_rho.real();   bf_rho_im   = bf_rho.imag();
+          bf_theta_re = bf_theta.real(); bf_theta_im = bf_theta.imag();
+          bf_phi_re   = bf_phi.real();   bf_phi_im   = bf_phi.imag();
+        }
+        if(do_lapl) {
+          bf_lapl_re = bf_lapl.real(); bf_lapl_im = bf_lapl.imag();
         }
       }
 

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -56,11 +56,35 @@ namespace helfem {
         /// Values of laplacians in grid points, (3*Nbf) * Ngrid
         Eigen::MatrixXcd bf_lapl;
 
-        /// Density helper matrices: P_{uv} chi_v, and P_{uv} nabla(chi_v)
-        Eigen::MatrixXcd Pv, Pv_rho, Pv_theta, Pv_phi;
+        /// Real and imaginary parts of the basis values above, split once
+        /// per element in compute_bf.
+        ///
+        /// The density matrix is REAL while the basis is complex, so the
+        /// natural-looking P.cast<complex>() * bf.conjugate() runs a full
+        /// complex GEMM against an operand whose imaginary half is
+        /// identically zero -- four real products where two suffice. It is
+        /// where most of this driver's time goes: 72% of an oxygen run sat
+        /// in zgemm.
+        ///
+        /// Writing bf = a + i b, and noting P is symmetric so
+        /// Pv = P conj(bf) = P a - i P b, every contraction the density and
+        /// its gradients need has the form
+        ///     Re( sum_u Pv(u,ip) Y(u,ip) ) = (P a).Re(Y) + (P b).Im(Y),
+        /// i.e. purely real throughout. Splitting here rather than at the
+        /// point of use matters: extracting .real()/.imag() inside the
+        /// density loop costs about what the halved flops save.
+        helfem::Matrix bf_re, bf_im;
+        helfem::Matrix bf_rho_re, bf_rho_im;
+        helfem::Matrix bf_theta_re, bf_theta_im;
+        helfem::Matrix bf_phi_re, bf_phi_im;
+        helfem::Matrix bf_lapl_re, bf_lapl_im;
+
+        /// P*Re(X) and P*Im(X) for X = bf and its gradients -- the real
+        /// stand-ins for the complex Pv/Pv_rho/... helpers.
+        helfem::Matrix PvA, PvB, PvA_rho, PvB_rho, PvA_theta, PvB_theta, PvA_phi, PvB_phi;
         /// Same for spin-polarized
-        Eigen::MatrixXcd Pav, Pav_rho, Pav_theta, Pav_phi;
-        Eigen::MatrixXcd Pbv, Pbv_rho, Pbv_theta, Pbv_phi;
+        helfem::Matrix PavA, PavB, PavA_rho, PavB_rho, PavA_theta, PavB_theta, PavA_phi, PavB_phi;
+        helfem::Matrix PbvA, PbvB, PbvA_rho, PbvB_rho, PbvA_theta, PbvB_theta, PbvA_phi, PbvB_phi;
 
         /// Gradient of electron density, (3 x Nrho) x Npts (atomic-only:
         /// diatomic keeps its own decomposition; sadatom uses cube layout)

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -163,6 +163,40 @@ namespace helfem {
       /// LDA quadrature accumulation is shared across geometries.
       using helfem::dftgrid_common::increment_lda;
 
+      /// GGA accumulation for an already-split basis.
+      ///
+      /// With f = a + i b and the gradient-weighted helper gamma likewise
+      /// split, Re( gamma f^H + f gamma^H ) = X + X^T with
+      ///     X = Re(gamma) a^T + Im(gamma) b^T,
+      /// so the two complex products collapse to two real ones plus a
+      /// symmetrisation. Re(gamma) and Im(gamma) are each built from the
+      /// real and imaginary parts of the three gradient components.
+      inline void increment_gga_split(helfem::Matrix & H, const helfem::Matrix & gn,
+                                      const helfem::Matrix & a,  const helfem::Matrix & b,
+                                      const helfem::Matrix & ax, const helfem::Matrix & bx,
+                                      const helfem::Matrix & ay, const helfem::Matrix & by,
+                                      const helfem::Matrix & az, const helfem::Matrix & bz) {
+        if(gn.cols()!=3)
+          throw std::runtime_error("Grad rho must have three columns!\n");
+        if(H.rows() != a.rows() || H.cols() != a.rows())
+          throw std::runtime_error("Sizes of basis function and Fock matrices doesn't match!\n");
+
+        helfem::Matrix gre(ax), gim(bx);
+        for(Eigen::Index j=0;j<gre.cols();j++) {
+          gre.col(j) *= gn(j,0);
+          gim.col(j) *= gn(j,0);
+        }
+        for(Eigen::Index j=0;j<gre.cols();j++) {
+          gre.col(j) += gn(j,1)*ay.col(j) + gn(j,2)*az.col(j);
+          gim.col(j) += gn(j,1)*by.col(j) + gn(j,2)*bz.col(j);
+        }
+
+        helfem::Matrix X(gre * a.transpose());
+        X.noalias() += gim * b.transpose();
+        H += X;
+        H += X.transpose();
+      }
+
       /// BLAS routine for GGA-type quadrature
       template<typename T> void increment_gga(helfem::Matrix & H, const helfem::Matrix & gn, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & f, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_x, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_y, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_z) {
         if(gn.cols()!=3) {

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -111,6 +111,35 @@ namespace helfem {
       void compute_xc(int func_id, const helfem::Vector & params, double thr, bool pot = true);
     };
 
+    /// Same as increment_lda below, but for a basis whose real and
+    /// imaginary parts have already been split.
+    ///
+    /// H is real, so for complex f the imaginary half of f diag(v) f^H is
+    /// built and thrown away. With f = a + i b,
+    ///     Re( f diag(v) f^H ) = a diag(v) a^T + b diag(v) b^T,
+    /// two real products instead of one complex one -- half the multiplies,
+    /// on the better-optimised real kernels.
+    ///
+    /// Taking a and b as arguments rather than splitting f here is the
+    /// point: extracting .real()/.imag() per call costs about what the
+    /// halved flops save, so the split has to be hoisted to where the
+    /// basis is built.
+    inline void increment_lda_split(helfem::Matrix & H, const helfem::Vector & vxc,
+                                    const helfem::Matrix & a, const helfem::Matrix & b) {
+      if(a.cols() != vxc.size() || b.cols() != vxc.size()) {
+        std::ostringstream oss;
+        oss << "Number of functions " << a.cols() << " and potential values " << vxc.size() << " do not match!\n";
+        throw std::runtime_error(oss.str());
+      }
+      helfem::Matrix av(a), bv(b);
+      for(Eigen::Index j=0;j<av.cols();j++) {
+        av.col(j) *= vxc(j);
+        bv.col(j) *= vxc(j);
+      }
+      H.noalias() += av * a.transpose();
+      H.noalias() += bv * b.transpose();
+    }
+
     /// BLAS routine for LDA-type quadrature: accumulate
     /// H += Re( (f .* vxc) * f^T ), i.e. the weighted outer product of
     /// the basis-function values f (Nbf x Npts) against themselves with

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -169,6 +169,32 @@ namespace helfem {
       H += (fhlp * f.adjoint()).real();
     }
 
+    /// Laplacian meta-GGA accumulation for an already-split basis.
+    ///
+    /// H is real, so with f = a + i b and l = c + i d,
+    ///     Re( f diag(v) l^H + l diag(v) f^H ) = X + X^T,
+    ///     X = a diag(v) c^T + b diag(v) d^T,
+    /// i.e. two real products and a symmetrisation, against two complex
+    /// products (eight real ones) before.
+    inline void increment_mgga_lapl_split(helfem::Matrix & H, const helfem::Vector & vlapl,
+                                          const helfem::Matrix & a, const helfem::Matrix & b,
+                                          const helfem::Matrix & c, const helfem::Matrix & d) {
+      if(a.cols() != vlapl.size()) {
+        std::ostringstream oss;
+        oss << "Number of functions " << a.cols() << " and potential values " << vlapl.size() << " do not match!\n";
+        throw std::runtime_error(oss.str());
+      }
+      helfem::Matrix av(a), bv(b);
+      for(Eigen::Index j=0;j<av.cols();j++) {
+        av.col(j) *= vlapl(j);
+        bv.col(j) *= vlapl(j);
+      }
+      helfem::Matrix X(av * c.transpose());
+      X.noalias() += bv * d.transpose();
+      H += X;
+      H += X.transpose();
+    }
+
     /// BLAS routine for the Laplacian part of meta-GGA quadrature:
     ///   H += f diag(w vlapl) l^dagger + l diag(w vlapl) f^dagger
     template<typename T> void increment_mgga_lapl(helfem::Matrix & H, const helfem::Vector & vlapl, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & f, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & l) {


### PR DESCRIPTION
The `atomic` driver spent **72% of an oxygen run in complex GEMM**, and it
did not need to be complex at all.

The density matrix is real while the basis is complex, so
`P.cast<complex>() * bf.conjugate()` ran a full complex product against an
operand whose imaginary half is identically zero. The Fock accumulations
did the mirror image, building the full complex product and then
discarding `.imag()`.

Writing `bf = a + i b`, and using that P is symmetric so
`Pv = P conj(bf) = P a − i P b`:

**Density and gradients** — `Re( sum_u Pv(u,ip) Y(u,ip) ) = (P a)·Re(Y) + (P b)·Im(Y)`

**LDA Fock** — `Re( f diag(v) f^H ) = a diag(v) a^T + b diag(v) b^T`

**GGA / Laplacian mGGA** — `Re( gamma f^H + f gamma^H ) = X + X^T`, with
`X = Re(gamma) a^T + Im(gamma) b^T`. Two complex products become two real
ones plus a symmetrisation: the symmetry was being computed and half
discarded as well as the imaginary part.

## The part that matters

The split is hoisted into `compute_bf`, once per element. An earlier
attempt that extracted `.real()`/`.imag()` inside the accumulation
measured **neutral** — per-call extraction costs about what the halved
flops save. The `*_split` helpers take the parts as arguments for that
reason.

## Measured

Instructions rather than wall clock, since the machine is loaded.
O, M=3, nelem=6, nnodes=10, lmax=3, mmax=3:

| `lda_x` | instructions |
|---|---|
| before | 0.4867e12 |
| density side | 0.3852e12 (−21%) |
| + LDA Fock | **0.2591e12 (1.88x)** |

| `gga_x_pbe` | instructions |
|---|---|
| before | 1.3133e12 |
| density side | 1.0862e12 (−17%) |
| + GGA/mGGA accumulations | **0.6305e12 (2.08x)** |

The accumulations were worth 1.72x on their own under GGA, on top of what
the shared density work already gave.

## Verification

Energies unchanged throughout: `lda_x` −73.9944558709, `gga_x_pbe`
−74.7827460224, and BR89 on Be −14.6467312778 to exercise the Laplacian
branch specifically (SCAN would not have — it uses τ, not `∇²ρ`).

## Scope

`diatomic` has the identical pattern in its own `dftgrid.cpp` (12 sites),
but profiling shows no complex GEMM in its top entries under either
`lda_x` or `gga_x_pbe` — its two-electron build dominates — so it is
deliberately not touched here.