### PR TITLE
dftgrid: consolidate the three grid implementations' shared machinery

### DIFF
--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -329,7 +329,7 @@ namespace helfem {
             gr(i,2)*=2.0*wtot(i)*vs(i)/scale_phi(i);
           }
           // Increment matrix
-          increment_gga_split(H,gr,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
+          increment_gga_split(H,gr,bf_re,bf_im,{&bf_rho_re,&bf_theta_re,&bf_phi_re},{&bf_rho_im,&bf_theta_im,&bf_phi_im});
         }
 
         if(do_mgga_t || do_mgga_l) {
@@ -402,7 +402,7 @@ namespace helfem {
             gr_a(i,2)=wtot(i)*(2.0*vs_aa(i)*gr_a0(i,2) + vs_ab(i)*gr_b0(i,2))/scale_phi(i);
           }
           // Increment matrix
-          increment_gga_split(Ha,gr_a,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
+          increment_gga_split(Ha,gr_a,bf_re,bf_im,{&bf_rho_re,&bf_theta_re,&bf_phi_re},{&bf_rho_im,&bf_theta_im,&bf_phi_im});
 
           if(beta) {
             helfem::Vector vs_bb=vsigma.row(2).transpose();
@@ -412,7 +412,7 @@ namespace helfem {
               gr_b(i,1)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,1) + vs_ab(i)*gr_a0(i,1))/scale_theta(i);
               gr_b(i,2)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,2) + vs_ab(i)*gr_a0(i,2))/scale_phi(i);
             }
-            increment_gga_split(Hb,gr_b,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
+            increment_gga_split(Hb,gr_b,bf_re,bf_im,{&bf_rho_re,&bf_theta_re,&bf_phi_re},{&bf_rho_im,&bf_theta_im,&bf_phi_im});
           }
         }
 

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -162,77 +162,9 @@ namespace helfem {
 
       /// LDA quadrature accumulation is shared across geometries.
       using helfem::dftgrid_common::increment_lda;
+      /// GGA accumulation is shared across geometries too.
+      using helfem::dftgrid_common::increment_gga_split;
 
-      /// GGA accumulation for an already-split basis.
-      ///
-      /// With f = a + i b and the gradient-weighted helper gamma likewise
-      /// split, Re( gamma f^H + f gamma^H ) = X + X^T with
-      ///     X = Re(gamma) a^T + Im(gamma) b^T,
-      /// so the two complex products collapse to two real ones plus a
-      /// symmetrisation. Re(gamma) and Im(gamma) are each built from the
-      /// real and imaginary parts of the three gradient components.
-      inline void increment_gga_split(helfem::Matrix & H, const helfem::Matrix & gn,
-                                      const helfem::Matrix & a,  const helfem::Matrix & b,
-                                      const helfem::Matrix & ax, const helfem::Matrix & bx,
-                                      const helfem::Matrix & ay, const helfem::Matrix & by,
-                                      const helfem::Matrix & az, const helfem::Matrix & bz) {
-        if(gn.cols()!=3)
-          throw std::runtime_error("Grad rho must have three columns!\n");
-        if(H.rows() != a.rows() || H.cols() != a.rows())
-          throw std::runtime_error("Sizes of basis function and Fock matrices doesn't match!\n");
-
-        helfem::Matrix gre(ax), gim(bx);
-        for(Eigen::Index j=0;j<gre.cols();j++) {
-          gre.col(j) *= gn(j,0);
-          gim.col(j) *= gn(j,0);
-        }
-        for(Eigen::Index j=0;j<gre.cols();j++) {
-          gre.col(j) += gn(j,1)*ay.col(j) + gn(j,2)*az.col(j);
-          gim.col(j) += gn(j,1)*by.col(j) + gn(j,2)*bz.col(j);
-        }
-
-        helfem::Matrix X(gre * a.transpose());
-        X.noalias() += gim * b.transpose();
-        H += X;
-        H += X.transpose();
-      }
-
-      /// BLAS routine for GGA-type quadrature
-      template<typename T> void increment_gga(helfem::Matrix & H, const helfem::Matrix & gn, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & f, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_x, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_y, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_z) {
-        if(gn.cols()!=3) {
-          throw std::runtime_error("Grad rho must have three columns!\n");
-        }
-        if(f.rows() != f_x.rows() || f.cols() != f_x.cols() || f.rows() != f_y.rows() || f.cols() != f_y.cols() || f.rows() != f_z.rows() || f.cols() != f_z.cols()) {
-          throw std::runtime_error("Sizes of basis function and derivative matrices doesn't match!\n");
-        }
-        if(H.rows() != f.rows() || H.cols() != f.rows()) {
-          throw std::runtime_error("Sizes of basis function and Fock matrices doesn't match!\n");
-        }
-
-        // Compute helper: gamma_{ip} = \sum_c \chi_{ip;c} gr_{p;c}
-        //                 (N, Np)    =        (N Np; c)    (Np, 3)
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> gamma =
-          Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>::Zero(f.rows(), f.cols());
-
-        // x gradient: scale column j of f_x by gn(j,0)
-        for(Eigen::Index j=0;j<f_x.cols();j++)
-          f_x.col(j) *= gn(j,0);
-        gamma += f_x;
-
-        // y gradient
-        for(Eigen::Index j=0;j<f_y.cols();j++)
-          f_y.col(j) *= gn(j,1);
-        gamma += f_y;
-
-        // z gradient
-        for(Eigen::Index j=0;j<f_z.cols();j++)
-          f_z.col(j) *= gn(j,2);
-        gamma += f_z;
-
-        // Form Fock matrix (arma::trans on complex is the conjugate
-        // transpose -> .adjoint()).
-        H += (gamma*f.adjoint() + f*gamma.adjoint()).real();
-      }
 
     }
   }

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -65,7 +65,7 @@ namespace helfem {
         polarized=false;
 
         // Update density vector
-        Pv=P.cast<std::complex<double> >()*bf.conjugate();
+        PvA.noalias()=P*bf_re;  PvB.noalias()=P*bf_im;
 
         // Calculate density
         rho = helfem::Matrix::Zero(1,wtot.size());
@@ -73,7 +73,7 @@ namespace helfem {
 #pragma omp parallel for
 #endif
         for(size_t ip=0;ip<(size_t) wtot.size();ip++)
-          rho(0,ip)=std::real((Pv.col(ip).array()*bf.col(ip).array()).sum());
+          rho(0,ip)=(PvA.col(ip).dot(bf_re.col(ip))+PvB.col(ip).dot(bf_im.col(ip)));
 
         // Calculate gradient
         if(do_grad) {
@@ -84,9 +84,9 @@ namespace helfem {
 #endif
           for(size_t ip=0;ip<(size_t) wtot.size();ip++) {
             // Calculate values
-            double g_rad=grho(0,ip)=2.0*std::real((Pv.col(ip).array()*bf_rho.col(ip).array()).sum())/scale_r(ip);
-            double g_th=grho(1,ip)=2.0*std::real((Pv.col(ip).array()*bf_theta.col(ip).array()).sum())/scale_theta(ip);
-            double g_phi=grho(2,ip)=2.0*std::real((Pv.col(ip).array()*bf_phi.col(ip).array()).sum())/scale_phi(ip);
+            double g_rad=grho(0,ip)=2.0*(PvA.col(ip).dot(bf_rho_re.col(ip))+PvB.col(ip).dot(bf_rho_im.col(ip)))/scale_r(ip);
+            double g_th=grho(1,ip)=2.0*(PvA.col(ip).dot(bf_theta_re.col(ip))+PvB.col(ip).dot(bf_theta_im.col(ip)))/scale_theta(ip);
+            double g_phi=grho(2,ip)=2.0*(PvA.col(ip).dot(bf_phi_re.col(ip))+PvB.col(ip).dot(bf_phi_im.col(ip)))/scale_phi(ip);
             // Compute sigma as well
             sigma(0,ip)=g_rad*g_rad + g_th*g_th + g_phi*g_phi;
           }
@@ -98,9 +98,9 @@ namespace helfem {
           tau = helfem::Matrix::Zero(1,wtot.size());
 
           // Update helpers
-          Pv_rho=P.cast<std::complex<double> >()*bf_rho.conjugate();
-          Pv_theta=P.cast<std::complex<double> >()*bf_theta.conjugate();
-          Pv_phi=P.cast<std::complex<double> >()*bf_phi.conjugate();
+          PvA_rho.noalias()=P*bf_rho_re;  PvB_rho.noalias()=P*bf_rho_im;
+          PvA_theta.noalias()=P*bf_theta_re;  PvB_theta.noalias()=P*bf_theta_im;
+          PvA_phi.noalias()=P*bf_phi_re;  PvB_phi.noalias()=P*bf_phi_im;
 
           // Calculate values
 #ifdef _OPENMP
@@ -108,9 +108,9 @@ namespace helfem {
 #endif
           for(size_t ip=0;ip<(size_t) wtot.size();ip++) {
             // Gradient term
-            double kinrho(std::real((Pv_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2));
-            double kintheta(std::real((Pv_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2));
-            double kinphi(std::real((Pv_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2));
+            double kinrho((PvA_rho.col(ip).dot(bf_rho_re.col(ip))+PvB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2));
+            double kintheta((PvA_theta.col(ip).dot(bf_theta_re.col(ip))+PvB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2));
+            double kinphi((PvA_phi.col(ip).dot(bf_phi_re.col(ip))+PvB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2));
             double kin(kinrho + kintheta + kinphi);
 
             // Store values
@@ -141,8 +141,8 @@ namespace helfem {
             Pb(i,j)=Pbexp(bf_ind[i],bf_ind[j]);
           }
 
-        Pav=Pa.cast<std::complex<double> >()*bf.conjugate();
-        Pbv=Pb.cast<std::complex<double> >()*bf.conjugate();
+        PavA.noalias()=Pa*bf_re;  PavB.noalias()=Pa*bf_im;
+        PbvA.noalias()=Pb*bf_re;  PbvB.noalias()=Pb*bf_im;
 
         // Calculate density
         rho = helfem::Matrix::Zero(2,wtot.size());
@@ -150,8 +150,8 @@ namespace helfem {
 #pragma omp parallel for
 #endif
         for(size_t ip=0;ip<(size_t) wtot.size();ip++) {
-          rho(0,ip)=std::real((Pav.col(ip).array()*bf.col(ip).array()).sum());
-          rho(1,ip)=std::real((Pbv.col(ip).array()*bf.col(ip).array()).sum());
+          rho(0,ip)=(PavA.col(ip).dot(bf_re.col(ip))+PavB.col(ip).dot(bf_im.col(ip)));
+          rho(1,ip)=(PbvA.col(ip).dot(bf_re.col(ip))+PbvB.col(ip).dot(bf_im.col(ip)));
 
           /*
             double na=compute_density(Pa0,*basp,grid[ip].r);
@@ -170,13 +170,13 @@ namespace helfem {
 #pragma omp parallel for
 #endif
           for(size_t ip=0;ip<(size_t) wtot.size();ip++) {
-            double ga_rad=grho(0,ip)=2.0*std::real((Pav.col(ip).array()*bf_rho.col(ip).array()).sum())/scale_r(ip);
-            double ga_th=grho(1,ip)=2.0*std::real((Pav.col(ip).array()*bf_theta.col(ip).array()).sum())/scale_theta(ip);
-            double ga_phi=grho(2,ip)=2.0*std::real((Pav.col(ip).array()*bf_phi.col(ip).array()).sum())/scale_phi(ip);
+            double ga_rad=grho(0,ip)=2.0*(PavA.col(ip).dot(bf_rho_re.col(ip))+PavB.col(ip).dot(bf_rho_im.col(ip)))/scale_r(ip);
+            double ga_th=grho(1,ip)=2.0*(PavA.col(ip).dot(bf_theta_re.col(ip))+PavB.col(ip).dot(bf_theta_im.col(ip)))/scale_theta(ip);
+            double ga_phi=grho(2,ip)=2.0*(PavA.col(ip).dot(bf_phi_re.col(ip))+PavB.col(ip).dot(bf_phi_im.col(ip)))/scale_phi(ip);
 
-            double gb_rad=grho(3,ip)=2.0*std::real((Pbv.col(ip).array()*bf_rho.col(ip).array()).sum())/scale_r(ip);
-            double gb_th=grho(4,ip)=2.0*std::real((Pbv.col(ip).array()*bf_theta.col(ip).array()).sum())/scale_theta(ip);
-            double gb_phi=grho(5,ip)=2.0*std::real((Pbv.col(ip).array()*bf_phi.col(ip).array()).sum())/scale_phi(ip);
+            double gb_rad=grho(3,ip)=2.0*(PbvA.col(ip).dot(bf_rho_re.col(ip))+PbvB.col(ip).dot(bf_rho_im.col(ip)))/scale_r(ip);
+            double gb_th=grho(4,ip)=2.0*(PbvA.col(ip).dot(bf_theta_re.col(ip))+PbvB.col(ip).dot(bf_theta_im.col(ip)))/scale_theta(ip);
+            double gb_phi=grho(5,ip)=2.0*(PbvA.col(ip).dot(bf_phi_re.col(ip))+PbvB.col(ip).dot(bf_phi_im.col(ip)))/scale_phi(ip);
 
             // Compute sigma as well
             sigma(0,ip)=ga_rad*ga_rad + ga_th*ga_th + ga_phi*ga_phi;
@@ -191,13 +191,13 @@ namespace helfem {
           tau.resize(2,wtot.size());
 
           // Update helpers
-          Pav_rho=Pa.cast<std::complex<double> >()*bf_rho.conjugate();
-          Pav_theta=Pa.cast<std::complex<double> >()*bf_theta.conjugate();
-          Pav_phi=Pa.cast<std::complex<double> >()*bf_phi.conjugate();
+          PavA_rho.noalias()=Pa*bf_rho_re;  PavB_rho.noalias()=Pa*bf_rho_im;
+          PavA_theta.noalias()=Pa*bf_theta_re;  PavB_theta.noalias()=Pa*bf_theta_im;
+          PavA_phi.noalias()=Pa*bf_phi_re;  PavB_phi.noalias()=Pa*bf_phi_im;
 
-          Pbv_rho=Pb.cast<std::complex<double> >()*bf_rho.conjugate();
-          Pbv_theta=Pb.cast<std::complex<double> >()*bf_theta.conjugate();
-          Pbv_phi=Pb.cast<std::complex<double> >()*bf_phi.conjugate();
+          PbvA_rho.noalias()=Pb*bf_rho_re;  PbvB_rho.noalias()=Pb*bf_rho_im;
+          PbvA_theta.noalias()=Pb*bf_theta_re;  PbvB_theta.noalias()=Pb*bf_theta_im;
+          PbvA_phi.noalias()=Pb*bf_phi_re;  PbvB_phi.noalias()=Pb*bf_phi_im;
 
           // Calculate values
 #ifdef _OPENMP
@@ -205,14 +205,14 @@ namespace helfem {
 #endif
           for(size_t ip=0;ip<(size_t) wtot.size();ip++) {
             // Gradient term
-            double kinar=std::real((Pav_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2);
-            double kinath=std::real((Pav_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2);
-            double kinaphi=std::real((Pav_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2);
+            double kinar=(PavA_rho.col(ip).dot(bf_rho_re.col(ip))+PavB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2);
+            double kinath=(PavA_theta.col(ip).dot(bf_theta_re.col(ip))+PavB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2);
+            double kinaphi=(PavA_phi.col(ip).dot(bf_phi_re.col(ip))+PavB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2);
             double kina(kinar + kinath + kinaphi);
 
-            double kinbr=std::real((Pbv_rho.col(ip).array()*bf_rho.col(ip).array()).sum())/std::pow(scale_r(ip),2);
-            double kinbth=std::real((Pbv_theta.col(ip).array()*bf_theta.col(ip).array()).sum())/std::pow(scale_theta(ip),2);
-            double kinbphi=std::real((Pbv_phi.col(ip).array()*bf_phi.col(ip).array()).sum())/std::pow(scale_phi(ip),2);
+            double kinbr=(PbvA_rho.col(ip).dot(bf_rho_re.col(ip))+PbvB_rho.col(ip).dot(bf_rho_im.col(ip)))/std::pow(scale_r(ip),2);
+            double kinbth=(PbvA_theta.col(ip).dot(bf_theta_re.col(ip))+PbvB_theta.col(ip).dot(bf_theta_im.col(ip)))/std::pow(scale_theta(ip),2);
+            double kinbphi=(PbvA_phi.col(ip).dot(bf_phi_re.col(ip))+PbvB_phi.col(ip).dot(bf_phi_im.col(ip)))/std::pow(scale_phi(ip),2);
             double kinb(kinbr + kinbth + kinbphi);
 
             // Store values
@@ -285,7 +285,7 @@ namespace helfem {
           // Multiply weights into potential
           vrho = vrho.array() * wtot.array();
           // Increment matrix
-          increment_lda< std::complex<double> >(H,vrho,bf);
+          helfem::dftgrid_common::increment_lda_split(H,vrho,bf_re,bf_im);
         }
 
         if(do_gga) {
@@ -300,16 +300,16 @@ namespace helfem {
             gr(i,2)*=2.0*wtot(i)*vs(i)/scale_phi(i);
           }
           // Increment matrix
-          increment_gga< std::complex<double> >(H,gr,bf,bf_rho,bf_theta,bf_phi);
+          increment_gga_split(H,gr,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
         }
 
         if(do_mgga_t) {
           helfem::Vector vt = vtau.row(0).transpose();
           vt = vt.array() * wtot.array() * 0.5;
 
-          increment_lda< std::complex<double> >(H,helfem::Vector(vt.array()*inv_scale_r2.array()),bf_rho);
-          increment_lda< std::complex<double> >(H,helfem::Vector(vt.array()*inv_scale_theta2.array()),bf_theta);
-          increment_lda< std::complex<double> >(H,helfem::Vector(vt.array()*inv_scale_phi2.array()),bf_phi);
+          helfem::dftgrid_common::increment_lda_split(H,helfem::Vector(vt.array()*inv_scale_r2.array()),bf_rho_re,bf_rho_im);
+          helfem::dftgrid_common::increment_lda_split(H,helfem::Vector(vt.array()*inv_scale_theta2.array()),bf_theta_re,bf_theta_im);
+          helfem::dftgrid_common::increment_lda_split(H,helfem::Vector(vt.array()*inv_scale_phi2.array()),bf_phi_re,bf_phi_im);
         }
         if(do_mgga_l)
           throw std::logic_error("Laplacian not implemented!\n");
@@ -335,12 +335,12 @@ namespace helfem {
           // Multiply weights into potential
           vrhoa = vrhoa.array() * wtot.array();
           // Increment matrix
-          increment_lda< std::complex<double> >(Ha,vrhoa,bf);
+          helfem::dftgrid_common::increment_lda_split(Ha,vrhoa,bf_re,bf_im);
 
           if(beta) {
             helfem::Vector vrhob = vxc.row(1).transpose();
             vrhob = vrhob.array() * wtot.array();
-            increment_lda< std::complex<double> >(Hb,vrhob,bf);
+            helfem::dftgrid_common::increment_lda_split(Hb,vrhob,bf_re,bf_im);
           }
         }
         if(!Ha.allFinite() || (beta && !Hb.allFinite()))
@@ -364,7 +364,7 @@ namespace helfem {
             gr_a(i,2)=wtot(i)*(2.0*vs_aa(i)*gr_a0(i,2) + vs_ab(i)*gr_b0(i,2))/scale_phi(i);
           }
           // Increment matrix
-          increment_gga< std::complex<double> >(Ha,gr_a,bf,bf_rho,bf_theta,bf_phi);
+          increment_gga_split(Ha,gr_a,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
 
           if(beta) {
             helfem::Vector vs_bb = vsigma.row(2).transpose();
@@ -374,7 +374,7 @@ namespace helfem {
               gr_b(i,1)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,1) + vs_ab(i)*gr_a0(i,1))/scale_theta(i);
               gr_b(i,2)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,2) + vs_ab(i)*gr_a0(i,2))/scale_phi(i);
             }
-            increment_gga< std::complex<double> >(Hb,gr_b,bf,bf_rho,bf_theta,bf_phi);
+            increment_gga_split(Hb,gr_b,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
           }
         }
 
@@ -383,16 +383,16 @@ namespace helfem {
           helfem::Vector vt_a = vtau.row(0).transpose();
           vt_a = vt_a.array() * wtot.array() * 0.5;
 
-          increment_lda< std::complex<double> >(Ha,helfem::Vector(vt_a.array()*inv_scale_r2.array()),bf_rho);
-          increment_lda< std::complex<double> >(Ha,helfem::Vector(vt_a.array()*inv_scale_theta2.array()),bf_theta);
-          increment_lda< std::complex<double> >(Ha,helfem::Vector(vt_a.array()*inv_scale_phi2.array()),bf_phi);
+          helfem::dftgrid_common::increment_lda_split(Ha,helfem::Vector(vt_a.array()*inv_scale_r2.array()),bf_rho_re,bf_rho_im);
+          helfem::dftgrid_common::increment_lda_split(Ha,helfem::Vector(vt_a.array()*inv_scale_theta2.array()),bf_theta_re,bf_theta_im);
+          helfem::dftgrid_common::increment_lda_split(Ha,helfem::Vector(vt_a.array()*inv_scale_phi2.array()),bf_phi_re,bf_phi_im);
           if(beta) {
             helfem::Vector vt_b = vtau.row(1).transpose();
             vt_b = vt_b.array() * wtot.array() * 0.5;
 
-            increment_lda< std::complex<double> >(Hb,helfem::Vector(vt_b.array()*inv_scale_r2.array()),bf_rho);
-            increment_lda< std::complex<double> >(Hb,helfem::Vector(vt_b.array()*inv_scale_theta2.array()),bf_theta);
-            increment_lda< std::complex<double> >(Hb,helfem::Vector(vt_b.array()*inv_scale_phi2.array()),bf_phi);
+            helfem::dftgrid_common::increment_lda_split(Hb,helfem::Vector(vt_b.array()*inv_scale_r2.array()),bf_rho_re,bf_rho_im);
+            helfem::dftgrid_common::increment_lda_split(Hb,helfem::Vector(vt_b.array()*inv_scale_theta2.array()),bf_theta_re,bf_theta_im);
+            helfem::dftgrid_common::increment_lda_split(Hb,helfem::Vector(vt_b.array()*inv_scale_phi2.array()),bf_phi_re,bf_phi_im);
           }
         }
         if(do_mgga_l) {
@@ -502,6 +502,17 @@ namespace helfem {
 
         if(do_lapl) {
           throw std::logic_error("Laplacian not implemented.\n");
+        }
+        // Split once per grid point: the density and Fock contractions
+        // below are real. See the atomic worker for the algebra.
+        bf_re = bf.real();  bf_im = bf.imag();
+        if(do_grad) {
+          bf_rho_re   = bf_rho.real();   bf_rho_im   = bf_rho.imag();
+          bf_theta_re = bf_theta.real(); bf_theta_im = bf_theta.imag();
+          bf_phi_re   = bf_phi.real();   bf_phi_im   = bf_phi.imag();
+        }
+        if(do_lapl) {
+          bf_lapl_re = bf_lapl.real(); bf_lapl_im = bf_lapl.imag();
         }
       }
 

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -300,7 +300,7 @@ namespace helfem {
             gr(i,2)*=2.0*wtot(i)*vs(i)/scale_phi(i);
           }
           // Increment matrix
-          increment_gga_split(H,gr,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
+          increment_gga_split(H,gr,bf_re,bf_im,{&bf_rho_re,&bf_theta_re,&bf_phi_re},{&bf_rho_im,&bf_theta_im,&bf_phi_im});
         }
 
         if(do_mgga_t) {
@@ -364,7 +364,7 @@ namespace helfem {
             gr_a(i,2)=wtot(i)*(2.0*vs_aa(i)*gr_a0(i,2) + vs_ab(i)*gr_b0(i,2))/scale_phi(i);
           }
           // Increment matrix
-          increment_gga_split(Ha,gr_a,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
+          increment_gga_split(Ha,gr_a,bf_re,bf_im,{&bf_rho_re,&bf_theta_re,&bf_phi_re},{&bf_rho_im,&bf_theta_im,&bf_phi_im});
 
           if(beta) {
             helfem::Vector vs_bb = vsigma.row(2).transpose();
@@ -374,7 +374,7 @@ namespace helfem {
               gr_b(i,1)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,1) + vs_ab(i)*gr_a0(i,1))/scale_theta(i);
               gr_b(i,2)=wtot(i)*(2.0*vs_bb(i)*gr_b0(i,2) + vs_ab(i)*gr_a0(i,2))/scale_phi(i);
             }
-            increment_gga_split(Hb,gr_b,bf_re,bf_im,bf_rho_re,bf_rho_im,bf_theta_re,bf_theta_im,bf_phi_re,bf_phi_im);
+            increment_gga_split(Hb,gr_b,bf_re,bf_im,{&bf_rho_re,&bf_theta_re,&bf_phi_re},{&bf_rho_im,&bf_theta_im,&bf_phi_im});
           }
         }
 

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -145,67 +145,9 @@ namespace helfem {
 
       /// LDA quadrature accumulation is shared across geometries.
       using helfem::dftgrid_common::increment_lda;
+      /// GGA accumulation is shared across geometries too.
+      using helfem::dftgrid_common::increment_gga_split;
 
-      /// GGA accumulation for an already-split basis; see the atomic
-      /// worker for the algebra.
-      inline void increment_gga_split(helfem::Matrix & H, const helfem::Matrix & gn,
-                                      const helfem::Matrix & a,  const helfem::Matrix & b,
-                                      const helfem::Matrix & ax, const helfem::Matrix & bx,
-                                      const helfem::Matrix & ay, const helfem::Matrix & by,
-                                      const helfem::Matrix & az, const helfem::Matrix & bz) {
-        if(gn.cols()!=3)
-          throw std::runtime_error("Grad rho must have three columns!\n");
-        helfem::Matrix gre(ax), gim(bx);
-        for(Eigen::Index j=0;j<gre.cols();j++) {
-          gre.col(j) *= gn(j,0);
-          gim.col(j) *= gn(j,0);
-        }
-        for(Eigen::Index j=0;j<gre.cols();j++) {
-          gre.col(j) += gn(j,1)*ay.col(j) + gn(j,2)*az.col(j);
-          gim.col(j) += gn(j,1)*by.col(j) + gn(j,2)*bz.col(j);
-        }
-        helfem::Matrix X(gre * a.transpose());
-        X.noalias() += gim * b.transpose();
-        H += X;
-        H += X.transpose();
-      }
-
-      /// BLAS routine for GGA-type quadrature
-      template<typename T> void increment_gga(helfem::Matrix & H, const helfem::Matrix & gn, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & f, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_x, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_y, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_z) {
-        if(gn.cols()!=3) {
-          throw std::runtime_error("Grad rho must have three columns!\n");
-        }
-        if(f.rows() != f_x.rows() || f.cols() != f_x.cols() || f.rows() != f_y.rows() || f.cols() != f_y.cols() || f.rows() != f_z.rows() || f.cols() != f_z.cols()) {
-          throw std::runtime_error("Sizes of basis function and derivative matrices doesn't match!\n");
-        }
-        if(H.rows() != f.rows() || H.cols() != f.rows()) {
-          throw std::runtime_error("Sizes of basis function and Fock matrices doesn't match!\n");
-        }
-
-        // Compute helper: gamma_{ip} = \sum_c \chi_{ip;c} gr_{p;c}
-        //                 (N, Np)    =        (N Np; c)    (Np, 3)
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> gamma =
-            Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>::Zero(f.rows(), f.cols());
-        {
-          // x gradient. gn(j,0) scales column j of f_x.
-          for(Eigen::Index j=0;j<f_x.cols();j++)
-            f_x.col(j) *= gn(j,0);
-          gamma += f_x;
-
-          // y gradient
-          for(Eigen::Index j=0;j<f_y.cols();j++)
-            f_y.col(j) *= gn(j,1);
-          gamma += f_y;
-
-          // z gradient
-          for(Eigen::Index j=0;j<f_z.cols();j++)
-            f_z.col(j) *= gn(j,2);
-          gamma += f_z;
-        }
-
-        // Form Fock matrix
-        H += (gamma*f.adjoint() + f*gamma.adjoint()).real();
-      }
     }
   }
 }

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -57,6 +57,21 @@ namespace helfem {
 
         /// Density helper matrices: P_{uv} chi_v, and P_{uv} nabla(chi_v)
         Eigen::MatrixXcd Pv, Pv_rho, Pv_theta, Pv_phi;
+
+        /// Real and imaginary parts of the basis values above, split once
+        /// per grid point in compute_bf. See the atomic worker for the
+        /// algebra: the density matrix is real, so every density and Fock
+        /// contraction reduces to real products and the complex forms are
+        /// pure overhead.
+        helfem::Matrix bf_re, bf_im;
+        helfem::Matrix bf_rho_re, bf_rho_im;
+        helfem::Matrix bf_theta_re, bf_theta_im;
+        helfem::Matrix bf_phi_re, bf_phi_im;
+        helfem::Matrix bf_lapl_re, bf_lapl_im;
+        /// P*Re(X) and P*Im(X), the real stand-ins for Pv and friends.
+        helfem::Matrix PvA, PvB, PvA_rho, PvB_rho, PvA_theta, PvB_theta, PvA_phi, PvB_phi;
+        helfem::Matrix PavA, PavB, PavA_rho, PavB_rho, PavA_theta, PavB_theta, PavA_phi, PavB_phi;
+        helfem::Matrix PbvA, PbvB, PbvA_rho, PbvB_rho, PbvA_theta, PbvB_theta, PbvA_phi, PbvB_phi;
         /// Same for spin-polarized
         Eigen::MatrixXcd Pav, Pav_rho, Pav_theta, Pav_phi;
         Eigen::MatrixXcd Pbv, Pbv_rho, Pbv_theta, Pbv_phi;
@@ -130,6 +145,30 @@ namespace helfem {
 
       /// LDA quadrature accumulation is shared across geometries.
       using helfem::dftgrid_common::increment_lda;
+
+      /// GGA accumulation for an already-split basis; see the atomic
+      /// worker for the algebra.
+      inline void increment_gga_split(helfem::Matrix & H, const helfem::Matrix & gn,
+                                      const helfem::Matrix & a,  const helfem::Matrix & b,
+                                      const helfem::Matrix & ax, const helfem::Matrix & bx,
+                                      const helfem::Matrix & ay, const helfem::Matrix & by,
+                                      const helfem::Matrix & az, const helfem::Matrix & bz) {
+        if(gn.cols()!=3)
+          throw std::runtime_error("Grad rho must have three columns!\n");
+        helfem::Matrix gre(ax), gim(bx);
+        for(Eigen::Index j=0;j<gre.cols();j++) {
+          gre.col(j) *= gn(j,0);
+          gim.col(j) *= gn(j,0);
+        }
+        for(Eigen::Index j=0;j<gre.cols();j++) {
+          gre.col(j) += gn(j,1)*ay.col(j) + gn(j,2)*az.col(j);
+          gim.col(j) += gn(j,1)*by.col(j) + gn(j,2)*bz.col(j);
+        }
+        helfem::Matrix X(gre * a.transpose());
+        X.noalias() += gim * b.transpose();
+        H += X;
+        H += X.transpose();
+      }
 
       /// BLAS routine for GGA-type quadrature
       template<typename T> void increment_gga(helfem::Matrix & H, const helfem::Matrix & gn, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & f, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_x, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_y, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_z) {

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -433,15 +433,18 @@ namespace helfem {
 
           if (do_gga) {
             const helfem::Vector vs = vsigma.row(0).transpose();
-            // increment_gga wants (npts x 3); the phi column is identically
-            // zero, so its derivative matrix never contributes.
-            helfem::Matrix gr = helfem::Matrix::Zero(nang, 3);
+            // Two live components: the phi column is identically zero in
+            // the pure-m path, and the shared accumulator takes exactly as
+            // many components as it is given -- so unlike the old
+            // three-column call this no longer carries a dummy third.
+            helfem::Matrix gr = helfem::Matrix::Zero(nang, 2);
             for (Eigen::Index ia = 0; ia < nang; ia++) {
               const double f = 2.0 * wtot(ia) * vs(ia) / scale_r(ia);
               gr(ia, 0) = f * grho(0, ia);
               gr(ia, 1) = f * grho(1, ia);
             }
-            dftgrid::increment_gga<double>(Hm, gr, bf_m[im], dr_m[im], dth_m[im], bf_m[im]);
+            helfem::dftgrid_common::increment_gga_split(Hm, gr, bf_m[im], helfem::Matrix(),
+                                                        {&dr_m[im], &dth_m[im]}, {});
           }
 
           if (do_mgga_t || do_mgga_l) {
@@ -506,23 +509,25 @@ namespace helfem {
           if (do_gga) {
             const helfem::Vector vs_aa = vsigma.row(0).transpose();
             const helfem::Vector vs_ab = vsigma.row(1).transpose();
-            helfem::Matrix gr_a = helfem::Matrix::Zero(nang, 3);
+            helfem::Matrix gr_a = helfem::Matrix::Zero(nang, 2);
             for (Eigen::Index ia = 0; ia < nang; ia++) {
               const double f = wtot(ia) / scale_r(ia);
               gr_a(ia, 0) = f * (2.0 * vs_aa(ia) * grho(0, ia) + vs_ab(ia) * grho(2, ia));
               gr_a(ia, 1) = f * (2.0 * vs_aa(ia) * grho(1, ia) + vs_ab(ia) * grho(3, ia));
             }
-            dftgrid::increment_gga<double>(Hma, gr_a, bf_m[im], dr_m[im], dth_m[im], bf_m[im]);
+            helfem::dftgrid_common::increment_gga_split(Hma, gr_a, bf_m[im], helfem::Matrix(),
+                                                        {&dr_m[im], &dth_m[im]}, {});
 
             if (beta) {
               const helfem::Vector vs_bb = vsigma.row(2).transpose();
-              helfem::Matrix gr_b = helfem::Matrix::Zero(nang, 3);
+              helfem::Matrix gr_b = helfem::Matrix::Zero(nang, 2);
               for (Eigen::Index ia = 0; ia < nang; ia++) {
                 const double f = wtot(ia) / scale_r(ia);
                 gr_b(ia, 0) = f * (2.0 * vs_bb(ia) * grho(2, ia) + vs_ab(ia) * grho(0, ia));
                 gr_b(ia, 1) = f * (2.0 * vs_bb(ia) * grho(3, ia) + vs_ab(ia) * grho(1, ia));
               }
-              dftgrid::increment_gga<double>(Hmb, gr_b, bf_m[im], dr_m[im], dth_m[im], bf_m[im]);
+              helfem::dftgrid_common::increment_gga_split(Hmb, gr_b, bf_m[im], helfem::Matrix(),
+                                                        {&dr_m[im], &dth_m[im]}, {});
             }
           }
 

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -23,6 +23,7 @@
 // compute_Nel, etc.) stay in the derived classes.
 
 #include <Matrix.h>
+#include <vector>
 #include <sstream>
 #include <stdexcept>
 
@@ -167,6 +168,52 @@ namespace helfem {
       for(Eigen::Index j=0;j<fhlp.cols();j++)
         fhlp.col(j) *= vxc(j);
       H += (fhlp * f.adjoint()).real();
+    }
+
+    /// GGA accumulation, shared by all three geometries.
+    ///
+    /// gn is (npts x ncomp): one column of gradient weights per spatial
+    /// component -- one for the spherically averaged atom (radial only),
+    /// three for the atomic and diatomic grids. ga/gb hold the matching
+    /// component derivatives of the basis, split into real and imaginary
+    /// parts; pass gb empty for a real basis, where the imaginary work
+    /// drops out entirely.
+    ///
+    /// With f = a + i b and the gradient-weighted helper gamma likewise
+    /// split, Re( gamma f^H + f gamma^H ) = X + X^T with
+    ///     X = Re(gamma) a^T + Im(gamma) b^T,
+    /// so the two complex products of the old formulation collapse to two
+    /// real ones plus a symmetrisation -- the symmetry was being computed
+    /// and half-discarded along with the imaginary part.
+    inline void increment_gga_split(helfem::Matrix & H, const helfem::Matrix & gn,
+                                    const helfem::Matrix & a, const helfem::Matrix & b,
+                                    const std::vector<const helfem::Matrix *> & ga,
+                                    const std::vector<const helfem::Matrix *> & gb) {
+      const bool complex_basis = !gb.empty();
+      if(gn.cols() != (Eigen::Index) ga.size()) {
+        std::ostringstream oss;
+        oss << "Grad rho has " << gn.cols() << " columns but " << ga.size()
+            << " gradient components were given!\n";
+        throw std::runtime_error(oss.str());
+      }
+      if(complex_basis && gb.size() != ga.size())
+        throw std::runtime_error("Real and imaginary gradient component counts differ!\n");
+      if(H.rows() != a.rows() || H.cols() != a.rows())
+        throw std::runtime_error("Sizes of basis function and Fock matrices doesn't match!\n");
+
+      helfem::Matrix gre(helfem::Matrix::Zero(a.rows(), a.cols()));
+      helfem::Matrix gim;
+      if(complex_basis) gim = helfem::Matrix::Zero(a.rows(), a.cols());
+      for(size_t c=0;c<ga.size();c++)
+        for(Eigen::Index j=0;j<gre.cols();j++) {
+          gre.col(j) += gn(j,(Eigen::Index) c) * ga[c]->col(j);
+          if(complex_basis) gim.col(j) += gn(j,(Eigen::Index) c) * gb[c]->col(j);
+        }
+
+      helfem::Matrix X(gre * a.transpose());
+      if(complex_basis) X.noalias() += gim * b.transpose();
+      H += X;
+      H += X.transpose();
     }
 
     /// Laplacian meta-GGA accumulation for an already-split basis.

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -289,7 +289,7 @@ namespace helfem {
             gr.col(0).array() += 2.0*vlapl.row(0).transpose().array()*r.array()*(wrad.array()*4.0*M_PI);
           }
           // Increment matrix
-          increment_gga<double>(H,gr,bf,bf_rho);
+          helfem::dftgrid_common::increment_gga_split(H,gr,bf,helfem::Matrix(),{&bf_rho},{});
           if(!H.allFinite())
             fprintf(stderr,"NaN in Hamiltonian after GGA!\n");
         }
@@ -379,7 +379,7 @@ namespace helfem {
             gr_a.col(0).array() += 2.0*vlapl.row(0).transpose().array()*r.array()*(wrad.array()*4.0*M_PI);
           }
           // Increment matrix
-          increment_gga<double>(Ha,gr_a,bf,bf_rho);
+          helfem::dftgrid_common::increment_gga_split(Ha,gr_a,bf,helfem::Matrix(),{&bf_rho},{});
 
           if(beta) {
             helfem::Vector vs_bb = vsigma.row(2).transpose();
@@ -388,7 +388,7 @@ namespace helfem {
             if(do_mgga_l) {
               gr_b.col(0).array() += 2.0*vlapl.row(1).transpose().array()*r.array()*(wrad.array()*4.0*M_PI);
             }
-            increment_gga<double>(Hb,gr_b,bf,bf_rho);
+            helfem::dftgrid_common::increment_gga_split(Hb,gr_b,bf,helfem::Matrix(),{&bf_rho},{});
           }
           if(!Ha.allFinite() || (beta && !Hb.allFinite()))
             //throw std::logic_error("NaN encountered!\n");

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -131,33 +131,6 @@ namespace helfem {
       /// LDA quadrature accumulation is shared across geometries.
       using helfem::dftgrid_common::increment_lda;
 
-      /// BLAS routine for GGA-type quadrature
-      template<typename T> void increment_gga(helfem::Matrix & H, const helfem::Matrix & gn, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & f, Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> f_x) {
-        if(gn.cols()!=1) {
-          throw std::runtime_error("Grad rho must have three columns!\n");
-        }
-        if(f.rows() != f_x.rows() || f.cols() != f_x.cols()) {
-          throw std::runtime_error("Sizes of basis function and derivative matrices doesn't match!\n");
-        }
-        if(H.rows() != f.rows() || H.cols() != f.rows()) {
-          throw std::runtime_error("Sizes of basis function and Fock matrices doesn't match!\n");
-        }
-
-        // Compute helper: gamma_{ip} = \sum_c \chi_{ip;c} gr_{p;c}
-        //                 (N, Np)    =        (N Np; c)    (Np, 3)
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> gamma =
-            Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>::Zero(f.rows(), f.cols());
-        {
-          // gn.col(0) holds the (single) radial gradient weight per point;
-          // scale column j of f_x by gn(j,0).
-          for(Eigen::Index j=0;j<f_x.cols();j++)
-            f_x.col(j) *= gn(j,0);
-          gamma += f_x;
-        }
-
-        // Form Fock matrix
-        H += (gamma*f.adjoint() + f*gamma.adjoint()).real();
-      }
 
       /// BLAS routine for mGGA-type quadrature
       template<typename T> void increment_mgga_lapl(helfem::Matrix & H, const helfem::Vector & vlapl, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & f, const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & l) {


### PR DESCRIPTION
Builds on #288. Three DFT grid implementations (sadatom, atomic,
diatomic) totalling ~3450 lines shared only 226 of them.

## What was actually duplicated

`increment_gga` existed **three times**. Atomic's and diatomic's copies
were semantically identical — the entire diff was whitespace, brace
placement and comment wording. Sadatom's was the same function with one
gradient component instead of three, and the copy-paste had carried a bug
with it: it checks `gn.cols()!=1` while throwing *"Grad rho must have
three columns"*.

## What this does

1. **Migrates diatomic's density and Fock build to real arithmetic**, as
   #288 did for atomic. Explicitly *not* a speedup — diatomic's profile
   shows no complex GEMM under either `lda_x` or `gga_x_pbe`, and it
   measures ~3%. The point is that sadatom was always real and atomic now
   is, so this makes all three contract in the same arithmetic.

2. **Replaces the three `increment_gga` with one** in
   `dftgrid_common.h`, taking gradient components as a vector so the
   geometry decides how many, and the basis pre-split into real and
   imaginary parts. An empty imaginary list means a real basis and the
   imaginary work drops out — that covers sadatom and diatomic's pure-m
   path.

Step 1 is what makes step 2 possible: with mixed scalar types a shared
implementation would have needed templating and would have dragged the
complex path into sadatom.

The pure-m path gains slightly — it used to build a three-column gradient
with an identically-zero phi column and pass its basis as a dummy third
component, because the old signature demanded three.

## What is deliberately *not* merged

`compute_bf` (23 / 107 / 94 lines) is where the geometries genuinely
differ — radial vs (r,θ,φ) with scale factors vs prolate spheroidal —
along with diatomic's boundary expansion, its 652-line pure-m fast path,
and sadatom's per-l density slicing. Folding those into one file with
three sets of branches would be worse than what exists.

## Verification, and a caveat worth reading

Checked against a **deterministic** case — single-threaded, closed-shell
Be with `gga_x_pbe` — where master, the pre-dedup build and this one all
give −14.5450002995. BR89 on Be (the Laplacian branch) gives
−14.6467312778 throughout.

The open-shell O/PBE case used earlier is **not reproducible**: the same
binary gives −74.7827460224 and −74.7707877743 on different runs, a
0.012 Eh spread that looks like convergence to different SCF solutions
rather than roundoff. It briefly appeared that this PR had broken
something; it had not. But it means earlier "energies unchanged" checks
on that case were weaker than they looked, and open-shell multi-solution
cases should not be used as regression references — cf. the known Fe M=5
multi-solution behaviour.