### PR TITLE
libhelfem: report the FE continuity check only when it fails

### DIFF
--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "FiniteElementBasis.h"
-#include <helfem.h>
+#include <sstream>
 #include <lobatto.h>
 #include <algorithm>
 #include <cfloat>
@@ -137,11 +137,20 @@ namespace helfem {
       }
       Eigen::Index imax;
       dnorm.maxCoeff(&imax);
-      if(helfem::verbose)
-        printf("Finite element basis set max discontinuity %s between elements %i and %i\n",helfem::io::fmt_sci(dnorm(imax)).c_str(),(int) imax,(int) imax+1);
-      fflush(stdout);
       if(dnorm(imax) > sqrt(DBL_EPSILON)) {
-        throw std::logic_error("Finite element basis set is not continuous\n");
+        // Only worth reporting when it is actually discontinuous, which
+        // is a hard error: a continuous basis is a precondition, not a
+        // result, so announcing "max discontinuity 0.0e+00" on every run
+        // told the user nothing. The offending element pair has already
+        // dumped its lh/rh values above; flush that before unwinding,
+        // and carry the magnitude in the exception so the failure is
+        // self-describing.
+        fflush(stdout);
+        std::ostringstream oss;
+        oss << "Finite element basis set is not continuous: max discontinuity "
+            << helfem::io::fmt_sci(dnorm(imax)) << " between elements "
+            << (int) imax << " and " << (int) imax+1 << " (C indexing).\n";
+        throw std::logic_error(oss.str());
       }
     }
 


### PR DESCRIPTION
`check_bf_continuity` printed this on every single run:

```
Finite element basis set max discontinuity 0.0000000000000000e+00 between elements 0 and 1
```

A continuous basis is a precondition, not a result. The interesting case is when it is violated — and that already throws — so announcing success told the reader nothing.

**What stays.** The offending element pair still dumps its `lh`/`rh` values and their difference. That diagnostic was already conditional on the discontinuity being real, so the failure path is untouched.

**What changes.** The summary line on the success path is gone, and the measured magnitude moves into the exception, so a failure carries its own evidence rather than relying on the reader having seen an earlier line:

```
Finite element basis set is not continuous: max discontinuity 3.1e-07
between elements 2 and 3 (C indexing).
```

Previously the exception said only `Finite element basis set is not continuous`, with the number in a separate print that a caller catching the exception would never see.

Verified: `"max discontinuity"` no longer appears in the output at the default verbosity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)