### PR TITLE
diatomic: fix one-electron calculations (segfault, and a guess reported as a solution)

### DIFF
--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -648,8 +648,17 @@ namespace helfem {
         }
         Exc = exc; Ekin = ekin; Nel = nel;
         Ha_e = basp->remove_boundaries(Ha);
-        if (beta)
-          Hb_e = basp->remove_boundaries(Hb);
+        // Assign the beta output unconditionally. `beta` says whether the
+        // beta channel has any electrons, not whether the caller wants an
+        // output matrix: the Fock assembly adds XCb whenever the calculation
+        // is unrestricted, so leaving it default-constructed makes that an
+        // addition of an empty matrix -- a segfault under NDEBUG, where
+        // Eigen's size assertions are compiled out. Hb is zero-initialised,
+        // so this is also the right value: an empty beta channel contributes
+        // no exchange-correlation potential. DFTGrid::eval_Fxc already
+        // assigns unconditionally; the two grids differed in contract, and
+        // this one is the default path.
+        Hb_e = basp->remove_boundaries(Hb);
       }
 
     }

--- a/src/general/model_potential.cpp
+++ b/src/general/model_potential.cpp
@@ -81,14 +81,20 @@ namespace helfem {
     SAPFEAtom::SAPFEAtom(int Z_) : SAPFEAtom(Z_, XC_LDA_X, 0) {
     }
 
-    SAPFEAtom::SAPFEAtom(int Z_, int x_func_, int c_func_) : atom(Z_), x_func(x_func_), c_func(c_func_) {
+    SAPFEAtom::SAPFEAtom(int Z_, int x_func_, int c_func_) : x_func(x_func_), c_func(c_func_) {
+      // A zero-charge centre carries no electrons, so there is nothing to
+      // look up and nothing to screen. Constructing the record would throw:
+      // the database covers 1..118.
+      if(Z_ != 0)
+        atom = std::make_unique<atomdb::Atom>(Z_);
     }
 
     SAPFEAtom::~SAPFEAtom() {
     }
 
     double SAPFEAtom::V(double r) const {
-      return -atom.effective_charge(r,x_func,c_func)/r;
+      if(!atom) return 0.0;   // dummy centre
+      return -atom->effective_charge(r,x_func,c_func)/r;
     }
 
     std::vector<double> SAPFEAtom::breakpoints(double a, double b) const {
@@ -96,7 +102,8 @@ namespace helfem {
       // in each element of the wave function's grid. Only the boundaries
       // strictly inside (a, b) are reported: one coinciding with an
       // element end is already handled by the element decomposition.
-      const helfem::Vector bval(atom.element_boundaries());
+      if(!atom) return std::vector<double>();   // dummy centre
+      const helfem::Vector bval(atom->element_boundaries());
       std::vector<double> bp;
       for(Eigen::Index i=0;i<bval.size();i++)
         if(bval(i) > a && bval(i) < b)

--- a/src/general/model_potential.h
+++ b/src/general/model_potential.h
@@ -93,8 +93,12 @@ namespace helfem {
     /// function's own grid, which breakpoints() reports so the quadrature
     /// can split there.
     class SAPFEAtom : public ModelPotential {
-      /// The tabulated atom
-      atomdb::Atom atom;
+      /// The tabulated atom. Empty for Z=0: the wave function database
+      /// covers 1..118 and rightly refuses Z=0, but a zero-charge dummy
+      /// centre is a legitimate thing to place in a diatomic calculation.
+      /// It has no electrons, hence no density and no screening, so the
+      /// potential is identically zero and no record is needed.
+      std::unique_ptr<atomdb::Atom> atom;
       /// Exchange and correlation functional ids used for the screening
       int x_func, c_func;
     public:

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -3487,7 +3487,7 @@
         "exact",
         "ci"
       ],
-      "_why": "H with a zero-charge partner: one electron, exact energy -0.5",
+      "_why": "H with a zero-charge partner: one electron, exact energy -0.5; runs with the default SAP guess, which the fix to the pure-m beta output made viable -- before it, this case crashed and reported the guess energy instead of a solution",
       "args": [
         "--Z1=1",
         "--Z2=0",
@@ -3497,8 +3497,7 @@
         "--lmax=4",
         "--nela=1",
         "--nelb=0",
-        "--method=HF",
-        "--iguess=0"
+        "--method=HF"
       ]
     },
     {
@@ -3511,7 +3510,7 @@
         "exact",
         "ci"
       ],
-      "_why": "H2+ at R=2: one electron, exact energy -0.6026342",
+      "_why": "H2+ at R=2: one electron, exact energy -0.6026342; runs with the default SAP guess, which the fix to the pure-m beta output made viable -- before it, this case crashed and reported the guess energy instead of a solution",
       "args": [
         "--Z1=1",
         "--Z2=1",
@@ -3521,8 +3520,7 @@
         "--lmax=4",
         "--nela=1",
         "--nelb=0",
-        "--method=HF",
-        "--iguess=0"
+        "--method=HF"
       ]
     }
   ],


### PR DESCRIPTION
Fixes #54. Two independent bugs, both reachable with a tiny basis. H with a
zero-charge partner reported **−0.4935413582 instead of −0.5** and then
segfaulted; H2⁺ gave −0.5971920407 against the known −0.6026342.

## 1. The pure-m grid left its beta output unassigned

`dftgrid_purem.cpp` guarded `Hb_e = remove_boundaries(Hb)` behind `if (beta)`,
where `beta` means *"the beta channel has electrons"* — not *"the caller wants
an output matrix"*. `DFTGrid::eval_Fxc` assigns unconditionally, so the two
grids disagreed on their contract, and the pure-m one is the **default** path
(`purem` is auto-on whenever `symmetry>=1`).

With `nelb=0` the Fock assembly then evaluated `Fb_ao += XCb` on a
default-constructed empty matrix. Under NDEBUG Eigen's size assertions are
compiled out, so that segfaults rather than aborting.

**This one fault produced both symptoms.** The crash landed inside the
Fock-builder callback *after* it had printed the energy, so what looked like
"the SCF stops at the guess" was really "the callback dies on its first
invocation, having already printed". With it fixed the SCF runs and converges
to the same answer from every guess:

| iguess | 0 | 1 | 2 | 3 | 4 |
|---|---|---|---|---|---|
| H | −0.4999999987 | −0.4999999987 | −0.4999999987 | −0.4999999987 | −0.4999999987 |

(exact −0.5, in 1–7 iterations). H2⁺ gives −0.6026341889 against the standard
−0.6026342.

`Hb` is zero-initialised, so assigning unconditionally is also the *right*
value: an empty beta channel contributes no XC potential.

## 2. `SAPFEAtom` could not take a zero-charge centre

It builds an atomdb record in its initialiser list, and the wave function
database deliberately covers 1..118, so `--iguess=4` threw *"no record for
Z = 0"* for any dummy centre. Not one-electron-specific — He with a dummy
failed identically.

A dummy centre has no electrons, hence no density and no screening, so the
potential is identically zero and no record is needed. The database's
rejection of Z=0 is correct and stays; `SAPFEAtom` now holds the record
optionally.

## Tests

The H and H2⁺ cases were pinned to `--iguess=0` to work around bug 1; that pin
is removed, so they now exercise the default path. Both have exact known
answers, so they test without reference values.

**40 CI cases against committed references: 0 failed, 0 errored, 0 invariant
violations.**