### PR TITLE
atomic: fix data race on the grid kinetic energy accumulator

### DIFF
--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -584,7 +584,7 @@ namespace helfem {
         double nel=0.0;
         double lapl=0;
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:exc,nel,lapl)
+#pragma omp parallel reduction(+:exc,ekin,nel,lapl)
 #endif
         {
           DFTGridWorker grid(basp,lang,mang);
@@ -647,7 +647,7 @@ namespace helfem {
         double nel=0.0;
         double ekin=0.0;
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:exc,nel)
+#pragma omp parallel reduction(+:exc,ekin,nel)
 #endif
         {
           DFTGridWorker grid(basp,lang,mang);


### PR DESCRIPTION
`DFTGrid::eval_Fxc` accumulates `ekin += grid.compute_Ekin()` from inside an
OpenMP parallel region, but `ekin` was missing from the `reduction(+:...)`
clause in both the restricted and unrestricted overloads — `exc`, `nel` and
`lapl` were listed, `ekin` was not:

```cpp
double ekin=0.0;
#pragma omp parallel reduction(+:exc,nel,lapl)   // no ekin
{
  ...
  ekin+=grid.compute_Ekin();                     // every thread, unsynchronised
```

So every thread performed an unsynchronised read-modify-write on the same
`double`.

### Impact

Benign today, but genuinely undefined behaviour. The racy value lands in the
`Ekin` out-parameter, and `src/atomic/main.cpp` ignores it — it computes the
kinetic energy itself as `(P*T).trace()` and never reads the grid's output.
Nothing consumes the corrupted number. It would silently produce a wrong
result the moment a caller did.

Predates the Eigen migration; the same omission is in the Armadillo-era code.

### Scope

All four `reduction(...)` clauses in the tree were checked. These two were the
only instances:

- sadatom's two clauses do not accumulate a kinetic energy at all.
- diatomic's `DFTGrid::eval_Fxc` loop is entirely serial — no OpenMP.

The XC Fock matrix itself is unaffected and remains bitwise deterministic:
workers accumulate into a local `bf_ind`-sized block and scatter with
`Ho(bf_ind[i],bf_ind[j]) += H(i,j)`, the even/odd element split is a
two-colouring so concurrent scatters touch disjoint entries, and the two
loops are separated by the implicit barrier.

### Testing

The edited translation unit compiles and `helfem-common` archives cleanly.
Executables do not currently link in this working tree for an unrelated
reason: the build directory's CMake cache hardcodes
`/usr/lib64/libwignernj.so.0.7.0` while the system now carries 0.8.0, so the
link fails on a missing input path rather than on any symbol. That is a stale
build-directory issue, not a code one, and it affects `master` identically.

No behaviour change is expected or observable, since no caller reads the
value.