### PR TITLE
gensap, aij: Fock component timings (and make FockTimer batch-safe)

### DIFF
--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -367,6 +367,7 @@ int main(int argc, char **argv) {
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
       [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
     ftimer.enter();
+    helfem::scf_driver::FockTimer::Components tcomps;
     const auto & orbitals    = dm.first;
     const auto & occupations = dm.second;
 
@@ -386,7 +387,7 @@ int main(int argc, char **argv) {
     if (restricted) {
       for (size_t k = 0; k < nsym; ++k)
         accumulate_density(P, k, orbitals[k], occupations[k]);
-      ftimer.density += tcomp.get();
+      tcomps.density += tcomp.get();
       if (have_xc) {
         tcomp.set();
         if (purem_xc)
@@ -395,7 +396,7 @@ int main(int argc, char **argv) {
         else
           grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa,
                          Exc, nelnum, ekin_grid, dftthr);
-        ftimer.xc += tcomp.get();
+        tcomps.xc += tcomp.get();
       }
       if (have_exx) Pa = 0.5 * P;
     } else {
@@ -406,7 +407,7 @@ int main(int argc, char **argv) {
         accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
       }
       P = Pa + Pb;
-      ftimer.density += tcomp.get();
+      tcomps.density += tcomp.get();
       if (have_xc) {
         tcomp.set();
         if (purem_xc)
@@ -415,7 +416,7 @@ int main(int argc, char **argv) {
         else
           grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb,
                          XCa, XCb, Exc, nelnum, ekin_grid, nelb > 0, dftthr);
-        ftimer.xc += tcomp.get();
+        tcomps.xc += tcomp.get();
       }
     }
 
@@ -430,7 +431,7 @@ int main(int argc, char **argv) {
     tcomp.set();
     const helfem::Matrix J = basis.coulomb(P);
     const double Ecoul = 0.5 * (P * J).trace();
-    ftimer.coulomb += tcomp.get();
+    tcomps.coulomb += tcomp.get();
 
     // Diatomic exchange kernel: pure Coulomb K (no RS split yet).
     auto exchange_fn = [&](const helfem::Matrix & P) {
@@ -441,7 +442,7 @@ int main(int argc, char **argv) {
     tcomp.set();
     helfem::scf_driver::assemble_hf_exchange(
         Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
-    ftimer.exchange += tcomp.get();
+    tcomps.exchange += tcomp.get();
 
     const double Etot = Ekin + Enuc + Eefield + Emfield
                        + Ecoul + Exc + Exx + Enucr;
@@ -451,6 +452,8 @@ int main(int argc, char **argv) {
     if (have_bfield) printf(" Emfield %.10f", Emfield);
     printf("  total %.10f  (nel err %.3e)\n",
             Etot, nelnum - static_cast<double>(Ntot));
+    tcomps.total = ftimer.build_elapsed();
+    ftimer.add_build(tcomps);
     ftimer.print_build(have_xc, have_exx);
     fflush(stdout);
 

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -57,74 +57,114 @@ namespace helfem {
     /// does between builds; it is the time NOT spent building Fock
     /// matrices, which is exactly the quantity the old per-component
     /// timings could not show.
+    ///
+    /// A builder invocation may evaluate SEVERAL densities, and gensap
+    /// evaluates them concurrently (the ODA polytope vertices). Component
+    /// times are therefore collected per build into a local Components --
+    /// never into shared state -- and folded in afterwards with
+    /// add_build(), the same discipline the batched builder already uses
+    /// for its log lines. When a batch runs n>1 entries at once the
+    /// component sums exceed the batch's wall clock, so wall clock is
+    /// tracked separately rather than derived from them.
     struct FockTimer {
-      /// This build.
-      double density = 0.0, xc = 0.0, coulomb = 0.0, exchange = 0.0;
-      /// Cumulative over the whole SCF.
-      double tot_density = 0.0, tot_xc = 0.0, tot_coulomb = 0.0,
-             tot_exchange = 0.0, tot_other = 0.0, tot_outside = 0.0;
-      size_t nbuild = 0;
+      /// Component times of ONE Fock build. Local to that build.
+      struct Components {
+        double density = 0.0, xc = 0.0, coulomb = 0.0, exchange = 0.0;
+        /// Wall clock of the whole build, including the leftovers.
+        double total = 0.0;
+        /// One-electron traces, Fock assembly, block scatter.
+        double other() const {
+          return total - (density + xc + coulomb + exchange);
+        }
+      };
 
-      /// Call at the top of the Fock builder.
+      /// Cumulative over the whole SCF. Summed over builds, so under a
+      /// concurrent batch these exceed the elapsed wall clock.
+      double tot_density = 0.0, tot_xc = 0.0, tot_coulomb = 0.0,
+             tot_exchange = 0.0, tot_other = 0.0;
+      /// Wall clock actually spent inside the builder, and outside it.
+      double tot_fock_wall = 0.0, tot_outside = 0.0;
+      /// Individual Fock builds, and builder invocations.
+      size_t nbuild = 0, nbatch = 0;
+
+      /// Call at the top of the (possibly batched) Fock builder.
       void enter() {
         outside_ = started_ ? between_.get() : 0.0;
         tot_outside += outside_;
-        ++nbuild;
-        density = xc = coulomb = exchange = 0.0;
-        build_.set();
+        ++nbatch;
+        cur_ = Components();
+        nbatch_builds_ = 0;
+        batch_.set();
       }
 
-      /// Call at the bottom of the Fock builder, after printing.
+      /// Fold in one completed build. Safe to call repeatedly; call it
+      /// from serial code, after any concurrent region has joined.
+      void add_build(const Components & c) {
+        ++nbuild;
+        ++nbatch_builds_;
+        tot_density  += c.density;   cur_.density  += c.density;
+        tot_xc       += c.xc;        cur_.xc       += c.xc;
+        tot_coulomb  += c.coulomb;   cur_.coulomb  += c.coulomb;
+        tot_exchange += c.exchange;  cur_.exchange += c.exchange;
+        tot_other    += c.other();   cur_.total    += c.total;
+      }
+
+      /// Call at the bottom of the builder, after printing.
       void leave() {
-        const double total = build_.get();
-        tot_density  += density;
-        tot_xc       += xc;
-        tot_coulomb  += coulomb;
-        tot_exchange += exchange;
-        // Whatever is left over: density assembly bookkeeping, the
-        // one-electron traces, the Fock scatter into blocks.
-        tot_other += total - (density + xc + coulomb + exchange);
+        tot_fock_wall += batch_.get();
         between_.set();
         started_ = true;
       }
 
-      /// Seconds spent outside the Fock build since the previous one.
+      /// Seconds spent outside the builder since the previous invocation.
       double outside() const { return outside_; }
-      /// Seconds spent in the current build so far.
-      double build() const { return build_.get(); }
+      /// Seconds elapsed in this builder invocation so far. A serial
+      /// builder uses this as its build's total; a batched one times
+      /// each entry itself, since they overlap.
+      double build_elapsed() const { return batch_.get(); }
 
-      /// One line per Fock build, appended after the energy decomposition.
+      /// One line per builder invocation, after the energy decomposition.
       void print_build(bool have_xc, bool have_exx) const {
-        const double t = build_.get();
-        printf("  time: Coulomb %.2f s", coulomb);
-        if (have_exx) printf(", exchange %.2f s", exchange);
-        if (have_xc)  printf(", XC %.2f s", xc);
-        printf(", density %.2f s, other %.2f s; Fock %.2f s",
-               density, t - (density + xc + coulomb + exchange), t);
-        if (started_) printf("; SCF solver %.2f s", outside_);
+        const double wall = batch_.get();
+        printf("  time: Coulomb %.3f s", cur_.coulomb);
+        if (have_exx) printf(", exchange %.3f s", cur_.exchange);
+        if (have_xc)  printf(", XC %.3f s", cur_.xc);
+        printf(", density %.3f s, other %.3f s", cur_.density, cur_.other());
+        if (nbatch_builds_ > 1)
+          printf(" (summed over %zu concurrent builds)", nbatch_builds_);
+        printf("; Fock %.3f s", wall);
+        if (started_) printf("; SCF solver %.3f s", outside_);
         printf("\n");
         fflush(stdout);
       }
 
       /// Cumulative summary, printed once the SCF has finished.
       void print_summary(bool have_xc, bool have_exx) const {
-        const double fock = tot_density + tot_xc + tot_coulomb
+        const double comp = tot_density + tot_xc + tot_coulomb
                           + tot_exchange + tot_other;
-        printf("\nSCF wall-clock breakdown over %zu Fock builds:\n", nbuild);
-        printf("  Coulomb      %10.2f s\n", tot_coulomb);
-        if (have_exx) printf("  exchange     %10.2f s\n", tot_exchange);
-        if (have_xc)  printf("  XC           %10.2f s\n", tot_xc);
-        printf("  density      %10.2f s\n", tot_density);
-        printf("  other (Fock) %10.2f s\n", tot_other);
-        printf("  Fock total   %10.2f s\n", fock);
-        printf("  SCF solver   %10.2f s  (diagonalization, DIIS/ADIIS,"
+        printf("\nSCF wall-clock breakdown over %zu Fock builds", nbuild);
+        if (nbatch != nbuild) printf(" in %zu batches", nbatch);
+        printf(":\n");
+        printf("  Coulomb      %12.3f s\n", tot_coulomb);
+        if (have_exx) printf("  exchange     %12.3f s\n", tot_exchange);
+        if (have_xc)  printf("  XC           %12.3f s\n", tot_xc);
+        printf("  density      %12.3f s\n", tot_density);
+        printf("  other (Fock) %12.3f s\n", tot_other);
+        printf("  Fock total   %12.3f s", comp);
+        // Only when builds ran concurrently do the two differ.
+        if (comp > 1.05 * tot_fock_wall)
+          printf("  (%.3f s elapsed; builds ran concurrently)", tot_fock_wall);
+        printf("\n");
+        printf("  SCF solver   %12.3f s  (diagonalization, DIIS/ADIIS,"
                " occupations)\n", tot_outside);
-        printf("  SCF total    %10.2f s\n", fock + tot_outside);
+        printf("  SCF total    %12.3f s\n", tot_fock_wall + tot_outside);
         fflush(stdout);
       }
 
     private:
-      Timer build_, between_;
+      Timer batch_, between_;
+      Components cur_;
+      size_t nbatch_builds_ = 0;
       double outside_ = 0.0;
       bool started_ = false;
     };

--- a/src/sadatom/aij.cpp
+++ b/src/sadatom/aij.cpp
@@ -18,6 +18,7 @@
 #include "../general/elements.h"
 #include "../general/scf_helpers.h"
 #include "../general/eigen_io.h"
+#include "../general/scf_driver_common.h"
 
 #include "openorbitaloptimizer/scfsolver.hpp"
 
@@ -356,9 +357,17 @@ int main(int argc, char **argv) {
   };
 
   // Fock builder
+  // Per-component wall clock for the Fock build, plus the time spent
+  // outside it in the SCF solver. Shared by both builders: only one of
+  // them is ever handed to the solver.
+  helfem::scf_driver::FockTimer ftimer;
+
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> restricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
+    ftimer.enter();
+    helfem::scf_driver::FockTimer::Components tc;
+    Timer tcomp;
 
     // Kinetic energy
     double Ekin=0.0;
@@ -380,19 +389,25 @@ int main(int argc, char **argv) {
       Ekin += (P*T).trace() + l*(l+1)*(P*Tl).trace();
     }
 
+    tc.density += tcomp.get();
+
     double Enuc=(Prad*Vnuc).trace();
     double Eunif=(Prad*Vunif).trace();
 
     // Coulomb matrix
+    tcomp.set();
     helfem::Matrix J(basis.coulomb(Prad/angfac));
+    tc.coulomb += tcomp.get();
 
     double Exc=0.0;
     helfem::Cube XC;
     double nelnum = 0.0;
     if(x_func > 0 || c_func > 0) {
+      tcomp.set();
       grid.eval_Fxc(x_func, x_pars, c_func, c_pars, divided_cube(Pl,angfac), XC, Exc, nelnum, dftthr);
       // Potential needs to be divided as well
       for(size_t l=0;l<XC.size();l++) XC[l]/=angfac;
+      tc.xc += tcomp.get();
       if(verbose) {
         printf("DFT energy %.10e\n",Exc);
         printf("Error in integrated number of electrons % e\n",nelnum-(Z-Q+njellium));
@@ -421,6 +436,10 @@ int main(int argc, char **argv) {
         fock[l] += XC[l];
       fock[l] = Sinvh.transpose() * fock[l] * Sinvh;
     }
+    tc.total = ftimer.build_elapsed();
+    ftimer.add_build(tc);
+    ftimer.print_build(x_func > 0 || c_func > 0, false);
+    ftimer.leave();
     return std::make_pair(Etot,fock);
   };
 
@@ -428,6 +447,9 @@ int main(int argc, char **argv) {
   OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> unrestricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
+    ftimer.enter();
+    helfem::scf_driver::FockTimer::Components tc;
+    Timer tcomp;
 
     // Kinetic energy
     double Ekin=0.0;
@@ -454,20 +476,26 @@ int main(int argc, char **argv) {
       Ekin += ((Pa+Pb)*T).trace() + l*(l+1)*((Pa+Pb)*Tl).trace();
     }
 
+    tc.density += tcomp.get();
+
     double Enuc=(Prad*Vnuc).trace();
     double Eunif=(Prad*Vunif).trace();
 
     // Coulomb matrix
+    tcomp.set();
     helfem::Matrix J(basis.coulomb(Prad/angfac));
+    tc.coulomb += tcomp.get();
 
     double Exc=0.0;
     helfem::Cube XCa, XCb;
     double nelnum = 0.0;
     if(x_func > 0 || c_func > 0) {
+      tcomp.set();
       grid.eval_Fxc(x_func, x_pars, c_func, c_pars, divided_cube(Pal,angfac), divided_cube(Pbl,angfac), XCa, XCb, Exc, nelnum, true, dftthr);
       // Potential needs to be divided as well
       for(size_t l=0;l<XCa.size();l++) XCa[l]/=angfac;
       for(size_t l=0;l<XCb.size();l++) XCb[l]/=angfac;
+      tc.xc += tcomp.get();
       if(verbose) {
         printf("DFT energy %.10e\n",Exc);
         printf("Error in integrated number of electrons % e\n",nelnum-(Z-Q+njellium));
@@ -501,6 +529,10 @@ int main(int argc, char **argv) {
         fock[l+lmax+1] += XCb[l];
       fock[l+lmax+1] = Sinvh.transpose() * fock[l+lmax+1] * Sinvh;
     }
+    tc.total = ftimer.build_elapsed();
+    ftimer.add_build(tc);
+    ftimer.print_build(x_func > 0 || c_func > 0, false);
+    ftimer.leave();
     return std::make_pair(Etot,fock);
   };
 
@@ -779,6 +811,7 @@ int main(int argc, char **argv) {
     scfsolver.print_citation();
     scfsolver.initialize_with_fock(coreH);
     scfsolver.run();
+    ftimer.print_summary(x_func > 0 || c_func > 0, false);
 
     auto dm = std::make_pair(scfsolver.get_orbitals(), scfsolver.get_orbital_occupations());
     auto fock = scfsolver.get_fock_matrix();
@@ -850,6 +883,7 @@ int main(int argc, char **argv) {
     scfsolver.print_citation();
     scfsolver.initialize_with_fock(coreH);
     scfsolver.run();
+    ftimer.print_summary(x_func > 0 || c_func > 0, false);
 
     auto dm = std::make_pair(scfsolver.get_orbitals(), scfsolver.get_orbital_occupations());
     auto fock = scfsolver.get_fock_matrix();

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -18,6 +18,7 @@
 #include "../general/dftfuncs.h"
 #include "../general/scf_helpers.h"
 #include "../general/checkpoint.h"
+#include "../general/scf_driver_common.h"
 
 #include "openorbitaloptimizer/scfsolver.hpp"
 
@@ -142,9 +143,13 @@ namespace helfem {
         // either a local or a const capture, so the body is safe to run
         // from several threads at once.
         auto build_fock = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm,
-                              std::string * log_line) {
+                              std::string * log_line,
+                              helfem::scf_driver::FockTimer::Components * tc) {
           const auto & orbitals    = dm.first;
           const auto & occupations = dm.second;
+          // Component timings go into the caller's own Components, never
+          // into shared state: a batched build runs these concurrently.
+          Timer tbuild, tcomp;
 
           OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nblock * nparttype);
           helfem::Matrix Prad = helfem::Matrix::Zero(Nrad, Nrad);
@@ -158,10 +163,13 @@ namespace helfem {
           if (restricted) {
             for (size_t l = 0; l < nblock; ++l)
               accumulate_density(Prad, Pal, l, orbitals[l], occupations[l], Ekin);
+            if (tc) tc->density += tcomp.get();
             if (have_xc) {
+              tcomp.set();
               grid.eval_Fxc(opts.x_func, opts.x_pars, opts.c_func, opts.c_pars,
                              divided_cube(Pal, angfac), XCa, Exc, nelnum, opts.dftthr);
               for (size_t l = 0; l < XCa.size(); ++l) XCa[l] /= angfac;
+              if (tc) tc->xc += tcomp.get();
             }
           } else {
             Pbl.assign(nblock, helfem::Matrix::Zero(Nrad, Nrad));
@@ -172,23 +180,29 @@ namespace helfem {
               accumulate_density(Prad_b, Pbl, l, orbitals[nblock + l], occupations[nblock + l], Ekin);
             }
             Prad = Prad_a + Prad_b;
+            if (tc) tc->density += tcomp.get();
             if (have_xc) {
+              tcomp.set();
               grid.eval_Fxc(opts.x_func, opts.x_pars, opts.c_func, opts.c_pars,
                              divided_cube(Pal, angfac), divided_cube(Pbl, angfac), XCa, XCb,
                              Exc, nelnum, opts.nelb > 0, opts.dftthr);
               for (size_t l = 0; l < XCa.size(); ++l) XCa[l] /= angfac;
               if (opts.nelb > 0)
                 for (size_t l = 0; l < XCb.size(); ++l) XCb[l] /= angfac;
+              if (tc) tc->xc += tcomp.get();
             }
           }
 
           const double Enuc = (Prad * Vnuc).trace();
           const double Econf = have_conf ? (Prad * Vconf).trace() : 0.0;
+          tcomp.set();
           const helfem::Matrix J = basis.coulomb(Prad / angfac);
           const double Ecoul = 0.5 * (Prad * J).trace();
+          if (tc) tc->coulomb += tcomp.get();
 
           helfem::Cube Ka, Kb;
           double Exx = 0.0;
+          tcomp.set();
           if (have_exx) {
             helfem::Cube ang_a = Pal;
             for (size_t l = 0; l < nblock; ++l)
@@ -221,6 +235,8 @@ namespace helfem {
                 Exx += 0.5 * (Kb[l] * Pbl[l]).trace();
             }
           }
+
+          if (tc) tc->exchange += tcomp.get();
 
           const double Etot = Ekin + Enuc + Econf + Ecoul + Exc + Exx;
 
@@ -262,12 +278,23 @@ namespace helfem {
                                                    Kb, have_exx && opts.nelb > 0);
             }
           }
+          if (tc) tc->total = tbuild.get();
           return std::make_pair(Etot, fock);
         };
 
+        // Per-component wall clock for the Fock build, plus the time
+        // spent outside it in the SCF solver.
+        helfem::scf_driver::FockTimer ftimer;
+
         OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
             [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
-          return build_fock(dm, nullptr);
+          ftimer.enter();
+          helfem::scf_driver::FockTimer::Components tc;
+          auto ret = build_fock(dm, nullptr, &tc);
+          ftimer.add_build(tc);
+          if (opts.verbosity > 0) ftimer.print_build(have_xc, have_exx);
+          ftimer.leave();
+          return ret;
         };
 
         // Batched Fock build. The solver hands us every density it wants
@@ -285,9 +312,14 @@ namespace helfem {
         // oversubscription results.
         OpenOrbitalOptimizer::BatchedFockBuilder<OOO_Real, OOO_Real> batched_fock_builder =
             [&](const std::vector<OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real>> & dms) {
+          ftimer.enter();
           const size_t n = dms.size();
           std::vector<OpenOrbitalOptimizer::FockBuilderReturn<OOO_Real, OOO_Real>> out(n);
           std::vector<std::string> lines(n);
+          // One Components per entry, exactly as for the log lines: the
+          // entries below run concurrently, so nothing shared may be
+          // written from inside the loop.
+          std::vector<helfem::scf_driver::FockTimer::Components> comps(n);
 
           // Fill any lazily-built caches while still serial: the builds
           // below only read them, but filling concurrently would race.
@@ -299,17 +331,21 @@ namespace helfem {
 #pragma omp parallel for schedule(dynamic)
 #endif
             for (long i = 0; i < (long) n; ++i)
-              out[i] = build_fock(dms[i], &lines[i]);
+              out[i] = build_fock(dms[i], &lines[i], &comps[i]);
           } else {
             for (size_t i = 0; i < n; ++i)
-              out[i] = build_fock(dms[i], &lines[i]);
+              out[i] = build_fock(dms[i], &lines[i], &comps[i]);
           }
+          // Serial again: safe to fold the per-entry timings in.
+          for (const auto & c : comps) ftimer.add_build(c);
 
           // Report in batch order, so the log reads the same whether or
           // not the entries were evaluated concurrently.
           for (const auto & line : lines)
             if (line.size()) fputs(line.c_str(), stdout);
+          if (opts.verbosity > 0) ftimer.print_build(have_xc, have_exx);
           fflush(stdout);
+          ftimer.leave();
           return out;
         };
 
@@ -502,6 +538,7 @@ namespace helfem {
         if (opts.verbosity > 0)
           scfsolver.print_citation();
         scfsolver.run();
+        if (opts.verbosity > 0) ftimer.print_summary(have_xc, have_exx);
 
         // Extract results. Convert OOO's per-block orbital matrices
         // (in the Sinvh-orthonormal basis) back to AO coefficients


### PR DESCRIPTION
Follow-up to #298, extending the same accounting to `gensap` and `aij`.

## Labels were already fine

Both index their blocks by angular momentum directly and already print `l=0`, `l=1`, ..., so there was nothing to fix on that half — only the timings were missing.

## FockTimer had to become batch-safe first

The timer assumed one Fock build per builder invocation and accumulated component times into its own members. `gensap` breaks both assumptions: its `BatchedFockBuilder` receives every density the ODA polytope wants evaluated at once and evaluates them **concurrently**. Accumulating into shared members from inside that loop would be a data race, and the "time outside the Fock build" would stop meaning anything.

Component times now go into a per-build `FockTimer::Components`, local to the build and handed over afterwards via `add_build()` — the same discipline the batched builder already uses for its log lines, for the same reason.

Two consequences:

- Under a concurrent batch the component sums exceed the batch's elapsed wall clock, so wall clock is tracked separately rather than derived by subtraction. The summary says so when the two diverge, and the per-build line notes when it is reporting a sum over concurrent builds.
- `other` is computed per build (that build's total minus its components) rather than once at the end — subtracting concurrent sums from a batch wall clock would have gone negative.

Resolution also goes from centiseconds to milliseconds: gensap converges an atom in tens of ms, where two decimals is all zeroes.

## Gating

`gensap` gates on `opts.verbosity` (default 5). `aij` prints unconditionally, as the diatomic driver does — its existing `DFT energy` prints are gated on `helfem::verbose`, which nothing in the binary ever sets, so gating there would have made the output unreachable.

## What it shows

Both are dominated by the SCF solver rather than the Fock build:

```
aij Al in jellium (79 builds)      gensap Og / B3LYP (11 builds)
  Coulomb        0.004 s             Coulomb        0.001 s
  XC             0.044 s             exchange       0.065 s
  density        0.089 s             XC             0.010 s
  other (Fock)   0.114 s             density        0.013 s
  Fock total     0.251 s             Fock total     0.101 s
  SCF solver     1.535 s             SCF solver     0.202 s
  SCF total      1.787 s             SCF total      0.303 s
```

## Verification

`tests/run_tests.py --check tests/refs/ci.json --tag ci`: **40 passed, 0 failed, 0 invariant violations** (includes the three gensap cases). Both `aij` cases run and still parse, with the `njellium=0` consistency invariant passing. Printout-only; no energy moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)