### PR TITLE
diatomic_cbasis: memoize evaluations and converge one direction at a time

### DIFF
--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -24,12 +24,65 @@
 #include "twodquadrature.h"
 #include "../general/eigen_io.h"
 #include <cfloat>
+#include <map>
 
 using namespace helfem;
+
+namespace {
+  // The convergence search re-tests the same basis many times. Two reasons.
+  //
+  // The outer threshold loop restarts the whole search at each threshold, but
+  // dEa and dEr for a given basis do not depend on the threshold -- only the
+  // acceptance bound does. So the trial pair rejected at 1e-k is rebuilt and
+  // rediagonalised, to the same numbers, at 1e-(k+1), and again at every
+  // threshold after that.
+  //
+  // And each channel re-evaluates its current basis as an "initial estimate"
+  // at every threshold, though that energy was already computed when the basis
+  // was accepted.
+  //
+  // Everything the basis depends on except Nelem and lmmax is fixed for the
+  // run (nuclear charges, geometry, quadrature, grid, fields, model
+  // potential), and norb only selects how many eigenvalues to sum. So the
+  // eigenvalues are a pure function of (Nelem, lmmax) and can be memoized.
+  struct EvalKey {
+    int Nelem;
+    std::vector<int> lmmax;
+    bool operator<(const EvalKey & o) const {
+      if(Nelem != o.Nelem) return Nelem < o.Nelem;
+      return lmmax < o.lmmax;
+    }
+  };
+  struct EvalValue {
+    helfem::Vector Ev;
+    Eigen::Index nang, nrad;
+  };
+  std::map<EvalKey, EvalValue> eval_cache;
+  size_t eval_hits = 0, eval_misses = 0;
+}
 
 void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::shared_ptr<const polynomial_basis::PolynomialBasis> &poly, int Nquad, int Nelem, double Rmax, const Eigen::VectorXi & lmmax, int igrid, double zexp, double Ez, double Qzz, double Bz, int norb, double & E, Eigen::Index & nang, Eigen::Index & nrad, helfem::Vector & Eval, int imodel) {
 
   int symm=1;
+
+  // Memoized on (Nelem, lmmax): see the note above eval_cache.
+  EvalKey key;
+  key.Nelem = Nelem;
+  key.lmmax.assign(lmmax.data(), lmmax.data() + lmmax.size());
+  {
+    auto it = eval_cache.find(key);
+    if(it != eval_cache.end()) {
+      ++eval_hits;
+      const helfem::Vector & Ev = it->second.Ev;
+      int nuse = std::min((int) Ev.size(), norb);
+      Eval = Ev.head(nuse);
+      E = Ev.head(nuse).sum();
+      nang = it->second.nang;
+      nrad = it->second.nrad;
+      return;
+    }
+  }
+  ++eval_misses;
 
   double Rhalf=0.5*Rbond;
   double mumax(utils::arcosh(Rmax/Rhalf));
@@ -103,11 +156,18 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
   scf::eig_gsym_sub(Ev, C, H0, Sinvh, dsym);
 
   // Sanity check
+  nang=basis.Nang();
+  nrad=basis.Nrad();
+
+  EvalValue val;
+  val.Ev = Ev;
+  val.nang = nang;
+  val.nrad = nrad;
+  eval_cache[key] = val;
+
   norb=std::min((int) Ev.size(),norb);
   Eval=Ev.head(norb);
   E=Ev.head(norb).sum();
-  nang=basis.Nang();
-  nrad=basis.Nrad();
 }
 
 int main(int argc, char **argv) {
@@ -300,6 +360,10 @@ int main(int argc, char **argv) {
       ithr++;
     }
   }
+
+  printf("Basis evaluations: %i built, %i served from cache (%.0f%% avoided).\n",
+         (int) eval_misses, (int) eval_hits,
+         100.0*eval_hits/std::max<size_t>(1,eval_hits+eval_misses));
 
   return 0;
 }

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -294,51 +294,65 @@ int main(int argc, char **argv) {
 
       printf("Initial energy is %e\n",E);
 
+      // Coordinate descent: exhaust the angular direction at fixed Nelem, then
+      // test the radial one once; if it helps, accept it and go round again.
+      //
+      // The previous structure tested BOTH directions at every step and took
+      // whichever helped more. That is a lot of wasted work, because the
+      // radial direction converges almost immediately and is then rejected
+      // over and over: 46 of 47 radial trials rejected for Ar, 70 of 72 for
+      // Kr. Each has a different lmmax, so each is a distinct basis that
+      // caching cannot help with -- and it is the expensive one of the pair,
+      // Nelem+nadd being a larger basis than the angular trial.
+      //
+      // The stopping condition is unchanged: the loop exits only when neither
+      // direction improves the energy by more than thr.
       int iiter=0;
-      double dE;
       while(true) {
-        iiter++;
+        // Angular, to exhaustion at the current Nelem.
+        while(true) {
+          iiter++;
+          double Ea;
+          helfem::Vector Eva;
+          Eigen::Index Nra, Naa;
+          Eigen::VectorXi lmtr(lmmax);
+          lmtr(m)+=nadd;
 
-        double Ea, Er;
-        helfem::Vector Eva, Evr;
-        Eigen::Index Nra, Naa;
-        Eigen::Index Nrr, Nar;
+          printf("m=%i iteration %i\n",(int) m,iiter);
+          eval(Z1, Z2, Rrms1, Rrms2, Rbond, poly, Nquad, Nelem, Rmax, lmtr, igrid, zexp, Ez, Qzz, Bz, norbs[m], Ea, Nra, Naa, Eva, imodel);
+          double dEa=Ea-E;
+          printf("Addition of %i partial waves decreases energy by %e\n",nadd,dEa);
+          if(dEa>-thr)
+            break;
 
-        Eigen::VectorXi lmtr(lmmax);
-        lmtr(m)+=nadd;
-
-        printf("m=%i iteration %i\n",(int) m,iiter);
-
-        eval(Z1, Z2, Rrms1, Rrms2, Rbond, poly, Nquad, Nelem, Rmax, lmtr, igrid, zexp, Ez, Qzz, Bz, norbs[m], Ea, Nra, Naa, Eva, imodel);
-        double dEa=Ea-E;
-        printf("Addition of %i partial waves decreases energy by %e\n",nadd,dEa);
-
-        eval(Z1, Z2, Rrms1, Rrms2, Rbond, poly, Nquad, Nelem+nadd, Rmax, lmmax, igrid, zexp, Ez, Qzz, Bz, norbs[m], Er, Nrr, Nar, Evr, imodel);
-        double dEr=Er-E;
-        printf("Addition of %i radial elements decreases energy by %e\n",nadd,dEr);
-
-        dE=std::min(dEa,dEr);
-        if(dE>-thr)
-          break;
-
-        // Angular loop is not converged
-        cvd=false;
-
-        if(dEa==dE) {
+          cvd=false;
           lmmax=lmtr;
           E=Ea;
           Eval=Eva;
           Nrad=Nra;
           Nang=Naa;
           printf("Basis set has now %i partial waves\n",(int) lmmax(m));
-        } else {
-          Nelem+=nadd;
-          E=Er;
-          Eval=Evr;
-          Nrad=Nrr;
-          Nang=Nar;
-          printf("Basis set has now %i radial elements\n",Nelem);
+          helfem::io::print_matrix("Current eigenvalues", helfem::Matrix(Eval.transpose()));
+          printf("\n");
         }
+
+        // Radial, once.
+        double Er;
+        helfem::Vector Evr;
+        Eigen::Index Nrr, Nar;
+        eval(Z1, Z2, Rrms1, Rrms2, Rbond, poly, Nquad, Nelem+nadd, Rmax, lmmax, igrid, zexp, Ez, Qzz, Bz, norbs[m], Er, Nrr, Nar, Evr, imodel);
+        double dEr=Er-E;
+        printf("Addition of %i radial elements decreases energy by %e\n",nadd,dEr);
+        if(dEr>-thr)
+          break;
+
+        cvd=false;
+        Nelem+=nadd;
+        E=Er;
+        Eval=Evr;
+        Nrad=Nrr;
+        Nang=Nar;
+        printf("Basis set has now %i radial elements\n",Nelem);
         helfem::io::print_matrix("Current eigenvalues", helfem::Matrix(Eval.transpose()));
         printf("\n");
       }


### PR DESCRIPTION
Generating a basis for a heavy atom had become slow enough to be the
bottleneck of a calculation, since cylindrical symmetry makes the HF/DFT steps
that follow comparatively fast. Two changes, both verified to leave the
resulting basis unchanged.

## Memoization

The search rebuilt and rediagonalised the same bases repeatedly.

The outer threshold loop restarts the whole search at each threshold, but
`dEa` and `dEr` for a given basis do not depend on the threshold — only the
acceptance bound does. So the trial pair rejected at 1e-k is recomputed, to
identical numbers, at 1e-(k+1) and at every threshold after. Each channel also
re-evaluates its current basis as an "initial estimate" at every threshold,
though that energy was computed when the basis was accepted.

Everything the basis depends on except `Nelem` and `lmmax` is fixed for the
run, and `norb` only selects how many eigenvalues to sum, so the eigenvalues
are a pure function of `(Nelem, lmmax)`. The full eigenvalue vector is cached
and any `norb` served from it. He avoids 77% of its evaluations (11 built, 36
served).

## Coordinate descent

The search tested *both* directions at every step and took whichever helped
more. The radial direction converges almost immediately and is then rejected
over and over — **46 of 47** radial trials rejected for Ar, **70 of 72** for
Kr. Each has a different `lmmax`, so each is a distinct basis that memoization
cannot help with, and it is the expensive one of the pair (`Nelem+nadd` is a
larger basis than the angular trial).

Now: exhaust the angular direction at fixed `Nelem`, then test radial once; if
it helps, accept and go round again. Radial trials drop to about one per
radial acceptance.

## Results

    Ar   651s  ->  151s (memoization)  ->  114s (both)

The stopping condition is unchanged — the loop exits only when neither
direction improves by more than the threshold — but the path differs, so the
resulting basis could in principle differ. Checked on all 14 atoms used to
derive the test-suite grids (H, He, Be, N, Ne, Na, Mg, P, Ar, K, Ca, Cr, Zn,
Kr, each with a zero-charge dummy centre at 1 bohr): **every one produces an
identical basis**, up to Kr at `nelem=5, lmax=24,18,16`.