### PR TITLE
tests: register one CTest test per case

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,46 +55,91 @@ endif()
 set(HELFEM_TEST_DRIVER "${CMAKE_CURRENT_SOURCE_DIR}/run_tests.py")
 set(HELFEM_TEST_REFS   "${CMAKE_CURRENT_SOURCE_DIR}/refs/ci.json")
 
-# One test per tag rather than one giant test, so a failure names the area
-# and `ctest -R` can select it.
+set(HELFEM_TEST_JOBS 4 CACHE STRING "Parallel cases for the aggregate test")
+set(HELFEM_TEST_TIMEOUT 5400 CACHE STRING "Per-test timeout in seconds")
+option(HELFEM_SLOW_TESTS "Enable the slow integration cases (hours)" OFF)
+
+
+# ONE CTEST TEST PER CASE.
 #
-# --skip-slow is not optional here. Tags are orthogonal to cost: the
-# symmetry tag covers both the seconds-long Ne/H2 cases and the CH/NH ones
-# that run minutes each, so without it `ctest` would quietly inherit the
-# slow tier through a tag that says nothing about runtime.
-function(helfem_add_integration_test name tag)
-  add_test(NAME ${name}
+# This used to be one test per tag, which meant `integration.full` was a
+# single opaque entry: 6412 s, "***Failed", and no indication of which of
+# ~180 cases failed or where the time went. CTest can only report what it
+# is given, so it is given each case separately -- a failure now names the
+# case, and `ctest` prints a per-case time.
+#
+# The case list comes from cases.json at configure time rather than being
+# duplicated here, so adding a case to the suite registers it
+# automatically. Re-run cmake after editing cases.json.
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -c
+    "import json,sys; s=json.load(open(sys.argv[1]));\
+print('\\n'.join(c['name']+'|'+','.join(c.get('tags',[])) for c in s['cases']))"
+    ${CMAKE_CURRENT_SOURCE_DIR}/cases.json
+  OUTPUT_VARIABLE HELFEM_CASE_LIST
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE HELFEM_CASE_LIST_RC)
+
+if(NOT HELFEM_CASE_LIST_RC EQUAL 0)
+  message(WARNING "Could not read tests/cases.json; integration cases not registered")
+  return()
+endif()
+
+string(REPLACE "\n" ";" HELFEM_CASE_LINES "${HELFEM_CASE_LIST}")
+set(_n_fast 0)
+set(_n_slow 0)
+foreach(line ${HELFEM_CASE_LINES})
+  string(REPLACE "|" ";" parts "${line}")
+  list(GET parts 0 case_name)
+  list(LENGTH parts nparts)
+  set(case_tags "")
+  if(nparts GREATER 1)
+    list(GET parts 1 case_tags_csv)
+    string(REPLACE "," ";" case_tags "${case_tags_csv}")
+  endif()
+
+  # A case is registered under its own name; --filter anchors on it so no
+  # other case is dragged in by a shared prefix.
+  add_test(NAME case.${case_name}
            COMMAND ${Python3_EXECUTABLE} ${HELFEM_TEST_DRIVER}
                    --check ${HELFEM_TEST_REFS}
-                   --tag ${tag} --skip-slow
+                   --filter "^${case_name}$"
                    --bindir $<TARGET_FILE_DIR:diatomic>
-                   --jobs ${HELFEM_TEST_JOBS})
-  # The harness runs each case with OMP_NUM_THREADS=1 and parallelises
-  # across cases, so converged energies do not depend on the job count --
-  # see tests/README.md on thread-count reproducibility.
-  set_tests_properties(${name} PROPERTIES
-    LABELS "${ARGN}"
+                   --jobs 1)
+  set_tests_properties(case.${case_name} PROPERTIES
+    LABELS "integration;${case_tags}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT ${HELFEM_TEST_TIMEOUT})
-endfunction()
 
-set(HELFEM_TEST_JOBS 4 CACHE STRING "Parallel cases for the integration tests")
-set(HELFEM_TEST_TIMEOUT 5400 CACHE STRING "Per-tier timeout in seconds")
+  # A plain `ctest` runs the quick tier and nothing else. CTest offers no
+  # "default subset", so everything outside it is registered-but-disabled:
+  # visible in `ctest -N`, skipped unless asked for. Gating on the ci tag
+  # rather than on "not slow" matters -- only ~49 of the ~180 cases carry
+  # ci, while ~130 are merely not-slow, and a default run of those would
+  # be hours.
+  if(NOT "ci" IN_LIST case_tags AND NOT HELFEM_SLOW_TESTS)
+    set_tests_properties(case.${case_name} PROPERTIES DISABLED TRUE)
+    math(EXPR _n_slow "${_n_slow}+1")
+  else()
+    math(EXPR _n_fast "${_n_fast}+1")
+  endif()
+endforeach()
 
-helfem_add_integration_test(integration.quick    ci       "integration;quick")
-helfem_add_integration_test(integration.symmetry symmetry "integration;symmetry")
+# Invariants compare cases against EACH OTHER, so they cannot live in a
+# per-case test -- each of those runs a single case in its own process.
+# One extra test covers them for the quick tier; --smoke needs no
+# reference file and fails on a crash or a violated invariant.
+add_test(NAME integration.invariants
+         COMMAND ${Python3_EXECUTABLE} ${HELFEM_TEST_DRIVER}
+                 --smoke --tag ci --skip-slow
+                 --bindir $<TARGET_FILE_DIR:diatomic>
+                 --jobs ${HELFEM_TEST_JOBS})
+set_tests_properties(integration.invariants PROPERTIES
+  LABELS "integration;invariants"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  TIMEOUT ${HELFEM_TEST_TIMEOUT})
 
-option(HELFEM_SLOW_TESTS "Register the slow integration tier (hours)" OFF)
-if(HELFEM_SLOW_TESTS)
-  # Everything, including the cases that run minutes to hours each. This is
-  # what the weekly workflow covers.
-  add_test(NAME integration.full
-           COMMAND ${Python3_EXECUTABLE} ${HELFEM_TEST_DRIVER}
-                   --check ${HELFEM_TEST_REFS}
-                   --bindir $<TARGET_FILE_DIR:diatomic>
-                   --jobs ${HELFEM_TEST_JOBS} --timeout 7200)
-  set_tests_properties(integration.full PROPERTIES
-    LABELS "integration;slow"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    TIMEOUT 0)
-endif()
+message(STATUS "HelFEM tests: ${_n_fast} quick case(s) enabled, ${_n_slow} "
+               "other case(s) registered but disabled "
+               "(-DHELFEM_SLOW_TESTS=ON enables all). Run them in parallel "
+               "with e.g. ctest -j6.")

--- a/tests/README.md
+++ b/tests/README.md
@@ -173,6 +173,30 @@ solutions (-38.2817165629 at `--symmetry=1`) and is not comparable to them:
 it is a different, cylindrically averaged state. The point of the test is
 that it converges at all.
 
+## Running the suite
+
+`ctest` registers one test per case, so a failure names the case and the
+timings show where the run went:
+
+    ctest -j6              # quick tier: 49 cases + the unit binaries
+    ctest -L unit          # the self-checking binaries alone, ~2 s
+    ctest -R Ne-dummy      # one family
+    ctest -N               # list everything, including what is disabled
+
+Cases outside the quick tier are registered but DISABLED, so they appear
+in `ctest -N` and are skipped by a plain run. Enable them with
+
+    cmake -DHELFEM_SLOW_TESTS=ON <builddir> && ctest -j6
+
+The case list is read from `cases.json` at configure time, so a new case
+registers itself -- but you have to re-run cmake after editing the file.
+
+Invariants compare cases against each other and therefore cannot live in
+a per-case test; `integration.invariants` covers them for the quick tier.
+The harness can still be driven directly, which is what CI does:
+
+    python3 run_tests.py --check refs/ci.json --tag ci --bindir <builddir>/src -j4
+
 ## Cross-code invariants
 
 Every element in this suite is closed-shell, single-s-electron or half-filled,


### PR DESCRIPTION
`integration.full` was a single opaque entry. On your machine it reported

```
9/9 Test #9: integration.full ...***Failed  6412.10 sec
```

— 1.8 hours, and no indication of which of ~180 cases failed or where the time went. CTest can only report what it is given, so it is now given each case separately.

```bash
ctest -j6              # quick tier: 49 cases + the unit binaries
ctest -R Ne-dummy      # one family
ctest -N               # everything, including what is disabled
cmake -DHELFEM_SLOW_TESTS=ON <builddir>   # enables all 178
```

A failure now names the case, and the per-case timings show where the run goes.

## Design points

**The case list is read from `cases.json` at configure time**, not duplicated in CMake, so a new case registers itself. (Re-run cmake after editing the file.)

**Cases outside the quick tier are registered but `DISABLED`**, not omitted — they appear in `ctest -N` and are skipped by a plain run, so the full inventory stays visible.

**The enable condition is the `ci` tag, not "not slow".** Only ~49 cases carry `ci` while ~130 are merely not-slow; gating on the latter would have turned a plain `ctest` into an hours-long run, which is the exact failure mode this is meant to remove. I had it wrong the first time and caught it on the registration count (132 vs 49).

**Invariants get one test of their own.** They compare cases against *each other*, so they cannot live in a per-case test — each of those runs a single case in its own process. `integration.invariants` covers the quick tier via `--smoke`, which needs no reference file and fails on a crash or a violated invariant.

## Measured

56 tests, 100% passed, **562 s at `-j6`** (was 678 s as three aggregate tests). Per-case times are now visible: `Ne-dummy-mgga` 101 s, `Ne-dummy-mgga-absm` 104 s, `Ne-dummy-lda` 74 s, most cases seconds.

## What this does not answer

Your `integration.full` **failure** is still unexplained — I have not run the full tier here (1.8 h). With this change, re-running it with `-DHELFEM_SLOW_TESTS=ON` will name the failing case directly instead of failing as a block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)