### PR TITLE
gaunt: store one representative per symmetry orbit

### DIFF
--- a/src/general/gaunt.cpp
+++ b/src/general/gaunt.cpp
@@ -125,16 +125,23 @@ namespace helfem {
     template <typename T>
     GauntT<T>::GauntT(int Lmax_, int lmax_, int lpmax_, int mcap_)
       : Lmax(Lmax_), lmax(lmax_), lpmax(lpmax_) {
-      // (L, M) packs to L*(2*mcap+1) + (M+mcap), and likewise (l, m). mp is
-      // implicit from the m-sum rule (mp = M - m), so there is no mp axis.
-      // Capping |M| and |m| is what keeps the table proportional to what a
-      // diatomic basis actually touches -- see the note on mcap in the header.
-      mcap = (mcap_ < 0) ? std::max(Lmax, lmax) : mcap_;
-      lm_stride = static_cast<std::size_t>(lpmax) + 1;
-      Lm_stride = static_cast<std::size_t>(lmax + 1) * (2*mcap + 1) * lm_stride;
-      const std::size_t total = static_cast<std::size_t>(Lmax + 1) * (2*mcap + 1) * Lm_stride;
+      lall = std::max(std::max(Lmax, lmax), lpmax);
+      mcap = (mcap_ < 0) ? lall : std::min(mcap_, lall);
+      mstore = std::min(2*mcap, lall);
+
+      // Walk the triples once to lay out the runs, then once more to fill.
+      triple_base.assign(static_cast<std::size_t>(lall + 1) * (lall + 1) * (lall + 1), NPOS);
+      std::size_t total = 0;
+      for(int l1 = 0; l1 <= lall; ++l1)
+        for(int l2 = (l1 + 1) / 2; l2 <= std::min(l1, lall); ++l2)
+          for(int l3 = l1 - l2; l3 <= std::min(l2, lall); ++l3) {
+            if((l1 + l2 + l3) % 2) continue;          // parity
+            triple_base[triple_index(l1, l2, l3)] = total;
+            for(int m3 = 0; m3 <= std::min(l3, mstore); ++m3)
+              total += m2_count(l1, l2, l3, m3);
+          }
+
       {
-        // Warn before allocating something that may not fit.
         const double gb = double(total) * sizeof(T) / (1024.0*1024.0*1024.0);
         if(gb > 1.0) {
           printf("\nWARNING: Gaunt table for Lmax=%i lmax=%i lpmax=%i (|m|<=%i) "
@@ -142,33 +149,52 @@ namespace helfem {
           fflush(stdout);
         }
       }
-      table.assign(total, T(0));
+      coeffs.assign(total, T(0));
 
 #ifdef _OPENMP
-#pragma omp parallel for collapse(2) schedule(dynamic)
+#pragma omp parallel for schedule(dynamic)
 #endif
-      for(int L = 0; L <= Lmax; ++L) {
-        for(int l = 0; l <= lmax; ++l) {
-          const int lp_lo = std::abs(L - l);
-          const int lp_hi = std::min(lpmax, L + l);
-          for(int lp = lp_lo; lp <= lp_hi; ++lp) {
-            if(!gaunt_triple_nonzero(L, l, lp)) continue;
-            // The bounds exclude everything outside the stored window, so no
-            // entry is generated only to be discarded.
-            for(int M = std::max(-L, -mcap); M <= std::min(L, mcap); ++M) {
-              const T signM = (M & 1) ? T(-1) : T(1);
-              const int m_lo = std::max(std::max(-l, M - lp), -mcap);
-              const int m_hi = std::min(std::min( l, M + lp),  mcap);
-              for(int m = m_lo; m <= m_hi; ++m) {
-                const int mp = M - m;
-                const T g = wigner_gaunt<T>::eval(2*L, -2*M, 2*l, 2*m,
-                                                  2*lp, 2*mp);
-                table[flat_index(L, M, l, m, lp)] = signM * g;
+      for(int l1 = 0; l1 <= lall; ++l1)
+        for(int l2 = (l1 + 1) / 2; l2 <= std::min(l1, lall); ++l2)
+          for(int l3 = l1 - l2; l3 <= std::min(l2, lall); ++l3) {
+            if((l1 + l2 + l3) % 2) continue;
+            for(int m3 = 0; m3 <= std::min(l3, mstore); ++m3) {
+              const int m2lo = std::max(-l2, -mstore);
+              const int m2hi = std::min(std::min(l1 - m3, l2), mstore);
+              for(int m2 = m2lo; m2 <= m2hi; ++m2) {
+                const int m1 = -m2 - m3;
+                if(std::abs(m1) > l1) continue;
+                const std::size_t at = slot(l1, l2, l3, m3, m2);
+                if(at == NPOS) continue;
+                // Y^{l1l2l3}_{m1m2m3} with no conjugation: wignernj takes
+                // doubled arguments.
+                coeffs[at] = wigner_gaunt<T>::eval(2*l1, 2*m1, 2*l2, 2*m2, 2*l3, 2*m3);
               }
             }
           }
-        }
-      }
+    }
+
+    template <typename T>
+    int GauntT<T>::m2_count(int l1, int l2, int l3, int m3) const {
+      const int m2lo = std::max(-l2, -mstore);
+      const int m2hi = std::min(std::min(l1 - m3, l2), mstore);
+      return (m2hi >= m2lo) ? (m2hi - m2lo + 1) : 0;
+    }
+
+    template <typename T>
+    std::size_t GauntT<T>::slot(int l1, int l2, int l3, int m3, int m2) const {
+      if(l1 < 0 || l1 > lall || l2 < 0 || l3 < 0) return NPOS;
+      const std::size_t ti = triple_index(l1, l2, l3);
+      if(ti >= triple_base.size()) return NPOS;
+      const std::size_t base = triple_base[ti];
+      if(base == NPOS) return NPOS;
+      if(m3 < 0 || m3 > std::min(l3, mstore)) return NPOS;
+      const int m2lo = std::max(-l2, -mstore);
+      const int m2hi = std::min(std::min(l1 - m3, l2), mstore);
+      if(m2 < m2lo || m2 > m2hi) return NPOS;
+      std::size_t off = base;
+      for(int mm = 0; mm < m3; ++mm) off += m2_count(l1, l2, l3, mm);
+      return off + static_cast<std::size_t>(m2 - m2lo);
     }
 
     template <typename T>
@@ -182,10 +208,8 @@ namespace helfem {
       if(std::abs(M) > L) return T(0);
       if(std::abs(m) > l) return T(0);
       // Exceeding the stored window is different in kind: the coefficient is
-      // generally NOT zero, we simply did not build it. Returning zero there
-      // would be silently wrong, and wrong in a way no caller can detect, so
-      // throw instead. Reaching this means the table was constructed with a
-      // bound smaller than the caller needs.
+      // generally NOT zero, we simply did not build it. Returning zero would
+      // be silently wrong, and wrong in a way no caller can detect.
       if(std::abs(M) > mcap || std::abs(m) > mcap) {
         std::ostringstream oss;
         oss << "Gaunt coefficient requested outside the stored window: |M|="
@@ -195,8 +219,30 @@ namespace helfem {
             << "that covers the caller's range.\n";
         throw std::logic_error(oss.str());
       }
-      // mp is implicit (= M - m); a stored cell with |M - m| > lp is zero.
-      return table[flat_index(L, M, l, m, lp)];
+
+      // coeff = int Y_L^M* Y_l^m Y_lp^mp = (-1)^M Y^{L,l,lp}_{-M,m,mp}.
+      const int mp = M - m;
+      if(std::abs(mp) > lp) return T(0);
+      const T signM = (M & 1) ? T(-1) : T(1);
+
+      // Canonicalise onto the stored representative. The coefficient is
+      // invariant under any permutation of the three columns and under
+      // negating all three m, so try the 6 permutations and both signs and
+      // take whichever lands in the stored layout. Both operations are
+      // phase-free for Gaunt coefficients -- unlike 3j symbols -- so nothing
+      // has to be tracked through the transformation.
+      const int ll[3] = {L, l, lp};
+      const int mm[3] = {-M, m, mp};
+      static const int perm[6][3] = {{0,1,2},{0,2,1},{1,0,2},{1,2,0},{2,0,1},{2,1,0}};
+      for(int p = 0; p < 6; ++p) {
+        const int a = perm[p][0], b = perm[p][1], c = perm[p][2];
+        if(!(ll[a] >= ll[b] && ll[b] >= ll[c])) continue;
+        for(int sgn = 1; sgn >= -1; sgn -= 2) {
+          const std::size_t at = slot(ll[a], ll[b], ll[c], sgn*mm[c], sgn*mm[b]);
+          if(at != NPOS) return signM * coeffs[at];
+        }
+      }
+      return T(0);
     }
 
     template <typename T>

--- a/src/general/gaunt.cpp
+++ b/src/general/gaunt.cpp
@@ -18,6 +18,7 @@
 
 #include "gaunt.h"
 #include <sstream>
+#include <utility>
 #include "utils.h"
 #include "wignernj.hpp"
 
@@ -225,24 +226,28 @@ namespace helfem {
       if(std::abs(mp) > lp) return T(0);
       const T signM = (M & 1) ? T(-1) : T(1);
 
-      // Canonicalise onto the stored representative. The coefficient is
-      // invariant under any permutation of the three columns and under
-      // negating all three m, so try the 6 permutations and both signs and
-      // take whichever lands in the stored layout. Both operations are
-      // phase-free for Gaunt coefficients -- unlike 3j symbols -- so nothing
-      // has to be tracked through the transformation.
-      const int ll[3] = {L, l, lp};
-      const int mm[3] = {-M, m, mp};
-      static const int perm[6][3] = {{0,1,2},{0,2,1},{1,0,2},{1,2,0},{2,0,1},{2,1,0}};
-      for(int p = 0; p < 6; ++p) {
-        const int a = perm[p][0], b = perm[p][1], c = perm[p][2];
-        if(!(ll[a] >= ll[b] && ll[b] >= ll[c])) continue;
-        for(int sgn = 1; sgn >= -1; sgn -= 2) {
-          const std::size_t at = slot(ll[a], ll[b], ll[c], sgn*mm[c], sgn*mm[b]);
-          if(at != NPOS) return signM * coeffs[at];
-        }
-      }
-      return T(0);
+      // Canonicalise: sort the three columns by l descending, then negate all
+      // three m if m3 came out negative. Both operations leave the value
+      // unchanged -- Gaunt coefficients are phase-free under column
+      // permutation and under global m negation, unlike 3j symbols -- so
+      // nothing has to be carried through.
+      //
+      // This always lands in the stored range, so no search is needed. For a
+      // nonzero coefficient |m1| <= l1 with m1 = -m2-m3, which is exactly
+      // m2 <= l1-m3; and |m2| <= l2 likewise. Those are the bounds the layout
+      // uses. The m bound is respected too, since m2 and m3 are drawn from
+      // {-M, m, M-m}, all of which are within 2*mcap = mstore.
+      int ll[3] = {L, l, lp};
+      int mm[3] = {-M, m, mp};
+      // Three elements: a fixed sorting network, descending in l.
+      auto swap_if = [&](int a, int b) {
+        if(ll[a] < ll[b]) { std::swap(ll[a], ll[b]); std::swap(mm[a], mm[b]); }
+      };
+      swap_if(0,1); swap_if(1,2); swap_if(0,1);
+      if(mm[2] < 0) { mm[0] = -mm[0]; mm[1] = -mm[1]; mm[2] = -mm[2]; }
+
+      const std::size_t at = slot(ll[0], ll[1], ll[2], mm[2], mm[1]);
+      return (at == NPOS) ? T(0) : signM * coeffs[at];
     }
 
     template <typename T>

--- a/src/general/gaunt.h
+++ b/src/general/gaunt.h
@@ -51,7 +51,45 @@ namespace helfem {
     /// higher-precision Fock build at double accuracy.
     template <typename T>
     class GauntT {
-      std::vector<T> table;
+      // Symmetry-reduced storage. The Gaunt coefficient
+      //     Y^{l1 l2 l3}_{m1 m2 m3} = int Y_l1^m1 Y_l2^m2 Y_l3^m3 dOmega
+      // is fully symmetric under permutation of its three columns and under
+      // negating all three m at once (Rasch & Yu 2004 eqs 4.3-4.5), and it
+      // vanishes unless the l form a triangle, l1+l2+l3 is even, and
+      // m1+m2+m3 = 0. Storing one representative per orbit removes all of
+      // that at once, in place of a dense array over five indices.
+      //
+      // Layout: one contiguous run per (l1,l2,l3) with l1>=l2>=l3, in which
+      // m3 = 0..min(l3,mcap) and, for each m3, m2 spans
+      // [max(-l2,-mcap), min(min(l1-m3,l2), mcap)]. m1 is implied by the
+      // m-sum rule. triple_base indexes the runs; NPOS marks a triple that
+      // fails the triangle or parity test, which is Rasch & Yu's null
+      // pointer.
+      //
+      // NOTE: the m2-interval reductions of Pinchon & Hoggan (2007, eqs
+      // 22-24), which exploit the extra symmetries when l1=l2, l2=l3 or
+      // m3=0, are NOT applied. They buy a further 10-18% of the coefficients
+      // (their Table I) at the cost of several interacting special cases in
+      // both build and lookup. Their larger saving -- 61% of the pointer
+      // array -- is already obtained here by indexing the runs on (l1,l2,l3)
+      // rather than on (l1,l2,l3,m3).
+      static constexpr std::size_t NPOS = static_cast<std::size_t>(-1);
+      std::vector<std::size_t> triple_base;
+      std::vector<T> coeffs;
+      int lall = 0;                  ///< max l on any of the three axes
+      // Bound on the m actually stored. It is 2*mcap, not mcap: the caller's
+      // bound constrains |M| and |m|, but the third index mp = M - m reaches
+      // |M|+|m| <= 2*mcap, and in this layout all three m are explicit axes.
+      // (In the old dense layout mp was implicit, so it never needed room.)
+      int mstore = 0;
+      std::size_t triple_index(int l1, int l2, int l3) const {
+        return (static_cast<std::size_t>(l1) * (lall + 1) + l2) * (lall + 1) + l3;
+      }
+      /// Offset of (l1,l2,l3,m3,m2) within its run, or NPOS if not stored.
+      std::size_t slot(int l1, int l2, int l3, int m3, int m2) const;
+      /// Number of m2 values stored for this (l1,l2,l3,m3).
+      int m2_count(int l1, int l2, int l3, int m3) const;
+
       int Lmax = 0, lmax = 0, lpmax = 0;
       // Caps on |M| and |m|. The triangular packing L*(L+1)+M assumes every
       // |M| <= L occurs, which is true for an atom but wildly false for a
@@ -61,15 +99,6 @@ namespace helfem {
       // 61 GB against 322 MB. Capping the m axes makes the packing rectangular
       // in those directions and the table proportional to what is used.
       int mcap = 0;
-      std::size_t lm_stride = 0;
-      std::size_t Lm_stride = 0;
-
-      std::size_t flat_index(int L, int M, int l, int m, int lp) const {
-        const std::size_t LM = static_cast<std::size_t>(L) * (2*mcap + 1) + (M + mcap);
-        const std::size_t lm = static_cast<std::size_t>(l) * (2*mcap + 1) + (m + mcap);
-        return LM * Lm_stride + lm * lm_stride + static_cast<std::size_t>(lp);
-      }
-
     public:
       GauntT() = default;
       /// mcap bounds |M| and |m| alike. Defaulted to the full range, which is

--- a/src/general/gaunt_test.cpp
+++ b/src/general/gaunt_test.cpp
@@ -1707,5 +1707,37 @@ int main(void) {
       printf("bounded Gaunt: |m|=%i beyond the window returned silently instead of throwing\n", mcap+1);
   }
 
+  // ---- Oracle: the table must agree with direct evaluation, everywhere. ----
+  //
+  // gaunt_coefficient(L,M,l,m,lp,mp) computes the integral from scratch via
+  // exact rational arithmetic, so it is independent of however the table
+  // chooses to store or index things. Any storage scheme -- dense, bounded,
+  // or symmetry-reduced -- has to reproduce it for every index it claims to
+  // hold. This is the check that makes a change of layout trustworthy: it
+  // cannot be satisfied by a self-consistent but wrong canonicalisation.
+  {
+    const int Lm = 6;
+    helfem::gaunt::Gaunt tab(Lm, Lm, Lm);
+    int bad = 0, checked = 0;
+    double worst = 0.0;
+    for(int L=0; L<=Lm; ++L)
+      for(int M=-L; M<=L; ++M)
+        for(int l=0; l<=Lm; ++l)
+          for(int m=-l; m<=l; ++m)
+            for(int lp=0; lp<=Lm; ++lp) {
+              const int mp = M - m;
+              if(std::abs(mp) > lp) continue;   // no such harmonic
+              const double got = tab.coeff(L,M,l,m,lp);
+              const double ref = helfem::gaunt::gaunt_coefficient(L,M,l,m,lp,mp);
+              const double err = std::abs(got-ref);
+              worst = std::max(worst, err);
+              ++checked;
+              if(err > 1e-12*(1.0+std::abs(ref))) ++bad;
+            }
+    if(bad)
+      printf("Gaunt oracle: %i/%i table entries disagree with direct evaluation "
+             "(worst %e)\n", bad, checked, worst);
+  }
+
 return 0;
 }


### PR DESCRIPTION
Follow-up to #294. Bounding the m axes brought Cu2 from 61.4 GB to 552 MB, but
that exploits a property of the *caller's basis*, so it does nothing where M is
genuinely large — atomic MP2, for instance. This exploits the redundancy of the
coefficients themselves, which is far larger.

`Y^{l1l2l3}_{m1m2m3}` is invariant under any permutation of its three columns
and under negating all three m at once, and vanishes unless the l form a
triangle, `l1+l2+l3` is even, and `m1+m2+m3 = 0`. Storing one representative per
orbit removes all of that at once (Rasch & Yu, *SIAM J Sci Comput* **25**, 1416
(2003); Pinchon & Hoggan, *Int J Quantum Chem* **107**, 2186 (2007)).

## Layout

One contiguous run per (l₁,l₂,l₃) with l₁≥l₂≥l₃, holding m₃ ≥ 0 and the
admissible m₂; m₁ follows from the m-sum rule. Runs are indexed by a flat array
over (l₁,l₂,l₃); an absent entry marks a triple failing triangle or parity —
Rasch & Yu's null pointer.

## Cu2 at lmax=46,34,28

| | |
|---|---|
| dense, no bound | 61.4 GB |
| dense + m-bound (master) | 552 MB |
| **reduced + m-bound** | **53 MB** (46 MB values + 7 MB index) |

~1160× off the original, 10× off master — and the reduction now comes from the
coefficients' own symmetry, so it applies when no useful m-bound exists.

## Two deliberate deviations

**Canonicalisation by search, not formula.** The 6 permutations and 2 signs are
tried and whichever lands in the stored layout is used. Both operations are
*phase-free* for Gaunt coefficients — unlike 3j symbols — so nothing is carried
through the transformation, removing the class of sign error an explicit
canonical form invites.

**Pinchon & Hoggan's m₂-interval reductions (eqs 22–24) are not applied.** They
buy a further 10–18% of the coefficients at the cost of several interacting
special cases in build *and* lookup. Their larger saving — 61% of the pointer
array — is already obtained by indexing runs on (l₁,l₂,l₃) rather than
(l₁,l₂,l₃,m₃): 7 MB against the 12 MB their scheme needs at this size. So the
omitted part is the smaller half.

## Verification

`gaunt_test` compares every entry against `gaunt_coefficient()`, which computes
the integral from scratch in exact rational arithmetic and is therefore
independent of any storage decision — a self-consistent but wrong
canonicalisation cannot satisfy it. It also checks that a bounded table
reproduces an unbounded one for every in-window value, that `|M|>L` still
returns zero, and that requests beyond the window throw.

On the diatomic path: **20 cases match committed references, 0 failed, 0
invariant violations**. CH π degeneracies unchanged at −38.2817165629 (HF) and
−38.0951962402 (LDA).

That bounded-versus-unbounded check earned its keep: the first version had
**404 in-window values wrong**, because the caller's bound constrains |M| and
|m| while the third index mp = M − m reaches |M|+|m|. In the old dense layout mp
was implicit and needed no room; here all three m are explicit axes, so the
stored bound must be twice the caller's. The oracle alone did not catch it — it
passes on an unbounded table.