### PR TITLE
Label symmetry blocks by quantum numbers; time the Fock components

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -26,6 +26,8 @@
 #include <cassert>
 #include <cfloat>
 #include <algorithm>
+#include <sstream>
+#include <string>
 #include <limits>
 #include <type_traits>
 #include <helfem.h>
@@ -222,6 +224,42 @@ namespace helfem {
           throw std::logic_error("Unknown symmetry\n");
 
         return idx;
+      }
+
+      template <typename T>
+      std::vector<std::string> TwoDBasisT<T>::get_sym_labels(int symm) const {
+        // Mirrors get_sym_idx block for block: same branches, same
+        // ordering, same unique-m sort. Anything changed there has to be
+        // changed here too.
+        std::vector<std::string> labels;
+        auto mlabel = [](int m) {
+          std::ostringstream oss;
+          // Explicit sign for nonzero m, but plain "m=0" rather than "m=+0".
+          oss << "m=" << (m > 0 ? "+" : "") << m;
+          return oss.str();
+        };
+
+        if(symm==0) {
+          labels.push_back("all");
+        } else if(symm==1) {
+          std::vector<int> mv;
+          for (Eigen::Index i = 0; i < mval.size(); ++i)
+            if (std::find(mv.begin(), mv.end(), mval(i)) == mv.end())
+              mv.push_back(mval(i));
+          std::sort(mv.begin(), mv.end());
+          for(size_t i=0;i<mv.size();i++)
+            labels.push_back(mlabel(mv[i]));
+        } else if(symm==2) {
+          // One block per (l,m) channel of the angular basis.
+          for(size_t i=0;i<(size_t) mval.size();i++) {
+            std::ostringstream oss;
+            oss << "l=" << lval(i) << " " << mlabel(mval(i));
+            labels.push_back(oss.str());
+          }
+        } else
+          throw std::logic_error("Unknown symmetry\n");
+
+        return labels;
       }
 
       template <typename T>

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -15,6 +15,7 @@
 #ifndef ATOMIC_BASIS_TWODBASIS_H
 #define ATOMIC_BASIS_TWODBASIS_H
 
+#include <string>
 #include <limits>
 #include "../general/model_potential.h"
 #include "../general/sap.h"
@@ -253,6 +254,10 @@ namespace helfem {
         std::vector<Eigen::Index> lm_indices(int l, int m) const;
         /// Get indices for wanted symmetry (one index list per block)
         std::vector<std::vector<Eigen::Index>> get_sym_idx(int isym) const;
+        /// Physical labels for the blocks of get_sym_idx, in the same
+        /// order ("m=+1", "l=2 m=-1", ...). Kept alongside get_sym_idx so
+        /// the two cannot drift apart.
+        std::vector<std::string> get_sym_labels(int isym) const;
 
         /// Evaluate basis functions (T = double only)
         Eigen::MatrixXcd eval_bf(size_t iel, double cth, double phi) const;

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -362,6 +362,7 @@ int main(int argc, char **argv) {
   std::vector<std::string> block_descriptions;
   helfem::scf_driver::build_ooo_block_metadata<OOO_Real>(
       nsym, nparttype, restricted, Ntot, nela, nelb,
+      basis.get_sym_labels(symm_eff),
       number_of_blocks_per_particle_type, maximum_occupation,
       number_of_particles, block_descriptions);
 

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -30,6 +30,8 @@
 #include "../general/timer.h"
 #include "../general/scf_helpers.h"
 #include <algorithm>
+#include <sstream>
+#include <string>
 #include <cassert>
 #include <cfloat>
 #include <cmath>
@@ -892,6 +894,46 @@ namespace helfem {
           throw std::logic_error("Unknown symmetry\n");
 
         return idx;
+      }
+
+      std::vector<std::string> TwoDBasis::get_sym_labels(int symm) const {
+        // Mirrors get_sym_idx block for block: same branches, same
+        // ordering, same unique-m sort. Anything changed there has to be
+        // changed here too.
+        std::vector<std::string> labels;
+        auto mlabel = [](int m) {
+          std::ostringstream oss;
+          // Explicit sign for nonzero m, but plain "m=0" rather than "m=+0".
+          oss << "m=" << (m > 0 ? "+" : "") << m;
+          return oss.str();
+        };
+
+        if(symm==0) {
+          labels.push_back("all");
+        } else if(symm==1 || symm==2) {
+          std::vector<int> mv;
+          for(size_t i=0;i<mval.size();i++)
+            if(std::find(mv.begin(),mv.end(),mval(i))==mv.end())
+              mv.push_back(mval(i));
+          std::sort(mv.begin(),mv.end());
+
+          if(symm==1) {
+            for(size_t i=0;i<mv.size();i++)
+              labels.push_back(mlabel(mv[i]));
+          } else {
+            // symm==2 splits each m by the parity of l, which for a
+            // homonuclear molecule is the inversion parity: even l is
+            // gerade, odd l ungerade. m_indices(m,odd) selects l%2==odd,
+            // so the even (g) block comes first.
+            for(size_t i=0;i<mv.size();i++) {
+              labels.push_back(mlabel(mv[i]) + " g");
+              labels.push_back(mlabel(mv[i]) + " u");
+            }
+          }
+        } else
+          throw std::logic_error("Unknown symmetry\n");
+
+        return labels;
       }
 
       helfem::Matrix TwoDBasis::Sinvh(bool chol, int sym) const {

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -15,6 +15,7 @@
 #ifndef DIATOMIC_BASIS_H
 #define DIATOMIC_BASIS_H
 
+#include <string>
 #include "FiniteElementBasis.h"
 #include "../general/gaunt.h"
 #include "quadrature.h"
@@ -328,6 +329,10 @@ namespace helfem {
         std::vector<Eigen::Index> m_indices(int m) const;
         /// Get indices of basis functions with wanted m quantum number and parity
         std::vector<Eigen::Index> m_indices(int m, bool odd) const;
+        /// Physical labels for the blocks of get_sym_idx, in the same
+        /// order ("m=+1", "m=-2 u", ...). Kept alongside get_sym_idx so
+        /// the two cannot drift apart.
+        std::vector<std::string> get_sym_labels(int symm) const;
         /// Get indices for wanted symmetry (one index list per block)
         std::vector<std::vector<Eigen::Index>> get_sym_idx(int isym) const;
 

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -340,6 +340,7 @@ int main(int argc, char **argv) {
   std::vector<std::string> block_descriptions;
   helfem::scf_driver::build_ooo_block_metadata<OOO_Real>(
       nsym, nparttype, restricted, Ntot, nela, nelb,
+      basis.get_sym_labels(symm),
       number_of_blocks_per_particle_type, maximum_occupation,
       number_of_particles, block_descriptions);
 
@@ -359,8 +360,13 @@ int main(int argc, char **argv) {
         fock, b, dsym, k, Sinvh, F_full);
   };
 
+  // Per-component wall clock for the Fock build, plus the time spent
+  // outside it in the SCF solver. See helfem::scf_driver::FockTimer.
+  helfem::scf_driver::FockTimer ftimer;
+
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
       [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    ftimer.enter();
     const auto & orbitals    = dm.first;
     const auto & occupations = dm.second;
 
@@ -376,16 +382,20 @@ int main(int argc, char **argv) {
 
     // grid.eval_Fxc takes/returns Eigen at its public boundary; densities
     // and XC potentials are Eigen throughout, so no bridging is needed.
+    Timer tcomp;
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
+      ftimer.density += tcomp.get();
       if (have_xc) {
+        tcomp.set();
         if (purem_xc)
           pmgrid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa,
                            Exc, nelnum, ekin_grid, dftthr);
         else
           grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa,
                          Exc, nelnum, ekin_grid, dftthr);
+        ftimer.xc += tcomp.get();
       }
       if (have_exx) Pa = 0.5 * P;
     } else {
@@ -396,13 +406,16 @@ int main(int argc, char **argv) {
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
+      ftimer.density += tcomp.get();
       if (have_xc) {
+        tcomp.set();
         if (purem_xc)
           pmgrid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb,
                            XCa, XCb, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
         else
           grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb,
                          XCa, XCb, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
+        ftimer.xc += tcomp.get();
       }
     }
 
@@ -414,8 +427,10 @@ int main(int argc, char **argv) {
     const double Emfield = have_bfield
         ? (P * Vmag).trace() - 0.5 * Bz * (nela - nelb) : 0.0;
 
+    tcomp.set();
     const helfem::Matrix J = basis.coulomb(P);
     const double Ecoul = 0.5 * (P * J).trace();
+    ftimer.coulomb += tcomp.get();
 
     // Diatomic exchange kernel: pure Coulomb K (no RS split yet).
     auto exchange_fn = [&](const helfem::Matrix & P) {
@@ -423,8 +438,10 @@ int main(int argc, char **argv) {
     };
     helfem::Matrix Ka, Kb;
     double Exx = 0.0;
+    tcomp.set();
     helfem::scf_driver::assemble_hf_exchange(
         Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
+    ftimer.exchange += tcomp.get();
 
     const double Etot = Ekin + Enuc + Eefield + Emfield
                        + Ecoul + Exc + Exx + Enucr;
@@ -434,6 +451,7 @@ int main(int argc, char **argv) {
     if (have_bfield) printf(" Emfield %.10f", Emfield);
     printf("  total %.10f  (nel err %.3e)\n",
             Etot, nelnum - static_cast<double>(Ntot));
+    ftimer.print_build(have_xc, have_exx);
     fflush(stdout);
 
     // Fock assembly. Restricted: one AO Fock matrix per block.
@@ -450,6 +468,7 @@ int main(int argc, char **argv) {
         fock, H1, J, XCa, XCb, Ka, Kb, S,
         nsym, restricted, have_xc, have_exx, have_bfield, Bz,
         apply_mavg, orthonormalize_block);
+    ftimer.leave();
     return std::make_pair(Etot, fock);
   };
 
@@ -617,6 +636,7 @@ int main(int argc, char **argv) {
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
   scfsolver.print_citation();
   scfsolver.run();
+  ftimer.print_summary(have_xc, have_exx);
 
   if (savefile.size()) {
     Checkpoint savechk(savefile, /*writemode=*/true);

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -30,15 +30,104 @@
 
 #include <Eigen/Eigenvalues>
 #include <algorithm>
+#include <sstream>
+#include <string>
 #include <cstdio>
 #include <stdexcept>
 #include <utility>
 #include <vector>
 #include "scf_helpers.h"
+#include "timer.h"
 #include "openorbitaloptimizer/scfsolver.hpp"
 
 namespace helfem {
   namespace scf_driver {
+
+    /// Wall-clock accounting for the SCF loop, split by Fock component.
+    ///
+    /// The diatomic Fock build is dominated by exchange and, for DFT, by
+    /// the XC quadrature, but which one dominates depends strongly on the
+    /// basis -- so the split is worth printing rather than guessing.
+    ///
+    /// OOO has no timers of its own, so everything it does -- the
+    /// diagonalization, the DIIS/ADIIS extrapolation, the occupation
+    /// search -- is measured indirectly, as the gap between one Fock
+    /// build returning and the next one starting. That bucket ("SCF
+    /// solver" below) therefore also absorbs anything the driver itself
+    /// does between builds; it is the time NOT spent building Fock
+    /// matrices, which is exactly the quantity the old per-component
+    /// timings could not show.
+    struct FockTimer {
+      /// This build.
+      double density = 0.0, xc = 0.0, coulomb = 0.0, exchange = 0.0;
+      /// Cumulative over the whole SCF.
+      double tot_density = 0.0, tot_xc = 0.0, tot_coulomb = 0.0,
+             tot_exchange = 0.0, tot_other = 0.0, tot_outside = 0.0;
+      size_t nbuild = 0;
+
+      /// Call at the top of the Fock builder.
+      void enter() {
+        outside_ = started_ ? between_.get() : 0.0;
+        tot_outside += outside_;
+        ++nbuild;
+        density = xc = coulomb = exchange = 0.0;
+        build_.set();
+      }
+
+      /// Call at the bottom of the Fock builder, after printing.
+      void leave() {
+        const double total = build_.get();
+        tot_density  += density;
+        tot_xc       += xc;
+        tot_coulomb  += coulomb;
+        tot_exchange += exchange;
+        // Whatever is left over: density assembly bookkeeping, the
+        // one-electron traces, the Fock scatter into blocks.
+        tot_other += total - (density + xc + coulomb + exchange);
+        between_.set();
+        started_ = true;
+      }
+
+      /// Seconds spent outside the Fock build since the previous one.
+      double outside() const { return outside_; }
+      /// Seconds spent in the current build so far.
+      double build() const { return build_.get(); }
+
+      /// One line per Fock build, appended after the energy decomposition.
+      void print_build(bool have_xc, bool have_exx) const {
+        const double t = build_.get();
+        printf("  time: Coulomb %.2f s", coulomb);
+        if (have_exx) printf(", exchange %.2f s", exchange);
+        if (have_xc)  printf(", XC %.2f s", xc);
+        printf(", density %.2f s, other %.2f s; Fock %.2f s",
+               density, t - (density + xc + coulomb + exchange), t);
+        if (started_) printf("; SCF solver %.2f s", outside_);
+        printf("\n");
+        fflush(stdout);
+      }
+
+      /// Cumulative summary, printed once the SCF has finished.
+      void print_summary(bool have_xc, bool have_exx) const {
+        const double fock = tot_density + tot_xc + tot_coulomb
+                          + tot_exchange + tot_other;
+        printf("\nSCF wall-clock breakdown over %zu Fock builds:\n", nbuild);
+        printf("  Coulomb      %10.2f s\n", tot_coulomb);
+        if (have_exx) printf("  exchange     %10.2f s\n", tot_exchange);
+        if (have_xc)  printf("  XC           %10.2f s\n", tot_xc);
+        printf("  density      %10.2f s\n", tot_density);
+        printf("  other (Fock) %10.2f s\n", tot_other);
+        printf("  Fock total   %10.2f s\n", fock);
+        printf("  SCF solver   %10.2f s  (diagonalization, DIIS/ADIIS,"
+               " occupations)\n", tot_outside);
+        printf("  SCF total    %10.2f s\n", fock + tot_outside);
+        fflush(stdout);
+      }
+
+    private:
+      Timer build_, between_;
+      double outside_ = 0.0;
+      bool started_ = false;
+    };
 
     /// Per-block symmetric orthonormalisation of the AO overlap S
     /// restricted to each symmetry index set. Both drivers build this
@@ -211,14 +300,27 @@ namespace helfem {
     /// alpha (t=0) and beta (t=1) into two particle types with
     /// max_occ = 1 per block; block descriptions get an "a:" / "b:"
     /// prefix per channel.
+    ///
+    /// sym_labels names the blocks physically ("m=+1", "l=2 m=-1",
+    /// "m=-2 u") and comes from the basis's get_sym_labels, which is the
+    /// same place the block ordering itself is defined. The occupations
+    /// OOO prints are then readable as quantum numbers rather than as
+    /// bare block indices.
     template <typename Real>
     inline void build_ooo_block_metadata(
         size_t nsym, size_t nparttype, bool restricted,
         int Ntot, int nela, int nelb,
+        const std::vector<std::string> & sym_labels,
         OpenOrbitalOptimizer::IndexVector & number_of_blocks_per_particle_type,
         Eigen::Matrix<Real, Eigen::Dynamic, 1> & maximum_occupation,
         Eigen::Matrix<Real, Eigen::Dynamic, 1> & number_of_particles,
         std::vector<std::string> & block_descriptions) {
+      if (sym_labels.size() != nsym) {
+        std::ostringstream oss;
+        oss << "Got " << sym_labels.size() << " symmetry labels for " << nsym
+            << " blocks: get_sym_labels and get_sym_idx are out of sync.\n";
+        throw std::logic_error(oss.str());
+      }
       number_of_blocks_per_particle_type.resize(nparttype);
       maximum_occupation.resize(nsym * nparttype);
       number_of_particles.resize(nparttype);
@@ -230,8 +332,7 @@ namespace helfem {
         for (size_t k = 0; k < nsym; ++k) {
           maximum_occupation(t * nsym + k) = restricted ? 2.0 : 1.0;
           block_descriptions.push_back(
-              (nparttype == 1 ? "" : (t == 0 ? "a:" : "b:"))
-              + std::string("sym") + std::to_string(k));
+              (nparttype == 1 ? "" : (t == 0 ? "a:" : "b:")) + sym_labels[k]);
         }
       }
     }


### PR DESCRIPTION
Two independent readability/diagnostics improvements to the SCF output.

## 1. Symmetry blocks are labelled by their quantum numbers

The occupation printout identified blocks as `sym0`, `sym1`, ..., which says nothing about what they are. The old codes printed the physical identity, and that is what makes the output readable:

```
sym0 occupations: 2 2                 m=-2 occupations: 2 2
sym1 occupations: 2 2 2 2 2 2   ->    m=-1 occupations: 2 2 2 2 2 2
sym2 occupations: 2 2 2 ...           m=0  occupations: 2 2 2 ...
```

OOO already accepts `block_descriptions` in its constructor, so this only needed something meaningful passed in.

Labels come from a new `get_sym_labels()` placed directly next to `get_sym_idx()` in each basis, mirroring it branch for branch. The block *ordering* is defined by `get_sym_idx`, so a label list built anywhere else would be free to drift out of sync; `build_ooo_block_metadata` also checks the lengths agree and throws if not.

Covered: atomic `--symmetry=1` (`m=-1`, `m=0`, `m=+1`) and `--symmetry=2` (`l=1 m=-1`, ...); diatomic `--symmetry=1` (per m) and `--symmetry=2`, where the l-parity split is the inversion parity for a homonuclear molecule and is labelled `g`/`u`. Unrestricted keeps its existing `a:`/`b:` prefix.

## 2. Per-component Fock timings, plus the time spent outside the Fock build

The diatomic code is slow enough that knowing where the time goes matters. OOO exposes no timers, so the diagonalization, DIIS/ADIIS extrapolation and occupation search are invisible from the driver — but they can be measured indirectly, as the gap between one Fock build returning and the next starting. That is the `SCF solver` bucket.

Per build:
```
  time: Coulomb 0.08 s, exchange 7.35 s, XC 3.26 s, density 0.04 s, other 0.02 s; Fock 10.74 s; SCF solver 2.96 s
```

and a cumulative summary after the SCF:
```
SCF wall-clock breakdown over 7 Fock builds:
  Coulomb            0.79 s
  exchange          45.72 s
  XC                21.40 s
  density            0.40 s
  other (Fock)       0.75 s
  Fock total        69.06 s
  SCF solver        11.30 s  (diagonalization, DIIS/ADIIS, occupations)
  SCF total         80.36 s
```

(N2/B3LYP, `--nelem=3 --nnodes=15 --lmax=11,7`, 4 threads.) The accounting lives in `helfem::scf_driver::FockTimer`, so the atomic driver can adopt it unchanged if wanted.

## Verification

`tests/run_tests.py --check tests/refs/ci.json --tag ci`: **40 passed, 0 failed, 0 invariant violations**. Both changes are printout-only; no energy moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)