### PR TITLE
SAD initial guess for diatomic, from the tabulated wave functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,11 @@ target_link_libraries(1e_atom helfem-common legendre)
 add_executable(diatomic_purem_test diatomic/purem_test.cpp)
 target_link_libraries(diatomic_purem_test helfem-common legendre)
 
+# Checks the projection of the tabulated atomic orbitals onto the diatomic
+# basis, which the projected initial guess is built from.
+add_executable(diatomic_projection_test diatomic/projection_test.cpp)
+target_link_libraries(diatomic_projection_test helfem-common legendre)
+
 # Arbitrary-precision demonstration: the same FEM code at several scalar types.
 add_executable(precision harmonic/precision.cpp)
 target_link_libraries(precision helfem-common legendre)

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -30,6 +30,7 @@
 // HF (x_func == 0 && c_func == 0) is deferred; picking any HF method throws.
 
 #include "../general/cmdline.h"
+#include "../general/atomdb.h"
 #include "../general/constants.h"
 #include "../general/dftfuncs.h"
 #include "../general/elements.h"
@@ -104,7 +105,7 @@ int main(int argc, char **argv) {
   // is the default because it typically converges materially faster
   // than the bare core-Hamiltonian guess. Ignored when --load supplies
   // orbitals from a checkpoint.
-  parser.add<int>("iguess", 0, "initial guess: 0 core Hamiltonian, 1 GSZ, 2 SAP (tabulated), 3 Thomas-Fermi, 4 SAP (from the tabulated wave function)", false, 2);
+  parser.add<int>("iguess", 0, "initial guess: 0 core Hamiltonian, 1 GSZ, 2 SAP (tabulated), 3 Thomas-Fermi, 4 SAP (from the tabulated wave function), 5 SAD (tabulated wave functions projected onto the diatomic basis)", false, 2);
 
   // Load orbital guess from a checkpoint written by an earlier run.
   parser.add<std::string>("load", 0, "load orbital guess from checkpoint file", false, "");
@@ -487,7 +488,72 @@ int main(int argc, char **argv) {
   //     is the default because it typically converges materially
   //     faster than core-H.
   helfem::Matrix Vguess;
-  if (iguess == 0) {
+  if (iguess == 5) {
+    // SAD: superpose the tabulated ATOMIC DENSITIES, obtained by
+    // projecting the database's orbitals onto this basis, and use the
+    // mean field they generate. The SAP options above approximate that
+    // mean field by a fitted local potential; here it is built from the
+    // density itself, so no fit is involved.
+    if (verbosity >= 1)
+      printf("Guess orbitals from the tabulated atomic wave functions, "
+             "projected onto the diatomic basis\n");
+    const int lquad = 4 * lmmax.maxCoeff() + 12;
+    helfem::diatomic::twodquad::TwoDGrid qgrid(&basis, lquad);
+    // Whole-basis orthonormalization: the guess density is assembled in
+    // the AO basis and only afterwards split into symmetry blocks.
+    const helfem::Matrix Sinvh_full = basis.Sinvh(false, 0);
+    const Eigen::VectorXi basis_m = basis.get_mval();
+    const int mlo = basis_m.minCoeff(), mhi = basis_m.maxCoeff();
+
+    helfem::Matrix Psad = helfem::Matrix::Zero(Nbf, Nbf);
+    auto add_centre = [&](int Z, helfem::diatomic::twodquad::probe_t probe) {
+      if (Z <= 0)
+        return;   // a dummy centre carries no electrons
+      for (int l = 0; l <= helfem::atomdb::lmax(); l++) {
+        const int norb = helfem::atomdb::norb(Z, l);
+        if (norb <= 0)
+          continue;
+        const helfem::Vector occ = helfem::atomdb::occupations(Z, l);
+        for (int m = -l; m <= l; m++) {
+          if (m < mlo || m > mhi)
+            continue;   // this m is not in the basis at all
+          const helfem::Matrix proj = qgrid.atomdb_projection(Z, l, m, probe);
+          // proj holds <psi_a|chi_i>, so the AO coefficients are
+          // C = S^-1 proj^T, which Sinvh gives as Sinvh (proj Sinvh)^T.
+          const helfem::Matrix C = Sinvh_full * (proj * Sinvh_full).transpose();
+          for (int a = 0; a < norb; a++) {
+            // The stored occupation is summed over the 2l+1 components,
+            // and the atom is spherical, so each m carries its share.
+            const double w = occ(a) / (2.0 * l + 1.0);
+            if (w <= 0.0)
+              continue;
+            Psad += w * (C.col(a) * C.col(a).transpose());
+          }
+        }
+      }
+    };
+    add_centre(Z1, helfem::diatomic::twodquad::PROBE_LEFT);
+    add_centre(Z2, helfem::diatomic::twodquad::PROBE_RIGHT);
+
+    // The mean field of that density, in the same channels the SCF uses.
+    Vguess = Vnuc + basis.coulomb(Psad);
+    if (have_xc) {
+      helfem::Matrix XCg;
+      double Excg = 0.0, nelg = 0.0, eking = 0.0;
+      if (purem_xc)
+        pmgrid.eval_Fxc(x_func, x_pars, c_func, c_pars, Psad, XCg,
+                        Excg, nelg, eking, dftthr);
+      else
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Psad, XCg,
+                      Excg, nelg, eking, dftthr);
+      Vguess += XCg;
+      if (verbosity >= 1)
+        printf("SAD guess density carries %.6f electrons (nuclear total %i)\n",
+               nelg, Z1 + Z2);
+    }
+    if (have_exx)
+      Vguess += kfrac * basis.exchange(0.5 * Psad);
+  } else if (iguess == 0) {
     if (verbosity >= 1)
       printf("Guess orbitals from core Hamiltonian\n");
     Vguess = Vnuc;
@@ -519,7 +585,7 @@ int main(int argc, char **argv) {
       p2 = new modelpotential::SAPFEAtom(Z2);
       break;
     default:
-      throw std::logic_error("Unsupported iguess value (expected 0..4).\n");
+      throw std::logic_error("Unsupported iguess value (expected 0..5).\n");
     }
     const int lquad = 4 * lmmax.maxCoeff() + 12;
     helfem::diatomic::twodquad::TwoDGrid qgrid(&basis, lquad);

--- a/src/diatomic/projection_test.cpp
+++ b/src/diatomic/projection_test.cpp
@@ -1,0 +1,157 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+
+// Checks TwoDGrid::atomdb_projection, the projection of the tabulated
+// atomic orbitals onto the diatomic basis that a projected initial guess
+// is built from.
+//
+// The projection reuses the quadrature the completeness and importance
+// profiles run on, so a structural error is unlikely; what is easy to get
+// wrong is a NORMALIZATION or an ANGULAR FACTOR, and neither would make
+// the guess fail visibly -- it would simply converge more slowly, which
+// is invisible. Hence two checks with independent failure modes.
+//
+// 1. atomdb_overlap must come out as the identity. The stored orbitals
+//    are orthonormal, so evaluating them on the diatomic grid and
+//    integrating tests the radial evaluation, the r(mu,nu) geometry and
+//    the quadrature weight, WITHOUT involving the basis at all. A radial
+//    function off by a factor of r fails here.
+//
+// 2. The projection must recover the orbital's norm. Expanding the
+//    projected orbital in the orthonormal basis and taking its length
+//    gives the fraction of the orbital the diatomic basis captures; for
+//    an atom the basis is built for that must be ~1. Less than 1 means an
+//    incomplete basis, MORE than 1 is impossible and means the projection
+//    or the angular factor is wrong.
+
+#include "../general/cmdline.h"
+#include "../general/constants.h"
+#include "../general/elements.h"
+#include "../general/atomdb.h"
+#include "basis.h"
+#include "twodquadrature.h"
+#include "../atomic/basis.h"
+#include "utils.h"
+#include <cstdio>
+#include <cmath>
+#include <helfem.h>
+
+using namespace helfem;
+
+int main(int argc, char **argv) {
+  helfem::set_verbosity(false);
+
+  cmdline::parser parser;
+  parser.add<std::string>("Z1", 0, "nuclear charge of the atom", false, "Be");
+  parser.add<double>("Rbond", 0, "distance to the dummy centre", false, 1.0);
+  parser.add<int>("lmax", 0, "maximum l", false, 8);
+  parser.add<int>("mmax", 0, "maximum m", false, 2);
+  parser.add<int>("nelem", 0, "number of elements", false, 5);
+  parser.add<int>("nnodes", 0, "nodes per element", false, 15);
+  parser.add<double>("Rmax", 0, "practical infinity", false, 40.0);
+  parser.add<int>("primbas", 0, "primitive basis", false, 4);
+  parser.add<double>("thresh", 0, "how much of the norm may be missing", false, 1e-3);
+  parser.parse_check(argc, argv);
+
+  const int Z1 = get_Z(parser.get<std::string>("Z1"));
+  const double Rbond = parser.get<double>("Rbond");
+  const int lmax = parser.get<int>("lmax");
+  const int mmax = parser.get<int>("mmax");
+  const int Nelem = parser.get<int>("nelem");
+  const int Nnodes = parser.get<int>("nnodes");
+  const double Rmax = parser.get<double>("Rmax");
+  const int primbas = parser.get<int>("primbas");
+  const double thresh = parser.get<double>("thresh");
+
+  auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
+      polynomial_basis::get_basis(primbas, Nnodes));
+  const int Nquad = 5 * poly->get_nbf();
+
+  const Eigen::VectorXi lmmax = Eigen::VectorXi::Constant(mmax + 1, lmax);
+  Eigen::VectorXi lval, mval;
+  diatomic::basis::lm_to_l_m(lmmax, lval, mval);
+
+  const double Rhalf = 0.5 * Rbond;
+  const double mumax = utils::arcosh(Rmax / Rhalf);
+  const helfem::Vector bval = atomic::basis::normal_grid(Nelem, mumax, 4, 1.0);
+
+  // A single atom with a zero-charge partner: the basis then has to
+  // represent an atomic solution, so the projection ought to be complete.
+  diatomic::basis::TwoDBasis basis(Z1, 0, Rhalf, poly, Nquad, bval, lval, mval);
+  const int lang = 4 * lval.maxCoeff() + 12;
+  diatomic::twodquad::TwoDGrid grid(&basis, lang);
+
+  const helfem::Matrix Sinvh = basis.Sinvh(false, 0);
+
+  printf("Z = %i, %i angular x %i radial = %i functions, lang = %i\n",
+         Z1, (int) basis.Nang(), (int) basis.Nrad(), (int) basis.Nbf(), lang);
+
+  int nfail = 0;
+  double worst_ortho = 0.0, worst_missing = 0.0, worst_excess = 0.0;
+
+  for (int l = 0; l <= std::min(lmax, helfem::atomdb::lmax()); l++) {
+    const int norb = helfem::atomdb::norb(Z1, l);
+    if (norb <= 0)
+      continue;
+    for (int m = -std::min(l, mmax); m <= std::min(l, mmax); m++) {
+      const helfem::Matrix ovl =
+          grid.atomdb_overlap(Z1, l, m, diatomic::twodquad::PROBE_LEFT);
+      const helfem::Matrix proj =
+          grid.atomdb_projection(Z1, l, m, diatomic::twodquad::PROBE_LEFT);
+
+      // (1) the stored orbitals are orthonormal on this grid
+      for (int a = 0; a < norb; a++)
+        for (int b = 0; b < norb; b++) {
+          const double ref = (a == b) ? 1.0 : 0.0;
+          worst_ortho = std::max(worst_ortho, std::abs(ovl(a, b) - ref));
+        }
+
+      // (2) the projection recovers the norm
+      const helfem::Matrix C = proj * Sinvh;
+      for (int a = 0; a < norb; a++) {
+        const double recovered = C.row(a).squaredNorm();
+        const double missing = 1.0 - recovered;
+        if (missing > 0.0) worst_missing = std::max(worst_missing, missing);
+        else               worst_excess  = std::max(worst_excess, -missing);
+        printf("  l=%i m=%+d orbital %i: <psi|psi>=%.10f  recovered %.10f\n",
+               l, m, a, ovl(a, a), recovered);
+      }
+    }
+  }
+
+  printf("\nWorst deviation of the tabulated orbitals from orthonormality: %.3e\n",
+         worst_ortho);
+  printf("Worst norm MISSING from the projection (basis incompleteness): %.3e\n",
+         worst_missing);
+  printf("Worst norm IN EXCESS of unity (impossible; a bug): %.3e\n", worst_excess);
+
+  if (worst_ortho > 1e-6) {
+    printf("\n** The tabulated orbitals are not orthonormal on the diatomic grid.\n"
+           "   That is the radial evaluation or the quadrature, not the basis.\n");
+    nfail++;
+  }
+  if (worst_excess > 1e-8) {
+    printf("\n** A projection recovered MORE than the whole orbital, which no\n"
+           "   finite basis can do. Normalization or angular factor is wrong.\n");
+    nfail++;
+  }
+  if (worst_missing > thresh) {
+    printf("\n** The projection loses more of the orbital than expected.\n");
+    nfail++;
+  }
+
+  printf("\n%s\n", nfail ? "FAILED" : "All checks passed.");
+  return nfail ? 1 : 0;
+}

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "twodquadrature.h"
+#include "../general/atomdb.h"
 #include "chebyshev.h"
 #include "../general/lcao.h"
 #include "../general/model_potential.h"
@@ -394,6 +395,50 @@ namespace helfem {
         // Use the Eigen-native boundary removal (same cached pure index list
         // as the Fock path); no arma round trip.
         return basp->remove_boundaries(H);
+      }
+
+      helfem::Matrix TwoDGrid::atomdb_projection(int Z, int l, int m, probe_t p) {
+        const helfem::atomdb::Atom at(Z);
+        // The radial functions the database stores; ao_projection takes
+        // any callable of r, so nothing else has to change.
+        auto compute_ao = [&at, l](double r) { return at.orbitals(l, r); };
+
+        const int norb = helfem::atomdb::norb(Z, l);
+        helfem::Matrix S = helfem::Matrix::Zero(std::max(norb, 0), basp->Ndummy());
+        if (norb <= 0)
+          return S(Eigen::all, basp->pure_indices());
+
+        TwoDGridWorker grid(basp, lang);
+        for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
+          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+            grid.compute_bf(iel,irad,m);
+            grid.ao_projection(compute_ao, p);
+            grid.multiply_Plm(l, m, p);
+            grid.eval_proj(S);
+          }
+        }
+        return S(Eigen::all,basp->pure_indices());
+      }
+
+      helfem::Matrix TwoDGrid::atomdb_overlap(int Z, int l, int m, probe_t p) {
+        const helfem::atomdb::Atom at(Z);
+        auto compute_ao = [&at, l](double r) { return at.orbitals(l, r); };
+
+        const int norb = helfem::atomdb::norb(Z, l);
+        helfem::Matrix S = helfem::Matrix::Zero(std::max(norb, 0), std::max(norb, 0));
+        if (norb <= 0)
+          return S;
+
+        TwoDGridWorker grid(basp, lang);
+        for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
+          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+            grid.compute_bf(iel,irad,m);
+            grid.ao_projection(compute_ao, p);
+            grid.multiply_Plm(l, m, p);
+            grid.eval_proj_overlap(S);
+          }
+        }
+        return S;
       }
 
       helfem::Matrix TwoDGrid::gto_projection(int l, int m, const helfem::Vector & expn, probe_t p) {

--- a/src/diatomic/twodquadrature.h
+++ b/src/diatomic/twodquadrature.h
@@ -116,6 +116,20 @@ namespace helfem {
         helfem::Matrix model_potential(const modelpotential::ModelPotential * p1, const modelpotential::ModelPotential * p2);
 
         /// Compute GTO projection
+        /// Project the tabulated atomic orbitals of (Z, l) onto the
+        /// diatomic basis, for the atom sitting at probe p. Rows are the
+        /// stored orbitals of that l, columns the diatomic basis
+        /// functions -- the same layout gto_projection returns.
+        ///
+        /// This is the GTO/STO projection with the trial function
+        /// replaced by the database's radial orbitals, which is all a
+        /// projected initial guess needs: ao_projection already takes an
+        /// arbitrary radial function.
+        helfem::Matrix atomdb_projection(int Z, int l, int m, probe_t p);
+        /// Overlap of those same tabulated orbitals with each other on
+        /// this grid, for normalizing the projection.
+        helfem::Matrix atomdb_overlap(int Z, int l, int m, probe_t p);
+
         helfem::Matrix gto_projection(int l, int m, const helfem::Vector & expn, probe_t p);
         /// Compute GTO projection
         helfem::Matrix gto_overlap(int l, int m, const helfem::Vector & expn, probe_t p);

--- a/src/general/atomdb.cpp
+++ b/src/general/atomdb.cpp
@@ -145,6 +145,25 @@ namespace helfem {
       return iel;
     }
 
+    helfem::Vector Atom::orbitals(int l, double r) const {
+      const int n = (l >= 0 && l <= data::lmax) ? norb(Z_, l) : 0;
+      helfem::Vector out = helfem::Vector::Zero(std::max(n, 0));
+      if (n <= 0 || r <= 0.0 || r > Rmax_)
+        return out;
+      double xprim;
+      const size_t iel = locate(radial_.get_fem(), r, xprim);
+      helfem::Vector x(1);
+      x(0) = xprim;
+      // get_bf returns B(r)/r, so contracting it with the stored
+      // coefficients gives the radial function R(r) itself, not r*R(r).
+      const helfem::Matrix bf = radial_.get_bf(x, iel);
+      size_t ifirst, ilast;
+      radial_.get_idx(iel, ifirst, ilast);
+      const helfem::Matrix C = coefficients(Z_, l);
+      out = (bf * C.block(ifirst, 0, ilast - ifirst + 1, n)).transpose();
+      return out;
+    }
+
     double Atom::radial_density(double r) const {
       if (r <= 0.0 || r > Rmax_)
         return 0.0;

--- a/src/general/atomdb.h
+++ b/src/general/atomdb.h
@@ -121,6 +121,21 @@ namespace helfem {
       /// are only piecewise smooth. Feed these to the quadrature.
       helfem::Vector element_boundaries() const;
 
+      /// Radial functions R_nl(r) of the stored orbitals of this l, one
+      /// entry per stored orbital, evaluated at radius r.
+      ///
+      /// The database stores the ORBITALS rather than the density (see
+      /// [[sap-ship-wave-functions-not-potential]]: the density is twice
+      /// their polynomial degree and the potential worse still), so this
+      /// is the primitive a projected guess needs -- everything else here
+      /// is derived from it. The identity that fixes the convention is
+      ///
+      ///     rho(r) = sum_l sum_n occupations(Z,l)(n) * R_nl(r)^2 / (4 pi)
+      ///
+      /// which atomdb_test checks against density() rather than leaving
+      /// the normalization to be rediscovered by each caller.
+      helfem::Vector orbitals(int l, double r) const;
+
       /// Electron density rho(r).
       double density(double r) const;
       /// Radial derivative of the density, d rho / dr. The density is

--- a/src/general/atomdb_test.cpp
+++ b/src/general/atomdb_test.cpp
@@ -178,6 +178,42 @@ int main(void) {
     }
   }
 
+  // The stored orbitals must reproduce the stored density:
+  //   rho(r) = sum_l sum_n occ_nl R_nl(r)^2 / (4 pi)
+  // This pins the normalization convention of Atom::orbitals -- get_bf
+  // returns B(r)/r, so the contraction is R(r) and not r*R(r) -- so that
+  // a projected guess does not have to rediscover it, and gets it wrong
+  // by a factor of r if it does.
+  {
+    double worst_orb = 0.0;
+    int worst_orb_Z = 0;
+    for (int Z = 1; Z <= helfem::atomdb::max_Z(); Z++) {
+      const helfem::atomdb::Atom at(Z);
+      for (double r : {0.05, 0.2, 0.7, 1.5, 3.0, 8.0, 20.0}) {
+        double rho = 0.0;
+        for (int l = 0; l <= helfem::atomdb::lmax(); l++) {
+          const int n = helfem::atomdb::norb(Z, l);
+          if (n <= 0)
+            continue;
+          const helfem::Vector occ = helfem::atomdb::occupations(Z, l);
+          const helfem::Vector R = at.orbitals(l, r);
+          for (int i = 0; i < n; i++)
+            rho += occ(i) * R(i) * R(i);
+        }
+        rho /= 4.0 * M_PI;
+        const double ref = at.density(r);
+        const double dev = std::abs(rho - ref) / std::max(std::abs(ref), 1e-12);
+        if (dev > worst_orb) { worst_orb = dev; worst_orb_Z = Z; }
+      }
+    }
+    printf("\nWorst orbital-vs-density reconstruction (relative): %.3e (Z = %i)\n",
+           worst_orb, worst_orb_Z);
+    if (worst_orb > 1e-12) {
+      printf("** Atom::orbitals does not reproduce Atom::density.\n");
+      nfail++;
+    }
+  }
+
   printf("\nWorst enclosed-charge deviation from quadrature: %.3e\n", worst_q);
   printf("Worst Hartree-screening deviation from quadrature: %.3e\n", worst_v);
   printf("Worst deviation from the exact r -> 0 / r -> inf limits: %.3e\n", worst_lim);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ find_package(Python3 COMPONENTS Interpreter)
 # worse than not testing them; turning them into real checks is a
 # separate job (they need a tolerance and a non-zero exit).
 foreach(t legendre_test legendre_unit_test gaunt_test sphtest over_r_test
-          atomdb_test checkpoint_precision_test)
+          atomdb_test diatomic_projection_test checkpoint_precision_test)
   if(TARGET ${t})
     add_test(NAME unit.${t} COMMAND ${t})
     set_tests_properties(unit.${t} PROPERTIES LABELS "unit")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,20 +22,22 @@ find_package(Python3 COMPONENTS Interpreter)
 # Self-contained checks with no reference data, exercising layers the
 # integration suite reaches only indirectly.
 #
-# ONLY binaries that can actually fail are listed. Deliberately excluded:
+# ONLY binaries that can actually fail are listed. atomdb_test was
+# excluded here originally on a faulty grep -- it ends in
+# `return nfail ? 1 : 0;`, an idiom the pattern missed -- and is now
+# registered. Still excluded, verified by reading them:
 #
 #   atomic_itest          takes "nquad R" arguments and, whatever it
 #                         measures, ends in `return 0` -- it prints
 #                         "Error in inner integral is %e" and exits
 #                         successfully no matter how large that error is.
-#   atomdb_test           print-only, no failure path.
 #   diatomic_purem_test   print-only, no failure path -- and 149 s of it.
 #
 # Registering those would report a pass that means nothing, which is
 # worse than not testing them; turning them into real checks is a
 # separate job (they need a tolerance and a non-zero exit).
 foreach(t legendre_test legendre_unit_test gaunt_test sphtest over_r_test
-          checkpoint_precision_test)
+          atomdb_test checkpoint_precision_test)
   if(TARGET ${t})
     add_test(NAME unit.${t} COMMAND ${t})
     set_tests_properties(unit.${t} PROPERTIES LABELS "unit")


### PR DESCRIPTION
Projects the database's atomic orbitals onto the diatomic basis and starts from the mean field of the superposed atomic densities. `--iguess=5`.

Four commits, each verified before the next builds on it.

## 1. `Atom::orbitals(l, r)`

The database ships orbitals rather than the density (the density is twice their polynomial degree and the potential worse still), so they are the right primitive — everything else in `Atom` is downstream of them.

The normalization is the trap: `get_bf` returns B(r)/r, so contracting with the stored coefficients gives R(r), **not** r·R(r). Rather than leave each caller to rediscover that, `atomdb_test` now asserts

```
rho(r) = sum_l sum_n occ_nl * R_nl(r)^2 / (4 pi)
```

against `Atom::density` over every Z and a spread of radii. Worst relative deviation **1.7e-15**.

This also re-registers `atomdb_test` with CTest. I excluded it when the per-case registration landed, on the grounds it had no failure path — wrong. It ends `return nfail ? 1 : 0;`, an idiom my classifying grep missed. `purem_test` and `atomic_itest` really are print-only; verified by reading them this time.

## 2. `atomdb_projection` / `atomdb_overlap`

The machinery already existed: `TwoDGridWorker::ao_projection` takes an arbitrary `std::function<Vector(double r)>` and integrates it against the diatomic basis, with `multiply_Plm` supplying the angular factor. `gto_projection` and `sto_projection` differ *only* in the radial function passed. So this adds no new quadrature and no new geometry — it reuses the path the completeness and importance profiles run on.

## 3. Verification

The risk was never structural but a **normalization or angular factor**, neither of which makes a guess fail visibly — it would just converge more slowly, and nobody would look. Two checks with independent failure modes:

- **Orthonormality on the diatomic grid**, which uses no basis at all and so isolates the radial evaluation, the r(μ,ν) geometry and the quadrature weight. A radial function off by a factor of r fails here and nowhere else.
- **Norm recovery.** Below 1 is legitimate basis incompleteness; **above 1 is impossible for any finite basis**, so the excess is bounded tightly at 1e-8 precisely because it cannot have an innocent cause.

| | orthonormality | norm missing | excess |
|---|---|---|---|
| Be (l=0) | 2.07e-14 | 3.91e-11 | 0 |
| Ne (l=0,1) | 1.40e-14 | 7.05e-11 | 0 |
| Ar (l=0,1) | 2.54e-13 | 1.12e-07 | 0 |

Be alone would have been a poor test — it has only s orbitals in the database, so `multiply_Plm` contributes nothing and the angular factor goes unexercised. Ne and Ar cover l=1 at m = −1, 0, +1.

## 4. The guess

For each centre, each l with stored orbitals and each m the basis carries: project, convert to AO coefficients (`C = S^-1 proj^T`), add `occ/(2l+1)` of each orbital — the stored occupation is summed over the 2l+1 components and the atom is spherical. A zero-charge centre contributes nothing. The guess Fock is `Vnuc + J + XC` (+ exact exchange where applicable), the same channels the SCF uses.

N2/LDA against SAP:

| | first iteration | converged | builds |
|---|---|---|---|
| SAP `iguess=2` | −108.5526032797 | −108.6998063831 | 7 |
| SAD `iguess=5` | **−108.6647899356** | −108.6998063834 | 7 |

The guess starts **4× closer** — 0.035 Eh from the answer against SAP's 0.147 — and lands on the same solution.

## Not claimed

It did **not** reduce the iteration count here. N2 is an easy case that SAP already converges in seven builds; whether SAD pays off is a question for cases where the guess actually matters, and that is not established by this evidence. Default remains `iguess=2`, and the default path still reproduces the recorded N2 reference exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)