### PR TITLE
Add --verbosity to all four SCF drivers; route library chatter through helfem::verbose

### DIFF
--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "FiniteElementBasis.h"
+#include <helfem.h>
 #include <lobatto.h>
 #include <algorithm>
 #include <cfloat>
@@ -136,7 +137,8 @@ namespace helfem {
       }
       Eigen::Index imax;
       dnorm.maxCoeff(&imax);
-      printf("Finite element basis set max discontinuity %s between elements %i and %i\n",helfem::io::fmt_sci(dnorm(imax)).c_str(),(int) imax,(int) imax+1);
+      if(helfem::verbose)
+        printf("Finite element basis set max discontinuity %s between elements %i and %i\n",helfem::io::fmt_sci(dnorm(imax)).c_str(),(int) imax,(int) imax+1);
       fflush(stdout);
       if(dnorm(imax) > sqrt(DBL_EPSILON)) {
         throw std::logic_error("Finite element basis set is not continuous\n");

--- a/libhelfem/src/PolynomialBasis.cpp
+++ b/libhelfem/src/PolynomialBasis.cpp
@@ -21,6 +21,7 @@
 // factory that constructs the concrete bases by primitive ID.
 
 #include "PolynomialBasis.h"
+#include <helfem.h>
 #include <cmath>
 
 // (GeneralHIPBasis was removed when its callers were either rerouted to
@@ -43,7 +44,8 @@ namespace helfem {
 
       case(3):
         poly=new polynomial_basis::LegendreBasis(Nnodes,primbas);
-        printf("Basis set composed of %i-node spectral elements.\n",Nnodes);
+        if(helfem::verbose)
+          printf("Basis set composed of %i-node spectral elements.\n",Nnodes);
         break;
 
       case(4):
@@ -51,7 +53,8 @@ namespace helfem {
           helfem::Vec<double> x, w;
           helfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
           poly=new polynomial_basis::LIPBasis(x, primbas);
-          printf("Basis set composed of %i-node LIPs with Gauss-Lobatto nodes.\n",Nnodes);
+          if(helfem::verbose)
+            printf("Basis set composed of %i-node LIPs with Gauss-Lobatto nodes.\n",Nnodes);
           break;
         }
 
@@ -60,7 +63,8 @@ namespace helfem {
           helfem::Vec<double> x, w;
           helfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
           poly=new polynomial_basis::HIPBasis(x, primbas);
-          printf("Basis set composed of %i-node HIPs with Gauss-Lobatto nodes.\n",Nnodes);
+          if(helfem::verbose)
+            printf("Basis set composed of %i-node HIPs with Gauss-Lobatto nodes.\n",Nnodes);
           break;
         }
 
@@ -70,7 +74,8 @@ namespace helfem {
           for(int i=0;i<Nnodes;i++)
             x(i) = std::cos(M_PI*(Nnodes-1-i)/(Nnodes-1));
           poly=new polynomial_basis::LIPBasis(x, 4);
-          printf("Basis set composed of %i-node LIPs with Chebyshev nodes.\n",Nnodes);
+          if(helfem::verbose)
+            printf("Basis set composed of %i-node LIPs with Chebyshev nodes.\n",Nnodes);
           break;
         }
 
@@ -80,7 +85,8 @@ namespace helfem {
           for(int i=0;i<Nnodes;i++)
             x(i) = std::cos(M_PI*(Nnodes-1-i)/(Nnodes-1));
           poly=new polynomial_basis::HIPBasis(x, 5);
-          printf("Basis set composed of %i-node HIPs with Chebyshev nodes.\n",Nnodes);
+          if(helfem::verbose)
+            printf("Basis set composed of %i-node HIPs with Chebyshev nodes.\n",Nnodes);
           break;
         }
 
@@ -91,7 +97,8 @@ namespace helfem {
           helfem::Vec<double> x, w;
           helfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
           poly = new polynomial_basis::HIP2BasisT<double>(x, primbas);
-          printf("Basis set composed of %i-node 2nd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
+          if(helfem::verbose)
+            printf("Basis set composed of %i-node 2nd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
           break;
         }
 
@@ -102,7 +109,8 @@ namespace helfem {
           helfem::Vec<double> x, w;
           helfem::lobatto::lobatto_compute<double>(Nnodes, x, w);
           poly = new polynomial_basis::HIP3BasisT<double>(x, primbas);
-          printf("Basis set composed of %i-node 3rd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
+          if(helfem::verbose)
+            printf("Basis set composed of %i-node 3rd order analytic HIPs with Gauss-Lobatto nodes.\n", Nnodes);
           break;
         }
 

--- a/libhelfem/src/helfem.cpp
+++ b/libhelfem/src/helfem.cpp
@@ -20,10 +20,8 @@ using namespace std;
 bool helfem::verbose = false;
 
 void helfem::set_verbosity(bool new_verbosity) {
-  if (verbose && new_verbosity)
-    printf("HelFEM library already in verbose mode.");
-  else if (!verbose && new_verbosity)
-    printf("HelFEM library set to verbose mode.");
+  // Announcing the change is itself unwanted output -- and every driver
+  // now calls this once at startup, so it would print on every run.
   verbose = new_verbosity;
 }
 

--- a/libhelfem/src/utils.cpp
+++ b/libhelfem/src/utils.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "utils.h"
+#include <helfem.h>
 #include <math.h>
 // Scalar formatter that prints a T value at its own precision (no truncation
 // to double). Header-only, needs only Matrix.h + std; see src/general/eigen_io.h.
@@ -146,7 +147,8 @@ namespace helfem {
         // double). Sval(0) is the smallest eigenvalue of the (SPD) overlap
         // matrix and hence positive, so the leading " " reproduces the old
         // "% e" space flag exactly.
-        printf("Smallest eigenvalue of overlap matrix is %s, condition number %s\n",
+        if(helfem::verbose)
+          printf("Smallest eigenvalue of overlap matrix is %s, condition number %s\n",
                (" " + helfem::io::fmt_sci(Sval(0))).c_str(),
                helfem::io::fmt_sci(Sval(Sval.size() - 1) / Sval(0)).c_str());
         Sinvh = Svec * inv_sqrt<T>(Sval).asDiagonal() * Svec.transpose();

--- a/src/atomic/basis.cpp
+++ b/src/atomic/basis.cpp
@@ -147,7 +147,8 @@ namespace helfem {
           printf("Off-center grid\n");
           bval=atomic::basis::offcenter_nuclear_grid(Nelem0,Z,std::max(Zl,Zr),Rhalf,Nelem,Rmax,igrid,zexp);
         } else {
-          printf("Normal grid\n");
+          if(helfem::verbose)
+            printf("Normal grid\n");
           bval=atomic::basis::normal_grid(Nelem,Rmax,igrid,zexp);
         }
 
@@ -169,7 +170,8 @@ namespace helfem {
 
 	}
 
-        helfem::io::print_matrix("Grid", helfem::Matrix(bval));
+        if(helfem::verbose)
+          helfem::io::print_matrix("Grid", helfem::Matrix(bval));
 
         return bval;
       }

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <cfloat>
+#include <helfem.h>
 #include <cmath>
 #include <cstdio>
 // LibXC
@@ -580,7 +581,8 @@ namespace helfem {
       DFTGrid::DFTGrid(const helfem::atomic::basis::TwoDBasis * basp_, int lang_, int mang_) : basp(basp_), lang(lang_), mang(mang_) {
         helfem::Vector cth, phi, wang;
         helfem::angular::angular_chebyshev(lang,mang,cth,phi,wang);
-        printf("DFT angular grid of order l=%i m=%i has %i points\n",lang,mang,(int) wang.size());
+        if(helfem::verbose)
+          printf("DFT angular grid of order l=%i m=%i has %i points\n",lang,mang,(int) wang.size());
       }
 
       DFTGrid::~DFTGrid() {
@@ -646,7 +648,8 @@ namespace helfem {
         Ekin=ekin;
         Nel=nel;
 
-        printf("Integral over laplacian %e\n",lapl);
+        if(helfem::verbose)
+          printf("Integral over laplacian %e\n",lapl);
       }
 
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa, const helfem::Matrix & Pb, helfem::Matrix & Ha, helfem::Matrix & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr) {

--- a/src/atomic/inttest.cpp
+++ b/src/atomic/inttest.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "quadrature.h"
+#include <helfem.h>
 #include "PolynomialBasis.h"
 #include "LIPBasis.h"
 #include "Matrix.h"
@@ -103,6 +104,9 @@ void run(double R, int n_quad) {
 }
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   if (argc != 3) {
     printf("Usage: %s nquad R\n", argv[0]);
     return 1;

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -685,7 +685,7 @@ int main(int argc, char **argv) {
   }
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
-  if (verbosity >= 1) scfsolver.print_citation();
+  scfsolver.print_citation();
   scfsolver.run();
 
   // --save: reconstruct the AO densities from the converged per-block

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -75,6 +75,7 @@ int main(int argc, char **argv) {
   parser.add<double>("Rrms", 0, "finite nuclear rms radius", false, 0.0);
   parser.add<int>("restricted", 0, "spin-restricted: 1 restricted, 0 unrestricted, -1 auto from nela/nelb", false, -1);
   parser.add<int>("symmetry", 0, "orbital symmetry: 0 none, 1 per-m, 2 per-(l,m)", false, 1);
+  parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration Fock timings; also passed to the SCF solver", false, 5);
   // Off-centre point charges on the z-axis at +/- Rmid (parity with the
   // bespoke atomic driver): an atom of charge Z at the origin embedded
   // between two extra nuclei Zl, Zr. Breaks spherical (l) symmetry but
@@ -131,6 +132,11 @@ int main(int argc, char **argv) {
 
   parser.parse_check(argc, argv);
 
+  // Gates every non-warning printout below; see the option help.
+  const int    verbosity  = parser.get<int>("verbosity");
+  // The shared basis/grid/functional code reports through this flag.
+  helfem::set_verbosity(verbosity >= 1);
+
   const int    Z          = get_Z(parser.get<std::string>("Z"));
         int    Q          = parser.get<int>("Q");
         int    M          = parser.get<int>("M");
@@ -160,7 +166,8 @@ int main(int argc, char **argv) {
   const int    Zr         = get_Z(parser.get<std::string>("Zr"));
         double Rhalf      = parser.get<double>("Rmid");
   if (parser.get<bool>("angstrom") && Rhalf != 0.0) {
-    printf("Converting Rmid from %g angstrom to %g bohr.\n", Rhalf, Rhalf * ANGSTROMINBOHR);
+    if (verbosity >= 1)
+      printf("Converting Rmid from %g angstrom to %g bohr.\n", Rhalf, Rhalf * ANGSTROMINBOHR);
     Rhalf *= ANGSTROMINBOHR;
   }
   const std::string xparf = parser.get<std::string>("x_pars");
@@ -250,8 +257,10 @@ int main(int argc, char **argv) {
       ? Z * (Zl + Zr) / Rhalf + Zl * Zr / (2.0 * Rhalf)
       : 0.0;
   if (Zl != 0 || Zr != 0) {
-    printf("Off-centre charges Zl=%i Zr=%i at distance %.6f bohr from the origin.\n", Zl, Zr, Rhalf);
-    printf("Nuclear repulsion energy is %.10e\n", Enucr);
+    if (verbosity >= 1)
+      printf("Off-centre charges Zl=%i Zr=%i at distance %.6f bohr from the origin.\n", Zl, Zr, Rhalf);
+    if (verbosity >= 1)
+      printf("Nuclear repulsion energy is %.10e\n", Enucr);
     if (Rhalf <= 0.0)
       throw std::logic_error("Off-centre charges require --Rmid > 0.\n");
     if (Nelem0 < 1)
@@ -272,9 +281,11 @@ int main(int argc, char **argv) {
                                   mval,
                                   Zl, Zr, Rhalf);
   const size_t Nbf = basis.Nbf();
-  printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
+  if (verbosity >= 1)
+    printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
           (int) basis.Nang(), (int) basis.Nrad(), (int) Nbf);
-  printf("Mode: %s, symmetry=%d, nela=%d nelb=%d\n",
+  if (verbosity >= 1)
+    printf("Mode: %s, symmetry=%d, nela=%d nelb=%d\n",
           restricted ? "restricted" : "unrestricted", symm, nela, nelb);
 
   // --- One-electron + overlap (basis returns helfem::Matrix directly).
@@ -289,7 +300,8 @@ int main(int argc, char **argv) {
   //     coupling is off, so the additions cost nothing but a trace pass.
   helfem::Matrix Vconf = helfem::Matrix::Zero(Nbf, Nbf);
   if (iconf) {
-    printf("Computing confinement potential\n");
+    if (verbosity >= 1)
+      printf("Computing confinement potential\n");
     Vconf = basis.confinement(conf_N, conf_R, iconf, conf_barrier, shift_conf);
   }
   const helfem::Matrix dip  = basis.dipole_z();
@@ -461,14 +473,16 @@ int main(int argc, char **argv) {
 
     const double Etot = Ekin + Enuc + Eefield + Emfield + Econf
                        + Ecoul + Exc + Exx + Enucr;
-    printf("kinetic %.10f nuclear %.10f Coulomb %.10f XC %.10f Exx %.10f",
-            Ekin, Enuc, Ecoul, Exc, Exx);
-    if (have_efield) printf(" Eefield %.10f", Eefield);
-    if (have_bfield) printf(" Emfield %.10f", Emfield);
-    if (have_conf)   printf(" Econf %.10f",   Econf);
-    if (Enucr != 0.0) printf(" Enucr %.10f",  Enucr);
-    printf("  total %.10f  (nel err %.3e)\n",
-            Etot, nelnum - static_cast<double>(Ntot));
+    if (verbosity >= 1) {
+      printf("kinetic %.10f nuclear %.10f Coulomb %.10f XC %.10f Exx %.10f",
+              Ekin, Enuc, Ecoul, Exc, Exx);
+      if (have_efield) printf(" Eefield %.10f", Eefield);
+      if (have_bfield) printf(" Emfield %.10f", Emfield);
+      if (have_conf)   printf(" Econf %.10f",   Econf);
+      if (Enucr != 0.0) printf(" Enucr %.10f",  Enucr);
+      printf("  total %.10f  (nel err %.3e)\n",
+              Etot, nelnum - static_cast<double>(Ntot));
+    }
     fflush(stdout);
 
     // --- Fock assembly. Restricted: one AO Fock, orthonormalize per block.
@@ -499,25 +513,30 @@ int main(int argc, char **argv) {
   //     because it typically converges materially faster than core-H.
   helfem::Matrix Vguess;
   if (iguess == 0) {
-    printf("Guess orbitals from core Hamiltonian\n");
+    if (verbosity >= 1)
+      printf("Guess orbitals from core Hamiltonian\n");
     Vguess = Vnuc;
   } else {
     modelpotential::ModelPotential * model = nullptr;
     switch (iguess) {
     case 1:
-      printf("Guess orbitals from GSZ screened nucleus\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from GSZ screened nucleus\n");
       model = new modelpotential::GSZAtom(Z);
       break;
     case 2:
-      printf("Guess orbitals from SAP screened nucleus\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from SAP screened nucleus\n");
       model = new modelpotential::SAPAtom(Z);
       break;
     case 3:
-      printf("Guess orbitals from Thomas-Fermi screened nucleus\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from Thomas-Fermi screened nucleus\n");
       model = new modelpotential::TFAtom(Z);
       break;
     case 4:
-      printf("Guess orbitals from SAP screened nucleus, evaluated from the tabulated wave function\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from SAP screened nucleus, evaluated from the tabulated wave function\n");
       model = new modelpotential::SAPFEAtom(Z);
       break;
     default:
@@ -534,6 +553,9 @@ int main(int argc, char **argv) {
   OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
       number_of_blocks_per_particle_type, maximum_occupation,
       number_of_particles, fock_builder, block_descriptions);
+  // Before any Fock evaluation: initialize_with_fock builds one,
+  // and it would otherwise report at the default level.
+  scfsolver.set("verbosity", verbosity);
 
   // --readocc: parse occs.dat and hand OOO a fixed per-block particle
   // count, bypassing Aufbau for the whole SCF. Bespoke atomic reads
@@ -663,7 +685,7 @@ int main(int argc, char **argv) {
   }
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
-  scfsolver.print_citation();
+  if (verbosity >= 1) scfsolver.print_citation();
   scfsolver.run();
 
   // --save: reconstruct the AO densities from the converged per-block
@@ -683,7 +705,8 @@ int main(int argc, char **argv) {
     savechk.write("Pb", Pb_final);
     savechk.write("nela", nela);
     savechk.write("nelb", nelb);
-    printf("Saved results to %s\n", savefile.c_str());
+    if (verbosity >= 1)
+      printf("Saved results to %s\n", savefile.c_str());
   }
 
   return 0;

--- a/src/atomic/teirank.cpp
+++ b/src/atomic/teirank.cpp
@@ -31,6 +31,7 @@
 // must go through RI rather than compressing the exchange-ordered tensor.
 
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "basis.h"
 #include "utils.h"
 #include "FiniteElementBasis.h"
@@ -43,6 +44,9 @@
 using namespace helfem;
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
   parser.add<double>("Rmax", 0, "practical infinity", false, 40.0);
   parser.add<int>("nelem", 0, "number of elements", false, 5);

--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/checkpoint.h"
 #include "../general/constants.h"
 #include "../general/dftfuncs.h"
@@ -31,6 +32,9 @@
 using namespace helfem;
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   // full option name, no short option, description, argument required

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "basis.h"
+#include <helfem.h>
 #include "quadrature.h"
 #include "PolynomialBasis.h"
 #include "chebyshev.h"
@@ -619,11 +620,15 @@ namespace helfem {
           const int mcap = 2*mabs;
 
           Timer t;
-          printf("Computing Gaunt coefficients ... ");
-          fflush(stdout);
+          if(helfem::verbose) {
+            printf("Computing Gaunt coefficients ... ");
+            fflush(stdout);
+          }
           gaunt=gaunt::Gaunt(lrval,midval,lrval,mcap);
-          printf("done (% .3f s)\n",t.get());
-          fflush(stdout);
+          if(helfem::verbose) {
+            printf("done (% .3f s)\n",t.get());
+            fflush(stdout);
+          }
 
         } else {
           // One-electron matrices need gmax,5,gmax

--- a/src/diatomic/completeness.cpp
+++ b/src/diatomic/completeness.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/checkpoint.h"
 #include "../general/constants.h"
 #include "../general/timer.h"
@@ -29,6 +30,9 @@
 using namespace helfem;
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   // full option name, no short option, description, argument required

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/constants.h"
 #include "../general/timer.h"
 #include "../general/elements.h"
@@ -171,6 +172,9 @@ void eval(int Z1, int Z2, double Rrms1, double Rrms2, double Rbond, const std::s
 }
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   // full option name, no short option, description, argument required

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/checkpoint.h"
 #include "Matrix.h"
 #include "../general/constants.h"
@@ -31,6 +32,9 @@
 using namespace helfem;
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   // full option name, no short option, description, argument required

--- a/src/diatomic/density_line.cpp
+++ b/src/diatomic/density_line.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/checkpoint.h"
 #include "../general/constants.h"
 #include "../general/timer.h"
@@ -27,6 +28,9 @@
 using namespace helfem;
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   parser.add<std::string>("load", 0, "load guess from checkpoint", false, "");

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <cfloat>
+#include <helfem.h>
 #include <cmath>
 #include <cstdio>
 // LibXC
@@ -522,7 +523,8 @@ namespace helfem {
       DFTGrid::DFTGrid(const helfem::diatomic::basis::TwoDBasis * basp_, int lang_, int mang_) : basp(basp_), lang(lang_), mang(mang_) {
         helfem::Vector cth, phi, wang;
         helfem::angular::angular_chebyshev(lang,mang,cth,phi,wang);
-        printf("DFT angular grid of order l=%i m=%i has %i points\n",lang,mang,(int) wang.size());
+        if(helfem::verbose)
+          printf("DFT angular grid of order l=%i m=%i has %i points\n",lang,mang,(int) wang.size());
       }
 
       DFTGrid::~DFTGrid() {

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "dftgrid_purem.h"
+#include <helfem.h>
 #include "dftgrid.h"     // increment_gga
 #include "chebyshev.h"
 #include "../general/spherical_harmonics.h"
@@ -583,7 +584,8 @@ namespace helfem {
       PureMDFTGrid::PureMDFTGrid(const helfem::diatomic::basis::TwoDBasis * basp_, int lang_) : basp(basp_), lang(lang_) {
         helfem::Vector cth, wang;
         chebyshev::chebyshev(lang, cth, wang);
-        printf("Pure-m DFT grid: nu rule of order l=%i has %i points; the phi integral is analytic (2 pi).\n",
+        if(helfem::verbose)
+          printf("Pure-m DFT grid: nu rule of order l=%i has %i points; the phi integral is analytic (2 pi).\n",
                 lang, (int) wang.size());
       }
 

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char **argv) {
   parser.add<double>("Rrms2", 0, "nucleus 2 finite rms radius", false, 0.0);
   parser.add<int>("restricted", 0, "spin-restricted: 1 restricted, 0 unrestricted, -1 auto from nela/nelb", false, -1);
   parser.add<int>("symmetry", 0, "orbital symmetry: 0 none, 1 per-m, 2 per-(m,parity) (homonuclear only)", false, 1);
+  parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration Fock timings; also passed to the SCF solver", false, 5);
   parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
   parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
 
@@ -119,11 +120,17 @@ int main(int argc, char **argv) {
 
   parser.parse_check(argc, argv);
 
+  // Gates every non-warning printout below; see the option help.
+  const int    verbosity = parser.get<int>("verbosity");
+  // The shared basis/grid/functional code reports through this flag.
+  helfem::set_verbosity(verbosity >= 1);
+
   const int Z1        = get_Z(parser.get<std::string>("Z1"));
   const int Z2        = get_Z(parser.get<std::string>("Z2"));
         double Rbond  = parser.get<double>("Rbond");
   if (parser.get<bool>("angstrom")) {
-    printf("Converting Rbond from %g angstrom to %g bohr.\n", Rbond, Rbond * ANGSTROMINBOHR);
+    if (verbosity >= 1)
+      printf("Converting Rbond from %g angstrom to %g bohr.\n", Rbond, Rbond * ANGSTROMINBOHR);
     Rbond *= ANGSTROMINBOHR;
   }
         int Q         = parser.get<int>("Q");
@@ -235,9 +242,11 @@ int main(int argc, char **argv) {
 
   diatomic::basis::TwoDBasis basis(Z1, Z2, Rhalf, poly, Nquad, bval, lval, mval);
   const size_t Nbf = basis.Nbf();
-  printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
+  if (verbosity >= 1)
+    printf("Basis set: %i angular shells x %i radial = %i basis functions\n",
           (int) basis.Nang(), (int) basis.Nrad(), (int) Nbf);
-  printf("Mode: %s, symmetry=%d, nela=%d nelb=%d\n",
+  if (verbosity >= 1)
+    printf("Mode: %s, symmetry=%d, nela=%d nelb=%d\n",
           restricted ? "restricted" : "unrestricted", symm, nela, nelb);
 
   // Diatomic chemistry-layer methods now return Eigen (helfem::Matrix).
@@ -262,7 +271,8 @@ int main(int argc, char **argv) {
     Vnuc = qgrid.model_potential(pot1, pot2);
     delete pot1;
     delete pot2;
-    printf("Using finite nuclear model %d (Rrms1=%g, Rrms2=%g)\n", finitenuc, Rrms1, Rrms2);
+    if (verbosity >= 1)
+      printf("Using finite nuclear model %d (Rrms1=%g, Rrms2=%g)\n", finitenuc, Rrms1, Rrms2);
   }
 
   // External static-field one-electron matrices. Diatomic has two
@@ -446,15 +456,19 @@ int main(int argc, char **argv) {
 
     const double Etot = Ekin + Enuc + Eefield + Emfield
                        + Ecoul + Exc + Exx + Enucr;
-    printf("kinetic %.10f nuclear %.10f Enucr %.10f Coulomb %.10f XC %.10f Exx %.10f",
-            Ekin, Enuc, Enucr, Ecoul, Exc, Exx);
-    if (have_efield) printf(" Eefield %.10f", Eefield);
-    if (have_bfield) printf(" Emfield %.10f", Emfield);
-    printf("  total %.10f  (nel err %.3e)\n",
-            Etot, nelnum - static_cast<double>(Ntot));
+    if (verbosity >= 1) {
+      printf("kinetic %.10f nuclear %.10f Enucr %.10f Coulomb %.10f XC %.10f Exx %.10f",
+              Ekin, Enuc, Enucr, Ecoul, Exc, Exx);
+      if (have_efield) printf(" Eefield %.10f", Eefield);
+      if (have_bfield) printf(" Emfield %.10f", Emfield);
+      printf("  total %.10f  (nel err %.3e)\n",
+              Etot, nelnum - static_cast<double>(Ntot));
+    }
     tcomps.total = ftimer.build_elapsed();
     ftimer.add_build(tcomps);
-    ftimer.print_build(have_xc, have_exx);
+    // Timings roughly double the per-iteration volume, so they sit one
+    // rung above the energies rather than alongside them.
+    if (verbosity >= 5) ftimer.print_build(have_xc, have_exx);
     fflush(stdout);
 
     // Fock assembly. Restricted: one AO Fock matrix per block.
@@ -485,28 +499,33 @@ int main(int argc, char **argv) {
   //     faster than core-H.
   helfem::Matrix Vguess;
   if (iguess == 0) {
-    printf("Guess orbitals from core Hamiltonian\n");
+    if (verbosity >= 1)
+      printf("Guess orbitals from core Hamiltonian\n");
     Vguess = Vnuc;
   } else {
     modelpotential::ModelPotential *p1 = nullptr, *p2 = nullptr;
     switch (iguess) {
     case 1:
-      printf("Guess orbitals from GSZ screened nuclei\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from GSZ screened nuclei\n");
       p1 = new modelpotential::GSZAtom(Z1);
       p2 = new modelpotential::GSZAtom(Z2);
       break;
     case 2:
-      printf("Guess orbitals from SAP screened nuclei\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from SAP screened nuclei\n");
       p1 = new modelpotential::SAPAtom(Z1);
       p2 = new modelpotential::SAPAtom(Z2);
       break;
     case 3:
-      printf("Guess orbitals from Thomas-Fermi screened nuclei\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from Thomas-Fermi screened nuclei\n");
       p1 = new modelpotential::TFAtom(Z1);
       p2 = new modelpotential::TFAtom(Z2);
       break;
     case 4:
-      printf("Guess orbitals from SAP screened nuclei, evaluated from the tabulated wave functions\n");
+      if (verbosity >= 1)
+        printf("Guess orbitals from SAP screened nuclei, evaluated from the tabulated wave functions\n");
       p1 = new modelpotential::SAPFEAtom(Z1);
       p2 = new modelpotential::SAPFEAtom(Z2);
       break;
@@ -527,6 +546,9 @@ int main(int argc, char **argv) {
   OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(
       number_of_blocks_per_particle_type, maximum_occupation,
       number_of_particles, fock_builder, block_descriptions);
+  // Before any Fock evaluation: initialize_with_fock builds one,
+  // and it would otherwise report at the default level.
+  scfsolver.set("verbosity", verbosity);
 
   // --readocc: parse occs.dat and hand OOO a fixed per-block particle
   // count. Bespoke diatomic reads (nocca, noccb, m) rows for both
@@ -637,9 +659,9 @@ int main(int argc, char **argv) {
   }
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
-  scfsolver.print_citation();
+  if (verbosity >= 1) scfsolver.print_citation();
   scfsolver.run();
-  ftimer.print_summary(have_xc, have_exx);
+  if (verbosity >= 5) ftimer.print_summary(have_xc, have_exx);
 
   if (savefile.size()) {
     Checkpoint savechk(savefile, /*writemode=*/true);
@@ -658,7 +680,8 @@ int main(int argc, char **argv) {
     savechk.write("Rhalf", Rhalf);
     savechk.write("Z1", Z1);
     savechk.write("Z2", Z2);
-    printf("Saved results to %s\n", savefile.c_str());
+    if (verbosity >= 1)
+      printf("Saved results to %s\n", savefile.c_str());
   }
 
   return 0;

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -659,7 +659,7 @@ int main(int argc, char **argv) {
   }
 
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
-  if (verbosity >= 1) scfsolver.print_citation();
+  scfsolver.print_citation();
   scfsolver.run();
   if (verbosity >= 5) ftimer.print_summary(have_xc, have_exx);
 

--- a/src/diatomic/purem_test.cpp
+++ b/src/diatomic/purem_test.cpp
@@ -26,6 +26,7 @@
 // Laplacian built from the arbitrary-point evaluator eval_bf(mu,cth,phi).
 
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/constants.h"
 #include "../general/dftfuncs.h"
 #include "../general/elements.h"
@@ -74,6 +75,9 @@ static double fd_laplacian(const diatomic::basis::TwoDBasis & basis, size_t idx,
 }
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
   parser.add<std::string>("Z1", 0, "first nuclear charge", false, "1");
   parser.add<std::string>("Z2", 0, "second nuclear charge", false, "1");

--- a/src/diatomic/teirank.cpp
+++ b/src/diatomic/teirank.cpp
@@ -30,6 +30,7 @@
 // A rank r replaces the O(Nprim^4) storage and contraction by O(Nprim^2 * r).
 
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "basis.h"
 #include "utils.h"
 #include "../atomic/basis.h"
@@ -40,6 +41,9 @@
 using namespace helfem;
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
   parser.add<double>("Rbond", 0, "internuclear distance", false, 2.07);
   parser.add<double>("Rmax", 0, "practical infinity", false, 15.0);

--- a/src/general/dftfuncs.cpp
+++ b/src/general/dftfuncs.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <string>
+#include <helfem.h>
 #include <sstream>
 #include <stdexcept>
 #include <cstring>
@@ -142,6 +143,11 @@ void parse_xc_func(int & x_func, int & c_func, const std::string & xc) {
 }
 
 void print_info(int x_func, int c_func) {
+  // The libxc citation goes quiet with the rest of the output: at
+  // --verbosity=0 the caller has asked for no output at all. Every
+  // other level, including the default, still prints it.
+  if(!helfem::verbose)
+    return;
   printf("\nRunning with Libxc version %s\n",xc_version_string());
   printf("%s (doi:%s)\n", xc_reference(), xc_reference_doi());
   printf("Please cite this paper for the use of Libxc in any resulting publications.\n\n");

--- a/src/general/dftfuncs.cpp
+++ b/src/general/dftfuncs.cpp
@@ -143,14 +143,15 @@ void parse_xc_func(int & x_func, int & c_func, const std::string & xc) {
 }
 
 void print_info(int x_func, int c_func) {
-  // The libxc citation goes quiet with the rest of the output: at
-  // --verbosity=0 the caller has asked for no output at all. Every
-  // other level, including the default, still prints it.
-  if(!helfem::verbose)
-    return;
+  // The citation is unconditional: attribution for the libraries a
+  // result depends on is not something a verbosity setting may
+  // suppress. Only the description of which functional was selected
+  // follows the verbosity flag.
   printf("\nRunning with Libxc version %s\n",xc_version_string());
   printf("%s (doi:%s)\n", xc_reference(), xc_reference_doi());
   printf("Please cite this paper for the use of Libxc in any resulting publications.\n\n");
+  if(!helfem::verbose)
+    return;
   if(is_exchange_correlation(x_func)) {
     printf("Used exchange-correlation functional is %s, ",get_keyword(x_func).c_str());
     print_info(x_func);

--- a/src/harmonic/main.cpp
+++ b/src/harmonic/main.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "PolynomialBasis.h"
+#include <helfem.h>
 #include "FiniteElementBasis.h"
 #include "Matrix.h"
 #include "../general/eigen_io.h"
@@ -46,6 +47,9 @@ namespace {
 }
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   if (argc != 6) {
     printf("Usage: %s xmax Nel Nnode primbas Nquad\n", argv[0]);
     return 1;

--- a/src/harmonic/morse.cpp
+++ b/src/harmonic/morse.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/checkpoint.h"
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
@@ -39,6 +40,9 @@ helfem::Matrix kinetic(const helfem::polynomial_basis::FiniteElementBasis & fem,
 }
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   // full option name, no short option, description, argument required

--- a/src/harmonic/precision.cpp
+++ b/src/harmonic/precision.cpp
@@ -39,6 +39,7 @@
 // lobatto_compute<T>) was already generic.
 
 #include "PolynomialBasis.h"
+#include <helfem.h>
 #include "FiniteElementBasis.h"
 #include "Matrix.h"
 #include <chebyshev.h>
@@ -118,6 +119,9 @@ namespace {
 } // namespace
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   const double xmax = (argc > 1) ? std::atof(argv[1]) : 10.0;
   const int Nelem   = (argc > 2) ? std::atoi(argv[2]) : 10;
   const int Nnodes  = (argc > 3) ? std::atoi(argv[3]) : 15;

--- a/src/harmonic/softcoulomb.cpp
+++ b/src/harmonic/softcoulomb.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/checkpoint.h"
 #include "PolynomialBasis.h"
 #include "FiniteElementBasis.h"
@@ -54,6 +55,9 @@ namespace {
 }
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   parser.add<double>("xmax",   0, "practical infinity in au",   false, 40.0);

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -13,6 +13,7 @@
  * for the full license text.
  */
 #include "../general/cmdline.h"
+#include <helfem.h>
 #include "../general/checkpoint.h"
 #include "../general/constants.h"
 #include "../general/dftfuncs.h"
@@ -28,6 +29,9 @@
 using namespace helfem;
 
 int main(int argc, char **argv) {
+  // Not a --verbosity driver: opt into the library's setup reporting
+  // so this tool prints exactly what it always did.
+  helfem::set_verbosity(true);
   cmdline::parser parser;
 
   // full option name, no short option, description, argument required

--- a/src/sadatom/aij.cpp
+++ b/src/sadatom/aij.cpp
@@ -824,8 +824,7 @@ int main(int argc, char **argv) {
     scfsolver.set("maximum_iterations", maxiter);
     scfsolver.set("convergence_threshold", convthr);
     scfsolver.set("methods", scfmethods);
-    if(verbosity >= 1)
-      scfsolver.print_citation();
+    scfsolver.print_citation();
     scfsolver.initialize_with_fock(coreH);
     scfsolver.run();
     if(verbosity >= 5) ftimer.print_summary(x_func > 0 || c_func > 0, false);
@@ -900,8 +899,7 @@ int main(int argc, char **argv) {
     scfsolver.set("maximum_iterations", maxiter);
     scfsolver.set("convergence_threshold", convthr);
     scfsolver.set("methods", scfmethods);
-    if(verbosity >= 1)
-      scfsolver.print_citation();
+    scfsolver.print_citation();
     scfsolver.initialize_with_fock(coreH);
     scfsolver.run();
     if(verbosity >= 5) ftimer.print_summary(x_func > 0 || c_func > 0, false);

--- a/src/sadatom/aij.cpp
+++ b/src/sadatom/aij.cpp
@@ -83,6 +83,7 @@ int main(int argc, char **argv) {
   parser.add<std::string>("loadfock", 0, "file to load guess fock matrix from", false, "");
   parser.add<std::string>("savefock", 0, "file to save fock matrix to", false, "");
   parser.add<bool>("saveorb", 0, "save radial orbitals to disk?", false, false);
+  parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration diagnostics and Fock timings; also passed to the SCF solver", false, 5);
   parser.parse_check(argc, argv);
 
   // Get parameters
@@ -97,6 +98,9 @@ int main(int argc, char **argv) {
 
   int Nnodes(parser.get<int>("nnodes"));
   int Nquad(parser.get<int>("nquad"));
+  const int verbosity(parser.get<int>("verbosity"));
+  // The shared basis/grid/functional code reports through this flag.
+  helfem::set_verbosity(verbosity >= 1);
   std::string method(parser.get<std::string>("method"));
   double dftthr(parser.get<double>("dftthr"));
 
@@ -141,7 +145,8 @@ int main(int argc, char **argv) {
   else if(Nquad<2*poly->get_nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
   // Order of quadrature rule
-  printf("Using %i point quadrature rule.\n",Nquad);
+  if(verbosity >= 1)
+    printf("Using %i point quadrature rule.\n",Nquad);
 
   // Functional
   int x_func, c_func;
@@ -179,19 +184,23 @@ int main(int argc, char **argv) {
   int Nuelem = (rs>0) ? std::ceil(R/friedel_period*Nufreq) : 0;
 
   if(vacancy) {
-    printf("%i jellium electrons with rs = % .3f and vacancy model leads to r_inner = % .10f r_outer = % .10f lmax = %i\n",njellium,rs,r_inner,r_outer,lmax);
+    if(verbosity >= 1)
+      printf("%i jellium electrons with rs = % .3f and vacancy model leads to r_inner = % .10f r_outer = % .10f lmax = %i\n",njellium,rs,r_inner,r_outer,lmax);
   } else {
-    printf("%i jellium electrons with rs = % .3f leads to R = % .10f lmax = %i\n",njellium,rs,R,lmax);
+    if(verbosity >= 1)
+      printf("%i jellium electrons with rs = % .3f leads to R = % .10f lmax = %i\n",njellium,rs,R,lmax);
   }
   // The background charge follows from the shell geometry; report it so
   // a mismatch with njellium is visible rather than silent.
   if(rs > 0) {
     const double bgcharge = std::pow(r_outer/rs,3) - std::pow(r_inner/rs,3);
-    printf("Background charge is % .10f, should be %i\n", bgcharge, njellium);
+    if(verbosity >= 1)
+      printf("Background charge is % .10f, should be %i\n", bgcharge, njellium);
     if(std::abs(bgcharge - njellium) > 1e-8*std::max(1,njellium))
       throw std::logic_error("Background charge does not match the number of jellium electrons!\n");
   }
-  printf("Friedel period is % .3f, using %i uniform elements.\n", friedel_period, Nuelem);
+  if(verbosity >= 1)
+    printf("Friedel period is % .3f, using %i uniform elements.\n", friedel_period, Nuelem);
   // Self-repulsion of the positive background. The background is the
   // shell [r_inner, r_outer], i.e. ball(r_outer) minus ball(r_inner) at
   // the same density, so its self-energy is E_out + E_in - W with
@@ -262,11 +271,13 @@ int main(int argc, char **argv) {
     }
     bval=bval_new;
   }
-  helfem::io::print_matrix("Final grid for calculation", helfem::Matrix(bval));
+  if(verbosity >= 1)
+    helfem::io::print_matrix("Final grid for calculation", helfem::Matrix(bval));
 
   bool zeroder = false;
   auto basis = sadatom::basis::TwoDBasis(Z, modelpotential::POINT_NUCLEUS, 0.0, poly, zeroder, Nquad, bval, lmax, zeroright);
-  printf("Basis set has %i radial functions\n",(int) basis.Nbf());
+  if(verbosity >= 1)
+    printf("Basis set has %i radial functions\n",(int) basis.Nbf());
 
   std::function<double(double, double)> sphere_pot = [&](double r, double R) {
     const double prefac = std::pow(R/rs,3);
@@ -297,7 +308,8 @@ int main(int argc, char **argv) {
 
   // Energy of nucleus in external field
   double Enucfield = -Z*potfunc(0);
-  printf("potfunc(0) = %e Enucfield = %e\n",potfunc(0),Enucfield);
+  if(verbosity >= 1)
+    printf("potfunc(0) = %e Enucfield = %e\n",potfunc(0),Enucfield);
   fflush(stdout);
 
   // Form overlap matrix
@@ -335,8 +347,10 @@ int main(int argc, char **argv) {
     // Convert to non-orthogonal basis
     Cjellium[l] = Sinvh*es.eigenvectors();
 
-    printf("l = %i eigenvalues\n",l);
-    helfem::io::print_matrix("", helfem::Matrix(Ejellium[l].transpose()));
+    if(verbosity >= 1)
+      printf("l = %i eigenvalues\n",l);
+    if(verbosity >= 1)
+      helfem::io::print_matrix("", helfem::Matrix(Ejellium[l].transpose()));
 
     for(Eigen::Index io=0;io<Ejellium[l].size();io++)
       jellium_energies.push_back(std::make_tuple(Ejellium[l](io),l,(int) io));
@@ -408,7 +422,7 @@ int main(int argc, char **argv) {
       // Potential needs to be divided as well
       for(size_t l=0;l<XC.size();l++) XC[l]/=angfac;
       tc.xc += tcomp.get();
-      if(verbose) {
+      if(verbosity >= 5) {
         printf("DFT energy %.10e\n",Exc);
         printf("Error in integrated number of electrons % e\n",nelnum-(Z-Q+njellium));
         fflush(stdout);
@@ -418,7 +432,7 @@ int main(int argc, char **argv) {
     double Ecoul = 0.5*(Prad*J).trace();
     double Etot = Ekin + Enuc + Enucfield + Eunif + Erep + Ecoul + Exc;
 
-    if(true) {
+    if(verbosity >= 1) {
       printf("kinetic energy         % .10f\n",Ekin);
       printf("nuclear attraction     % .10f\n",Enuc);
       printf("nucleus-field term     % .10f\n",Enucfield);
@@ -438,7 +452,7 @@ int main(int argc, char **argv) {
     }
     tc.total = ftimer.build_elapsed();
     ftimer.add_build(tc);
-    ftimer.print_build(x_func > 0 || c_func > 0, false);
+    if(verbosity >= 5) ftimer.print_build(x_func > 0 || c_func > 0, false);
     ftimer.leave();
     return std::make_pair(Etot,fock);
   };
@@ -496,7 +510,7 @@ int main(int argc, char **argv) {
       for(size_t l=0;l<XCa.size();l++) XCa[l]/=angfac;
       for(size_t l=0;l<XCb.size();l++) XCb[l]/=angfac;
       tc.xc += tcomp.get();
-      if(verbose) {
+      if(verbosity >= 5) {
         printf("DFT energy %.10e\n",Exc);
         printf("Error in integrated number of electrons % e\n",nelnum-(Z-Q+njellium));
         fflush(stdout);
@@ -506,7 +520,7 @@ int main(int argc, char **argv) {
     double Ecoul = 0.5*(Prad*J).trace();
     double Etot = Ekin + Enuc + Enucfield + Eunif + Erep + Ecoul + Exc;
 
-    if(true) {
+    if(verbosity >= 1) {
       printf("kinetic energy         % .10f\n",Ekin);
       printf("nuclear attraction     % .10f\n",Enuc);
       printf("nucleus-field term     % .10f\n",Enucfield);
@@ -531,7 +545,7 @@ int main(int argc, char **argv) {
     }
     tc.total = ftimer.build_elapsed();
     ftimer.add_build(tc);
-    ftimer.print_build(x_func > 0 || c_func > 0, false);
+    if(verbosity >= 5) ftimer.print_build(x_func > 0 || c_func > 0, false);
     ftimer.leave();
     return std::make_pair(Etot,fock);
   };
@@ -785,7 +799,8 @@ int main(int argc, char **argv) {
       oss << "l=" << l;
       block_descriptions[l] = oss.str();
     }
-    helfem::io::print_matrix("Max occ", helfem::Matrix(maximum_occupation.transpose()));
+    if(verbosity >= 1)
+      helfem::io::print_matrix("Max occ", helfem::Matrix(maximum_occupation.transpose()));
 
     Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles(1);
     number_of_particles(0) = nelec;
@@ -805,13 +820,15 @@ int main(int argc, char **argv) {
     }
 
     OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, restricted_builder, block_descriptions);
+    scfsolver.set("verbosity", verbosity);
     scfsolver.set("maximum_iterations", maxiter);
     scfsolver.set("convergence_threshold", convthr);
     scfsolver.set("methods", scfmethods);
-    scfsolver.print_citation();
+    if(verbosity >= 1)
+      scfsolver.print_citation();
     scfsolver.initialize_with_fock(coreH);
     scfsolver.run();
-    ftimer.print_summary(x_func > 0 || c_func > 0, false);
+    if(verbosity >= 5) ftimer.print_summary(x_func > 0 || c_func > 0, false);
 
     auto dm = std::make_pair(scfsolver.get_orbitals(), scfsolver.get_orbital_occupations());
     auto fock = scfsolver.get_fock_matrix();
@@ -824,7 +841,8 @@ int main(int argc, char **argv) {
       std::vector<helfem::Vector> Eblock;
       std::vector<helfem::Matrix> Cblock;
       diagonalize_blocks(fock, Eblock, Cblock);
-      print_orbitals(dm, Eblock, Cblock, block_descriptions, 0, fock.size());
+      if(verbosity >= 1)
+        print_orbitals(dm, Eblock, Cblock, block_descriptions, 0, fock.size());
       if(saveorb)
         save_orbitals(dm, Eblock, Cblock, 0, fock.size(), orb_prefix);
     }
@@ -849,7 +867,8 @@ int main(int argc, char **argv) {
       block_descriptions[l] = oss.str() + " alpha";
       block_descriptions[l+lmax+1] = oss.str() + " beta";
     }
-    helfem::io::print_matrix("Max occ", helfem::Matrix(maximum_occupation.transpose()));
+    if(verbosity >= 1)
+      helfem::io::print_matrix("Max occ", helfem::Matrix(maximum_occupation.transpose()));
 
     Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> number_of_particles(2);
     number_of_particles(0) = nela;
@@ -877,13 +896,15 @@ int main(int argc, char **argv) {
     }
 
     OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, unrestricted_builder, block_descriptions);
+    scfsolver.set("verbosity", verbosity);
     scfsolver.set("maximum_iterations", maxiter);
     scfsolver.set("convergence_threshold", convthr);
     scfsolver.set("methods", scfmethods);
-    scfsolver.print_citation();
+    if(verbosity >= 1)
+      scfsolver.print_citation();
     scfsolver.initialize_with_fock(coreH);
     scfsolver.run();
-    ftimer.print_summary(x_func > 0 || c_func > 0, false);
+    if(verbosity >= 5) ftimer.print_summary(x_func > 0 || c_func > 0, false);
 
     auto dm = std::make_pair(scfsolver.get_orbitals(), scfsolver.get_orbital_occupations());
     auto fock = scfsolver.get_fock_matrix();
@@ -896,10 +917,14 @@ int main(int argc, char **argv) {
       std::vector<helfem::Vector> Eblock;
       std::vector<helfem::Matrix> Cblock;
       diagonalize_blocks(fock, Eblock, Cblock);
-      printf("\nAlpha orbitals\n");
-      print_orbitals(dm, Eblock, Cblock, block_descriptions, 0, lmax+1);
-      printf("\nBeta orbitals\n");
-      print_orbitals(dm, Eblock, Cblock, block_descriptions, lmax+1, 2*lmax+2);
+      if(verbosity >= 1)
+        printf("\nAlpha orbitals\n");
+      if(verbosity >= 1)
+        print_orbitals(dm, Eblock, Cblock, block_descriptions, 0, lmax+1);
+      if(verbosity >= 1)
+        printf("\nBeta orbitals\n");
+      if(verbosity >= 1)
+        print_orbitals(dm, Eblock, Cblock, block_descriptions, lmax+1, 2*lmax+2);
       if(saveorb) {
         save_orbitals(dm, Eblock, Cblock, 0,        lmax+1,   orb_prefix + "_alpha");
         save_orbitals(dm, Eblock, Cblock, lmax+1,   2*lmax+2, orb_prefix + "_beta");

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -237,6 +237,7 @@ int main(int argc, char **argv) {
   // SCF convergence algorithms handed to OOO's state machine: a '+'
   // separated subset of DIIS, ODA, CG and LBFGS.
   parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "DIIS + ODA + CG");
+  parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration Fock timings; also passed to the SCF solver", false, 5);
   parser.add<int>("maxiter", 0, "maximum number of SCF iterations", false, 128);
   parser.add<double>("convthr", 0, "SCF convergence threshold", false, 1e-7);
 
@@ -256,6 +257,11 @@ int main(int argc, char **argv) {
   parser.add<double>("eps_el", 0, "density threshold for the electron-count atomic radius", false, 0.073416683704840394115); // H analytic radius matches the vdW routine at 1e-3 (Rahm 2016)
 
   parser.parse_check(argc, argv);
+
+  // Gates every non-warning printout below; see the option help.
+  const int verbosity = parser.get<int>("verbosity");
+  // The shared basis/grid/functional code reports through this flag.
+  helfem::set_verbosity(verbosity >= 1);
 
   const int igrid   = parser.get<int>("grid");
   const double zexp = parser.get<double>("zexp");
@@ -299,10 +305,12 @@ int main(int argc, char **argv) {
     std::cout << "Correlation functional parameters\n" << c_pars.transpose() << std::endl;
   }
 
-  printf("Running %s %s calculation with Rmax=%e and %i elements.\n",
+  if (verbosity >= 1)
+    printf("Running %s %s calculation with Rmax=%e and %i elements.\n",
           restricted ? "restricted" : "unrestricted",
           method.c_str(), Rmax, Nelem);
-  printf("nela=%d nelb=%d\n", nela, nelb);
+  if (verbosity >= 1)
+    printf("nela=%d nelb=%d\n", nela, nelb);
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
       polynomial_basis::get_basis(primbas, Nnodes));
@@ -311,7 +319,8 @@ int main(int argc, char **argv) {
     Nquad = 5 * poly->get_nbf();
   else if (Nquad < 2 * poly->get_nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
-  printf("Using %i point quadrature rule.\n", Nquad);
+  if (verbosity >= 1)
+    printf("Using %i point quadrature rule.\n", Nquad);
 
   int x_func, c_func;
   ::parse_xc_func(x_func, c_func, method);
@@ -345,7 +354,7 @@ int main(int argc, char **argv) {
   opts.conf_R       = conf_R;
   opts.conf_barrier = conf_barrier;
   opts.shift_conf   = shift_conf;
-  opts.verbosity    = 5;
+  opts.verbosity    = verbosity;
   opts.scf_methods  = parser.get<std::string>("scfmethods");
   opts.maxiter      = parser.get<int>("maxiter");
   opts.convthr      = parser.get<double>("convthr");
@@ -406,7 +415,8 @@ int main(int argc, char **argv) {
       } else {
         throw std::logic_error("Unrestricted --occs needs lmax+1 totals or 2*(lmax+1) alpha/beta counts.\n");
       }
-      printf("Using explicit occupations from --occs.\n");
+      if (verbosity >= 1)
+        printf("Using explicit occupations from --occs.\n");
     }
   }
 
@@ -421,19 +431,25 @@ int main(int argc, char **argv) {
     const helfem::Matrix & Pdiag = result.Prad;
     const double nucd  = result.basis.nuclear_density(Pdiag);
     const double gnucd = result.basis.nuclear_density_gradient(Pdiag);
-    printf("\nElectron density          at the nucleus is % e\n", nucd);
-    printf("Electron density gradient at the nucleus is % e\n", gnucd);
+    if (verbosity >= 1)
+      printf("\nElectron density          at the nucleus is % e\n", nucd);
+    if (verbosity >= 1)
+      printf("Electron density gradient at the nucleus is % e\n", gnucd);
     if (nucd != 0.0)
-      printf("Cusp condition is %.10f\n", -1.0 / (2 * Z) * gnucd / nucd);
+      if (verbosity >= 1)
+        printf("Cusp condition is %.10f\n", -1.0 / (2 * Z) * gnucd / nucd);
 
     const double vdwthr = parser.get<double>("vdwthr");
     const double eps_el = parser.get<double>("eps_el");
     const double rvdw = result.basis.vdw_radius(Pdiag, vdwthr);
-    printf("\nEstimated vdW radius with density threshold %e is %.6f bohr = %.6f A\n",
+    if (verbosity >= 1)
+      printf("\nEstimated vdW radius with density threshold %e is %.6f bohr = %.6f A\n",
            vdwthr, rvdw, rvdw * BOHRINANGSTROM);
-    printf("Note that this criterion is sensitive to numerical noise.\n");
+    if (verbosity >= 1)
+      printf("Note that this criterion is sensitive to numerical noise.\n");
     const double rincl = result.basis.electron_count_radius(Pdiag, eps_el);
-    printf("Estimated radius with electron count threshold %e is %.6f bohr = %.6f A\n",
+    if (verbosity >= 1)
+      printf("Estimated radius with electron count threshold %e is %.6f bohr = %.6f A\n",
            eps_el, rincl, rincl * BOHRINANGSTROM);
   }
 
@@ -455,7 +471,8 @@ int main(int argc, char **argv) {
     dump(result.orbs_a, restricted ? "r" : "a");
     if (!restricted)
       dump(result.orbs_b, "b");
-    printf("Saved radial orbitals to orbs_%s_*.dat\n", element_symbols[Z].c_str());
+    if (verbosity >= 1)
+      printf("Saved radial orbitals to orbs_%s_*.dat\n", element_symbols[Z].c_str());
   }
 
   // Effective-potential / SAP-table output. The potential functional is
@@ -502,7 +519,8 @@ int main(int argc, char **argv) {
     std::ostringstream oss;
     oss << "result_" << element_symbols[Z] << ".dat";
     io::write_raw_ascii(oss.str(), pot);
-    printf("Saved effective potential (SAP table) to %s\n", oss.str().c_str());
+    if (verbosity >= 1)
+      printf("Saved effective potential (SAP table) to %s\n", oss.str().c_str());
 
     if (savepot) {
       // xc screening potential: [r, v_xc]
@@ -510,7 +528,8 @@ int main(int argc, char **argv) {
       xcpot.col(0) = pot.col(0);
       xcpot.col(1) = pot.col(6);
       io::write_raw_ascii("xcpot.dat", xcpot);
-      printf("Saved xc screening potential to xcpot.dat\n");
+      if (verbosity >= 1)
+        printf("Saved xc screening potential to xcpot.dat\n");
     }
     if (saveing) {
       // density ingredients: [r, rho, grad, lapl, tau]
@@ -521,10 +540,12 @@ int main(int argc, char **argv) {
       ing.col(3) = pot.col(3);
       ing.col(4) = pot.col(4);
       io::write_raw_ascii("xcing.dat", ing);
-      printf("Saved density ingredients to xcing.dat\n");
+      if (verbosity >= 1)
+        printf("Saved density ingredients to xcing.dat\n");
     }
   } else if (savepot || saveing) {
-    printf("No functional active (HF) -- no xc potential/ingredients to save.\n");
+    if (verbosity >= 1)
+      printf("No functional active (HF) -- no xc potential/ingredients to save.\n");
   }
 
   return 0;

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -292,7 +292,7 @@ namespace helfem {
           helfem::scf_driver::FockTimer::Components tc;
           auto ret = build_fock(dm, nullptr, &tc);
           ftimer.add_build(tc);
-          if (opts.verbosity > 0) ftimer.print_build(have_xc, have_exx);
+          if (opts.verbosity >= 5) ftimer.print_build(have_xc, have_exx);
           ftimer.leave();
           return ret;
         };
@@ -343,7 +343,7 @@ namespace helfem {
           // not the entries were evaluated concurrently.
           for (const auto & line : lines)
             if (line.size()) fputs(line.c_str(), stdout);
-          if (opts.verbosity > 0) ftimer.print_build(have_xc, have_exx);
+          if (opts.verbosity >= 5) ftimer.print_build(have_xc, have_exx);
           fflush(stdout);
           ftimer.leave();
           return out;
@@ -538,7 +538,7 @@ namespace helfem {
         if (opts.verbosity > 0)
           scfsolver.print_citation();
         scfsolver.run();
-        if (opts.verbosity > 0) ftimer.print_summary(have_xc, have_exx);
+        if (opts.verbosity >= 5) ftimer.print_summary(have_xc, have_exx);
 
         // Extract results. Convert OOO's per-block orbital matrices
         // (in the Sinvh-orthonormal basis) back to AO coefficients

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -535,8 +535,7 @@ namespace helfem {
           scfsolver.initialize_with_fock(CoreH);
         }
         scfsolver.set("methods", opts.scf_methods);
-        if (opts.verbosity > 0)
-          scfsolver.print_citation();
+        scfsolver.print_citation();
         scfsolver.run();
         if (opts.verbosity >= 5) ftimer.print_summary(have_xc, have_exx);
 


### PR DESCRIPTION
Addresses the unconditional printouts across the drivers — including aij, whose output was gated on a flag nothing ever set. Rebased onto `master` now that #299 has merged.

## The starting state

Output control was in three inconsistent states, none reachable from the command line:

| | |
|---|---|
| `atomic`, `diatomic` | no control whatsoever; everything printed |
| `gensap` | `opts.verbosity` hardcoded to 5 |
| `aij` | gated on `helfem::verbose`, which nothing ever set — so those blocks were **dead code**, alongside two `if(true)` blocks left over from debugging |

## One scale, shared with the solver

All four take `--verbosity` on OOO's own 0..30 scale (default 5, so output is unchanged), handed straight to the solver so the number means the same thing to the driver and the optimizer:

- **0** — citations, warnings and errors only
- **≥1** — setup, guess, per-iteration energies, final results
- **≥5** — also the per-iteration Fock component timings
- **≥10** — also OOO's per-block orbital energies

Timings sit one rung above the energies because they roughly double the per-iteration volume. The energy decomposition stays at ≥1 because it *is* the result — burying it deeper would leave `--verbosity=1` printing no energy at all.

## Two things --verbosity deliberately cannot suppress

**Citations.** Attribution for the libraries a result depends on is not something an output setting may switch off, so the libxc and OpenOrbitalOptimizer citations print at every level including 0. For libxc this meant splitting `print_info`: the version + reference + "please cite" block is unconditional, and only the description of *which* functional was selected follows the verbosity flag.

**Warnings.** A quadrature order cap hit without converging, or a symmetry restriction being relaxed, means the run did something other than what was asked.

## Library side

`helfem::verbose` has existed all along, documented as non-verbose by default, but `grid.cpp` was its only consumer. Nine other setup messages printed unconditionally, so a caller had no way to quieten the library. They now consult the flag that was always meant to control them, and each driver calls `helfem::set_verbosity(verbosity >= 1)`.

`set_verbosity` itself announced the change (`"HelFEM library set to verbose mode."`, no trailing newline) — which would now have printed on every run. Removed.

## Two ordering bugs found on the way

- `set("verbosity")` ran **after** `initialize_with_fock` in atomic, diatomic and aij. That call evaluates a Fock matrix, so the first energy always printed at the default level regardless of the setting. Hoisted to just after construction.
- `print_citation()` was called after `set("methods")` but its output was being gated; now unconditional, per above.

## Non-driver binaries are unchanged

`1e`, `cbasis`, `completeness`, `density_line`/`grid`, `teirank`, `harmonic`, `softcoulomb`, `morse`, `inttest`, `purem_test` now opt in with `set_verbosity(true)`, so their output is byte-for-byte what it was. Only the four SCF drivers gain a knob. (`atomic/precision.cpp` already called `set_verbosity(false)` deliberately and is untouched.)

## Verification

Line counts (Be/LDA, H2/LDA, Be/LDA, Al-in-jellium/LDA):

```
           v=0    v=1    v=5   v=10
  atomic     6     36     54     98
  diatomic   6     31     74    139
  gensap     6     38     67    111
  aij        5   1154   1925   2222
```

At v=0 that is the two citations plus, for three of the four, one unconverged-quadrature warning — everything that is meant to survive, and nothing else.

`tests/run_tests.py --check`: **40/40 in the ci tier**, plus both jellium cases with the `njellium=0` invariant passing, re-run after the rebase onto merged master. The suite runs at the default verbosity, so every parsed line is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)