### PR TITLE
diatomic pure-m XC: share the gradient, tau and Laplacian passes too

### DIFF
--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -266,8 +266,13 @@ namespace helfem {
           sigma = helfem::Matrix::Zero(1, nang);
           for (size_t im = 0; im < nm; im++) {
             if (bf_ind_m[im].empty()) continue;
-            grho.row(0) += 2.0 * (Pv_m[im].array() * dr_m[im].array()).colwise().sum().matrix();
-            grho.row(1) += 2.0 * (Pv_m[im].array() * dth_m[im].array()).colwise().sum().matrix();
+            const size_t imirror = share ? mirror_block(im) : nm;
+            if (mlist[im] < 0 && imirror != nm) continue;
+            // A mirrored pair contributes identically, so take it once
+            // and weight it rather than walking both blocks.
+            const double w = (mlist[im] > 0 && imirror != nm) ? 2.0 : 1.0;
+            grho.row(0) += (2.0 * w) * (Pv_m[im].array() * dr_m[im].array()).colwise().sum().matrix();
+            grho.row(1) += (2.0 * w) * (Pv_m[im].array() * dth_m[im].array()).colwise().sum().matrix();
           }
           for (Eigen::Index ia = 0; ia < nang; ia++) {
             // h_mu == h_nu == scale_r
@@ -285,9 +290,21 @@ namespace helfem {
           Pv_dth_m.assign(nm, helfem::Matrix());
           for (size_t im = 0; im < nm; im++) {
             if (bf_ind_m[im].empty()) continue;
+            // Pblk * dr_m and Pblk * dth_m are two more (nbf x nbf) x
+            // (nbf x nang) products per block -- together the dominant
+            // cost of the meta-GGA path, and identical between mirrored
+            // partners since Pblk, dr_m, dth_m and m^2 all are. Build
+            // them once, share the result, and weight kin.
+            const size_t imirror = share ? mirror_block(im) : nm;
+            if (mlist[im] < 0 && imirror != nm) continue;
+            const double wpair = (mlist[im] > 0 && imirror != nm) ? 2.0 : 1.0;
             const helfem::Matrix Pblk = gather_block(P, bf_ind_m[im]);
             Pv_dr_m[im]  = Pblk * dr_m[im];
             Pv_dth_m[im] = Pblk * dth_m[im];
+            if (imirror != nm && mlist[im] > 0) {
+              Pv_dr_m[imirror]  = Pv_dr_m[im];
+              Pv_dth_m[imirror] = Pv_dth_m[im];
+            }
             const double m2 = (double) (mlist[im] * mlist[im]);
             for (Eigen::Index ia = 0; ia < nang; ia++) {
               const double kr = (Pv_dr_m[im].col(ia).array()  * dr_m[im].col(ia).array()).sum()  * inv_scale_r2(ia);
@@ -295,7 +312,7 @@ namespace helfem {
               // Analytic phi contribution: d psi / d phi = i m psi, so
               // |d psi / d phi|^2 = m^2 |psi|^2 -> m^2 rho_m / h_phi^2.
               const double kp = m2 * rho_m[im](ia) * inv_scale_phi2(ia);
-              kin(ia) += kr + kt + kp;
+              kin(ia) += wpair * (kr + kt + kp);
             }
           }
 
@@ -313,7 +330,10 @@ namespace helfem {
             lapl = helfem::Matrix::Zero(1, nang);
             for (size_t im = 0; im < nm; im++) {
               if (bf_ind_m[im].empty()) continue;
-              lapl.row(0) += 2.0 * (Pv_m[im].array() * bf_lapl_m[im].array()).colwise().sum().matrix();
+              const size_t imirror = share ? mirror_block(im) : nm;
+              if (mlist[im] < 0 && imirror != nm) continue;
+              const double w = (mlist[im] > 0 && imirror != nm) ? 2.0 : 1.0;
+              lapl.row(0) += (2.0 * w) * (Pv_m[im].array() * bf_lapl_m[im].array()).colwise().sum().matrix();
             }
             lapl.row(0) += 2.0 * kin.transpose();
           }

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -2978,7 +2978,8 @@
       "tags": [
         "cross-code",
         "diatomic",
-        "gga"
+        "gga",
+        "ci"
       ],
       "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
       "args": [
@@ -2999,7 +3000,8 @@
       "tags": [
         "cross-code",
         "diatomic",
-        "mgga"
+        "mgga",
+        "ci"
       ],
       "_why": "Ne through the diatomic code with a zero-charge dummy centre at 1 bohr; must reproduce the atomic solver",
       "args": [
@@ -3690,6 +3692,52 @@
         "--nela=4",
         "--nelb=3",
         "--method=lda_x-lda_c_vwn",
+        "--symmetry=3"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-gga-absm",
+      "code": "diatomic",
+      "tags": [
+        "diatomic",
+        "gga",
+        "symmetry",
+        "ci"
+      ],
+      "_why": "The LDA symmetry=3 cases exercise none of the gradient machinery. This one covers the shared gradient pass in the pure-m density evaluation, where a mirrored pair's contribution is taken once and weighted instead of walking both blocks.",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=gga_x_pbe-gga_c_pbe",
+        "--symmetry=3"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-mgga-absm",
+      "code": "diatomic",
+      "tags": [
+        "diatomic",
+        "mgga",
+        "symmetry",
+        "ci"
+      ],
+      "_why": "Covers the tau and Laplacian passes, which build two further (nbf x nbf) x (nbf x nang) products per block (Pblk * dr_m and Pblk * dth_m) and are the dominant meta-GGA cost. Those are shared between mirrored partners, so an error there would show up here and nowhere else in the quick tier.",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--nnodes=15",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=mgga_x_tpss-mgga_c_tpss",
         "--symmetry=3"
       ]
     }
@@ -4420,6 +4468,26 @@
       ],
       "field": "total",
       "tolerance": 1e-08
+    },
+    {
+      "name": "absm-equals-perm-Ne-gga",
+      "_why": "Closed p shell: grouping the m blocks must not change the answer. Measured identical to all printed digits.",
+      "cases": [
+        "diatomic-Ne-dummy-gga-absm",
+        "diatomic-Ne-dummy-gga"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
+    },
+    {
+      "name": "absm-equals-perm-Ne-mgga",
+      "_why": "As absm-equals-perm-Ne-gga, through the tau/Laplacian passes.",
+      "cases": [
+        "diatomic-Ne-dummy-mgga-absm",
+        "diatomic-Ne-dummy-mgga"
+      ],
+      "field": "total",
+      "tolerance": 1e-09
     }
   ]
 }

--- a/tests/refs/ci.json
+++ b/tests/refs/ci.json
@@ -780,6 +780,62 @@
       "nel_err": 4.796e-14,
       "nuclear": -136.0439884514,
       "total": -54.7674295848
+    },
+    "diatomic-Ne-dummy-gga": {
+      "Coulomb": 65.8431102189,
+      "Enucr": 0.0,
+      "Exx": 0.0,
+      "XC": -12.3745235069,
+      "_converged": true,
+      "_iterations": 6,
+      "_seconds": 67.7,
+      "err": 4.796,
+      "kinetic": 128.5626504546,
+      "nel_err": 4.796e-14,
+      "nuclear": -310.8976634256,
+      "total": -128.866426259
+    },
+    "diatomic-Ne-dummy-gga-absm": {
+      "Coulomb": 65.8430908473,
+      "Enucr": 0.0,
+      "Exx": 0.0,
+      "XC": -12.3745211257,
+      "_converged": true,
+      "_iterations": 6,
+      "_seconds": 73.0,
+      "err": 4.086,
+      "kinetic": 128.5626339641,
+      "nel_err": 4.086e-14,
+      "nuclear": -310.8976299448,
+      "total": -128.866426259
+    },
+    "diatomic-Ne-dummy-mgga": {
+      "Coulomb": 65.9281594454,
+      "Enucr": 0.0,
+      "Exx": 0.0,
+      "XC": -12.5034147616,
+      "_converged": true,
+      "_iterations": 6,
+      "_seconds": 83.6,
+      "err": 6.928,
+      "kinetic": 128.675543347,
+      "nel_err": 6.928e-14,
+      "nuclear": -311.0813910368,
+      "total": -128.981103006
+    },
+    "diatomic-Ne-dummy-mgga-absm": {
+      "Coulomb": 65.9281582423,
+      "Enucr": 0.0,
+      "Exx": 0.0,
+      "XC": -12.503414604,
+      "_converged": true,
+      "_iterations": 6,
+      "_seconds": 77.4,
+      "err": 2.132,
+      "kinetic": 128.6755414405,
+      "nel_err": 2.132e-14,
+      "nuclear": -311.0813880849,
+      "total": -128.981103006
     }
   },
   "metadata": {


### PR DESCRIPTION
Continues task 57 on the XC side. Only the density product was shared between mirrored ±m blocks; the three passes after it still walked both partners.

The meta-GGA path was the worst of it — `Pblk * dr_m` and `Pblk * dth_m` are two further (nbf × nbf) × (nbf × nang) products per block, together the dominant cost there, and they were computed twice for every pair.

All four passes now take a mirrored pair once:

| pass | before | now |
|---|---|---|
| density | `Pblk * bf_m` | already shared |
| gradient | walked both blocks | contribution weighted |
| tau / Laplacian | `Pblk * dr_m`, `Pblk * dth_m` twice | built once, `kin` weighted |
| Laplacian cross term | walked both blocks | weighted |

Gated on the same `is_absm_symmetric()` — sharing needs `P(+m) == P(-m)`, which only `--symmetry=3` guarantees.

## This code was completely untested

The only `--symmetry=3` cases in the quick tier were HF and LDA, and **neither touches a gradient, a τ or a Laplacian**. An error in any of the three passes would have gone unnoticed by the whole suite.

Verified directly against `--symmetry=1`, which shares nothing:

| | `--symmetry=1` | `--symmetry=3` |
|---|---|---|
| PBE | −128.8664262590 | −128.8664262590 |
| TPSS | −128.9811030060 | −128.9811030060 |

Identical to every printed digit. Added as `diatomic-Ne-dummy-{gga,mgga}-absm` with invariants against their per-m partners, so the coverage stays — 68–84 s each, well within the quick tier.

## Verification

ci tier: **49 passed** (was 45), 0 failed, 0 invariant violations.

## Not claimed

I have not measured the speedup. The N2 profile says XC is 27% of a hybrid Fock build, and this halves several passes within it for mmax ≥ 1 — but after two over-optimistic estimates in this area I would rather land the correctness and let the timing be measured separately, on an idle machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)