### PR TITLE
gaunt: bound the m axis instead of assuming |m| <= l

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -606,10 +606,20 @@ namespace helfem {
           int lrval(std::max(Lmax+2,gmax));
           int midval(std::max(Lmax,5));
 
+          // |M| and |m| are bounded by the basis, not by L. Every M reaching
+          // the table is a difference mk-ml of two basis m values, and every m
+          // is a basis m or 0, so 2*max|m| covers both with margin. L, by
+          // contrast, runs up to lk+ll+2. Without this the triangular packing
+          // would size the m axes as if every |M|<=L occurred: for Cu2 at
+          // lmax=46,34,28 that is 61 GB rather than 322 MB.
+          const int mabs = std::max(std::abs(mval.maxCoeff()),
+                                    std::abs(mval.minCoeff()));
+          const int mcap = 2*mabs;
+
           Timer t;
           printf("Computing Gaunt coefficients ... ");
           fflush(stdout);
-          gaunt=gaunt::Gaunt(lrval,midval,lrval);
+          gaunt=gaunt::Gaunt(lrval,midval,lrval,mcap);
           printf("done (% .3f s)\n",t.get());
           fflush(stdout);
 
@@ -617,9 +627,11 @@ namespace helfem {
           // One-electron matrices need gmax,5,gmax
           int lrval(gmax);
           int midval(5);
-          int Mmax=mval.maxCoeff()-mval.minCoeff();
+          const int mabs = std::max(std::abs(mval.maxCoeff()),
+                                    std::abs(mval.minCoeff()));
+          const int mcap = 2*mabs;
 
-          gaunt=gaunt::Gaunt(lrval,midval,lrval);
+          gaunt=gaunt::Gaunt(lrval,midval,lrval,mcap);
         }
 
         // Cache the real->dummy index map once. pure_indices() rebuilds it on

--- a/src/general/gaunt.cpp
+++ b/src/general/gaunt.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 
 #include "gaunt.h"
+#include <sstream>
 #include "utils.h"
 #include "wignernj.hpp"
 
@@ -122,13 +123,25 @@ namespace helfem {
     template <typename T> static inline T sqrt_pi_by_3() { return std::sqrt(utils::pi<T>()/T(3)); }
 
     template <typename T>
-    GauntT<T>::GauntT(int Lmax_, int lmax_, int lpmax_)
+    GauntT<T>::GauntT(int Lmax_, int lmax_, int lpmax_, int mcap_)
       : Lmax(Lmax_), lmax(lmax_), lpmax(lpmax_) {
-      // (l, m) packs to l*(l+1) + m; range [0, (lmax+1)^2 - 1]. Same for (L, M).
-      // mp is implicit from the m-sum rule (mp = M - m), so we omit an mp axis.
+      // (L, M) packs to L*(2*mcap+1) + (M+mcap), and likewise (l, m). mp is
+      // implicit from the m-sum rule (mp = M - m), so there is no mp axis.
+      // Capping |M| and |m| is what keeps the table proportional to what a
+      // diatomic basis actually touches -- see the note on mcap in the header.
+      mcap = (mcap_ < 0) ? std::max(Lmax, lmax) : mcap_;
       lm_stride = static_cast<std::size_t>(lpmax) + 1;
-      Lm_stride = static_cast<std::size_t>(lmax + 1) * (lmax + 1) * lm_stride;
-      const std::size_t total = static_cast<std::size_t>(Lmax + 1) * (Lmax + 1) * Lm_stride;
+      Lm_stride = static_cast<std::size_t>(lmax + 1) * (2*mcap + 1) * lm_stride;
+      const std::size_t total = static_cast<std::size_t>(Lmax + 1) * (2*mcap + 1) * Lm_stride;
+      {
+        // Warn before allocating something that may not fit.
+        const double gb = double(total) * sizeof(T) / (1024.0*1024.0*1024.0);
+        if(gb > 1.0) {
+          printf("\nWARNING: Gaunt table for Lmax=%i lmax=%i lpmax=%i (|m|<=%i) "
+                 "needs %.1f GB.\n", Lmax, lmax, lpmax, mcap, gb);
+          fflush(stdout);
+        }
+      }
       table.assign(total, T(0));
 
 #ifdef _OPENMP
@@ -140,10 +153,12 @@ namespace helfem {
           const int lp_hi = std::min(lpmax, L + l);
           for(int lp = lp_lo; lp <= lp_hi; ++lp) {
             if(!gaunt_triple_nonzero(L, l, lp)) continue;
-            for(int M = -L; M <= L; ++M) {
+            // The bounds exclude everything outside the stored window, so no
+            // entry is generated only to be discarded.
+            for(int M = std::max(-L, -mcap); M <= std::min(L, mcap); ++M) {
               const T signM = (M & 1) ? T(-1) : T(1);
-              const int m_lo = std::max(-l, M - lp);
-              const int m_hi = std::min( l, M + lp);
+              const int m_lo = std::max(std::max(-l, M - lp), -mcap);
+              const int m_hi = std::min(std::min( l, M + lp),  mcap);
               for(int m = m_lo; m <= m_hi; ++m) {
                 const int mp = M - m;
                 const T g = wigner_gaunt<T>::eval(2*L, -2*M, 2*l, 2*m,
@@ -162,8 +177,24 @@ namespace helfem {
       if(L < 0 || L > Lmax) return T(0);
       if(l < 0 || l > lmax) return T(0);
       if(lp < 0 || lp > lpmax) return T(0);
+      // |M|>L and |m|>l are zero as a matter of mathematics -- no such
+      // spherical harmonic -- so returning zero is the right answer.
       if(std::abs(M) > L) return T(0);
       if(std::abs(m) > l) return T(0);
+      // Exceeding the stored window is different in kind: the coefficient is
+      // generally NOT zero, we simply did not build it. Returning zero there
+      // would be silently wrong, and wrong in a way no caller can detect, so
+      // throw instead. Reaching this means the table was constructed with a
+      // bound smaller than the caller needs.
+      if(std::abs(M) > mcap || std::abs(m) > mcap) {
+        std::ostringstream oss;
+        oss << "Gaunt coefficient requested outside the stored window: |M|="
+            << std::abs(M) << ", |m|=" << std::abs(m) << ", but the table was "
+            << "built with |M|,|m| <= " << mcap << ". This coefficient is not "
+            << "zero -- it was never computed. Build the table with a bound "
+            << "that covers the caller's range.\n";
+        throw std::logic_error(oss.str());
+      }
       // mp is implicit (= M - m); a stored cell with |M - m| > lp is zero.
       return table[flat_index(L, M, l, m, lp)];
     }

--- a/src/general/gaunt.h
+++ b/src/general/gaunt.h
@@ -53,18 +53,31 @@ namespace helfem {
     class GauntT {
       std::vector<T> table;
       int Lmax = 0, lmax = 0, lpmax = 0;
+      // Caps on |M| and |m|. The triangular packing L*(L+1)+M assumes every
+      // |M| <= L occurs, which is true for an atom but wildly false for a
+      // diatomic: there L is large while |M| is bounded by the basis, since M
+      // is a difference of two basis m values. Cu2 at lmax=46 reaches L=96
+      // with |M| <= 4, so the triangular table is ~190x larger than needed --
+      // 61 GB against 322 MB. Capping the m axes makes the packing rectangular
+      // in those directions and the table proportional to what is used.
+      int mcap = 0;
       std::size_t lm_stride = 0;
       std::size_t Lm_stride = 0;
 
       std::size_t flat_index(int L, int M, int l, int m, int lp) const {
-        const std::size_t LM = static_cast<std::size_t>(L) * (L + 1) + M;
-        const std::size_t lm = static_cast<std::size_t>(l) * (l + 1) + m;
+        const std::size_t LM = static_cast<std::size_t>(L) * (2*mcap + 1) + (M + mcap);
+        const std::size_t lm = static_cast<std::size_t>(l) * (2*mcap + 1) + (m + mcap);
         return LM * Lm_stride + lm * lm_stride + static_cast<std::size_t>(lp);
       }
 
     public:
       GauntT() = default;
-      GauntT(int Lmax, int lmax, int lpmax);
+      /// mcap bounds |M| and |m| alike. Defaulted to the full range, which is
+      /// what an atomic basis needs; a diatomic basis should pass its actual,
+      /// far smaller, bound. One cap suffices: mod_coeff routes plain basis m
+      /// values into the M axis (coeff(lj,mj,li,mi,L)), so the M axis cannot be
+      /// bounded more tightly than the m axis anyway.
+      GauntT(int Lmax, int lmax, int lpmax, int mcap = -1);
 
       /// Get Gaunt coefficient. mp is implicit: mp = M - m. Cells outside the
       /// stored range or violating |M|<=L, |m|<=l return 0.

--- a/src/general/gaunt_test.cpp
+++ b/src/general/gaunt_test.cpp
@@ -1,4 +1,5 @@
 #include <cfloat>
+#include <stdexcept>
 #include <cmath>
 #include <cstdio>
 #include "gaunt.h"
@@ -1655,5 +1656,56 @@ int main(void) {
   val=helfem::gaunt::modified_gaunt_coefficient(10,0,4,0,4,0);
   ref=5.8774027291321862e-02;
   if(std::abs(val-ref)>=DBL_EPSILON*(1.0+std::abs(ref))) printf("mod_coeff(10,0,4,0,4,0) value %e reference %e error %e\n",val,ref,val-ref);
+
+  // ---- Bounded-window table: correct values inside, a throw outside. ----
+  //
+  // The window is a storage choice, not a selection rule, so a request beyond
+  // it must fail loudly: the coefficient is generally nonzero and was simply
+  // never built, and returning zero would be wrong in a way no caller could
+  // detect. (|M|>L and |m|>l stay zero-valued -- those vanish as a matter of
+  // mathematics.)
+  {
+    const int Lm = 8, mcap = 2;
+    helfem::gaunt::Gaunt full(Lm, Lm, Lm);          // full m range
+    helfem::gaunt::Gaunt capped(Lm, Lm, Lm, mcap);  // |M|,|m| <= mcap
+
+    int mismatches = 0, checked = 0;
+    for(int L=0; L<=Lm; ++L)
+      for(int M=-std::min(L,mcap); M<=std::min(L,mcap); ++M)
+        for(int l=0; l<=Lm; ++l)
+          for(int m=-std::min(l,mcap); m<=std::min(l,mcap); ++m)
+            for(int lp=0; lp<=Lm; ++lp) {
+              const double a = full.coeff(L,M,l,m,lp);
+              const double b = capped.coeff(L,M,l,m,lp);
+              ++checked;
+              if(std::abs(a-b) > DBL_EPSILON*(1.0+std::abs(a))) ++mismatches;
+            }
+    if(mismatches)
+      printf("bounded Gaunt: %i/%i values differ from the full table\n", mismatches, checked);
+
+    // Inside the window but outside |M|<=L / |m|<=l: still zero, no throw.
+    if(capped.coeff(1, 2, 1, 0, 1) != 0.0)
+      printf("bounded Gaunt: |M|>L should be zero\n");
+
+    // Beyond the window: must throw rather than return zero.
+    bool threw = false;
+    try {
+      (void) capped.coeff(Lm, mcap+1, Lm, 0, Lm);
+    } catch(const std::logic_error &) {
+      threw = true;
+    }
+    if(!threw)
+      printf("bounded Gaunt: |M|=%i beyond the window returned silently instead of throwing\n", mcap+1);
+
+    threw = false;
+    try {
+      (void) capped.coeff(Lm, 0, Lm, mcap+1, Lm);
+    } catch(const std::logic_error &) {
+      threw = true;
+    }
+    if(!threw)
+      printf("bounded Gaunt: |m|=%i beyond the window returned silently instead of throwing\n", mcap+1);
+  }
+
 return 0;
 }


### PR DESCRIPTION
Reported: Cu2 dies with `std::bad_alloc` immediately, on 16 GB of RAM.

    ./diatomic --Z1=Cu --Z2=Cu --Rbond=2.22 --angstrom=1 --nnodes=15 \
               --nelem=7 --lmax=46,34,28 --method=HF --M=1

It never reaches an integral: the Gaunt table alone wants **61.4 GB**.

## Cause

The table is dense over (L,M) × (l,m) × lp, packing m triangularly as
`l*(l+1)+m` — which assumes every |m| ≤ l occurs. True for an atom. Wildly
false for a diatomic, where **L is large but |M| is small**: every M reaching
the table is a difference `mk-ml` of two basis m values, and every m is a
basis m or 0. Cu2 reaches L=96 with |M| ≤ 4, so the m axes were sized ~200×
larger than anything touched.

|          | dense          | m-bounded    |
|----------|----------------|--------------|
| (L,M)    | 97² = 9409     | 97×9 = 873   |
| (l,m)    | 95² = 9025     | 95×9 = 855   |
| lp       | 97             | 97           |
| **total**| **8.24e9 = 61.4 GB** | **7.24e7 = 579 MB** |

## Change

Rectangular packing in the m directions, with the bound passed to the
constructor. It defaults to the full range, so `atomic` — where m does span
[−l, l] — is unchanged; its tables are kilobytes either way.

**One bound covers both axes.** |M| ≤ 2·mmax while |m| ≤ mmax would suggest
two, but `mod_coeff` routes plain basis m values into the M axis via
`coeff(lj,mj,li,mi,L)`, so the M axis cannot be bounded more tightly than the
m axis anyway — a second parameter would earn nothing.

The build loop bounds are tightened to the stored window rather than iterating
the full −L..L range and discarding what falls outside. A guard there would
have been a symptom of wrong bounds, not a safety net.

## Verification

Diatomic cases checked against committed references: **0 failed, 0 invariant
violations**, both before and after the single-bound rework. The O ³P and CH π
degeneracies still hold exactly — the test that matters here, since an
out-of-window lookup returns zero *silently* rather than failing.

## Scope, and what comes next

This exploits a property of the caller's basis, not of the coefficients. A
bound that is too small yields silent zeros, so it is a precondition the class
cannot check — acceptable while one caller sets it from its own basis, but not
a general solution.

A follow-up will add symmetry-based storage (Pinchon & Hoggan, *Int J Quantum
Chem* **107**, 2186 (2007), refining Rasch & Yu, *SIAM J Sci Comput* **25**,
1416 (2003)), which folds permutation symmetry, the triangle rule and parity
into the index by construction. That stays efficient when M is genuinely large
— the atomic MP2 case — and would reduce the same table to ~1.3 GB without any
assumption about the caller. The two are complementary.