### PR TITLE
±|m| symmetry: --symmetry=3 replaces --maverage, plus exchange and pure-m XC optimisations

### DIFF
--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "FiniteElementBasis.h"
-#include <helfem.h>
+#include <sstream>
 #include <lobatto.h>
 #include <algorithm>
 #include <cfloat>
@@ -137,11 +137,20 @@ namespace helfem {
       }
       Eigen::Index imax;
       dnorm.maxCoeff(&imax);
-      if(helfem::verbose)
-        printf("Finite element basis set max discontinuity %s between elements %i and %i\n",helfem::io::fmt_sci(dnorm(imax)).c_str(),(int) imax,(int) imax+1);
-      fflush(stdout);
       if(dnorm(imax) > sqrt(DBL_EPSILON)) {
-        throw std::logic_error("Finite element basis set is not continuous\n");
+        // Only worth reporting when it is actually discontinuous, which
+        // is a hard error: a continuous basis is a precondition, not a
+        // result, so announcing "max discontinuity 0.0e+00" on every run
+        // told the user nothing. The offending element pair has already
+        // dumped its lh/rh values above; flush that before unwinding,
+        // and carry the magnitude in the exception so the failure is
+        // self-describing.
+        fflush(stdout);
+        std::ostringstream oss;
+        oss << "Finite element basis set is not continuous: max discontinuity "
+            << helfem::io::fmt_sci(dnorm(imax)) << " between elements "
+            << (int) imax << " and " << (int) imax+1 << " (C indexing).\n";
+        throw std::logic_error(oss.str());
       }
     }
 

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -101,8 +101,6 @@ int main(int argc, char **argv) {
   parser.add<double>("shift_conf",   0, "Where does confinement start?",       false, 0.0);
   parser.add<bool>  ("add_conf",     0, "Add element boundary at shifted confinement radius?", false, true);
 
-  // Fock symmetry averaging over m values (parity with bespoke atomic).
-  parser.add<bool>("maverage", 0, "average Fock matrix over m values", false, false);
 
   // Frozen per-block occupations read from occs.dat (parity with bespoke
   // atomic's --readocc, but as a bool since OOO's fixed-per-block
@@ -183,7 +181,6 @@ int main(int argc, char **argv) {
   const double conf_barrier = parser.get<double>("conf_barrier");
   const double shift_conf   = parser.get<double>("shift_conf");
   const bool   add_conf     = parser.get<bool>("add_conf");
-  const bool   maverage     = parser.get<bool>("maverage");
   const bool   readocc      = parser.get<bool>("readocc");
   const int    iguess       = parser.get<int>("iguess");
   const std::string loadfile = parser.get<std::string>("load");
@@ -312,32 +309,6 @@ int main(int argc, char **argv) {
   const bool have_bfield = (Bz != 0.0);
   const bool have_conf   = (iconf != 0);
 
-  // l_idx groups AO basis-function index sets by (l, m): the l-th outer
-  // entry contains the BF-index arrays for the m values that are
-  // actually present in the basis (|m| <= min(l, mmax)). The Fock
-  // symmetry-average step below averages each l-block's Fock over that
-  // m subset, enforcing degenerate orbital energies for orbitals of the
-  // same l but different m (a physical symmetry of the atomic
-  // Hamiltonian that finite-precision SCF can drift out of).
-  //
-  // Note: the bespoke atomic driver builds an m = -l..+l range
-  // unconditionally, which crashes fock_symmetry_average when the basis
-  // has mmax < lmax (empty index arrays hit a 0x0 = NxN assignment).
-  // Filtering by lm_indices(l, m).n_elem > 0 keeps parity when
-  // mmax == lmax and degrades gracefully when mmax < lmax (partial
-  // m-average over the represented m subset -- a no-op when only m=0
-  // is present, which is what you want).
-  std::vector<std::vector<std::vector<Eigen::Index>>> l_idx;
-  if (maverage) {
-    const Eigen::VectorXi l_all = basis.get_lval();
-    const int lmax_bf = l_all.maxCoeff();
-    l_idx.assign(lmax_bf + 1, {});
-    for (int l = 0; l <= lmax_bf; ++l)
-      for (int m = -l; m <= l; ++m) {
-        std::vector<Eigen::Index> idx = basis.lm_indices(l, m);
-        if (!idx.empty()) l_idx[l].push_back(idx);
-      }
-  }
 
   // --- Symmetry decomposition. symm==0 collapses to one block containing
   //     all basis functions.
@@ -374,7 +345,7 @@ int main(int argc, char **argv) {
   std::vector<std::string> block_descriptions;
   helfem::scf_driver::build_ooo_block_metadata<OOO_Real>(
       nsym, nparttype, restricted, Ntot, nela, nelb,
-      basis.get_sym_labels(symm_eff),
+      basis.get_sym_labels(symm_eff), std::vector<int>(nsym, 1),
       number_of_blocks_per_particle_type, maximum_occupation,
       number_of_particles, block_descriptions);
 
@@ -491,15 +462,10 @@ int main(int argc, char **argv) {
     // their coupling is off so this is unchanged from H0 = T + Vnuc in
     // the no-field case.
     const helfem::Matrix H1 = T + Vnuc + Vel + Vmag + Vconf;
-    // Apply the maverage post-processor once per channel; noop otherwise.
-    auto apply_mavg = [&](helfem::Matrix & F) {
-      if (maverage)
-        F = scf::fock_symmetry_average(F, l_idx);
-    };
     helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
         fock, H1, J, XCa, XCb, Ka, Kb, S,
         nsym, restricted, have_xc, have_exx, have_bfield, Bz,
-        apply_mavg, orthonormalize_block);
+        orthonormalize_block);
     return std::make_pair(Etot, fock);
   };
 

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -1827,6 +1827,34 @@ namespace helfem {
         // the parallel accumulation into K is race-free.
         helfem::Matrix K(helfem::Matrix::Zero(Ndummy(),Ndummy()));
 
+        const size_t Nang = lval.size();
+
+        // Density blocks, bucketed once by dm = m_i - m_l.
+        //
+        // A (jang,kang) output block can only be fed by a density block
+        // whose M matches: mj-mi == mk-ml, i.e. mi-ml == mj-mk. So the
+        // candidates for an output block depend on nothing but dm, and
+        // the same buckets serve every (jang,kang).
+        //
+        // This used to be an unconditional Nang^2 rescan per output
+        // block, recomputing P.block(...).norm() every time -- O(Nang^4)
+        // norms of an Nrad x Nrad block per Fock build, none of which
+        // depend on (jang,kang). Now each norm is taken once, and an
+        // output block iterates only over density blocks that can
+        // actually reach it.
+        const int mabs = absm_max();
+        const int dmoff = 2*mabs;
+        std::vector<std::vector<std::pair<size_t,size_t>>> pairs_by_dm(4*mabs+1);
+        for(size_t iang=0;iang<Nang;iang++)
+          for(size_t lang=0;lang<Nang;lang++) {
+            if(P.block(iang*Nrad,lang*Nrad,Nrad,Nrad).norm() < 10*DBL_EPSILON)
+              continue;
+            const int dm = mval(iang)-mval(lang);
+            if(std::abs(dm) > 2*mabs)
+              continue;
+            pairs_by_dm[dm+dmoff].emplace_back(iang,lang);
+          }
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -1843,41 +1871,41 @@ namespace helfem {
               int lk(lval(kang));
               int mk(mval(kang));
 
-              // Form radial helpers
+              // Only density blocks with mi-ml == mj-mk can feed this
+              // output block. If there are none, there is nothing to
+              // allocate and nothing to contract: skip before paying for
+              // either.
+              const int dmjk = mj-mk;
+              if(std::abs(dmjk) > 2*mabs)
+                continue;
+              const std::vector<std::pair<size_t,size_t>> & cand = pairs_by_dm[dmjk+dmoff];
+              if(cand.empty())
+                continue;
+
+              // Form radial helpers. Left empty until a channel actually
+              // couples: allocating 4*lm_map.size() Nrad x Nrad zero
+              // matrices per output block is pure churn when, as is
+              // usual, only a handful of L couple.
               std::vector<helfem::Matrix> Rmat00(lm_map.size());
               std::vector<helfem::Matrix> Rmat02(lm_map.size());
               std::vector<helfem::Matrix> Rmat20(lm_map.size());
               std::vector<helfem::Matrix> Rmat22(lm_map.size());
-              for(size_t i=0;i<lm_map.size();i++) {
-                Rmat00[i]=helfem::Matrix::Zero(Nrad,Nrad);
-                Rmat02[i]=helfem::Matrix::Zero(Nrad,Nrad);
-                Rmat20[i]=helfem::Matrix::Zero(Nrad,Nrad);
-                Rmat22[i]=helfem::Matrix::Zero(Nrad,Nrad);
-              }
               // Is there a coupling to the channel?
               std::vector<bool> couple(lm_map.size(),false);
+              bool any_couple = false;
 
               // Perform angular sums
-              for(size_t iang=0;iang<lval.size();iang++) {
+              for(size_t ipair=0;ipair<cand.size();ipair++) {
+                const size_t iang = cand[ipair].first;
+                const size_t lang = cand[ipair].second;
                 int li(lval(iang));
                 int mi(mval(iang));
-
-                for(size_t lang=0;lang<lval.size();lang++) {
-                  int ll(lval(lang));
-                  int ml(mval(lang));
-
-                  // LH m value
+                int ll(lval(lang));
+                int ml(mval(lang));
+                {
+                  // mi-ml == mj-mk by construction of the bucket, hence
+                  // M == Mp; no test needed.
                   int M(mj-mi);
-                  // RH m value
-                  int Mp(mk-ml);
-                  if(M!=Mp)
-                    continue;
-
-                  // Do we have any density in this block?
-                  double bdens(P.block(iang*Nrad,lang*Nrad,Nrad,Nrad).norm());
-                  //printf("(%i %i) (%i %i) density block norm %e\n",li,mi,ll,ml,bdens);
-                  if(bdens<10*DBL_EPSILON)
-                    continue;
 
                   // M values match. Loop over possible couplings
                   int Lmin=std::max(std::max(std::abs(li-lj),std::abs(lk-ll))-2,abs(M));
@@ -1899,16 +1927,27 @@ namespace helfem {
                     const double signM = (M & 1) ? -1.0 : 1.0;
                     const double LMfac(signM * LMfac_abs[ilm]);
 
-                    helfem::Matrix Psub(P.block(iang*Nrad,lang*Nrad,Nrad,Nrad));
+                    const auto Psub = P.block(iang*Nrad,lang*Nrad,Nrad,Nrad);
 
+                    if(!couple[ilm]) {
+                      Rmat00[ilm]=helfem::Matrix::Zero(Nrad,Nrad);
+                      Rmat02[ilm]=helfem::Matrix::Zero(Nrad,Nrad);
+                      Rmat20[ilm]=helfem::Matrix::Zero(Nrad,Nrad);
+                      Rmat22[ilm]=helfem::Matrix::Zero(Nrad,Nrad);
+                      couple[ilm]=true;
+                      any_couple=true;
+                    }
                     Rmat00[ilm]+=(LMfac*cpl00)*Psub;
                     Rmat02[ilm]+=(LMfac*cpl02)*Psub;
                     Rmat20[ilm]+=(LMfac*cpl20)*Psub;
                     Rmat22[ilm]+=(LMfac*cpl22)*Psub;
-                    couple[ilm]=true;
                   }
                 }
               }
+
+              // Nothing coupled: no contribution to this output block.
+              if(!any_couple)
+                continue;
 
               // Loop over elements: output
               for(size_t iel=0;iel<Nel;iel++) {

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -895,10 +895,37 @@ namespace helfem {
             idx[2*i]=m_indices(mv[i],false);
             idx[2*i+1]=m_indices(mv[i],true);
           }
+        } else if(symm==3) {
+          // One block per |m|, holding the +|m| functions only. The -|m|
+          // partner is not a separate block: it is the SAME radial
+          // problem (F(+m,+m) == F(-m,-m), and the two overlaps are
+          // identical), so it is carried as a mirror of this block --
+          // see get_sym_mirror_idx -- with the two-fold degeneracy
+          // folded into the block's maximum occupation instead.
+          for(int m=0;m<=absm_max();m++)
+            idx.push_back(m_indices(m));
         } else
           throw std::logic_error("Unknown symmetry\n");
 
         return idx;
+      }
+
+      int TwoDBasis::absm_max() const {
+        return std::max(std::abs(mval.maxCoeff()), std::abs(mval.minCoeff()));
+      }
+
+      std::vector<std::vector<Eigen::Index>> TwoDBasis::get_sym_mirror_idx(int symm) const {
+        // The -|m| partner of each block of get_sym_idx, or an empty
+        // index list where the block is its own partner (m=0) or the
+        // symmetry does not pair blocks at all.
+        std::vector<std::vector<Eigen::Index>> mirror;
+        if(symm!=3) {
+          mirror.resize(get_sym_idx(symm).size());
+          return mirror;
+        }
+        for(int m=0;m<=absm_max();m++)
+          mirror.push_back(m ? m_indices(-m) : std::vector<Eigen::Index>());
+        return mirror;
       }
 
       std::vector<std::string> TwoDBasis::get_sym_labels(int symm) const {
@@ -934,6 +961,12 @@ namespace helfem {
               labels.push_back(mlabel(mv[i]) + " g");
               labels.push_back(mlabel(mv[i]) + " u");
             }
+          }
+        } else if(symm==3) {
+          for(int m=0;m<=absm_max();m++) {
+            std::ostringstream oss;
+            oss << "|m|=" << m;
+            labels.push_back(oss.str());
           }
         } else
           throw std::logic_error("Unknown symmetry\n");

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -910,6 +910,10 @@ namespace helfem {
         return idx;
       }
 
+      void TwoDBasis::set_absm_symmetric(bool sym) {
+        absm_symmetric = sym;
+      }
+
       int TwoDBasis::absm_max() const {
         return std::max(std::abs(mval.maxCoeff()), std::abs(mval.minCoeff()));
       }
@@ -1875,6 +1879,13 @@ namespace helfem {
               // output block. If there are none, there is nothing to
               // allocate and nothing to contract: skip before paying for
               // either.
+              // With a +-m symmetric density, K(-m,-m) is the mirror
+              // image of K(+m,+m): the same radial problem with every m
+              // negated, and the Gaunt couplings are invariant under a
+              // global m negation. Build the m >= 0 half and copy.
+              if(absm_symmetric && (mj < 0 || mk < 0))
+                continue;
+
               const int dmjk = mj-mk;
               if(std::abs(dmjk) > 2*mabs)
                 continue;
@@ -2045,6 +2056,27 @@ namespace helfem {
                   }
                 }
               }
+            }
+          }
+        }
+
+        // Mirror the m >= 0 half onto the negative-m output blocks.
+        // Channel (l,m) pairs with (l,-m); K(-mj,-mk) = K(mj,mk).
+        if(absm_symmetric) {
+          std::vector<size_t> mirror_ang(Nang, Nang);
+          for(size_t a1=0;a1<Nang;a1++)
+            for(size_t b1=0;b1<Nang;b1++)
+              if(lval(b1)==lval(a1) && mval(b1)==-mval(a1)) { mirror_ang[a1]=b1; break; }
+          for(size_t jang=0;jang<Nang;jang++) {
+            if(mval(jang) >= 0) continue;
+            const size_t jm = mirror_ang[jang];
+            if(jm==Nang) continue;
+            for(size_t kang=0;kang<Nang;kang++) {
+              if(mval(kang) >= 0) continue;
+              const size_t km = mirror_ang[kang];
+              if(km==Nang) continue;
+              K.block(jang*Nrad,kang*Nrad,Nrad,Nrad) =
+                  K.block(jm*Nrad,km*Nrad,Nrad,Nrad);
             }
           }
         }

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -136,6 +136,8 @@ namespace helfem {
         Eigen::VectorXi lval;
         /// Angular basis set: function m values
         Eigen::VectorXi mval;
+        /// Density is symmetric under m -> -m (see set_absm_symmetric).
+        bool absm_symmetric = false;
 
         /// Gaunt coefficient table
         gaunt::Gaunt gaunt;
@@ -335,6 +337,11 @@ namespace helfem {
         std::vector<std::string> get_sym_labels(int symm) const;
         /// Largest |m| present in the basis.
         int absm_max() const;
+        /// Declare that every density handed to exchange() will be
+        /// symmetric under m -> -m, which --symmetry=3 guarantees by
+        /// construction. Lets exchange() build only the m >= 0 output
+        /// blocks and mirror the rest.
+        void set_absm_symmetric(bool sym);
         /// For each block of get_sym_idx, the index set of its -|m|
         /// partner, or an empty list when the block has none. Only
         /// symm==3 pairs blocks; other symmetries return empties.

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -333,6 +333,12 @@ namespace helfem {
         /// order ("m=+1", "m=-2 u", ...). Kept alongside get_sym_idx so
         /// the two cannot drift apart.
         std::vector<std::string> get_sym_labels(int symm) const;
+        /// Largest |m| present in the basis.
+        int absm_max() const;
+        /// For each block of get_sym_idx, the index set of its -|m|
+        /// partner, or an empty list when the block has none. Only
+        /// symm==3 pairs blocks; other symmetries return empties.
+        std::vector<std::vector<Eigen::Index>> get_sym_mirror_idx(int symm) const;
         /// Get indices for wanted symmetry (one index list per block)
         std::vector<std::vector<Eigen::Index>> get_sym_idx(int isym) const;
 

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -414,6 +414,21 @@ namespace helfem {
       /// Accumulate one m block's XC contribution into the AO matrix H.
       /// `spin` selects the vxc / vsigma rows (0 = restricted or alpha,
       /// 1 = beta); `gr_rows` gives the (mu, nu) gradient rows for this spin.
+      // Index of the block holding -mlist[im], or mlist.size() if there
+      // is none. In the pure-m path the density is phi-independent, so
+      // V_xc is the SAME field for every m block: the only m dependence
+      // in the matrix elements is through m^2 and through basis values
+      // that depend on |m|. H(-m) is therefore equal to H(+m), and the
+      // negative half can be mirrored rather than rebuilt. This holds
+      // whatever the density symmetry -- it is a property of the pure-m
+      // quadrature, not of the state.
+      size_t PureMDFTGridWorker::mirror_block(size_t im) const {
+        for (size_t jm = 0; jm < mlist.size(); jm++)
+          if (mlist[jm] == -mlist[im] && bf_ind_m[jm].size() == bf_ind_m[im].size())
+            return jm;
+        return mlist.size();
+      }
+
       void PureMDFTGridWorker::eval_Fxc(helfem::Matrix & H) const {
         if (polarized)
           throw std::runtime_error("Refusing to compute restricted Fock matrix with unrestricted density.\n");
@@ -422,6 +437,9 @@ namespace helfem {
         for (size_t im = 0; im < mlist.size(); im++) {
           const std::vector<Eigen::Index> & idx = bf_ind_m[im];
           if (idx.empty()) continue;
+          // Built once for +|m| and mirrored onto -|m| below.
+          const size_t imirror = mirror_block(im);
+          if (mlist[im] < 0 && imirror != mlist.size()) continue;
           const Eigen::Index nbf = (Eigen::Index) idx.size();
           helfem::Matrix Hm = helfem::Matrix::Zero(nbf, nbf);
 
@@ -478,6 +496,12 @@ namespace helfem {
           for (Eigen::Index i = 0; i < nbf; i++)
             for (Eigen::Index j = 0; j < nbf; j++)
               H(idx[i], idx[j]) += Hm(i, j);
+          if (mlist[im] > 0 && imirror != mlist.size()) {
+            const std::vector<Eigen::Index> & jdx = bf_ind_m[imirror];
+            for (Eigen::Index i = 0; i < nbf; i++)
+              for (Eigen::Index j = 0; j < nbf; j++)
+                H(jdx[i], jdx[j]) += Hm(i, j);
+          }
         }
       }
 

--- a/src/diatomic/dftgrid_purem.h
+++ b/src/diatomic/dftgrid_purem.h
@@ -129,6 +129,8 @@ namespace helfem {
         /// Accumulate the XC Fock contribution, restricted. Only the
         /// m-diagonal blocks are built -- the off-diagonal blocks vanish by
         /// the analytic phi integration.
+        /// Index of the block holding -m, or mlist.size() if none.
+        size_t mirror_block(size_t im) const;
         void eval_Fxc(helfem::Matrix & H) const;
         /// Accumulate the XC Fock contribution, unrestricted
         void eval_Fxc(helfem::Matrix & Ha, helfem::Matrix & Hb, bool beta=true) const;

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -328,6 +328,9 @@ int main(int argc, char **argv) {
     throw std::logic_error("The pure-m XC path requires --symmetry >= 1: with symmetry=0 the orbitals may mix m and the density is no longer phi-independent.\n");
   auto grid   = helfem::diatomic::dftgrid::DFTGrid(&basis, lang, mang);
   auto pmgrid = helfem::diatomic::dftgrid_purem::PureMDFTGrid(&basis, lang);
+  // --symmetry=3 makes every density +-m symmetric by construction, so
+  // exchange() may build only the m >= 0 output blocks and mirror.
+  basis.set_absm_symmetric(symm == 3);
   basis.compute_tei(have_exx);
 
   const double Enucr = Z1 * Z2 / Rbond;

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
   parser.add<double>("Rrms1", 0, "nucleus 1 finite rms radius", false, 0.0);
   parser.add<double>("Rrms2", 0, "nucleus 2 finite rms radius", false, 0.0);
   parser.add<int>("restricted", 0, "spin-restricted: 1 restricted, 0 unrestricted, -1 auto from nela/nelb", false, -1);
-  parser.add<int>("symmetry", 0, "orbital symmetry: 0 none, 1 per-m, 2 per-(m,parity) (homonuclear only)", false, 1);
+  parser.add<int>("symmetry", 0, "orbital symmetry: 0 none, 1 per-m, 2 per-(m,parity) (homonuclear only), 3 per-|m| (imposes the +|m|/-|m| degeneracy on the occupations too)", false, 1);
   parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration Fock timings; also passed to the SCF solver", false, 5);
   parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
   parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
@@ -94,7 +94,6 @@ int main(int argc, char **argv) {
   parser.add<double>("Bz",  0, "magnetic dipole field",     false, 0.0);
 
   // Fock symmetry averaging over m values (parity with bespoke diatomic).
-  parser.add<bool>("maverage", 0, "average Fock matrix over m values", false, false);
 
   // Frozen per-block occupations from occs.dat (parity with bespoke
   // diatomic's --readocc, but a bool since OOO's fixed-per-block
@@ -161,7 +160,6 @@ int main(int argc, char **argv) {
   const double Ez     = parser.get<double>("Ez");
   const double Qzz    = parser.get<double>("Qzz");
   const double Bz     = parser.get<double>("Bz");
-  const bool   maverage = parser.get<bool>("maverage");
   const bool   readocc  = parser.get<bool>("readocc");
   const int    iguess       = parser.get<int>("iguess");
   const std::string loadfile = parser.get<std::string>("load");
@@ -292,21 +290,6 @@ int main(int argc, char **argv) {
   const bool have_efield = (Ez != 0.0 || Qzz != 0.0);
   const bool have_bfield = (Bz != 0.0);
 
-  // For diatomic m-averaging: each outer entry groups the (+m, -m) pair
-  // of BF-index sets so scf::fock_symmetry_average enforces
-  // f(+m) == f(-m). At m == 0 there is no partner so the group has a
-  // single member and the "average" is a no-op on that block. Matches
-  // src/diatomic/main.cpp lines 318..328.
-  std::vector<std::vector<std::vector<Eigen::Index>>> mavg_idx;
-  if (maverage) {
-    const int mmax_bf = basis.get_mval().cwiseAbs().maxCoeff();
-    for (int m = 0; m <= mmax_bf; ++m) {
-      std::vector<std::vector<Eigen::Index>> entry;
-      entry.push_back(basis.m_indices(m));
-      if (m > 0) entry.push_back(basis.m_indices(-m));
-      mavg_idx.push_back(entry);
-    }
-  }
 
   // Symmetry decomposition.
   std::vector<std::vector<Eigen::Index>> dsym;
@@ -318,6 +301,13 @@ int main(int argc, char **argv) {
     dsym = basis.get_sym_idx(symm);
   }
   const size_t nsym = dsym.size();
+  // Under --symmetry=3 each |m|>0 block also carries its -|m| partner:
+  // same radial problem, so it is mirrored rather than solved twice.
+  const std::vector<std::vector<Eigen::Index>> dmirror =
+      basis.get_sym_mirror_idx(symm);
+  std::vector<int> block_degeneracy(nsym, 1);
+  for (size_t k = 0; k < nsym; ++k)
+    if (!dmirror[k].empty()) block_degeneracy[k] = 2;
 
   // Per-block Sinvh_k.
   const std::vector<helfem::Matrix> Sinvh =
@@ -350,7 +340,7 @@ int main(int argc, char **argv) {
   std::vector<std::string> block_descriptions;
   helfem::scf_driver::build_ooo_block_metadata<OOO_Real>(
       nsym, nparttype, restricted, Ntot, nela, nelb,
-      basis.get_sym_labels(symm),
+      basis.get_sym_labels(symm), block_degeneracy,
       number_of_blocks_per_particle_type, maximum_occupation,
       number_of_particles, block_descriptions);
 
@@ -360,7 +350,7 @@ int main(int argc, char **argv) {
                                  const helfem::Matrix & orb_e,
                                  const helfem::Vector & occ_e) {
     helfem::scf_driver::accumulate_density_block<OOO_Real>(
-        P_full, dsym, k, Sinvh, orb_e, occ_e);
+        P_full, dsym, k, Sinvh, orb_e, occ_e, &dmirror[k]);
   };
 
   auto orthonormalize_block =
@@ -477,14 +467,10 @@ int main(int argc, char **argv) {
     // their coupling is off so this matches T + Vnuc + J exactly in the
     // no-field case.
     const helfem::Matrix H1 = T + Vnuc + Vel + Vmag;
-    auto apply_mavg = [&](helfem::Matrix & F) {
-      if (maverage)
-        F = scf::fock_symmetry_average(F, mavg_idx);
-    };
     helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
         fock, H1, J, XCa, XCb, Ka, Kb, S,
         nsym, restricted, have_xc, have_exx, have_bfield, Bz,
-        apply_mavg, orthonormalize_block);
+        orthonormalize_block);
     ftimer.leave();
     return std::make_pair(Etot, fock);
   };

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -346,15 +346,33 @@ namespace helfem {
     /// same place the block ordering itself is defined. The occupations
     /// OOO prints are then readable as quantum numbers rather than as
     /// bare block indices.
+    ///
+    /// block_degeneracy is how many degenerate spatial orbitals each
+    /// block stands for. It is 1 everywhere except under the diatomic
+    /// |m| symmetry, where a block with |m|>0 represents BOTH the +|m|
+    /// and -|m| orbitals, so it holds twice the electrons. Folding the
+    /// degeneracy into max_occ -- rather than carrying the partner as
+    /// its own block -- is what makes the occupations, and not only the
+    /// Fock matrix, respect the symmetry: an odd electron in a Pi shell
+    /// comes out as 0.5 in each of +-1 rather than landing arbitrarily
+    /// in one of two exactly degenerate blocks. (sadatom does the same
+    /// thing for l, with max_occ = 2*(2l+1).)
     template <typename Real>
     inline void build_ooo_block_metadata(
         size_t nsym, size_t nparttype, bool restricted,
         int Ntot, int nela, int nelb,
         const std::vector<std::string> & sym_labels,
+        const std::vector<int> & block_degeneracy,
         OpenOrbitalOptimizer::IndexVector & number_of_blocks_per_particle_type,
         Eigen::Matrix<Real, Eigen::Dynamic, 1> & maximum_occupation,
         Eigen::Matrix<Real, Eigen::Dynamic, 1> & number_of_particles,
         std::vector<std::string> & block_descriptions) {
+      if (block_degeneracy.size() != nsym) {
+        std::ostringstream oss;
+        oss << "Got " << block_degeneracy.size() << " block degeneracies for "
+            << nsym << " blocks.\n";
+        throw std::logic_error(oss.str());
+      }
       if (sym_labels.size() != nsym) {
         std::ostringstream oss;
         oss << "Got " << sym_labels.size() << " symmetry labels for " << nsym
@@ -370,7 +388,8 @@ namespace helfem {
         number_of_blocks_per_particle_type(t) = static_cast<int>(nsym);
         number_of_particles(t) = static_cast<Real>(restricted ? Ntot : (t == 0 ? nela : nelb));
         for (size_t k = 0; k < nsym; ++k) {
-          maximum_occupation(t * nsym + k) = restricted ? 2.0 : 1.0;
+          maximum_occupation(t * nsym + k) =
+              (restricted ? 2.0 : 1.0) * static_cast<Real>(block_degeneracy[k]);
           block_descriptions.push_back(
               (nparttype == 1 ? "" : (t == 0 ? "a:" : "b:")) + sym_labels[k]);
         }
@@ -388,11 +407,21 @@ namespace helfem {
     inline void accumulate_density_block(
         helfem::Matrix & P_full, const std::vector<std::vector<Eigen::Index>> & dsym, size_t k,
         const std::vector<helfem::Matrix> & Sinvh,
-        const helfem::Matrix & orb_e, const helfem::Vector & occ_e) {
+        const helfem::Matrix & orb_e, const helfem::Vector & occ_e,
+        const std::vector<Eigen::Index> * mirror = nullptr) {
       if (dsym[k].empty()) return;
       const std::vector<Eigen::Index> & idx = dsym[k];
       const helfem::Matrix C_k = Sinvh[k] * orb_e;
-      P_full(idx, idx) += C_k * occ_e.asDiagonal() * C_k.transpose();
+      // A mirrored block stands for two degenerate spatial orbitals, so
+      // its occupation is shared equally between them. The -|m| partner
+      // has the same radial coefficients and the same Sinvh, so the
+      // same C_k scatters into both index sets at half weight -- which
+      // is exactly the cylindrically averaged density.
+      const bool paired = (mirror != nullptr && !mirror->empty());
+      const helfem::Vector occ = paired ? helfem::Vector(0.5 * occ_e) : occ_e;
+      const helfem::Matrix Pblock = C_k * occ.asDiagonal() * C_k.transpose();
+      P_full(idx, idx) += Pblock;
+      if (paired) P_full(*mirror, *mirror) += Pblock;
     }
 
     /// Fock-builder helper: extract block k of a full AO Fock matrix,
@@ -451,13 +480,13 @@ namespace helfem {
     ///   * adds up H1 + J (+ XC + K) per spin channel,
     ///   * applies the spin-Zeeman +/- Bz/2 * S split (unrestricted
     ///     only),
-    ///   * runs the driver-supplied apply_mavg / orthonormalize_block
-    ///     callables to symmetrise and orthonormalise per block.
+    ///   * runs the driver-supplied orthonormalize_block callable to
+    ///     orthonormalise per block.
     /// XCa / XCb, Ka / Kb are assumed pre-zeroed (their addends only
     /// fire under the corresponding have_* flag), matching the
     /// convention the driver bodies keep for the XC and HF-exchange
     /// pieces.
-    template <typename Real, typename ApplyMAvg, typename OrthoBlock>
+    template <typename Real, typename OrthoBlock>
     inline void assemble_fock_blocks(
         OpenOrbitalOptimizer::FockMatrix<Real> & fock,
         const helfem::Matrix & H1, const helfem::Matrix & J,
@@ -466,12 +495,11 @@ namespace helfem {
         const helfem::Matrix & S,
         size_t nsym, bool restricted,
         bool have_xc, bool have_exx, bool have_bfield, double Bz,
-        ApplyMAvg apply_mavg, OrthoBlock orthonormalize_block) {
+        OrthoBlock orthonormalize_block) {
       if (restricted) {
         helfem::Matrix F_ao = H1 + J;
         if (have_xc)  F_ao += XCa;
         if (have_exx) F_ao += Ka;
-        apply_mavg(F_ao);
         for (size_t k = 0; k < nsym; ++k)
           orthonormalize_block(fock, k, F_ao, k);
       } else {
@@ -484,8 +512,6 @@ namespace helfem {
           Fa_ao -= 0.5 * Bz * S;
           Fb_ao += 0.5 * Bz * S;
         }
-        apply_mavg(Fa_ao);
-        apply_mavg(Fb_ao);
         for (size_t k = 0; k < nsym; ++k) {
           orthonormalize_block(fock, k,        Fa_ao, k);
           orthonormalize_block(fock, nsym + k, Fb_ao, k);

--- a/src/general/scf_helpers.cpp
+++ b/src/general/scf_helpers.cpp
@@ -102,24 +102,6 @@ namespace helfem {
 
     // Phase 5.13: Eigen-typed.
 
-    helfem::Matrix fock_symmetry_average(const helfem::Matrix & Fin,
-                                          const std::vector< std::vector<std::vector<Eigen::Index>> > & sym_idx) {
-      helfem::Matrix Fout = Fin;
-      for (size_t isym = 0; isym < sym_idx.size(); ++isym) {
-        const Eigen::Index n = static_cast<Eigen::Index>(sym_idx[isym][0].size());
-        helfem::Matrix Fmean = helfem::Matrix::Zero(n, n);
-        for (size_t ic = 0; ic < sym_idx[isym].size(); ++ic) {
-          const std::vector<Eigen::Index> & idx = sym_idx[isym][ic];
-          Fmean += Fin(idx, idx);
-        }
-        Fmean /= static_cast<double>(sym_idx[isym].size());
-        for (size_t ic = 0; ic < sym_idx[isym].size(); ++ic) {
-          const std::vector<Eigen::Index> & idx = sym_idx[isym][ic];
-          Fout(idx, idx) = Fmean;
-        }
-      }
-      return Fout;
-    }
 
     // Phase 5.14: Eigen-typed.
     // (sort_eig covers the work) and elided the dead code.

--- a/src/general/scf_helpers.h
+++ b/src/general/scf_helpers.h
@@ -20,7 +20,6 @@
 namespace helfem {
   namespace scf {
     /// Average out the Fock matrix (Eigen index lists).
-    helfem::Matrix fock_symmetry_average(const helfem::Matrix & Fin, const std::vector< std::vector<std::vector<Eigen::Index>> > & sym_idx);
 
     /// Solve generalized eigenvalue problem (Phase 5.11: Eigen-typed).
     void eig_gsym(helfem::Vector & E, helfem::Matrix & C, const helfem::Matrix & F, const helfem::Matrix & Sinvh);


### PR DESCRIPTION
`--maverage` did not do the job it claimed, so it is replaced by a `--symmetry` level that does — and that level is then exploited in the two hot paths.

## 1. Why --maverage cannot work

It averaged the **Fock matrix** over ±m but left the **occupations** free. On CH (²Π, `--Z1=6 --Z2=1 --Rbond=2.116 --nelem=3 --nnodes=15 --lmax=13,11 --nela=4 --nelb=3`, HF):

```
free (symmetry=1)   converged in 8 Fock builds, E = -38.2817165629
--maverage=1        energy frozen at -38.2745027320 from iteration 3,
                    "change 0.000000e+00", DIIS error pinned at 1.840422e-05
```

The occupation printout shows why: under averaging the ±1 blocks become exactly degenerate, Aufbau breaks the tie arbitrarily, and the odd electron lands wholly in `a:m=-1` — the *same* occupations as the free run. The density breaks the symmetry the Fock is forced to have, so F is not the gradient of E and DIIS has no fixed point.

## 2. --symmetry=3

One block per |m|, holding the +|m| functions, with the two-fold degeneracy folded into that block's **maximum occupation**. The constraint then lands on the occupations as well as the Fock, and an odd π electron comes out as 0.5 in each of ±1. `sadatom` already does this for l with `max_occ = 2*(2l+1)`.

The −|m| partner is never solved: same radial problem, so the density scatter writes the same coefficients into both index sets at half weight.

Closed-shell N2/LDA, where the π shell is full and there is nothing to break:

```
--symmetry=1   3 blocks, m=-1: 2   m=0: 2 2 2 2 2   m=+1: 2    E = -108.6998063831
--symmetry=3   2 blocks,         |m|=0: 2 2 2 2 2  |m|=1: 4    E = -108.6998063834
```

3e-10 apart — same solution, one fewer block. CH converges in 8 builds to −38.1696015354 where `--maverage` could not converge at all.

## 3. Exchange

**Bucketing (no symmetry assumption, always on).** Three costs in the `(jang,kang)` loop were independent of the physics:

- `P.block(...).norm()` was recomputed inside the `(iang,lang)` scan for every output block it was reached from — O(Nang⁴) norms of an Nrad×Nrad block per Fock build, none depending on `(jang,kang)`. Now taken once per density block.
- An output block can only be fed by a density block with `mi-ml == mj-mk`, so density blocks are bucketed by `dm` once and each output block iterates only its own bucket.
- `4*lm_map.size()` Nrad×Nrad zero matrices were allocated per output block *before* testing whether anything couples, and the Nel² element loops ran even when nothing did. Now allocated on first use, and uncoupled blocks are skipped outright.

Identical arithmetic, just not repeated. Measured on N2/HF, interleaved: exchange 32.2 s → 31.3 s, energies bit-identical (−108.9935183242). Only ~3% here because N2 has mmax=1 and Nang=26, so the RI-K element contraction dominates; the removed waste scales as Nang⁴/(2·mmax+1).

**Mirror (needs --symmetry=3).** With a ±m symmetric density, `K(-mj,-mk)` is the mirror of `K(mj,mk)`, so only the m ≥ 0 blocks are built:

```
symmetry=1   exchange 28.9 s   E = -108.9935183242
symmetry=3   exchange 26.0 s   E = -108.9935183242
```

Bit-identical energy. ~10% here — the skipped m=−1 channels are 20% of surviving output-block pairs and the smaller ones; it approaches half the exchange build as mmax grows, which is the Cu2-at-169-channels regime that motivated this.

## 4. Pure-m XC quadrature

In the pure-m path the density is φ-independent, so V_xc is the **same field** for every m block — the only m dependence left is through m² and through basis values that depend on |m|. So `H(-m) == H(+m)` and the negative half is copied rather than assembled. Unlike the exchange mirror this needs **no** assumption about the state: it is a property of the quadrature, so it applies at every `--symmetry` level using this grid.

```
N2/LDA   before  XC 8.054 s   E = -108.6998063831
         after   XC 7.635 s   E = -108.6998063831
```

Energy identical to the committed reference. Modest because only the per-block assembly is mirrored — the density evaluation and libxc calls are shared across blocks and were never duplicated.

Restricted path only; the unrestricted `eval_Fxc` has the same structure and is the obvious follow-up.

## Verification

`fock_symmetry_average` and the `apply_mavg` plumbing are deleted; nothing else used them, and neither tests nor docs referenced `--maverage`. ci tier **40 passed, 0 failed, 0 invariant violations** after each of the four commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)