### PR TITLE
diatomic pure-m XC: mirror the unrestricted path too

### DIFF
--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -513,6 +513,12 @@ namespace helfem {
         for (size_t im = 0; im < mlist.size(); im++) {
           const std::vector<Eigen::Index> & idx = bf_ind_m[im];
           if (idx.empty()) continue;
+          // Same argument as the restricted path: V_xc is one field
+          // shared by every m block, and both spin channels depend on m
+          // only through m^2 and |m|-dependent basis values. Build +|m|
+          // and mirror onto -|m|.
+          const size_t imirror = mirror_block(im);
+          if (mlist[im] < 0 && imirror != mlist.size()) continue;
           const Eigen::Index nbf = (Eigen::Index) idx.size();
           const double m2 = (double) (mlist[im] * mlist[im]);
 
@@ -597,6 +603,14 @@ namespace helfem {
               Ha(idx[i], idx[j]) += Hma(i, j);
               if (beta) Hb(idx[i], idx[j]) += Hmb(i, j);
             }
+          if (mlist[im] > 0 && imirror != mlist.size()) {
+            const std::vector<Eigen::Index> & jdx = bf_ind_m[imirror];
+            for (Eigen::Index i = 0; i < nbf; i++)
+              for (Eigen::Index j = 0; j < nbf; j++) {
+                Ha(jdx[i], jdx[j]) += Hma(i, j);
+                if (beta) Hb(jdx[i], jdx[j]) += Hmb(i, j);
+              }
+          }
         }
       }
 


### PR DESCRIPTION
Follow-up to #302, which mirrored the ±m blocks in the restricted `eval_Fxc` and left the unrestricted one for a separate, separately-verified change. This is that change.

## Why it is valid

Same argument as the restricted case: in the pure-m path the density is φ-independent, so V_xc is **one field shared by every m block**. Both spin channels depend on m only through `m²` and through basis values that depend on |m|, so `H(-m) == H(+m)` for alpha and beta alike. The negative half is copied rather than assembled.

This needs no assumption about the state — it is a property of the quadrature, so it holds at every `--symmetry` level that uses this grid.

## Verification

Checked against the pre-change binary on NH (`--Z1=7 --Z2=1 --Rbond=1.958 --nelem=3 --nnodes=15 --lmax=13,11 --nela=5 --nelb=3 --restricted=0`), one case per functional class, since each reaches a different branch of the assembly:

| | before | after |
|---|---|---|
| LDA | −54.7674295848 | −54.7674295848 |
| PBE (GGA gradient terms) | −55.1768545662 | −55.1768545662 |
| TPSS (τ, Laplacian, m² term) | −55.2604733008 | −55.2604733008 |

and the `beta == false` branch, which skips the `Hmb` assembly entirely, on a fully spin-polarised H2 (`--nela=1 --nelb=0`):

| | before | after |
|---|---|---|
| LDA | −0.5407994969 | −0.5407994969 |

All bit-identical.

ci tier: **40 passed, 0 failed, 0 invariant violations**, re-run on top of the merged master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)