### PR TITLE
tests: integration test suite for atomic, diatomic, gensap and aij; CI; pin OOO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+# Fast feedback on every push and pull request: build, then run the subset of
+# integration tests that finishes in minutes. The long tail runs weekly
+# (see weekly.yml).
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: build + quick tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build g++ \
+            libeigen3-dev libxc-dev libhdf5-dev \
+            libopenblas-dev liblapacke-dev
+
+      # wignernj and OpenOrbitalOptimizer are fetched by CMake. OOO is pinned
+      # to an explicit commit (see CMakeLists.txt), so this build is
+      # reproducible rather than tracking whatever master happens to be.
+      - name: Configure
+        run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+
+      - name: Build
+        run: cmake --build build -j $(nproc)
+
+      # Both kinds of check.
+      #
+      # Reference comparison: every case is a well-behaved system with the
+      # configuration pinned where there is any ambiguity, so the converged
+      # energy is a property of the problem rather than of the linear algebra
+      # and is reproducible across library stacks. Verified by running the same
+      # binary under FlexiBLAS with NETLIB and with OpenBLAS: He/HF gives
+      # -2.8616799946 and pinned Be/PBE -14.5450377121 under both, to every
+      # printed digit. The tolerance is therefore set by SCF convergence, not
+      # by the BLAS. A case that cannot meet it does not belong in the suite.
+      - name: Quick integration tests (references)
+        run: |
+          python3 tests/run_tests.py --check tests/refs/ci.json --tag ci \
+            --bindir build/src -j $(nproc)
+
+      # Invariants are checked by the run above, but --smoke also passes with
+      # no reference file at all, which keeps the suite runnable on a platform
+      # whose references have not been recorded yet.
+      - name: Quick integration tests (invariants only)
+        if: always()
+        run: |
+          python3 tests/run_tests.py --smoke --tag ci \
+            --bindir build/src -j $(nproc)
+
+      # On failure, publish what this runner actually produced so the numbers
+      # can be compared against tests/refs/ci.json without a local rerun.
+      - name: Record energies for this platform
+        if: failure()
+        run: |
+          python3 tests/run_tests.py --generate ci-energies.json --tag ci \
+            --bindir build/src -j $(nproc) || true
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ci-energies
+          path: ci-energies.json
+          if-no-files-found: warn

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,72 @@
+name: Weekly full test suite
+
+# The whole integration suite, including the cases that take minutes to hours:
+# the heavy elements (Cr, Zn, Kr), the range-separated hybrids, and the
+# diatomics beyond H2. Too slow for per-push CI (see ci.yml), but they cover
+# the parts of the code the quick tier never touches.
+on:
+  schedule:
+    # Sundays at 03:00 UTC.
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Only run cases carrying this tag (blank = all)'
+        required: false
+        default: ''
+
+jobs:
+  full-suite:
+    name: full suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build g++ \
+            libeigen3-dev libxc-dev libhdf5-dev \
+            libopenblas-dev liblapacke-dev
+
+      - name: Configure
+        run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+
+      - name: Build
+        run: cmake --build build -j $(nproc)
+
+      # Cases run one thread each and are parallelised across cases, which
+      # cannot change any result: converged energies are a deterministic
+      # function of OMP_NUM_THREADS, so each case pins it to 1.
+      # References first where we have them, then the reference-free
+      # invariants over the whole suite. See ci.yml for why recorded energies
+      # are portable: every case is well behaved and pinned, so the converged
+      # energy does not depend on the library stack.
+      - name: Full suite (references, where recorded)
+        run: |
+          python3 tests/run_tests.py --check tests/refs/ci.json \
+            ${{ github.event.inputs.tag && format('--tag {0}', github.event.inputs.tag) || '' }} \
+            --bindir build/src -j $(nproc) --timeout 7200
+
+      - name: Full suite (invariants over every case)
+        if: always()
+        run: |
+          python3 tests/run_tests.py --smoke \
+            ${{ github.event.inputs.tag && format('--tag {0}', github.event.inputs.tag) || '' }} \
+            --bindir build/src -j $(nproc) --timeout 7200
+
+      - name: Record energies for this platform
+        if: always()
+        run: |
+          python3 tests/run_tests.py --generate weekly-energies.json \
+            --bindir build/src -j $(nproc) --timeout 7200 || true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: weekly-energies
+          path: weekly-energies.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,9 +321,18 @@ if(NOT OpenOrbitalOptimizer_FOUND)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
         set(_ooo_exclude EXCLUDE_FROM_ALL)
     endif()
+    # Pinned to an explicit commit, NOT to master. With a floating branch two
+    # builds of identical HelFEM source can link different OOO and produce
+    # different numbers, with nothing in the HelFEM history to explain it --
+    # which makes `git bisect` meaningless, since every step samples a moving
+    # dependency. Bump this deliberately, in its own commit, so the bump is
+    # bisectable like any other change.
+    #
+    # a3abae9 is 83 commits past v0.4.0 and carries the Aufbau/occupation
+    # fixes; pinning to the v0.4.0 tag instead would silently revert them.
     FetchContent_Declare(OpenOrbitalOptimizer
         GIT_REPOSITORY https://github.com/susilehtola/OpenOrbitalOptimizer.git
-        GIT_TAG        master
+        GIT_TAG        a3abae9a2b7b2a3dd591579a7613643574da90c9
         ${_ooo_exclude})
     FetchContent_MakeAvailable(OpenOrbitalOptimizer)
     unset(_ooo_exclude)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,231 @@
+# HelFEM integration tests
+
+Regression tests for the `atomic`, `diatomic`, `gensap` (spherically-averaged
+atom) and `aij` (atom-in-jellium) drivers, covering the four axes that
+matter:
+
+1. spin-restricted and spin-unrestricted
+2. quick s-only systems (H, He, H2) and harder ones with p/pi orbitals
+   (Ne, Ar, Kr, BH, CH, NH, OH, FH, N2, CO)
+3. with and without orbital symmetry
+4. HF, LDA, GGA, mGGA (both tau- and laplacian-dependent) and hybrids
+
+`cases.json` is data; `run_tests.py` is independent of what it contains. Add
+or remove systems by editing the JSON.
+
+## Running
+
+    tests/run_tests.py --generate refs/mine.json      # record what this build does
+    tests/run_tests.py --check    refs/mine.json      # compare against a recorded set
+
+    tests/run_tests.py --check refs/mine.json --tag quick      # subset by tag
+    tests/run_tests.py --check refs/mine.json --skip-slow
+    tests/run_tests.py --check refs/mine.json -j 6             # cases run concurrently
+
+`--bindir` defaults to `objdir/src`.
+
+## What is compared, and why
+
+The drivers print a full decomposition:
+
+    kinetic ... nuclear ... Coulomb ... XC ... Exx ... total ... (nel err ...)
+
+Every component is recorded, not just the total, because the component that
+moved localises the fault: XC drifting while kinetic holds still points at the
+DFT grid; kinetic drifting points at the basis; `nel err` drifting points at
+the quadrature.
+
+Converged **occupations** are recorded separately and reported as a distinct
+kind of failure. A system with near-degenerate solutions can converge to a
+different *state* rather than to a wrong *number* (task #45), and those two
+failures need different responses — one is physics, the other is a bug.
+
+## Determinism: read this before believing a failure
+
+Converged energies are a deterministic function of `OMP_NUM_THREADS`. They are
+bit-reproducible at a fixed thread count and can differ *between* thread
+counts, because the OpenMP reduction over the XC energy sums in a different
+order (~1e-16) and a near-degenerate system amplifies that into a different
+SCF solution. Measured on atomic O/PBE: 2 threads gives -74.7827460224,
+6 threads gives -74.7707877743 — a 0.012 Eh gap, entirely reproducible on
+each side.
+
+Consequences:
+
+- every case runs at `OMP_NUM_THREADS=1`, recorded in the reference metadata;
+- `--jobs` parallelises across *cases*, never within one, so it cannot change
+  a result;
+- before calling a difference a regression, confirm the thread count matched.
+
+The same applies to the BLAS. This machine uses FlexiBLAS, a runtime
+dispatcher whose backend can change without anything in the repo changing, so
+the reference metadata records it too.
+
+## Basis sets: everything is at the CBS limit
+
+**Every case runs at a converged basis.** HelFEM exists to produce
+basis-set-limit numbers, so a suite pinned at some arbitrary small basis would
+exercise a regime the code is not for, would miss faults living in the
+auto-convergence machinery and the high-L integrals, and would leave every
+reference value physically meaningless — not comparable to literature or to
+another code.
+
+For the **atomic** cases this factorises. The angular direction is not a
+convergence question at all: the orbitals are L^2 eigenfunctions, so
+`lmax = max occupied l` is *exact*, not truncated. Verified — Ne at
+lmax = 1, 2, 3 agrees to 3e-10, and the Be unoccupied-p invariant asserts the
+same fact. So lmax is 0 for H/He/Be/Na/Mg/K/Ca, 1 for N/O/Ne/P/Ar, 2 for
+Cr/Zn/Kr, and only the radial grid needs converging: `nelem=5, nnodes=15`
+reproduces the nelem = 10/15/20 limit exactly (He -2.8616799956,
+Ne -128.5470981094). Field cases keep a polarisable lmax=2, since a field
+mixes l.
+
+Minimal lmax is also *cheaper*, because it stops carrying angular channels
+that contribute nothing: Ne/LDA went from ~150 s at lmax=2 to 12 s at lmax=1.
+
+For the **diatomic** cases the grids come from `diatomic_cbasis`, which
+reports the converged element and partial-wave counts directly. Note `--lmax`
+there takes a per-|m| list (`--lmax=11,7` means 11 partial waves for m=0, 7
+for m=1, and two entries means mmax=1).
+
+## Cross-version references
+
+The interesting use is checking today's code against a known-good build:
+
+    git worktree add /tmp/wt-old <commit>
+    cmake -B /tmp/wt-old/bd -S /tmp/wt-old && cmake --build /tmp/wt-old/bd -j
+    tests/run_tests.py --generate refs/old.json --bindir /tmp/wt-old/bd/src
+
+    tests/run_tests.py --check refs/old.json          # against the current build
+
+**The pre-Eigen anchor is `141d982`** (2026-06-29), the parent of
+`073aa42 "v2: Eigen migration Phase 1"`.
+
+Two caveats that make a strict comparison against it impossible, and which
+should temper how its numbers are read:
+
+- **It predates OpenOrbitalOptimizer entirely.** There is no OOO in its
+  CMakeLists; it used the bespoke in-tree SCF drivers. So the comparison spans
+  two rewrites at once — the linear algebra *and* the SCF solver.
+- **The convergence controls differ.** The old CLI had `--convthr` / `--maxit`
+  / `--diis*`; the current one has `--scfmethods`. The same convergence
+  threshold cannot be requested from both.
+
+So a cross-era comparison establishes *"both converge to the same stationary
+point"*, not *"both produce the same number to 1e-10"*. Use a loose tolerance
+(1e-6) across eras and lean on the occupation check to catch genuine
+state changes. Within one era, 1e-8 or tighter is appropriate.
+
+Every physics flag needed by `cases.json` (`Z, M, lmax, mmax, nelem, nnodes,
+method, symmetry, restricted, nela, nelb`) exists unchanged in both eras, so
+the case list itself needs no adaptation.
+
+## Configuration-dependent tests: the three components of O 3P
+
+Oxygen is 1s2 2s2 2p4, so at M=3 (nela=5, nelb=3) exactly one p orbital is
+doubly occupied, and *which* one selects the M_L component of the 3P term.
+`--readocc` pins the choice via an `occs.dat` of `(nocca, noccb, m)` rows
+(requires `--symmetry=1`):
+
+| doubly occupied | m=0   | m=+1  | m=-1  | M_L | HF energy       |
+|-----------------|-------|-------|-------|-----|-----------------|
+| p0              | `3 3` | `1 0` | `1 0` |  0  | -74.8175462069  |
+| p+              | `3 2` | `1 1` | `1 0` | -1  | -74.8146025595  |
+| p-              | `3 2` | `1 0` | `1 1` | +1  | -74.8146025595  |
+
+**p+ and p- must be exactly degenerate** — the two are related by reflection,
+so this is a symmetry identity with a known answer rather than a recorded
+number. Measured agreement is to all ten printed digits, at HF and at PBE.
+The p0 component sits 2.94 mEh away, which is the physical M_L splitting.
+
+This is also the mechanism behind the O/PBE irreproducibility chased earlier:
+unpinned, the SCF selects among these components depending on arbitrarily
+small perturbations (thread count, for instance), which is why unpinned
+open-shell oxygen makes a poor reference and a pinned one makes a good test.
+
+## Cross-code invariants
+
+Every element in this suite is closed-shell, single-s-electron or half-filled,
+so its density is spherically symmetric. The spherical average that `gensap`
+solves is therefore *exact* for these systems, not an approximation -- the two
+codes are solving the same problem and must agree. Measured: Ne
+-128.2334805607 and Cr -1042.2182811427 identical between `gensap` and
+`atomic` to every printed digit, N to 2e-10 (convergence-limited, hence the
+1e-8 tolerance).
+
+Likewise `aij` with `--njellium=0` is the bare atom, and must reproduce
+`gensap` exactly: -240.3560448251 from both for Al.
+
+These are the strongest tests here. Every other case validates the code
+against its own recorded past; these validate two independently written
+solvers against each other, with no reference values involved at all. Cr is
+the striking one -- a 24-electron transition metal, the full (l,m)-resolved
+treatment against the spherically-averaged one, agreeing exactly.
+
+## Invariants
+
+`cases.json` declares sets of cases that must agree with *each other*,
+independent of any reference:
+
+- a closed-shell system gives the same energy restricted or polarized (one per
+  closed-shell element in the set);
+- the O 3P p+ and p- components are exactly degenerate;
+- E(+Ez) = E(-Ez), and E(+Bz) = E(-Bz) with m-symmetric occupations;
+- an angular momentum present in the basis but unoccupied does not change the
+  energy: Be at `--lmax=0` equals pinned Be at `--lmax=2`.
+
+These are the most valuable tests here, and for a reason worth stating.
+Every *reference* case records what the code currently does; if the reference
+was generated from broken code, the test enshrines the breakage. The
+invariants are symmetry identities with answers known independently of any
+build, so they can detect a fault that predates the first reference. They also
+stay valid when reference values legitimately change.
+
+## Pinning configurations
+
+Systems with near-degenerate solutions need their configuration pinned, or the
+SCF picks among the candidates according to arbitrarily small perturbations
+and the recorded value is not reproducible. Be is the worked example: its
+2s/2p near-degeneracy let an unpinned run settle on a p-contaminated solution
+1.4e-6 away from the clean one.
+
+Pin at the right granularity. `--symmetry=1` counts particles per m, and Be's
+m=0 block holds 1s, 2s *and* 2p0 — so a per-m count cannot separate 2s from
+2p0 and the degeneracy survives the pin. `--symmetry=2` counts per (l,m) and
+does separate them. At `--lmax=0` there is no p in the basis at all, so
+`--symmetry=1` is sufficient there.
+
+Fields need pinning for the same reason: a field breaks the degeneracy that
+Aufbau would otherwise resolve arbitrarily.
+
+## What is deliberately absent
+
+**Laplacian-dependent meta-GGAs** (BR89 and relatives). They are numerically
+unstable and diverge in any reasonable calculation, so they cannot serve as
+stable references — a run that fails to converge is not a regression signal.
+`increment_mgga_lapl` therefore has no test coverage here; that is a known
+gap, not an oversight.
+
+## Continuous integration
+
+Two workflows, split by runtime:
+
+- `.github/workflows/ci.yml` — every push and pull request. Builds, then runs
+  the `ci` tag: 26 cases that finish in minutes, chosen to still cover both
+  spin modes, HF/LDA/GGA/mGGA/hybrid, a pinned configuration, a field and a
+  diatomic. Six of the thirteen invariants are fully covered by this tier.
+- `.github/workflows/weekly.yml` — Sundays, plus manual dispatch. The whole
+  suite, including the heavy elements (Cr, Zn, Kr), the range-separated
+  hybrids and the diatomics beyond H2.
+
+Both run `--smoke`, not `--check`, and that is deliberate. A recorded energy
+depends on the CPU and the BLAS, so a reference set generated on one machine
+cannot be compared bit-for-bit on a GitHub runner; checking it there would
+either fail spuriously or need a tolerance so loose it catches nothing. The
+invariants have no such problem — they are symmetry identities that hold on
+any machine to convergence precision — so CI enforces those, and additionally
+fails on any crash or timeout.
+
+Both workflows also upload the energies they produced as an artifact. That is
+how a platform-matched reference set gets created: take the artifact from a
+green run and promote it, rather than transcribing numbers by hand.

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,0 +1,4479 @@
+{
+  "_comment": [
+    "Integration test cases for HelFEM. This file is DATA -- edit it freely;",
+    "the runner (run_tests.py) is independent of what is listed here.",
+    "",
+    "Coverage axes, per code:",
+    "  1. spin-restricted and spin-unrestricted",
+    "  2. quick s-only systems (H, He, H2) and harder ones with p/pi orbitals",
+    "     (Ne, Ar, Kr, BH, CH, NH, OH, FH, N2, CO)",
+    "  3. with and without symmetry",
+    "  4. HF, LDA, GGA, mGGA (tau- and laplacian-dependent) and hybrids",
+    "",
+    "Bases are deliberately SMALL and FIXED. A regression test needs a",
+    "reproducible basis, not a converged one -- physical accuracy is a",
+    "separate concern. Diatomic grids were nonetheless derived with",
+    "diatomic_cbasis (see tools/gen_diatomic_grids.sh) so they are sane.",
+    "",
+    "Determinism: every case runs with OMP_NUM_THREADS=1. Converged energies",
+    "are a deterministic function of the thread count (see the memory note",
+    "energies-depend-on-thread-count), so the thread count is part of the",
+    "reference, not an incidental detail."
+  ],
+  "defaults": {
+    "env": {
+      "OMP_NUM_THREADS": "1"
+    },
+    "timeout_s": 900,
+    "tolerance": 1e-08
+  },
+  "cases": [
+    {
+      "name": "atomic-H-hf-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "open-shell",
+        "ci"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-H-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-H-gga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "gga",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-H-mgga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "mgga",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-H-hybrid-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hybrid",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-He-hf-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-He-hf-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-He-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-He-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-He-gga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "gga",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-He-gga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "gga",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-He-mgga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "mgga",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-He-mgga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "mgga",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-He-hybrid-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hybrid",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-He-hybrid-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hybrid",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-He-rsh-erfc-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-erfc",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-He-rsh-erfc-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-erfc",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-He-rsh-yukawa-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-yukawa",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-He-rsh-yukawa-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-yukawa",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Be-hf-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=1"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-hf-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=0"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-gga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "gga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=1"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-gga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "gga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=0"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-mgga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "mgga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=1"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-mgga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "mgga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=0"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-hybrid-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hybrid"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=1"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-hybrid-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hybrid"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=0"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-rsh-erfc-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-erfc",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=1"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-rsh-erfc-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-erfc",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=0"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-rsh-yukawa-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-yukawa",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=1"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-Be-rsh-yukawa-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-yukawa",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=0"
+      ],
+      "_why": "at lmax=0 there is no p in the basis, so the 2s/2p near-degeneracy cannot arise and no pin is needed"
+    },
+    {
+      "name": "atomic-N-hf-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hf",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-N-hf-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-N-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-N-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-N-gga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "gga",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-N-gga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "gga",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-N-mgga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "mgga",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-N-mgga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "mgga",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-N-hybrid-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hybrid",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-N-hybrid-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hybrid",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-N-rsh-erfc-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-erfc",
+        "open-shell",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-N-rsh-erfc-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-erfc",
+        "open-shell",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-N-rsh-yukawa-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-yukawa",
+        "open-shell",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-N-rsh-yukawa-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-yukawa",
+        "open-shell",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ne-hf-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hf"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ne-hf-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hf"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ne-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ne-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ne-gga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "gga"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ne-gga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "gga"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ne-mgga-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "mgga"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ne-mgga-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "mgga"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ne-hybrid-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "hybrid"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ne-hybrid-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "hybrid"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ne-rsh-erfc-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-erfc",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ne-rsh-erfc-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-erfc",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ne-rsh-yukawa-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "rsh-yukawa",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ne-rsh-yukawa-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "rsh-yukawa",
+        "range-separated",
+        "slow"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Na-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=Na",
+        "--M=2",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Na-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=Na",
+        "--M=2",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Mg-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda"
+      ],
+      "args": [
+        "--Z=Mg",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Mg-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda"
+      ],
+      "args": [
+        "--Z=Mg",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-P-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=P",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-P-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=P",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ar-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ar",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ar-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ar",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-K-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=K",
+        "--M=2",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-K-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "open-shell"
+      ],
+      "args": [
+        "--Z=K",
+        "--M=2",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Ca-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ca",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Ca-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ca",
+        "--M=1",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Cr-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "open-shell",
+        "slow",
+        "held-out"
+      ],
+      "args": [
+        "--Z=Cr",
+        "--M=7",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ],
+      "_why": "HELD OUT pending the OOO convergence issue: spin-restricted Cr puts fractional occupations across the degenerate d shell and ran 7042s / 128 iterations without converging. Spin-restricted Fe behaves the same way (oscillates over 0.1 Eh). Both are good tests of the fractional-occupation path once it converges reliably. The convergence guard already refuses to record a value for this, so it fails loudly rather than silently."
+    },
+    {
+      "name": "atomic-Cr-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "open-shell",
+        "slow"
+      ],
+      "args": [
+        "--Z=Cr",
+        "--M=7",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Zn-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "slow"
+      ],
+      "args": [
+        "--Z=Zn",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Zn-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "slow"
+      ],
+      "args": [
+        "--Z=Zn",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Kr-lda-r",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "slow"
+      ],
+      "args": [
+        "--Z=Kr",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "atomic-Kr-lda-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "slow"
+      ],
+      "args": [
+        "--Z=Kr",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-O-3P-p0-hf",
+      "code": "atomic",
+      "tags": [
+        "configuration",
+        "open-shell",
+        "hf",
+        "ci"
+      ],
+      "_why": "hole in p0 (M_L = +0)",
+      "args": [
+        "--Z=O",
+        "--M=3",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--symmetry=1",
+        "--readocc=1"
+      ],
+      "input_files": {
+        "occs.dat": "3 3 0\n1 0 1\n1 0 -1\n"
+      }
+    },
+    {
+      "name": "atomic-O-3P-pplus-hf",
+      "code": "atomic",
+      "tags": [
+        "configuration",
+        "open-shell",
+        "hf",
+        "ci"
+      ],
+      "_why": "hole in p+ (M_L = -1)",
+      "args": [
+        "--Z=O",
+        "--M=3",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--symmetry=1",
+        "--readocc=1"
+      ],
+      "input_files": {
+        "occs.dat": "3 2 0\n1 1 1\n1 0 -1\n"
+      }
+    },
+    {
+      "name": "atomic-O-3P-pminus-hf",
+      "code": "atomic",
+      "tags": [
+        "configuration",
+        "open-shell",
+        "hf",
+        "ci"
+      ],
+      "_why": "hole in p- (M_L = +1)",
+      "args": [
+        "--Z=O",
+        "--M=3",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--symmetry=1",
+        "--readocc=1"
+      ],
+      "input_files": {
+        "occs.dat": "3 2 0\n1 0 1\n1 1 -1\n"
+      }
+    },
+    {
+      "name": "atomic-O-3P-p0-gga",
+      "code": "atomic",
+      "tags": [
+        "configuration",
+        "open-shell",
+        "gga"
+      ],
+      "_why": "hole in p0 (M_L = +0)",
+      "args": [
+        "--Z=O",
+        "--M=3",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--symmetry=1",
+        "--readocc=1"
+      ],
+      "input_files": {
+        "occs.dat": "3 3 0\n1 0 1\n1 0 -1\n"
+      }
+    },
+    {
+      "name": "atomic-O-3P-pplus-gga",
+      "code": "atomic",
+      "tags": [
+        "configuration",
+        "open-shell",
+        "gga"
+      ],
+      "_why": "hole in p+ (M_L = -1)",
+      "args": [
+        "--Z=O",
+        "--M=3",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--symmetry=1",
+        "--readocc=1"
+      ],
+      "input_files": {
+        "occs.dat": "3 2 0\n1 1 1\n1 0 -1\n"
+      }
+    },
+    {
+      "name": "atomic-O-3P-pminus-gga",
+      "code": "atomic",
+      "tags": [
+        "configuration",
+        "open-shell",
+        "gga"
+      ],
+      "_why": "hole in p- (M_L = +1)",
+      "args": [
+        "--Z=O",
+        "--M=3",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--symmetry=1",
+        "--readocc=1"
+      ],
+      "input_files": {
+        "occs.dat": "3 2 0\n1 0 1\n1 1 -1\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Ez-pos",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--symmetry=1",
+        "--readocc=1",
+        "--Ez=0.001"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Ez-neg",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--symmetry=1",
+        "--readocc=1",
+        "--Ez=-0.001"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Bz-pos",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--symmetry=1",
+        "--readocc=1",
+        "--Bz=0.05"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Bz-neg",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF",
+        "--symmetry=1",
+        "--readocc=1",
+        "--Bz=-0.05"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "diatomic-H2-hf-r",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "hf",
+        "diatomic",
+        "ci"
+      ],
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=HF",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "diatomic-H2-hf-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "diatomic",
+        "ci"
+      ],
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "diatomic-H2-lda-r",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "diatomic"
+      ],
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "diatomic-H2-lda-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "diatomic"
+      ],
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "diatomic-BeH-hf-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "diatomic",
+        "open-shell"
+      ],
+      "args": [
+        "--Z1=4",
+        "--Z2=1",
+        "--Rbond=2.538",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=12",
+        "--nela=3",
+        "--nelb=2",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "diatomic-BeH-lda-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "diatomic",
+        "open-shell"
+      ],
+      "args": [
+        "--Z1=4",
+        "--Z2=1",
+        "--Rbond=2.538",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=12",
+        "--nela=3",
+        "--nelb=2",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "diatomic-NH-hf-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "diatomic",
+        "open-shell",
+        "slow"
+      ],
+      "args": [
+        "--Z1=7",
+        "--Z2=1",
+        "--Rbond=1.958",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=5",
+        "--nelb=3",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "diatomic-NH-lda-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "diatomic",
+        "open-shell",
+        "slow"
+      ],
+      "args": [
+        "--Z1=7",
+        "--Z2=1",
+        "--Rbond=1.958",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=5",
+        "--nelb=3",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "diatomic-N2-hf-r",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "hf",
+        "diatomic",
+        "slow"
+      ],
+      "args": [
+        "--Z1=7",
+        "--Z2=7",
+        "--Rbond=2.07",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=7",
+        "--nelb=7",
+        "--method=HF",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "diatomic-N2-hf-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "hf",
+        "diatomic",
+        "slow"
+      ],
+      "args": [
+        "--Z1=7",
+        "--Z2=7",
+        "--Rbond=2.07",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=7",
+        "--nelb=7",
+        "--method=HF",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "diatomic-N2-lda-r",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "diatomic",
+        "slow"
+      ],
+      "args": [
+        "--Z1=7",
+        "--Z2=7",
+        "--Rbond=2.07",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=7",
+        "--nelb=7",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1"
+      ]
+    },
+    {
+      "name": "diatomic-N2-lda-u",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "lda",
+        "diatomic",
+        "slow"
+      ],
+      "args": [
+        "--Z1=7",
+        "--Z2=7",
+        "--Rbond=2.07",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=7",
+        "--nelb=7",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-Be-nop-l0",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "gga",
+        "consistency",
+        "ci"
+      ],
+      "_why": "no p orbitals in the basis at all",
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe"
+      ]
+    },
+    {
+      "name": "atomic-Be-nop-pinned",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "gga",
+        "consistency",
+        "frozen-occupations",
+        "ci"
+      ],
+      "_why": "p orbitals present in the basis but unoccupied by construction",
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=gga_x_pbe",
+        "--symmetry=2",
+        "--readocc=1"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0 0\n"
+      }
+    },
+    {
+      "name": "diatomic-H2-purem-on",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "diatomic",
+        "consistency",
+        "ci"
+      ],
+      "_why": "cylindrical-symmetry fast path (analytic phi)",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=lda_x-lda_c_vwn",
+        "--purem=1"
+      ]
+    },
+    {
+      "name": "diatomic-H2-purem-off",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "diatomic",
+        "consistency",
+        "ci"
+      ],
+      "_why": "general path, explicit phi quadrature",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=lda_x-lda_c_vwn",
+        "--purem=0"
+      ]
+    },
+    {
+      "name": "atomic-H-rsh-erfc-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "open-shell",
+        "rsh-erfc",
+        "range-separated",
+        "ci"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_cam_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "atomic-H-rsh-yukawa-u",
+      "code": "atomic",
+      "tags": [
+        "polarized",
+        "open-shell",
+        "rsh-yukawa",
+        "range-separated",
+        "ci"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=hyb_gga_xc_camy_b3lyp",
+        "--restricted=0"
+      ]
+    },
+    {
+      "name": "gensap-H-hf",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=H",
+        "--M=2",
+        "--lmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "gensap-He-hf",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "hf",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "gensap-He-lda",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=He",
+        "--M=1",
+        "--lmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "gensap-Be-lda",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "gensap-N-hf",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "hf"
+      ],
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "gensap-Ne-lda",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ne",
+        "--M=1",
+        "--lmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "gensap-P-lda",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda"
+      ],
+      "args": [
+        "--Z=P",
+        "--M=4",
+        "--lmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "gensap-Ar-lda",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda"
+      ],
+      "args": [
+        "--Z=Ar",
+        "--M=1",
+        "--lmax=1",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "gensap-Cr-lda",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda",
+        "slow"
+      ],
+      "args": [
+        "--Z=Cr",
+        "--M=7",
+        "--lmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "gensap-Zn-lda",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda",
+        "slow"
+      ],
+      "args": [
+        "--Z=Zn",
+        "--M=1",
+        "--lmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "aij-Al-jellium",
+      "code": "aij",
+      "tags": [
+        "jellium",
+        "lda"
+      ],
+      "args": [
+        "--Z=Al",
+        "--M=2",
+        "--nelem=5",
+        "--nnodes=10",
+        "--method=lda_x",
+        "--njellium=6",
+        "--rs=2.07"
+      ]
+    },
+    {
+      "name": "aij-Al-njellium0",
+      "code": "aij",
+      "tags": [
+        "jellium",
+        "lda",
+        "consistency"
+      ],
+      "_why": "no jellium electrons: must reduce to the bare atom",
+      "args": [
+        "--Z=Al",
+        "--M=2",
+        "--nelem=5",
+        "--nnodes=10",
+        "--njellium=0",
+        "--rs=2.07",
+        "--method=lda_x"
+      ]
+    },
+    {
+      "name": "gensap-Al-lda_x",
+      "code": "gensap",
+      "tags": [
+        "spherical",
+        "lda",
+        "consistency"
+      ],
+      "_why": "bare Al, the limit aij must reproduce at njellium=0",
+      "args": [
+        "--Z=Al",
+        "--M=2",
+        "--lmax=2",
+        "--nelem=5",
+        "--nnodes=10",
+        "--method=lda_x"
+      ]
+    },
+    {
+      "name": "diatomic-He-dummy-hf",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "hf",
+        "diatomic",
+        "cross-code",
+        "ci"
+      ],
+      "_why": "He solved in prolate spheroidal coordinates with a zero-charge dummy centre; must reproduce the atomic solver",
+      "args": [
+        "--Z1=2",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=6",
+        "--nela=1",
+        "--nelb=1",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "diatomic-H2-purem-gga-on",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "gga",
+        "diatomic",
+        "consistency"
+      ],
+      "_why": "cylindrical-symmetry fast path (analytic phi)",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--purem=1"
+      ]
+    },
+    {
+      "name": "diatomic-H2-purem-gga-off",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "gga",
+        "diatomic",
+        "consistency",
+        "slow"
+      ],
+      "_why": "general path, explicit phi quadrature",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--purem=0"
+      ]
+    },
+    {
+      "name": "diatomic-H2-purem-mgga-on",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "mgga",
+        "diatomic",
+        "consistency"
+      ],
+      "_why": "cylindrical-symmetry fast path (analytic phi)",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--purem=1"
+      ]
+    },
+    {
+      "name": "diatomic-H2-purem-mgga-off",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "mgga",
+        "diatomic",
+        "consistency",
+        "slow"
+      ],
+      "_why": "general path, explicit phi quadrature",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=mgga_x_tpss-mgga_c_tpss",
+        "--purem=0"
+      ]
+    },
+    {
+      "name": "diatomic-H-dummy-hf",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hf"
+      ],
+      "_why": "H through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=1",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=0",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "diatomic-H-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda"
+      ],
+      "_why": "H through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=1",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=0",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-H-dummy-gga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "gga"
+      ],
+      "_why": "H through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=1",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=0",
+        "--method=gga_x_pbe-gga_c_pbe"
+      ]
+    },
+    {
+      "name": "diatomic-H-dummy-mgga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "mgga"
+      ],
+      "_why": "H through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=1",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=0",
+        "--method=mgga_x_tpss-mgga_c_tpss"
+      ]
+    },
+    {
+      "name": "diatomic-H-dummy-hybrid",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hybrid"
+      ],
+      "_why": "H through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=1",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=0",
+        "--method=hyb_gga_xc_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-H-dummy-rsh-erfc",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-erfc"
+      ],
+      "_why": "H through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=1",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=0",
+        "--method=hyb_gga_xc_cam_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-H-dummy-rsh-yukawa",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-yukawa"
+      ],
+      "_why": "H through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=1",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=0",
+        "--method=hyb_gga_xc_camy_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-He-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda"
+      ],
+      "_why": "He through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=2",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=6",
+        "--nela=1",
+        "--nelb=1",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-He-dummy-gga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "gga"
+      ],
+      "_why": "He through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=2",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=6",
+        "--nela=1",
+        "--nelb=1",
+        "--method=gga_x_pbe-gga_c_pbe"
+      ]
+    },
+    {
+      "name": "diatomic-He-dummy-mgga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "mgga"
+      ],
+      "_why": "He through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=2",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=6",
+        "--nela=1",
+        "--nelb=1",
+        "--method=mgga_x_tpss-mgga_c_tpss"
+      ]
+    },
+    {
+      "name": "diatomic-He-dummy-hybrid",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hybrid"
+      ],
+      "_why": "He through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=2",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=6",
+        "--nela=1",
+        "--nelb=1",
+        "--method=hyb_gga_xc_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-He-dummy-rsh-erfc",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-erfc"
+      ],
+      "_why": "He through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=2",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=6",
+        "--nela=1",
+        "--nelb=1",
+        "--method=hyb_gga_xc_cam_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-He-dummy-rsh-yukawa",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-yukawa"
+      ],
+      "_why": "He through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=2",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=6",
+        "--nela=1",
+        "--nelb=1",
+        "--method=hyb_gga_xc_camy_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-Be-dummy-hf",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hf"
+      ],
+      "_why": "Be through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=4",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=8",
+        "--nela=2",
+        "--nelb=2",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "diatomic-Be-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda"
+      ],
+      "_why": "Be through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=4",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=8",
+        "--nela=2",
+        "--nelb=2",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-Be-dummy-gga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "gga"
+      ],
+      "_why": "Be through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=4",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=8",
+        "--nela=2",
+        "--nelb=2",
+        "--method=gga_x_pbe-gga_c_pbe"
+      ]
+    },
+    {
+      "name": "diatomic-Be-dummy-mgga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "mgga"
+      ],
+      "_why": "Be through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=4",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=8",
+        "--nela=2",
+        "--nelb=2",
+        "--method=mgga_x_tpss-mgga_c_tpss"
+      ]
+    },
+    {
+      "name": "diatomic-Be-dummy-hybrid",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hybrid"
+      ],
+      "_why": "Be through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=4",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=8",
+        "--nela=2",
+        "--nelb=2",
+        "--method=hyb_gga_xc_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-Be-dummy-rsh-erfc",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-erfc"
+      ],
+      "_why": "Be through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=4",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=8",
+        "--nela=2",
+        "--nelb=2",
+        "--method=hyb_gga_xc_cam_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-Be-dummy-rsh-yukawa",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-yukawa"
+      ],
+      "_why": "Be through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=4",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=8",
+        "--nela=2",
+        "--nelb=2",
+        "--method=hyb_gga_xc_camy_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-N-dummy-hf",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hf"
+      ],
+      "_why": "N through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=7",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=11,9",
+        "--nela=5",
+        "--nelb=2",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "diatomic-N-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda"
+      ],
+      "_why": "N through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=7",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=11,9",
+        "--nela=5",
+        "--nelb=2",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-N-dummy-gga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "gga"
+      ],
+      "_why": "N through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=7",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=11,9",
+        "--nela=5",
+        "--nelb=2",
+        "--method=gga_x_pbe-gga_c_pbe"
+      ]
+    },
+    {
+      "name": "diatomic-N-dummy-mgga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "mgga"
+      ],
+      "_why": "N through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=7",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=11,9",
+        "--nela=5",
+        "--nelb=2",
+        "--method=mgga_x_tpss-mgga_c_tpss"
+      ]
+    },
+    {
+      "name": "diatomic-N-dummy-hybrid",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hybrid"
+      ],
+      "_why": "N through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=7",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=11,9",
+        "--nela=5",
+        "--nelb=2",
+        "--method=hyb_gga_xc_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-N-dummy-rsh-erfc",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-erfc"
+      ],
+      "_why": "N through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=7",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=11,9",
+        "--nela=5",
+        "--nelb=2",
+        "--method=hyb_gga_xc_cam_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-N-dummy-rsh-yukawa",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-yukawa"
+      ],
+      "_why": "N through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=7",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=11,9",
+        "--nela=5",
+        "--nelb=2",
+        "--method=hyb_gga_xc_camy_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-hf",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hf"
+      ],
+      "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda"
+      ],
+      "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-gga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "gga"
+      ],
+      "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=gga_x_pbe-gga_c_pbe"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-mgga",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "mgga"
+      ],
+      "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=mgga_x_tpss-mgga_c_tpss"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-hybrid",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "hybrid"
+      ],
+      "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=hyb_gga_xc_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-rsh-erfc",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-erfc"
+      ],
+      "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=hyb_gga_xc_cam_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-rsh-yukawa",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "rsh-yukawa"
+      ],
+      "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=hyb_gga_xc_camy_b3lyp"
+      ]
+    },
+    {
+      "name": "diatomic-Na-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "Na through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=11",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=6",
+        "--nelb=5",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-Mg-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "Mg through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=12",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=6",
+        "--nelb=6",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-P-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "P through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=15",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=15,11",
+        "--nela=9",
+        "--nelb=6",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-Ar-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "Ar through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=18",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=17,13",
+        "--nela=9",
+        "--nelb=9",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-K-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "K through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=19",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=17,13",
+        "--nela=10",
+        "--nelb=9",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "diatomic-Ca-dummy-lda",
+      "code": "diatomic",
+      "tags": [
+        "cross-code",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "Ca through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
+      "args": [
+        "--Z1=20",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=17,13",
+        "--nela=10",
+        "--nelb=10",
+        "--method=lda_x-lda_c_vwn"
+      ]
+    },
+    {
+      "name": "atomic-Be-field-Ez-lda-pos",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=lda_x-lda_c_vwn",
+        "--Ez=0.001"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Ez-lda-neg",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=lda_x-lda_c_vwn",
+        "--Ez=-0.001"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Bz-lda-pos",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=lda_x-lda_c_vwn",
+        "--Bz=0.05"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Bz-lda-neg",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "lda",
+        "ci"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=lda_x-lda_c_vwn",
+        "--Bz=-0.05"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Ez-gga-pos",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "gga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--Ez=0.001"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Ez-gga-neg",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "gga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--Ez=-0.001"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Bz-gga-pos",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "gga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--Bz=0.05"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "atomic-Be-field-Bz-gga-neg",
+      "code": "atomic",
+      "tags": [
+        "field",
+        "frozen-occupations",
+        "gga"
+      ],
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=2",
+        "--mmax=2",
+        "--nelem=5",
+        "--nnodes=15",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--Bz=-0.05"
+      ],
+      "input_files": {
+        "occs.dat": "2 2 0\n"
+      }
+    },
+    {
+      "name": "diatomic-CH-piplus-hf",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "open-shell",
+        "configuration",
+        "diatomic",
+        "hf",
+        "slow"
+      ],
+      "_why": "CH 2-Pi with the single pi electron pinned to m=+1",
+      "args": [
+        "--Z1=6",
+        "--Z2=1",
+        "--Rbond=2.116",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=4",
+        "--nelb=3",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=HF"
+      ],
+      "input_files": {
+        "occs.dat": "3 3 0\n1 0 1\n0 0 -1\n"
+      }
+    },
+    {
+      "name": "diatomic-CH-piminus-hf",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "open-shell",
+        "configuration",
+        "diatomic",
+        "hf",
+        "slow"
+      ],
+      "_why": "CH 2-Pi with the single pi electron pinned to m=-1",
+      "args": [
+        "--Z1=6",
+        "--Z2=1",
+        "--Rbond=2.116",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=4",
+        "--nelb=3",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=HF"
+      ],
+      "input_files": {
+        "occs.dat": "3 3 0\n0 0 1\n1 0 -1\n"
+      }
+    },
+    {
+      "name": "diatomic-CH-piplus-lda",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "open-shell",
+        "configuration",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "CH 2-Pi with the single pi electron pinned to m=+1",
+      "args": [
+        "--Z1=6",
+        "--Z2=1",
+        "--Rbond=2.116",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=4",
+        "--nelb=3",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=lda_x-lda_c_vwn"
+      ],
+      "input_files": {
+        "occs.dat": "3 3 0\n1 0 1\n0 0 -1\n"
+      }
+    },
+    {
+      "name": "diatomic-CH-piminus-lda",
+      "code": "diatomic",
+      "tags": [
+        "polarized",
+        "open-shell",
+        "configuration",
+        "diatomic",
+        "lda",
+        "slow"
+      ],
+      "_why": "CH 2-Pi with the single pi electron pinned to m=-1",
+      "args": [
+        "--Z1=6",
+        "--Z2=1",
+        "--Rbond=2.116",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,11",
+        "--nela=4",
+        "--nelb=3",
+        "--symmetry=1",
+        "--readocc=1",
+        "--method=lda_x-lda_c_vwn"
+      ],
+      "input_files": {
+        "occs.dat": "3 3 0\n0 0 1\n1 0 -1\n"
+      }
+    }
+  ],
+  "_invariants_comment": [
+    "Pairs of cases that must agree with EACH OTHER regardless of any",
+    "reference values. These catch whole classes of bug without needing a",
+    "known-good historical build, and they stay valid even when the",
+    "reference values legitimately change."
+  ],
+  "invariants": [
+    {
+      "name": "He-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-He-lda-r",
+        "atomic-He-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "Be-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-Be-lda-r",
+        "atomic-Be-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "Ne-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-Ne-lda-r",
+        "atomic-Ne-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "Mg-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-Mg-lda-r",
+        "atomic-Mg-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "Ar-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-Ar-lda-r",
+        "atomic-Ar-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "Ca-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-Ca-lda-r",
+        "atomic-Ca-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "Zn-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-Zn-lda-r",
+        "atomic-Zn-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "Kr-restricted-equals-polarized",
+      "_why": "closed shell: the polarized solution must collapse onto the restricted one",
+      "cases": [
+        "atomic-Kr-lda-r",
+        "atomic-Kr-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-07
+    },
+    {
+      "name": "O-3P-pplus-equals-pminus-hf",
+      "_why": "+m and -m holes are related by reflection: exactly degenerate. Measured -74.8146025595 (HF) for both, to all printed digits; the p0 component sits 2.94 mEh away.",
+      "cases": [
+        "atomic-O-3P-pplus-hf",
+        "atomic-O-3P-pminus-hf"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "O-3P-pplus-equals-pminus-gga",
+      "_why": "+m and -m holes are related by reflection: exactly degenerate. Measured -74.8146025595 (HF) for both, to all printed digits; the p0 component sits 2.94 mEh away.",
+      "cases": [
+        "atomic-O-3P-pplus-gga",
+        "atomic-O-3P-pminus-gga"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "Be-field-Ez-sign-degeneracy",
+      "_why": "an atom in a uniform electric field is reflection symmetric, so +field and -field must be EXACTLY degenerate",
+      "cases": [
+        "atomic-Be-field-Ez-pos",
+        "atomic-Be-field-Ez-neg"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "Be-field-Bz-sign-degeneracy",
+      "_why": "with m-symmetric occupations the Zeeman term cancels under B -> -B, so +field and -field must be EXACTLY degenerate",
+      "cases": [
+        "atomic-Be-field-Bz-pos",
+        "atomic-Be-field-Bz-neg"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "Be-unoccupied-p-does-not-contribute",
+      "_why": "an angular momentum present in the basis but unoccupied must not change the energy: lmax=0 and pinned-lmax=2 must agree. Measured -14.5450377121 for both, bit-for-bit. Catches the p basis leaking into the density.",
+      "cases": [
+        "atomic-Be-nop-l0",
+        "atomic-Be-nop-pinned"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "H2-purem-fast-path-equals-general-path",
+      "_why": "the pure-m path is an exact restriction, not an approximation: with a cylindrically symmetric density only M=0 survives, so dropping the phi quadrature changes nothing. Measured identical at every SCF iteration, -1.1374807779 both ways, at 4.74s vs 68.87s (14.5x). This guards the fast path against silently diverging from the general one.",
+      "cases": [
+        "diatomic-H2-purem-on",
+        "diatomic-H2-purem-off"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "gensap-equals-atomic-H-hf",
+      "_why": "H is half-filled/single-s, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-H-hf",
+        "atomic-H-hf-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-He-hf",
+      "_why": "He is closed shell, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-He-hf",
+        "atomic-He-hf-r"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-He-lda",
+      "_why": "He is closed shell, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-He-lda",
+        "atomic-He-lda-r"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-Be-lda",
+      "_why": "Be is closed shell, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-Be-lda",
+        "atomic-Be-lda-r"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-N-hf",
+      "_why": "N is half-filled/single-s, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-N-hf",
+        "atomic-N-hf-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-Ne-lda",
+      "_why": "Ne is closed shell, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-Ne-lda",
+        "atomic-Ne-lda-r"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-P-lda",
+      "_why": "P is half-filled/single-s, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-P-lda",
+        "atomic-P-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-Ar-lda",
+      "_why": "Ar is closed shell, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-Ar-lda",
+        "atomic-Ar-lda-r"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-Cr-lda",
+      "_why": "Cr is half-filled/single-s, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-Cr-lda",
+        "atomic-Cr-lda-u"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-equals-atomic-Zn-lda",
+      "_why": "Zn is closed shell, so its density is spherically symmetric and the spherical average sadatom solves is exact, not an approximation: the two codes solve the same problem. Cross-code check with no reference values.",
+      "cases": [
+        "gensap-Zn-lda",
+        "atomic-Zn-lda-r"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "aij-njellium0-equals-bare-atom",
+      "_why": "with no jellium electrons the atom-in-jellium problem IS the bare atom, so aij must reproduce the plain spherical solver exactly. Measured -240.3560448251 from both, to all printed digits. Ties the jellium machinery to the plain solvers at the one point where the two must coincide, with no reference values involved. (gensap carries an unoccupied d shell that aij does not; that it changes nothing is the same fact as the Be unoccupied-p invariant.)",
+      "cases": [
+        "aij-Al-njellium0",
+        "gensap-Al-lda_x"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-with-dummy-equals-atomic-He",
+      "_why": "a zero-charge centre adds no physics, so the diatomic code must reproduce the atomic one. Unlike gensap-equals-atomic this is convergence-limited rather than an identity -- the two use entirely different bases (prolate spheroidal vs radial x spherical harmonics) -- but with a cbasis-derived grid the agreement is sub-nanohartree: -2.8616799948 against -2.8616799946, and the tighter bases on each side converge to within 2e-10. Exercises the prolate spheroidal machinery -- Legendre expansion, off-centre nuclear attraction, the 2D basis -- against a known atomic answer.",
+      "cases": [
+        "diatomic-He-dummy-hf",
+        "atomic-He-hf-r"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "H2-purem-equals-general-gga",
+      "_why": "the pure-m path is an exact restriction: with a cylindrically symmetric density only M=0 survives, so dropping the phi quadrature changes nothing. Measured -1.1666914700 for both paths, speedup 91.6x (733s vs 8s). The general path is exercised by no other test and by no default run (purem is auto-on whenever symmetry>=1), so without this a divergence could persist indefinitely.",
+      "cases": [
+        "diatomic-H2-purem-gga-on",
+        "diatomic-H2-purem-gga-off"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "H2-purem-equals-general-mgga",
+      "_why": "the pure-m path is an exact restriction: with a cylindrically symmetric density only M=0 survives, so dropping the phi quadrature changes nothing. Measured -1.1804586903 for both paths, speedup 139x (3477s vs 25s). The general path is exercised by no other test and by no default run (purem is auto-on whenever symmetry>=1), so without this a divergence could persist indefinitely.",
+      "cases": [
+        "diatomic-H2-purem-mgga-on",
+        "diatomic-H2-purem-mgga-off"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-H-hf",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-H-dummy-hf",
+        "atomic-H-hf-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-H-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-H-dummy-lda",
+        "atomic-H-lda-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-H-gga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-H-dummy-gga",
+        "atomic-H-gga-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-H-mgga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-H-dummy-mgga",
+        "atomic-H-mgga-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-H-hybrid",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-H-dummy-hybrid",
+        "atomic-H-hybrid-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-H-rsh-erfc",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-H-dummy-rsh-erfc",
+        "atomic-H-rsh-erfc-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-H-rsh-yukawa",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-H-dummy-rsh-yukawa",
+        "atomic-H-rsh-yukawa-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-He-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-He-dummy-lda",
+        "atomic-He-lda-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-He-gga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-He-dummy-gga",
+        "atomic-He-gga-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-He-mgga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-He-dummy-mgga",
+        "atomic-He-mgga-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-He-hybrid",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-He-dummy-hybrid",
+        "atomic-He-hybrid-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-He-rsh-erfc",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-He-dummy-rsh-erfc",
+        "atomic-He-rsh-erfc-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-He-rsh-yukawa",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-He-dummy-rsh-yukawa",
+        "atomic-He-rsh-yukawa-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Be-hf",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Be-dummy-hf",
+        "atomic-Be-hf-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Be-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Be-dummy-lda",
+        "atomic-Be-lda-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Be-gga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Be-dummy-gga",
+        "atomic-Be-gga-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Be-mgga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Be-dummy-mgga",
+        "atomic-Be-mgga-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Be-hybrid",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Be-dummy-hybrid",
+        "atomic-Be-hybrid-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Be-rsh-erfc",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Be-dummy-rsh-erfc",
+        "atomic-Be-rsh-erfc-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Be-rsh-yukawa",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Be-dummy-rsh-yukawa",
+        "atomic-Be-rsh-yukawa-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-N-hf",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-N-dummy-hf",
+        "atomic-N-hf-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-N-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-N-dummy-lda",
+        "atomic-N-lda-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-N-gga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-N-dummy-gga",
+        "atomic-N-gga-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-N-mgga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-N-dummy-mgga",
+        "atomic-N-mgga-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-N-hybrid",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-N-dummy-hybrid",
+        "atomic-N-hybrid-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-N-rsh-erfc",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-N-dummy-rsh-erfc",
+        "atomic-N-rsh-erfc-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-N-rsh-yukawa",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-N-dummy-rsh-yukawa",
+        "atomic-N-rsh-yukawa-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ne-hf",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ne-dummy-hf",
+        "atomic-Ne-hf-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ne-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ne-dummy-lda",
+        "atomic-Ne-lda-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ne-gga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ne-dummy-gga",
+        "atomic-Ne-gga-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ne-mgga",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ne-dummy-mgga",
+        "atomic-Ne-mgga-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ne-hybrid",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ne-dummy-hybrid",
+        "atomic-Ne-hybrid-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ne-rsh-erfc",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ne-dummy-rsh-erfc",
+        "atomic-Ne-rsh-erfc-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ne-rsh-yukawa",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ne-dummy-rsh-yukawa",
+        "atomic-Ne-rsh-yukawa-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Na-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Na-dummy-lda",
+        "atomic-Na-lda-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Mg-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Mg-dummy-lda",
+        "atomic-Mg-lda-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-P-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-P-dummy-lda",
+        "atomic-P-lda-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ar-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ar-dummy-lda",
+        "atomic-Ar-lda-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-K-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-K-dummy-lda",
+        "atomic-K-lda-u"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-dummy-equals-atomic-Ca-lda",
+      "_why": "a zero-charge centre adds no physics: the diatomic code must reproduce the atomic one. Convergence-limited rather than an identity (prolate spheroidal vs radial x spherical harmonics), but sub-nanohartree with cbasis-derived grids.",
+      "cases": [
+        "diatomic-Ca-dummy-lda",
+        "atomic-Ca-lda-r"
+      ],
+      "field": "total",
+      "relative_tolerance": 1e-09,
+      "tolerance": 1e-08
+    },
+    {
+      "name": "Be-field-Ez-sign-degeneracy-lda",
+      "_why": "degeneracy on the DFT path, which is where it can actually break: the XC energy is a numerical quadrature, so a grid not symmetric under z -> -z would break the degeneracy here and nowhere else. At HF the exchange is analytic and the symmetry holds by construction.",
+      "cases": [
+        "atomic-Be-field-Ez-lda-pos",
+        "atomic-Be-field-Ez-lda-neg"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "Be-field-Bz-sign-degeneracy-lda",
+      "_why": "degeneracy on the DFT path, which is where it can actually break: the XC energy is a numerical quadrature, so a grid not symmetric under m -> -m would break the degeneracy here and nowhere else. At HF the exchange is analytic and the symmetry holds by construction.",
+      "cases": [
+        "atomic-Be-field-Bz-lda-pos",
+        "atomic-Be-field-Bz-lda-neg"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "Be-field-Ez-sign-degeneracy-gga",
+      "_why": "degeneracy on the DFT path, which is where it can actually break: the XC energy is a numerical quadrature, so a grid not symmetric under z -> -z would break the degeneracy here and nowhere else. At HF the exchange is analytic and the symmetry holds by construction.",
+      "cases": [
+        "atomic-Be-field-Ez-gga-pos",
+        "atomic-Be-field-Ez-gga-neg"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "Be-field-Bz-sign-degeneracy-gga",
+      "_why": "degeneracy on the DFT path, which is where it can actually break: the XC energy is a numerical quadrature, so a grid not symmetric under m -> -m would break the degeneracy here and nowhere else. At HF the exchange is analytic and the symmetry holds by construction.",
+      "cases": [
+        "atomic-Be-field-Bz-gga-pos",
+        "atomic-Be-field-Bz-gga-neg"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "CH-pi-plus-equals-minus-hf",
+      "_why": "pi+ and pi- are related by reflection, so they must be EXACTLY degenerate -- the molecular analogue of the O 3P p+/p- check. The HF variant is the one that can actually break: the XC energy is a numerical quadrature, so a grid not symmetric under m -> -m would break the degeneracy there and nowhere else.",
+      "cases": [
+        "diatomic-CH-piplus-hf",
+        "diatomic-CH-piminus-hf"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "CH-pi-plus-equals-minus-lda",
+      "_why": "pi+ and pi- are related by reflection, so they must be EXACTLY degenerate -- the molecular analogue of the O 3P p+/p- check. The DFT variant is the one that can actually break: the XC energy is a numerical quadrature, so a grid not symmetric under m -> -m would break the degeneracy there and nowhere else.",
+      "cases": [
+        "diatomic-CH-piplus-lda",
+        "diatomic-CH-piminus-lda"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    }
+  ]
+}

--- a/tests/refs/ci.json
+++ b/tests/refs/ci.json
@@ -1,0 +1,625 @@
+{
+  "cases": {
+    "atomic-Be-field-Bz-lda-neg": {
+      "Coulomb": 7.1236031772,
+      "Emfield": 0.0034916086,
+      "Exx": 0.0,
+      "XC": -2.5165534052,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 49.0,
+      "err": 1.64,
+      "kinetic": 14.3162834274,
+      "nel_err": 1.64e-12,
+      "nuclear": -33.3705175647,
+      "total": -14.4436927567
+    },
+    "atomic-Be-field-Bz-lda-pos": {
+      "Coulomb": 7.1236031772,
+      "Emfield": 0.0034916086,
+      "Exx": 0.0,
+      "XC": -2.5165534052,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 38.6,
+      "err": 1.64,
+      "kinetic": 14.3162834274,
+      "nel_err": 1.64e-12,
+      "nuclear": -33.3705175647,
+      "total": -14.4436927567
+    },
+    "atomic-Be-field-Bz-neg": {
+      "Coulomb": 7.164623518,
+      "Emfield": 0.003557543,
+      "Exx": -2.668576655,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 58.9,
+      "err": 1.54,
+      "kinetic": 14.5801109583,
+      "nel_err": 1.54e-12,
+      "nuclear": -33.6491561075,
+      "total": -14.5694407432
+    },
+    "atomic-Be-field-Bz-pos": {
+      "Coulomb": 7.164623518,
+      "Emfield": 0.003557543,
+      "Exx": -2.668576655,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 43.6,
+      "err": 1.54,
+      "kinetic": 14.5801109583,
+      "nel_err": 1.54e-12,
+      "nuclear": -33.6491561075,
+      "total": -14.5694407432
+    },
+    "atomic-Be-field-Ez-lda-neg": {
+      "Coulomb": 7.1151876026,
+      "Eefield": -4.37998e-05,
+      "Exx": 0.0,
+      "XC": -2.5148464009,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 65.3,
+      "err": 1.092,
+      "kinetic": 14.3093883724,
+      "nel_err": 1.092e-13,
+      "nuclear": -33.3569171489,
+      "total": -14.4472313745
+    },
+    "atomic-Be-field-Ez-lda-pos": {
+      "Coulomb": 7.1151876026,
+      "Eefield": -4.37998e-05,
+      "Exx": 0.0,
+      "XC": -2.5148464009,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 49.6,
+      "err": -7.55,
+      "kinetic": 14.3093883724,
+      "nel_err": -7.55e-15,
+      "nuclear": -33.3569171489,
+      "total": -14.4472313745
+    },
+    "atomic-Be-field-Ez-neg": {
+      "Coulomb": 7.1559722328,
+      "Eefield": -4.56495e-05,
+      "Exx": -2.6669019072,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 40.8,
+      "err": 1.013,
+      "kinetic": 14.5729543307,
+      "nel_err": 1.013e-13,
+      "nuclear": -33.635024985,
+      "total": -14.5730459781
+    },
+    "atomic-Be-field-Ez-pos": {
+      "Coulomb": 7.1559722328,
+      "Eefield": -4.56495e-05,
+      "Exx": -2.6669019072,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym2": "2 2"
+      },
+      "_seconds": 54.0,
+      "err": -2.22,
+      "kinetic": 14.5729543307,
+      "nel_err": -2.22e-15,
+      "nuclear": -33.635024985,
+      "total": -14.5730459781
+    },
+    "atomic-Be-hf-r": {
+      "Coulomb": 7.1560551636,
+      "Exx": -2.6669131299,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym0": "2 2"
+      },
+      "_seconds": 1.9,
+      "err": 3.375,
+      "kinetic": 14.573021084,
+      "nel_err": 3.375e-14,
+      "nuclear": -33.635186286,
+      "total": -14.5730231683
+    },
+    "atomic-Be-hf-u": {
+      "Coulomb": 7.1560551653,
+      "Exx": -2.6669131302,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "a:sym0": "1 1",
+        "b:sym0": "1 1"
+      },
+      "_seconds": 2.4,
+      "err": 1.51,
+      "kinetic": 14.5730210854,
+      "nel_err": 1.51e-14,
+      "nuclear": -33.6351862889,
+      "total": -14.5730231683
+    },
+    "atomic-Be-lda-r": {
+      "Coulomb": 7.1152581977,
+      "Exx": 0.0,
+      "XC": -2.5148562583,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym0": "2 2"
+      },
+      "_seconds": 2.4,
+      "err": 4.619,
+      "kinetic": 14.3094241396,
+      "nel_err": 4.619e-14,
+      "nuclear": -33.3570355531,
+      "total": -14.447209474
+    },
+    "atomic-Be-lda-u": {
+      "Coulomb": 7.1152685733,
+      "Exx": 0.0,
+      "XC": -2.5148587143,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "a:sym0": "1 1",
+        "b:sym0": "1 1"
+      },
+      "_seconds": 3.3,
+      "err": 1.954,
+      "kinetic": 14.309443242,
+      "nel_err": 1.954e-14,
+      "nuclear": -33.3570625751,
+      "total": -14.447209474
+    },
+    "atomic-Be-nop-l0": {
+      "Coulomb": 7.1401519313,
+      "Exx": 0.0,
+      "XC": -2.6275187903,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym0": "2 2"
+      },
+      "_seconds": 13.1,
+      "err": -3.153,
+      "kinetic": 14.5450415485,
+      "nel_err": -3.153e-14,
+      "nuclear": -33.6027137607,
+      "total": -14.5450390711
+    },
+    "atomic-Be-nop-pinned": {
+      "Coulomb": 7.1401519326,
+      "Exx": 0.0,
+      "XC": -2.6275187903,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym0": "2 2"
+      },
+      "_seconds": 134.2,
+      "err": -6.395,
+      "kinetic": 14.5450415466,
+      "nel_err": -6.395e-14,
+      "nuclear": -33.60271376,
+      "total": -14.5450390711
+    },
+    "atomic-H-hf-u": {
+      "Coulomb": 0.3125005143,
+      "Exx": -0.3125005143,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "a:sym0": "1"
+      },
+      "_seconds": 5.3,
+      "err": -8.327,
+      "kinetic": 0.5000011599,
+      "nel_err": -8.327e-15,
+      "nuclear": -1.0000011599,
+      "total": -0.5
+    },
+    "atomic-H-rsh-erfc-u": {
+      "Coulomb": 0.3063089886,
+      "Exx": -0.1296361279,
+      "XC": -0.1762331016,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "a:sym0": "1"
+      },
+      "_seconds": 35.5,
+      "err": 7.55,
+      "kinetic": 0.4912939436,
+      "nel_err": 7.55e-15,
+      "nuclear": -0.9908285421,
+      "total": -0.4990948394
+    },
+    "atomic-H-rsh-yukawa-u": {
+      "Coulomb": 0.3070325881,
+      "Exx": -0.1140776767,
+      "XC": -0.1914795646,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "a:sym0": "1"
+      },
+      "_seconds": 18.1,
+      "err": 1.155,
+      "kinetic": 0.4935914377,
+      "nel_err": 1.155e-14,
+      "nuclear": -0.993139398,
+      "total": -0.4980726135
+    },
+    "atomic-He-gga-r": {
+      "Coulomb": 2.0267367125,
+      "Exx": 0.0,
+      "XC": -1.0461619634,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 15.5,
+      "err": -3.775,
+      "kinetic": 2.8559461443,
+      "nel_err": -3.775e-15,
+      "nuclear": -6.7294557603,
+      "total": -2.8929348668
+    },
+    "atomic-He-gga-u": {
+      "Coulomb": 2.0267367139,
+      "Exx": 0.0,
+      "XC": -1.0461619641,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "a:sym0": "1",
+        "b:sym0": "1"
+      },
+      "_seconds": 12.9,
+      "err": 6.661,
+      "kinetic": 2.8559461477,
+      "nel_err": 6.661e-15,
+      "nuclear": -6.7294557643,
+      "total": -2.8929348668
+    },
+    "atomic-He-hf-r": {
+      "Coulomb": 2.0515380305,
+      "Exx": -1.0257690153,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 4.8,
+      "err": 4.441,
+      "kinetic": 2.8616803763,
+      "nel_err": 4.441e-16,
+      "nuclear": -6.7491293871,
+      "total": -2.8616799956
+    },
+    "atomic-He-hf-u": {
+      "Coulomb": 2.0515380298,
+      "Exx": -1.0257690149,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "a:sym0": "1",
+        "b:sym0": "1"
+      },
+      "_seconds": 3.4,
+      "err": -1.243,
+      "kinetic": 2.8616803751,
+      "nel_err": -1.243e-14,
+      "nuclear": -6.7491293856,
+      "total": -2.8616799956
+    },
+    "atomic-He-hybrid-r": {
+      "Coulomb": 2.0345562319,
+      "Exx": -0.2034556232,
+      "XC": -0.8684887933,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 15.0,
+      "err": 1.776,
+      "kinetic": 2.8691329288,
+      "nel_err": 1.776e-15,
+      "nuclear": -6.7469634071,
+      "total": -2.9152186629
+    },
+    "atomic-He-hybrid-u": {
+      "Coulomb": 2.0345562602,
+      "Exx": -0.203455626,
+      "XC": -0.8684888043,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "a:sym0": "1",
+        "b:sym0": "1"
+      },
+      "_seconds": 13.4,
+      "err": -4.885,
+      "kinetic": 2.8691329969,
+      "nel_err": -4.885e-15,
+      "nuclear": -6.7469634896,
+      "total": -2.9152186629
+    },
+    "atomic-He-lda-r": {
+      "Coulomb": 1.9961216725,
+      "Exx": 0.0,
+      "XC": -0.9733148392,
+      "_converged": true,
+      "_iterations": 4,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 3.0,
+      "err": 5.773,
+      "kinetic": 2.7679270868,
+      "nel_err": 5.773e-15,
+      "nuclear": -6.6255695442,
+      "total": -2.8348356241
+    },
+    "atomic-He-lda-u": {
+      "Coulomb": 1.9961217016,
+      "Exx": 0.0,
+      "XC": -0.9733148521,
+      "_converged": true,
+      "_iterations": 4,
+      "_occupations": {
+        "a:sym0": "1",
+        "b:sym0": "1"
+      },
+      "_seconds": 3.2,
+      "err": 1.243,
+      "kinetic": 2.7679271551,
+      "nel_err": 1.243e-14,
+      "nuclear": -6.6255696286,
+      "total": -2.8348356241
+    },
+    "atomic-He-mgga-r": {
+      "Coulomb": 2.0455707136,
+      "Exx": 0.0,
+      "XC": -1.0712420321,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 23.1,
+      "err": -5.551,
+      "kinetic": 2.8717487477,
+      "nel_err": -5.551e-15,
+      "nuclear": -6.7557412901,
+      "total": -2.9096638609
+    },
+    "atomic-He-mgga-u": {
+      "Coulomb": 2.0455773353,
+      "Exx": 0.0,
+      "XC": -1.0712453027,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "a:sym0": "1",
+        "b:sym0": "1"
+      },
+      "_seconds": 15.8,
+      "err": -1.91,
+      "kinetic": 2.8717639073,
+      "nel_err": -1.91e-14,
+      "nuclear": -6.7557598008,
+      "total": -2.9096638609
+    },
+    "atomic-O-3P-p0-hf": {
+      "Coulomb": 36.6463097487,
+      "Exx": -8.2081190083,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 9,
+      "_occupations": {
+        "a:sym0": "1",
+        "a:sym1": "1 1 1",
+        "a:sym2": "1",
+        "b:sym1": "1 1 1"
+      },
+      "_seconds": 15.6,
+      "err": 1.36,
+      "kinetic": 74.814047262,
+      "nel_err": 1.36e-09,
+      "nuclear": -178.0662882453,
+      "total": -74.8140502429
+    },
+    "atomic-O-3P-pminus-hf": {
+      "Coulomb": 36.6287477649,
+      "Exx": -8.1896987893,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 8,
+      "_occupations": {
+        "a:sym0": "1",
+        "a:sym1": "1 1 1",
+        "a:sym2": "1",
+        "b:sym0": "1",
+        "b:sym1": "1 1"
+      },
+      "_seconds": 26.8,
+      "err": -6.799,
+      "kinetic": 74.8137262559,
+      "nel_err": -6.799e-10,
+      "nuclear": -178.0665098203,
+      "total": -74.8137345888
+    },
+    "atomic-O-3P-pplus-hf": {
+      "Coulomb": 36.6287477649,
+      "Exx": -8.1896987893,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 8,
+      "_occupations": {
+        "a:sym0": "1",
+        "a:sym1": "1 1 1",
+        "a:sym2": "1",
+        "b:sym1": "1 1",
+        "b:sym2": "1"
+      },
+      "_seconds": 27.4,
+      "err": -6.799,
+      "kinetic": 74.8137262559,
+      "nel_err": -6.799e-10,
+      "nuclear": -178.0665098203,
+      "total": -74.8137345888
+    },
+    "diatomic-H2-hf-r": {
+      "Coulomb": 1.317196921,
+      "Enucr": 0.7142857143,
+      "Exx": -0.6585984605,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 10.8,
+      "err": -5.584,
+      "kinetic": 1.1260831695,
+      "nel_err": -5.584e-13,
+      "nuclear": -3.6325969144,
+      "total": -1.1336295702
+    },
+    "diatomic-H2-hf-u": {
+      "Coulomb": 1.3171969177,
+      "Enucr": 0.7142857143,
+      "Exx": -0.6585984589,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 6,
+      "_occupations": {
+        "a:sym0": "1",
+        "b:sym0": "1"
+      },
+      "_seconds": 13.0,
+      "err": -5.604,
+      "kinetic": 1.1260831646,
+      "nel_err": -5.604e-13,
+      "nuclear": -3.6325969079,
+      "total": -1.1336295702
+    },
+    "diatomic-H2-purem-off": {
+      "Coulomb": 1.2971230265,
+      "Enucr": 0.7142857143,
+      "Exx": 0.0,
+      "XC": -0.653152335,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 85.9,
+      "err": -3.348,
+      "kinetic": 1.1077032321,
+      "nel_err": -3.348e-13,
+      "nuclear": -3.6034404158,
+      "total": -1.1374807779
+    },
+    "diatomic-H2-purem-on": {
+      "Coulomb": 1.2971230265,
+      "Enucr": 0.7142857143,
+      "Exx": 0.0,
+      "XC": -0.653152335,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 7.6,
+      "err": -3.446,
+      "kinetic": 1.1077032321,
+      "nel_err": -3.446e-13,
+      "nuclear": -3.6034404159,
+      "total": -1.1374807779
+    },
+    "diatomic-He-dummy-hf": {
+      "Coulomb": 2.051537231,
+      "Enucr": 0.0,
+      "Exx": -1.0257686155,
+      "XC": 0.0,
+      "_converged": true,
+      "_iterations": 5,
+      "_occupations": {
+        "sym0": "2"
+      },
+      "_seconds": 14.3,
+      "err": 1.235,
+      "kinetic": 2.8616798345,
+      "nel_err": 1.235e-13,
+      "nuclear": -6.7491284448,
+      "total": -2.8616799948
+    },
+    "gensap-H-hf": {
+      "_converged": true,
+      "_format": "total-only",
+      "_iterations": 6,
+      "_seconds": 1.4,
+      "total": -0.5
+    },
+    "gensap-He-hf": {
+      "_converged": true,
+      "_format": "total-only",
+      "_iterations": 6,
+      "_seconds": 2.3,
+      "total": -2.8616799956
+    },
+    "gensap-He-lda": {
+      "_converged": true,
+      "_format": "total-only",
+      "_iterations": 4,
+      "_seconds": 1.1,
+      "total": -2.8348356241
+    }
+  },
+  "metadata": {
+    "bindir": "/home/work/HelFEM/objdir/src",
+    "date": "2026-08-05 19:28:25",
+    "flexiblas": "FlexiBLAS, version 3.5.0",
+    "git_commit": "65b2ed48c08abe04bad99161dbd857dd1e2d62bf",
+    "git_describe": "65b2ed4 tests: extend the pure-m equivalence to GGA and mGGA",
+    "omp_num_threads": "6"
+  }
+}

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Integration test driver for HelFEM.
+
+Two modes:
+
+    run_tests.py --generate refs/current.json     # run everything, record results
+    run_tests.py --check    refs/current.json     # run everything, compare
+
+The point of separating them is the cross-version workflow: generate a
+reference set with a known-good build, then check a newer build against it.
+
+    git checkout <old>; cmake --build ...; tests/run_tests.py --generate refs/pre-eigen.json
+    git checkout master; cmake --build ...; tests/run_tests.py --check    refs/pre-eigen.json
+
+What is compared
+----------------
+Not just the total energy. The drivers print a full decomposition
+
+    kinetic ... nuclear ... Coulomb ... XC ... Exx ... total ... (nel err ...)
+
+and every component is recorded, so a failure says *which* part moved: a
+drifting XC with a stable kinetic points at the DFT grid, a drifting kinetic
+points at the basis, and a drifting `nel err` points at the quadrature.
+
+Converged occupations are recorded too. Systems with near-degenerate
+solutions can converge to a *different state* rather than to a wrong number
+(see task #45), and an occupation change is a qualitatively different failure
+from a numerical drift -- the runner reports it as such instead of just
+printing a large delta.
+
+Determinism
+-----------
+Every case runs at OMP_NUM_THREADS=1. Converged energies are a deterministic
+function of the thread count, so it is part of the reference. The recorded
+metadata also captures the git commit and the BLAS backend, because both can
+move a result without any source change.
+"""
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import subprocess
+import tempfile
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# "kinetic -12.34 nuclear -1.2 ... total -14.5 (nel err 1.0e-12)".
+# Field names vary between codes and are conditional on the run (Enucr,
+# Eefield, Emfield, Econf appear only when nonzero), so scrape pairs rather
+# than matching a fixed layout.
+PAIR_RE = re.compile(r"([A-Za-z_]+)\s+(-?\d+\.\d+)")
+NELERR_RE = re.compile(r"nel err\s+(-?[\d.]+e[-+]\d+)")
+OCC_RE = re.compile(r"^([ab]:sym\d+|sym\d+) occupations:\s*(.*)$")
+
+# Builds from before the Eigen migration print a labelled block instead of the
+# one-line decomposition. Supporting both dialects is what makes a cross-era
+# reference comparison possible at all; the field names are normalised to the
+# modern short forms so the two are directly comparable.
+LEGACY_RE = re.compile(r"^([A-Za-z][A-Za-z \-]*?)\s+energy:\s*(-?\d+\.\d+)\s*$")
+# gensap and aij print no decomposition at all, only a converged total.
+CONVERGED_RE = re.compile(r"Converged to energy\s+(-?\d+\.\d+)")
+
+# OpenOrbitalOptimizer prints this on success, so it is a universal marker for
+# every current driver. A run killed by a timeout still prints per-iteration
+# energies, and a late SCF iterate is close enough to a converged one to slip
+# through any sane tolerance -- so a truncated run can silently become a
+# reference that then "passes" forever while asserting nothing. Require the
+# marker. Pre-Eigen builds predate OOO and never print it, so the requirement
+# is skipped for the legacy output format.
+
+LEGACY_FIELDS = {
+    "Kinetic": "kinetic",
+    "Nuclear attraction": "nuclear",
+    "Nuclear repulsion": "Enucr",
+    "Coulomb": "Coulomb",
+    "Exact exchange": "Exx",
+    "Exchange-correlation": "XC",
+    "Total": "total",
+}
+
+
+def load_cases(path):
+    with open(path) as f:
+        spec = json.load(f)
+    return spec
+
+
+def parse_output(text):
+    """Extract the energy decomposition and the converged occupations."""
+    energy_line = None
+    for line in text.splitlines():
+        if "total" in line and "kinetic" in line:
+            energy_line = line  # keep the last one
+    result = {}
+    if energy_line is not None:
+        for name, value in PAIR_RE.findall(energy_line):
+            result[name] = float(value)
+        m = NELERR_RE.search(energy_line)
+        if m:
+            result["nel_err"] = float(m.group(1))
+    else:
+        # Pre-Eigen dialect: a labelled block near the end of the run.
+        for line in text.splitlines():
+            m = LEGACY_RE.match(line.strip())
+            if m:
+                label = " ".join(m.group(1).split())
+                if label in LEGACY_FIELDS:
+                    result[LEGACY_FIELDS[label]] = float(m.group(2))
+        if result:
+            result["_format"] = "legacy"
+        else:
+            # gensap / aij: total only.
+            m = None
+            for line in text.splitlines():
+                mm = CONVERGED_RE.search(line)
+                if mm:
+                    m = mm
+            if m:
+                result["total"] = float(m.group(1))
+                result["_format"] = "total-only"
+
+    # Occupations are printed once per SCF iteration; keep the final block.
+    occs, block = {}, {}
+    for line in text.splitlines():
+        m = OCC_RE.match(line.strip())
+        if m:
+            key, val = m.group(1), " ".join(m.group(2).split())
+            if key in block:      # a new block started
+                occs, block = block, {}
+            block[key] = val
+    if block:
+        occs = block
+    if occs:
+        result["_occupations"] = occs
+
+    iters = text.count("Iteration ")
+    if iters:
+        result["_iterations"] = iters
+    result["_converged"] = bool(CONVERGED_RE.search(text))
+    return result
+
+
+def run_case(case, defaults, bindir, timeout_override=None):
+    # Absolute: each case runs in its own temp cwd, so a relative binary path
+    # would be resolved against that directory rather than against ours.
+    binary = os.path.abspath(os.path.join(bindir, case["code"]))
+    if not os.path.exists(binary):
+        return {"_error": "binary not found: %s" % binary}
+
+    env = dict(os.environ)
+    env.update(defaults.get("env", {}))
+    env.update(case.get("env", {}))
+
+    # Each case gets its own working directory. The drivers write checkpoint
+    # files (helfem.chk and friends) into the cwd under fixed names, so cases
+    # sharing a directory clobber each other's files -- which shows up as
+    # sporadic, method-dependent failures only when --jobs > 1.
+    t0 = time.time()
+    with tempfile.TemporaryDirectory(prefix="helfem-test-") as workdir:
+        # Cases that pin a configuration need an input file (occs.dat) next to
+        # the run. Writing it into the per-case directory keeps concurrent
+        # cases with different configurations from reading each other's.
+        for fname, content in case.get("input_files", {}).items():
+            with open(os.path.join(workdir, fname), "w") as fh:
+                fh.write(content)
+        try:
+            proc = subprocess.run(
+                [binary] + case["args"],
+                capture_output=True, text=True, env=env, cwd=workdir,
+                timeout=(timeout_override or case.get("timeout_s", defaults.get("timeout_s", 900))),
+            )
+        except subprocess.TimeoutExpired:
+            return {"_error": "timeout"}
+    elapsed = time.time() - t0
+
+    out = proc.stdout + proc.stderr
+    parsed = parse_output(out)
+    if "total" not in parsed:
+        tail = "\n".join(out.strip().splitlines()[-5:])
+        return {"_error": "no energy in output (exit %d)\n%s" % (proc.returncode, tail)}
+    if not parsed.get("_converged") and parsed.get("_format") != "legacy":
+        return {"_error": "did not converge (no 'Converged to energy' in output; "
+                          "ran %.0fs, %d iterations) -- refusing to record an "
+                          "unconverged energy as a reference"
+                          % (elapsed, parsed.get("_iterations", 0))}
+    parsed["_seconds"] = round(elapsed, 1)
+    if proc.returncode != 0:
+        parsed["_exit"] = proc.returncode
+    return parsed
+
+
+def metadata(bindir):
+    def sh(cmd):
+        try:
+            return subprocess.run(cmd, shell=True, capture_output=True, text=True,
+                                  cwd=HERE, timeout=20).stdout.strip()
+        except Exception:
+            return "?"
+    return {
+        "git_commit": sh("git rev-parse HEAD"),
+        "git_describe": sh("git log --oneline -1"),
+        "date": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "bindir": os.path.abspath(bindir),
+        "omp_num_threads": os.environ.get("OMP_NUM_THREADS", "(per-case default)"),
+        "flexiblas": sh("flexiblas print current 2>/dev/null | head -1") or "n/a",
+    }
+
+
+def select(cases, args):
+    out = []
+    for c in cases:
+        if args.filter and not re.search(args.filter, c["name"]):
+            continue
+        if args.tag and args.tag not in c.get("tags", []):
+            continue
+        if args.skip_slow and "slow" in c.get("tags", []):
+            continue
+        # Cases parked pending an upstream fix: they fail loudly rather than
+        # silently (the convergence guard refuses to record a value), but there
+        # is no point running them until the fix lands.
+        if "held-out" in c.get("tags", []) and not args.include_held_out:
+            continue
+        out.append(c)
+    return out
+
+
+def compare(name, ref, got, tol, ctol=None):
+    """Return a list of human-readable problems."""
+    problems = []
+    if "_error" in got:
+        return ["ERROR: %s" % got["_error"]]
+    if "_error" in ref:
+        return ["reference itself is an error entry; regenerate it"]
+
+    ref_occ = ref.get("_occupations")
+    got_occ = got.get("_occupations")
+    if ref_occ and got_occ and ref_occ != got_occ:
+        problems.append("OCCUPATIONS CHANGED (converged to a different state, "
+                        "not merely a different number)")
+        for k in sorted(set(ref_occ) | set(got_occ)):
+            if ref_occ.get(k) != got_occ.get(k):
+                problems.append("    %-12s ref %-16s got %s"
+                                % (k, ref_occ.get(k, "-"), got_occ.get(k, "-")))
+
+    # The total is the physically meaningful invariant and gets the tight
+    # tolerance. Individual components get a looser one because they are far
+    # more sensitive: near a stationary point the energy is quadratic in the
+    # density error while each component is linear, so two builds that stop at
+    # slightly different points inside the same convergence basin show
+    # component drift of O(delta) and total drift of O(delta^2). Measured
+    # across the Eigen+OOO rewrite: components moved up to 1.1e-4 while every
+    # total held to better than 1e-6. Component drift is worth seeing; on its
+    # own it is not a correctness failure.
+    comp_tol = ctol if ctol is not None else tol * 100.0
+    for field in ("kinetic", "nuclear", "Coulomb", "XC", "Exx", "Enucr"):
+        if field not in ref or field not in got:
+            continue
+        delta = got[field] - ref[field]
+        if abs(delta) > comp_tol:
+            problems.append("    %-8s ref %18.10f  got %18.10f  delta %+.3e"
+                            % (field, ref[field], got[field], delta))
+
+    if "total" in ref and "total" in got:
+        delta = got["total"] - ref["total"]
+        if abs(delta) > tol:
+            problems.append("    %-8s ref %18.10f  got %18.10f  delta %+.3e  <-- TOTAL"
+                            % ("total", ref["total"], got["total"], delta))
+        elif problems:
+            # Components moved but the total held: show it, since that is the
+            # difference between "converged elsewhere" and "computed wrongly".
+            problems.append("    (total agrees: %+.3e within %.1e -- component "
+                            "drift only)" % (delta, tol))
+    return problems
+
+
+def check_invariants(spec, results):
+    """Cases that must agree with each other, independent of any reference."""
+    failures = []
+    for inv in spec.get("invariants", []):
+        names = inv["cases"]
+        field = inv.get("field", "total")
+        tol = inv.get("tolerance", 1e-7)
+        vals = {}
+        for n in names:
+            r = results.get(n)
+            if r and field in r:
+                vals[n] = r[field]
+        if len(vals) < 2:
+            continue  # not enough cases were run to compare
+        lo, hi = min(vals.values()), max(vals.values())
+        # A relative bound is the right one whenever the quantities compared
+        # are converged to a relative accuracy rather than an absolute one --
+        # e.g. the atomic<->diatomic cross-checks, where the basis is converged
+        # by cbasis to a relative threshold. A flat absolute bound would pass
+        # He (-2.9 Eh) and fail N (-54 Eh) for no physical reason, and would be
+        # hopeless by Kr (-2750 Eh).
+        rel = inv.get("relative_tolerance")
+        if rel is not None:
+            scale = max(abs(lo), abs(hi), 1.0)
+            tol = rel * scale
+        if hi - lo > tol:
+            failures.append((inv["name"], inv.get("_why", ""), vals, hi - lo, tol))
+    return failures
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--generate", metavar="FILE", help="run cases and write references")
+    mode.add_argument("--check", metavar="FILE", help="run cases and compare to references")
+    mode.add_argument("--smoke", action="store_true",
+                      help="run cases and check invariants, without any reference "
+                           "file. Fails on a crash, a timeout, or an invariant "
+                           "violation. This is the portable check: invariants are "
+                           "symmetry identities that hold on any machine, whereas "
+                           "recorded energies depend on CPU and BLAS.")
+    p.add_argument("--cases", default=os.path.join(HERE, "cases.json"))
+    p.add_argument("--bindir", default=os.path.join(HERE, os.pardir, "objdir", "src"))
+    p.add_argument("--filter", help="regex on case name")
+    p.add_argument("--tag", help="only cases carrying this tag")
+    p.add_argument("--skip-slow", action="store_true")
+    p.add_argument("--include-held-out", action="store_true",
+                   help="also run cases parked pending an upstream fix")
+    p.add_argument("--timeout", type=float,
+                   help="per-case timeout in seconds, overriding the case and "
+                        "default values; needed for slow historical builds")
+    p.add_argument("--jobs", "-j", type=int, default=max(1, (os.cpu_count() or 2) - 2),
+                   help="cases to run concurrently; each case is single-threaded, "
+                        "so this does not affect any result")
+    p.add_argument("--tolerance", type=float,
+                   help="tolerance on the TOTAL energy (the correctness criterion)")
+    p.add_argument("--component-tolerance", type=float,
+                   help="tolerance on individual energy components; defaults to "
+                        "100x --tolerance, since components drift faster than the "
+                        "total between builds that converge to slightly different points")
+    args = p.parse_args()
+
+    spec = load_cases(args.cases)
+    defaults = spec.get("defaults", {})
+    cases = select(spec["cases"], args)
+    if not cases:
+        sys.exit("no cases selected")
+
+    ref_data = {}
+    if args.smoke:
+        args.generate = None
+    if args.check:
+        with open(args.check) as f:
+            ref_data = json.load(f)
+
+    print("Running %d case(s) from %s" % (len(cases), os.path.basename(args.cases)))
+    print("Binaries: %s\n" % os.path.abspath(args.bindir))
+
+    # Each case is pinned to one thread, so cases parallelise cleanly across
+    # cores without perturbing any result. Output is collected and printed in
+    # case order so a run is diffable regardless of completion order.
+    results, failed, errored = {}, [], []
+    if args.jobs > 1:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+            futures = {pool.submit(run_case, c, defaults, args.bindir, args.timeout): c["name"]
+                       for c in cases}
+            done = 0
+            for fut in concurrent.futures.as_completed(futures):
+                done += 1
+                sys.stderr.write("\r  [%d/%d] finished  " % (done, len(cases)))
+                sys.stderr.flush()
+            sys.stderr.write("\r" + " " * 40 + "\r")
+            results = {futures[f]: f.result() for f in futures}
+
+    for case in cases:
+        name = case["name"]
+        sys.stdout.write("  %-32s " % name)
+        sys.stdout.flush()
+        got = results.get(name) if args.jobs > 1 else run_case(case, defaults, args.bindir, args.timeout)
+        results[name] = got
+
+        if "_error" in got:
+            print("ERROR  (%s)" % got["_error"].splitlines()[0])
+            errored.append(name)
+            continue
+
+        if args.generate or args.smoke:
+            print("%18.10f  (%.0fs)" % (got["total"], got.get("_seconds", 0)))
+            continue
+
+        ref = ref_data.get("cases", {}).get(name)
+        if ref is None:
+            print("%18.10f  NO REFERENCE" % got["total"])
+            continue
+        tol = args.tolerance or case.get("tolerance", defaults.get("tolerance", 1e-8))
+        problems = compare(name, ref, got, tol, args.component_tolerance)
+        if problems:
+            print("FAIL")
+            for line in problems:
+                print("      " + line)
+            failed.append(name)
+        else:
+            print("ok   %18.10f" % got["total"])
+
+    inv_failures = check_invariants(spec, results)
+    if inv_failures:
+        print("\nInvariant violations:")
+        for iname, why, vals, spread, tol in inv_failures:
+            print("  %s  (spread %.3e > tol %.1e)" % (iname, spread, tol))
+            if why:
+                print("    %s" % why)
+            for n, v in sorted(vals.items()):
+                print("      %-32s %18.10f" % (n, v))
+
+    if args.smoke:
+        ok = not errored and not inv_failures
+        print("\n%d ran, %d errored, %d invariant violation(s)"
+              % (len(results) - len(errored), len(errored), len(inv_failures)))
+        return 0 if ok else 1
+
+    if args.generate:
+        payload = {"metadata": metadata(args.bindir), "cases": results}
+        os.makedirs(os.path.dirname(os.path.abspath(args.generate)), exist_ok=True)
+        with open(args.generate, "w") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+            f.write("\n")
+        print("\nWrote %d reference(s) to %s" % (len(results), args.generate))
+        if errored:
+            print("WARNING: %d case(s) errored and were recorded as errors: %s"
+                  % (len(errored), ", ".join(errored)))
+        return 1 if errored else 0
+
+    print("\n%d passed, %d failed, %d errored, %d invariant violation(s)"
+          % (len(results) - len(failed) - len(errored), len(failed),
+             len(errored), len(inv_failures)))
+    if ref_data.get("metadata"):
+        m = ref_data["metadata"]
+        print("Reference from %s (%s)" % (m.get("git_describe", "?"), m.get("date", "?")))
+    return 1 if (failed or errored or inv_failures) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
There has been no automated check that the codes still compute what they used
to. Between the Eigen migration, the OpenOrbitalOptimizer adoption and the
optimization passes since, that is a great deal of rewriting resting on
spot-checks.

**177 cases over four drivers — `atomic`, `diatomic`, `gensap`, `aij` — and 74
invariants**, plus CI. `tests/cases.json` is data; `tests/run_tests.py` is
independent of it, so the case list can be edited freely.

    tests/run_tests.py --generate refs/mine.json   # record what this build does
    tests/run_tests.py --check    refs/mine.json   # compare against a recorded set
    tests/run_tests.py --smoke                     # invariants only, no references

## Coverage

- **Elements**: H, He, Be, N, Ne, Na, Mg, P, Ar, K, Ca, Cr, Zn, Kr, each
  spin-restricted and spin-polarized. All are closed-shell, single-s-electron
  or half-filled, hence spherically symmetric with no orbital-occupation
  ambiguity — which is what makes them usable as references at all.
- **Methods**: HF, LDA, GGA, τ-dependent mGGA, hybrids, and range-separated
  hybrids in both flavours (CAM-B3LYP for erfc, CAMY-B3LYP for Yukawa).
- **Molecules**: H2, BeH, NH, N2, CH, with grids from `diatomic_cbasis`.
- **Configuration-dependent**: the three M_L components of O ³P, CH's π
  degeneracy, and finite Ez/Bz fields, all with occupations frozen.

## Everything is at the CBS limit

HelFEM exists to produce basis-set-limit numbers, so a suite pinned at an
arbitrary small basis would exercise a regime the code is not for, would miss
faults in exactly the auto-convergence machinery and high-L integrals that
recent work has touched, and would leave every reference physically
meaningless.

For atoms this factorises: the orbitals are L² eigenfunctions, so
`lmax = max occupied l` is *exact* rather than truncated (Ne at lmax = 1, 2, 3
agrees to 3e-10), leaving only the radial grid to converge. `nelem=5,
nnodes=15` reproduces the nelem = 10/15/20 limit exactly. Minimal lmax is also
*cheaper* — Ne/LDA went from ~150 s at lmax=2 to 12 s at lmax=1.

## Invariants: the half that cannot be fooled by a bad reference

A reference records what the code currently does, so one taken from broken
code enshrines the breakage. The 74 invariants instead assert things known
independently of any build:

| count | invariant |
|-------|-----------|
| 40 | diatomic with a zero-charge dummy centre == atomic |
| 10 | `gensap` == `atomic` |
| 8 | closed shell: restricted == polarized |
| 6 | E(+field) == E(−field) |
| 4 | configuration degeneracy (O ³P p±, CH π±) |
| 3 | pure-m fast path == general path |
| 1 | unoccupied angular momentum does not contribute |
| 1 | `aij` at njellium=0 == the bare atom |

The cross-code ones are the strongest: for these spherically symmetric systems
the spherical average `gensap` solves is exact, so the two codes *must* agree —
measured identical to ten digits (Ne −128.2334812692, Cr −1042.2183480375).

The pure-m equivalence guards a fast path worth **14.5× at LDA, 91.6× at GGA
and 139× at mGGA**, auto-enabled whenever `symmetry>=1` and therefore
exercised by no test and no default run.

Degeneracy checks exist at DFT as well as HF, which is the half that can
actually break: at HF the exchange is analytic so the symmetry holds by
construction, whereas the XC energy is a numerical quadrature.

## What the harness records

- **The full decomposition**, not just the total, so the component that moved
  localises the fault. The total carries the tight tolerance; components get a
  looser one, since near a stationary point the energy is quadratic in the
  density error while each component is linear.
- **Converged occupations**, as a distinct failure class: converging to a
  different state is not the same bug as converging to a wrong number.
- **Convergence itself.** A timed-out run still prints late iterates that sit
  inside any sane tolerance, so a truncated run could silently become a
  reference that passes forever while asserting nothing — observed once, at
  1e-10 from the true value.
- **Thread count, git commit and BLAS backend.** Converged energies are a
  deterministic function of `OMP_NUM_THREADS` (atomic O/PBE: −74.7827460224 at
  2 threads, −74.7707877743 at 6, each bit-reproducible), so every case runs
  single-threaded.

References are portable: every case is well behaved with the configuration
pinned where ambiguous, so the converged energy is a property of the problem
rather than of the linear algebra. Verified by running the CI tier under
FlexiBLAS with NETLIB against references generated under OpenBLAS — 26 passed,
0 failed.

## CI

`ci.yml` on every push and PR runs the 38 `ci`-tagged cases in ~4.5 min at
-j4, still covering both spin modes, every functional rung, a pinned
configuration, a field, a diatomic and both cross-code invariant families.
`weekly.yml` runs the whole suite on Sundays, including the heavy elements and
the general-path pure-m comparisons that take an hour apiece.

## Deliberate omissions

- **Laplacian-dependent meta-GGAs** are numerically unstable and diverge, so
  they cannot serve as stable references; `increment_mgga_lapl` is
  consequently untested.
- **Spin-restricted Cr** is parked behind a `held-out` tag: it puts fractional
  occupations across a degenerate d shell and ran 7042 s / 128 iterations
  without converging, as does spin-restricted Fe. Both are good tests of that
  machinery once the solver settles.
- **The Cr/Zn/Kr dummy-centre diatomic** cross-checks are dropped — they need
  a δ channel on top of a large lmax and exceed 900 s. Those elements remain
  in the atomic suite, where minimal-lmax CBS makes them cheap.