### PR TITLE
libhelfem: keep the Hermite fix-up polynomial factored; fixes HIP3 continuity

### DIFF
--- a/libhelfem/include/HIP2Basis_eval.h
+++ b/libhelfem/include/HIP2Basis_eval.h
@@ -11,12 +11,11 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#ifndef HELFEM_FEM_HIP2BASIS_EVAL_H
-#define HELFEM_FEM_HIP2BASIS_EVAL_H
+#ifndef LIB1DFEM_HIP2BASIS_EVAL_H
+#define LIB1DFEM_HIP2BASIS_EVAL_H
 
 #include <types.h>
 #include <LIPBasis_eval.h>
-#include <cmath>
 #include <sstream>
 #include <stdexcept>
 
@@ -59,21 +58,15 @@ case (0): {
       const T dLxi_v = lipxi(fi);
       const T ddLxi_v = lipxi2(fi);
       {
-        const T cse0 = T(3)*dLxi_v;
-        const T cse1 = xi*xv;
-        const T cse2 = (xi)*(xi);
-        const T cse3 = (T(3)/T(2))*ddLxi_v;
-        const T cse4 = (xv)*(xv);
-        const T cse5 = (dLxi_v)*(dLxi_v);
-        const T cse6 = T(6)*cse5;
-        dnf(ix, 3*fi + 0) = (Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv - T(12)*cse1*cse5 + T(3)*cse1*ddLxi_v - cse2*cse3 + cse2*cse6 - cse3*cse4 + cse4*cse6 + T(1));
+        const T cse0 = -xi + xv;
+        dnf(ix, 3*fi + 0) = (Lx)*(Lx)*(Lx)*(cse0*(cse0*(T(6)*(dLxi_v)*(dLxi_v) - T(3)/T(2)*ddLxi_v) - T(3)*dLxi_v) + T(1));
       }
       {
-        const T cse0 = T(3)*dLxi_v;
-        dnf(ix, 3*fi + 1) = (Lx)*(Lx)*(Lx)*(-cse0*(xi)*(xi) - cse0*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv);
+        const T cse0 = -xi + xv;
+        dnf(ix, 3*fi + 1) = (Lx)*(Lx)*(Lx)*cse0*(-T(3)*cse0*dLxi_v + T(1));
       }
       {
-        dnf(ix, 3*fi + 2) = (Lx)*(Lx)*(Lx)*((T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv));
+        dnf(ix, 3*fi + 2) = (Lx)*(Lx)*(Lx)*(-xi + xv)*(-T(1)/T(2)*xi + (T(1)/T(2))*xv);
       }
       dnf(ix, 3*fi + 1) *= element_length;
       dnf(ix, 3*fi + 2) *= element_length * element_length;
@@ -96,22 +89,18 @@ case (1): {
       const T ddLxi_v = lipxi2(fi);
       {
         const T cse0 = T(3)*dLxi_v;
-        const T cse1 = T(3)*ddLxi_v*xv;
+        const T cse1 = -xi + xv;
         const T cse2 = (dLxi_v)*(dLxi_v);
-        const T cse3 = T(12)*cse2*xi;
-        const T cse4 = (xi)*(xi);
-        const T cse5 = (T(3)/T(2))*ddLxi_v;
-        const T cse6 = (xv)*(xv);
-        const T cse7 = T(6)*cse2;
-        dnf(ix, 3*fi + 0) = (Lx)*(Lx)*(Lx)*(-cse0 - cse1 + T(12)*cse2*xv - cse3 + T(3)*ddLxi_v*xi) + T(3)*(Lx)*(Lx)*dLx*(cse0*xi - cse0*xv + cse1*xi - cse3*xv - cse4*cse5 + cse4*cse7 - cse5*cse6 + cse6*cse7 + T(1));
+        dnf(ix, 3*fi + 0) = (Lx)*(Lx)*(Lx)*(-cse0 + cse1*(T(12)*cse2 - T(3)*ddLxi_v)) + T(3)*(Lx)*(Lx)*dLx*(cse1*(-cse0 + cse1*(T(6)*cse2 - T(3)/T(2)*ddLxi_v)) + T(1));
       }
       {
-        const T cse0 = T(6)*dLxi_v;
-        const T cse1 = T(3)*dLxi_v;
-        dnf(ix, 3*fi + 1) = (Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv + T(1)) + T(3)*(Lx)*(Lx)*dLx*(-cse1*(xi)*(xi) - cse1*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv);
+        const T cse0 = -xi + xv;
+        const T cse1 = cse0*dLxi_v;
+        dnf(ix, 3*fi + 1) = (Lx)*(Lx)*(Lx)*(T(1) - T(6)*cse1) + T(3)*(Lx)*(Lx)*cse0*dLx*(T(1) - T(3)*cse1);
       }
       {
-        dnf(ix, 3*fi + 2) = (Lx)*(Lx)*(Lx)*(-xi + xv) + T(3)*(Lx)*(Lx)*dLx*((T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv));
+        const T cse0 = -xi + xv;
+        dnf(ix, 3*fi + 2) = (Lx)*(Lx)*(Lx)*cse0 + T(3)*(Lx)*(Lx)*cse0*dLx*(-T(1)/T(2)*xi + (T(1)/T(2))*xv);
       }
       dnf(ix, 3*fi + 1) *= element_length;
       dnf(ix, 3*fi + 2) *= element_length * element_length;
@@ -137,22 +126,20 @@ case (2): {
       const T ddLxi_v = lipxi2(fi);
       {
         const T cse0 = (dLxi_v)*(dLxi_v);
-        const T cse1 = T(3)*dLxi_v;
-        const T cse2 = T(3)*ddLxi_v*xv;
-        const T cse3 = T(12)*cse0*xi;
-        const T cse4 = (xi)*(xi);
-        const T cse5 = (T(3)/T(2))*ddLxi_v;
-        const T cse6 = (xv)*(xv);
-        const T cse7 = T(6)*cse0;
-        dnf(ix, 3*fi + 0) = T(3)*(Lx)*(Lx)*(Lx)*(T(4)*cse0 - ddLxi_v) + T(6)*(Lx)*(Lx)*dLx*(T(12)*cse0*xv - cse1 - cse2 - cse3 + T(3)*ddLxi_v*xi) + T(3)*Lx*(Lx*ddLx + T(2)*(dLx)*(dLx))*(cse1*xi - cse1*xv + cse2*xi - cse3*xv - cse4*cse5 + cse4*cse7 - cse5*cse6 + cse6*cse7 + T(1));
+        const T cse1 = T(12)*cse0 - T(3)*ddLxi_v;
+        const T cse2 = T(3)*dLxi_v;
+        const T cse3 = -xi + xv;
+        dnf(ix, 3*fi + 0) = (Lx)*(Lx)*(Lx)*cse1 + T(6)*(Lx)*(Lx)*dLx*(cse1*cse3 - cse2) + T(3)*Lx*(Lx*ddLx + T(2)*(dLx)*(dLx))*(cse3*(-cse2 + cse3*(T(6)*cse0 - T(3)/T(2)*ddLxi_v)) + T(1));
       }
       {
         const T cse0 = T(6)*dLxi_v;
-        const T cse1 = T(3)*dLxi_v;
-        dnf(ix, 3*fi + 1) = -(Lx)*(Lx)*(Lx)*cse0 + T(6)*(Lx)*(Lx)*dLx*(cse0*xi - cse0*xv + T(1)) + T(3)*Lx*(Lx*ddLx + T(2)*(dLx)*(dLx))*(-cse1*(xi)*(xi) - cse1*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv);
+        const T cse1 = -xi + xv;
+        const T cse2 = T(3)*cse1;
+        dnf(ix, 3*fi + 1) = -(Lx)*(Lx)*(Lx)*cse0 + T(6)*(Lx)*(Lx)*dLx*(-cse0*cse1 + T(1)) + Lx*cse2*(Lx*ddLx + T(2)*(dLx)*(dLx))*(-cse2*dLxi_v + T(1));
       }
       {
-        dnf(ix, 3*fi + 2) = (Lx)*(Lx)*(Lx) + T(6)*(Lx)*(Lx)*dLx*(-xi + xv) + T(3)*Lx*(Lx*ddLx + T(2)*(dLx)*(dLx))*((T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv));
+        const T cse0 = -xi + xv;
+        dnf(ix, 3*fi + 2) = (Lx)*(Lx)*(Lx) + T(6)*(Lx)*(Lx)*cse0*dLx + T(3)*Lx*cse0*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*(Lx*ddLx + T(2)*(dLx)*(dLx));
       }
       dnf(ix, 3*fi + 1) *= element_length;
       dnf(ix, 3*fi + 2) *= element_length * element_length;
@@ -182,27 +169,24 @@ case (3): {
       {
         const T cse0 = (Lx)*(Lx);
         const T cse1 = (dLxi_v)*(dLxi_v);
+        const T cse2 = T(12)*cse1 - T(3)*ddLxi_v;
+        const T cse3 = Lx*ddLx;
+        const T cse4 = T(3)*dLxi_v;
+        const T cse5 = -xi + xv;
+        dnf(ix, 3*fi + 0) = T(9)*Lx*(cse3 + T(2)*(dLx)*(dLx))*(cse2*cse5 - cse4) + T(9)*cse0*cse2*dLx + (cse5*(-cse4 + cse5*(T(6)*cse1 - T(3)/T(2)*ddLxi_v)) + T(1))*(T(3)*cse0*d3Lx + T(18)*cse3*dLx + T(6)*(dLx)*(dLx)*(dLx));
+      }
+      {
+        const T cse0 = (Lx)*(Lx);
+        const T cse1 = Lx*ddLx;
+        const T cse2 = -xi + xv;
+        const T cse3 = cse2*dLxi_v;
+        dnf(ix, 3*fi + 1) = T(9)*Lx*(T(1) - T(6)*cse3)*(cse1 + T(2)*(dLx)*(dLx)) - T(54)*cse0*dLx*dLxi_v + cse2*(T(1) - T(3)*cse3)*(T(3)*cse0*d3Lx + T(18)*cse1*dLx + T(6)*(dLx)*(dLx)*(dLx));
+      }
+      {
+        const T cse0 = (Lx)*(Lx);
+        const T cse1 = -xi + xv;
         const T cse2 = Lx*ddLx;
-        const T cse3 = T(3)*dLxi_v;
-        const T cse4 = T(3)*ddLxi_v*xv;
-        const T cse5 = T(12)*cse1*xi;
-        const T cse6 = (xi)*(xi);
-        const T cse7 = (T(3)/T(2))*ddLxi_v;
-        const T cse8 = (xv)*(xv);
-        const T cse9 = T(6)*cse1;
-        dnf(ix, 3*fi + 0) = T(9)*Lx*(cse2 + T(2)*(dLx)*(dLx))*(T(12)*cse1*xv - cse3 - cse4 - cse5 + T(3)*ddLxi_v*xi) + T(27)*cse0*dLx*(T(4)*cse1 - ddLxi_v) + (T(3)*cse0*d3Lx + T(18)*cse2*dLx + T(6)*(dLx)*(dLx)*(dLx))*(cse3*xi - cse3*xv + cse4*xi - cse5*xv - cse6*cse7 + cse6*cse9 - cse7*cse8 + cse8*cse9 + T(1));
-      }
-      {
-        const T cse0 = (Lx)*(Lx);
-        const T cse1 = Lx*ddLx;
-        const T cse2 = T(6)*dLxi_v;
-        const T cse3 = T(3)*dLxi_v;
-        dnf(ix, 3*fi + 1) = T(9)*Lx*(cse1 + T(2)*(dLx)*(dLx))*(cse2*xi - cse2*xv + T(1)) - T(54)*cse0*dLx*dLxi_v + (T(3)*cse0*d3Lx + T(18)*cse1*dLx + T(6)*(dLx)*(dLx)*(dLx))*(-cse3*(xi)*(xi) - cse3*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv);
-      }
-      {
-        const T cse0 = (Lx)*(Lx);
-        const T cse1 = Lx*ddLx;
-        dnf(ix, 3*fi + 2) = T(9)*Lx*(cse1 + T(2)*(dLx)*(dLx))*(-xi + xv) + T(9)*cse0*dLx + ((T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv))*(T(3)*cse0*d3Lx + T(18)*cse1*dLx + T(6)*(dLx)*(dLx)*(dLx));
+        dnf(ix, 3*fi + 2) = T(9)*Lx*cse1*(cse2 + T(2)*(dLx)*(dLx)) + T(9)*cse0*dLx + cse1*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*(T(3)*cse0*d3Lx + T(18)*cse2*dLx + T(6)*(dLx)*(dLx)*(dLx));
       }
       dnf(ix, 3*fi + 1) *= element_length;
       dnf(ix, 3*fi + 2) *= element_length * element_length;
@@ -234,32 +218,30 @@ case (4): {
       const T ddLxi_v = lipxi2(fi);
       {
         const T cse0 = (dLxi_v)*(dLxi_v);
-        const T cse1 = Lx*ddLx;
-        const T cse2 = (dLx)*(dLx);
-        const T cse3 = (Lx)*(Lx);
-        const T cse4 = T(3)*dLxi_v;
-        const T cse5 = T(3)*ddLxi_v*xv;
-        const T cse6 = T(12)*cse0*xi;
-        const T cse7 = (xi)*(xi);
-        const T cse8 = (T(3)/T(2))*ddLxi_v;
-        const T cse9 = (xv)*(xv);
-        const T cse10 = T(6)*cse0;
-        dnf(ix, 3*fi + 0) = T(54)*Lx*(T(4)*cse0 - ddLxi_v)*(cse1 + T(2)*cse2) + (T(72)*cse1*dLx + T(12)*cse3*d3Lx + T(24)*(dLx)*(dLx)*(dLx))*(T(12)*cse0*xv - cse4 - cse5 - cse6 + T(3)*ddLxi_v*xi) + (T(24)*Lx*d3Lx*dLx + T(18)*Lx*(ddLx)*(ddLx) + T(36)*cse2*ddLx + T(3)*cse3*d4Lx)*(cse10*cse7 + cse10*cse9 + cse4*xi - cse4*xv + cse5*xi - cse6*xv - cse7*cse8 - cse8*cse9 + T(1));
+        const T cse1 = T(12)*cse0 - T(3)*ddLxi_v;
+        const T cse2 = Lx*ddLx;
+        const T cse3 = (dLx)*(dLx);
+        const T cse4 = T(18)*Lx;
+        const T cse5 = (Lx)*(Lx);
+        const T cse6 = T(3)*dLxi_v;
+        const T cse7 = -xi + xv;
+        dnf(ix, 3*fi + 0) = cse1*cse4*(cse2 + T(2)*cse3) + (cse1*cse7 - cse6)*(T(72)*cse2*dLx + T(12)*cse5*d3Lx + T(24)*(dLx)*(dLx)*(dLx)) + (cse7*(-cse6 + cse7*(T(6)*cse0 - T(3)/T(2)*ddLxi_v)) + T(1))*(T(24)*Lx*d3Lx*dLx + T(36)*cse3*ddLx + cse4*(ddLx)*(ddLx) + T(3)*cse5*d4Lx);
       }
       {
         const T cse0 = Lx*ddLx;
         const T cse1 = (dLx)*(dLx);
-        const T cse2 = T(6)*dLxi_v;
-        const T cse3 = (Lx)*(Lx);
-        const T cse4 = T(3)*dLxi_v;
-        dnf(ix, 3*fi + 1) = -T(108)*Lx*dLxi_v*(cse0 + T(2)*cse1) + (T(72)*cse0*dLx + T(12)*cse3*d3Lx + T(24)*(dLx)*(dLx)*(dLx))*(cse2*xi - cse2*xv + T(1)) + (T(24)*Lx*d3Lx*dLx + T(18)*Lx*(ddLx)*(ddLx) + T(36)*cse1*ddLx + T(3)*cse3*d4Lx)*(-cse4*(xi)*(xi) - cse4*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv);
+        const T cse2 = -xi + xv;
+        const T cse3 = cse2*dLxi_v;
+        const T cse4 = (Lx)*(Lx);
+        dnf(ix, 3*fi + 1) = -T(108)*Lx*dLxi_v*(cse0 + T(2)*cse1) + cse2*(T(1) - T(3)*cse3)*(T(24)*Lx*d3Lx*dLx + T(18)*Lx*(ddLx)*(ddLx) + T(36)*cse1*ddLx + T(3)*cse4*d4Lx) + (T(1) - T(6)*cse3)*(T(72)*cse0*dLx + T(12)*cse4*d3Lx + T(24)*(dLx)*(dLx)*(dLx));
       }
       {
         const T cse0 = Lx*ddLx;
         const T cse1 = (dLx)*(dLx);
         const T cse2 = T(18)*Lx;
-        const T cse3 = (Lx)*(Lx);
-        dnf(ix, 3*fi + 2) = cse2*(cse0 + T(2)*cse1) + (-xi + xv)*(T(72)*cse0*dLx + T(12)*cse3*d3Lx + T(24)*(dLx)*(dLx)*(dLx)) + ((T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv))*(T(24)*Lx*d3Lx*dLx + T(36)*cse1*ddLx + cse2*(ddLx)*(ddLx) + T(3)*cse3*d4Lx);
+        const T cse3 = -xi + xv;
+        const T cse4 = (Lx)*(Lx);
+        dnf(ix, 3*fi + 2) = cse2*(cse0 + T(2)*cse1) + cse3*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*(T(24)*Lx*d3Lx*dLx + T(36)*cse1*ddLx + cse2*(ddLx)*(ddLx) + T(3)*cse4*d4Lx) + cse3*(T(72)*cse0*dLx + T(12)*cse4*d3Lx + T(24)*(dLx)*(dLx)*(dLx));
       }
       dnf(ix, 3*fi + 1) *= element_length;
       dnf(ix, 3*fi + 2) *= element_length * element_length;
@@ -294,40 +276,37 @@ case (5): {
       const T ddLxi_v = lipxi2(fi);
       {
         const T cse0 = (dLxi_v)*(dLxi_v);
-        const T cse1 = T(180)*ddLx;
-        const T cse2 = Lx*dLx;
-        const T cse3 = (Lx)*(Lx);
-        const T cse4 = T(90)*(ddLx)*(ddLx);
-        const T cse5 = (dLx)*(dLx);
-        const T cse6 = T(3)*dLxi_v;
-        const T cse7 = T(3)*ddLxi_v*xv;
-        const T cse8 = T(12)*cse0*xi;
+        const T cse1 = T(12)*cse0 - T(3)*ddLxi_v;
+        const T cse2 = T(180)*ddLx;
+        const T cse3 = Lx*dLx;
+        const T cse4 = (Lx)*(Lx);
+        const T cse5 = T(3)*dLxi_v;
+        const T cse6 = -xi + xv;
+        const T cse7 = T(90)*(ddLx)*(ddLx);
+        const T cse8 = (dLx)*(dLx);
         const T cse9 = T(60)*d3Lx;
-        const T cse10 = (xi)*(xi);
-        const T cse11 = (T(3)/T(2))*ddLxi_v;
-        const T cse12 = (xv)*(xv);
-        const T cse13 = T(6)*cse0;
-        dnf(ix, 3*fi + 0) = T(3)*(T(4)*cse0 - ddLxi_v)*(cse1*cse2 + T(30)*cse3*d3Lx + T(60)*(dLx)*(dLx)*(dLx)) + (Lx*cse4 + cse1*cse5 + T(120)*cse2*d3Lx + T(15)*cse3*d4Lx)*(T(12)*cse0*xv - cse6 - cse7 - cse8 + T(3)*ddLxi_v*xi) + (Lx*cse9*ddLx + T(30)*cse2*d4Lx + T(3)*cse3*d5Lx + cse4*dLx + cse5*cse9)*(-cse10*cse11 + cse10*cse13 - cse11*cse12 + cse12*cse13 + cse6*xi - cse6*xv + cse7*xi - cse8*xv + T(1));
+        dnf(ix, 3*fi + 0) = cse1*(cse2*cse3 + T(30)*cse4*d3Lx + T(60)*(dLx)*(dLx)*(dLx)) + (cse1*cse6 - cse5)*(Lx*cse7 + cse2*cse8 + T(120)*cse3*d3Lx + T(15)*cse4*d4Lx) + (cse6*(-cse5 + cse6*(T(6)*cse0 - T(3)/T(2)*ddLxi_v)) + T(1))*(Lx*cse9*ddLx + T(30)*cse3*d4Lx + T(3)*cse4*d5Lx + cse7*dLx + cse8*cse9);
       }
       {
         const T cse0 = T(180)*ddLx;
         const T cse1 = Lx*dLx;
         const T cse2 = (Lx)*(Lx);
         const T cse3 = T(6)*dLxi_v;
-        const T cse4 = T(90)*(ddLx)*(ddLx);
-        const T cse5 = (dLx)*(dLx);
-        const T cse6 = T(3)*dLxi_v;
+        const T cse4 = -xi + xv;
+        const T cse5 = T(90)*(ddLx)*(ddLx);
+        const T cse6 = (dLx)*(dLx);
         const T cse7 = T(60)*d3Lx;
-        dnf(ix, 3*fi + 1) = -cse3*(cse0*cse1 + T(30)*cse2*d3Lx + T(60)*(dLx)*(dLx)*(dLx)) + (cse3*xi - cse3*xv + T(1))*(Lx*cse4 + cse0*cse5 + T(120)*cse1*d3Lx + T(15)*cse2*d4Lx) + (-cse6*(xi)*(xi) - cse6*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv)*(Lx*cse7*ddLx + T(30)*cse1*d4Lx + T(3)*cse2*d5Lx + cse4*dLx + cse5*cse7);
+        dnf(ix, 3*fi + 1) = -cse3*(cse0*cse1 + T(30)*cse2*d3Lx + T(60)*(dLx)*(dLx)*(dLx)) + cse4*(-T(3)*cse4*dLxi_v + T(1))*(Lx*cse7*ddLx + T(30)*cse1*d4Lx + T(3)*cse2*d5Lx + cse5*dLx + cse6*cse7) + (-cse3*cse4 + T(1))*(Lx*cse5 + cse0*cse6 + T(120)*cse1*d3Lx + T(15)*cse2*d4Lx);
       }
       {
         const T cse0 = T(180)*ddLx;
         const T cse1 = Lx*dLx;
         const T cse2 = (Lx)*(Lx);
-        const T cse3 = T(90)*(ddLx)*(ddLx);
-        const T cse4 = (dLx)*(dLx);
-        const T cse5 = T(60)*d3Lx;
-        dnf(ix, 3*fi + 2) = cse0*cse1 + T(30)*cse2*d3Lx + T(60)*(dLx)*(dLx)*(dLx) + (-xi + xv)*(Lx*cse3 + cse0*cse4 + T(120)*cse1*d3Lx + T(15)*cse2*d4Lx) + ((T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv))*(Lx*cse5*ddLx + T(30)*cse1*d4Lx + T(3)*cse2*d5Lx + cse3*dLx + cse4*cse5);
+        const T cse3 = -xi + xv;
+        const T cse4 = T(90)*(ddLx)*(ddLx);
+        const T cse5 = (dLx)*(dLx);
+        const T cse6 = T(60)*d3Lx;
+        dnf(ix, 3*fi + 2) = cse0*cse1 + T(30)*cse2*d3Lx + cse3*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*(Lx*cse6*ddLx + T(30)*cse1*d4Lx + T(3)*cse2*d5Lx + cse4*dLx + cse5*cse6) + cse3*(Lx*cse4 + cse0*cse5 + T(120)*cse1*d3Lx + T(15)*cse2*d4Lx) + T(60)*(dLx)*(dLx)*(dLx);
       }
       dnf(ix, 3*fi + 1) *= element_length;
       dnf(ix, 3*fi + 2) *= element_length * element_length;

--- a/libhelfem/include/HIP2Basis_over_r.h
+++ b/libhelfem/include/HIP2Basis_over_r.h
@@ -11,8 +11,8 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#ifndef HELFEM_FEM_HIP2BASIS_OVER_R_H
-#define HELFEM_FEM_HIP2BASIS_OVER_R_H
+#ifndef LIB1DFEM_HIP2BASIS_OVER_R_H
+#define LIB1DFEM_HIP2BASIS_OVER_R_H
 
 #include <types.h>
 #include <LIPBasis_eval.h>
@@ -92,8 +92,7 @@ void eval_hip2_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
         case 0:
           switch (kind) {
           case 1: {
-            const T cse0 = T(3)*dLxi_v;
-            R = (Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv + T(1));
+            R = (Lx)*(Lx)*(Lx)*(-T(3)*dLxi_v*(-xi + xv) + T(1));
           } break;
           case 2: {
             R = (Lx)*(Lx)*(Lx)*(-T(1)/T(2)*xi + (T(1)/T(2))*xv);
@@ -104,7 +103,7 @@ void eval_hip2_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
           switch (kind) {
           case 1: {
             const T cse0 = T(3)*dLxi_v;
-            R = -(Lx)*(Lx)*(Lx)*cse0 + T(3)*(Lx)*(Lx)*dLx*(cse0*xi - cse0*xv + T(1));
+            R = -(Lx)*(Lx)*(Lx)*cse0 + T(3)*(Lx)*(Lx)*dLx*(-cse0*(-xi + xv) + T(1));
           } break;
           case 2: {
             R = (T(1)/T(2))*(Lx)*(Lx)*(Lx) + T(3)*(Lx)*(Lx)*dLx*(-T(1)/T(2)*xi + (T(1)/T(2))*xv);
@@ -114,8 +113,7 @@ void eval_hip2_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
         case 2:
           switch (kind) {
           case 1: {
-            const T cse0 = T(3)*dLxi_v;
-            R = -T(18)*(Lx)*(Lx)*dLx*dLxi_v + T(3)*Lx*(Lx*ddLx + T(2)*(dLx)*(dLx))*(cse0*xi - cse0*xv + T(1));
+            R = -T(18)*(Lx)*(Lx)*dLx*dLxi_v + T(3)*Lx*(Lx*ddLx + T(2)*(dLx)*(dLx))*(-T(3)*dLxi_v*(-xi + xv) + T(1));
           } break;
           case 2: {
             R = T(3)*(Lx)*(Lx)*dLx + T(3)*Lx*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*(Lx*ddLx + T(2)*(dLx)*(dLx));
@@ -133,21 +131,15 @@ void eval_hip2_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
         case 0:
           switch (kind) {
           case 0: {
-            const T cse0 = T(3)*dLxi_v;
-            const T cse1 = xi*xv;
-            const T cse2 = (xi)*(xi);
-            const T cse3 = (T(3)/T(2))*ddLxi_v;
-            const T cse4 = (xv)*(xv);
-            const T cse5 = (dLxi_v)*(dLxi_v);
-            const T cse6 = T(6)*cse5;
-            R = (pr)*(pr)*(pr)*std::pow(xv + T(1), T(2))*(cse0*xi - cse0*xv - T(12)*cse1*cse5 + T(3)*cse1*ddLxi_v - cse2*cse3 + cse2*cse6 - cse3*cse4 + cse4*cse6 + T(1))/std::pow(xi + T(1), T(3));
+            const T cse0 = -xi + xv;
+            R = (pr)*(pr)*(pr)*std::pow(xv + T(1), T(2))*(cse0*(cse0*(T(6)*(dLxi_v)*(dLxi_v) - T(3)/T(2)*ddLxi_v) - T(3)*dLxi_v) + T(1))/std::pow(xi + T(1), T(3));
           } break;
           case 1: {
-            const T cse0 = T(3)*dLxi_v;
-            R = (pr)*(pr)*(pr)*std::pow(xv + T(1), T(2))*(-cse0*(xi)*(xi) - cse0*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv)/std::pow(xi + T(1), T(3));
+            const T cse0 = -xi + xv;
+            R = cse0*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(2))*(-T(3)*cse0*dLxi_v + T(1))/std::pow(xi + T(1), T(3));
           } break;
           case 2: {
-            R = (pr)*(pr)*(pr)*std::pow(xv + T(1), T(2))*((T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv))/std::pow(xi + T(1), T(3));
+            R = (pr)*(pr)*(pr)*(-xi + xv)*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*std::pow(xv + T(1), T(2))/std::pow(xi + T(1), T(3));
           } break;
           }
           break;
@@ -157,29 +149,25 @@ void eval_hip2_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
             const T cse0 = (pr)*(pr)*(pr);
             const T cse1 = std::pow(xv + T(1), T(2));
             const T cse2 = T(3)*dLxi_v;
-            const T cse3 = T(3)*ddLxi_v*xv;
+            const T cse3 = -xi + xv;
             const T cse4 = (dLxi_v)*(dLxi_v);
-            const T cse5 = T(12)*cse4*xi;
-            const T cse6 = (xi)*(xi);
-            const T cse7 = (T(3)/T(2))*ddLxi_v;
-            const T cse8 = (xv)*(xv);
-            const T cse9 = T(6)*cse4;
-            const T cse10 = cse2*xi - cse2*xv + cse3*xi - cse5*xv - cse6*cse7 + cse6*cse9 - cse7*cse8 + cse8*cse9 + T(1);
-            R = (cse0*cse1*(-cse2 - cse3 + T(12)*cse4*xv - cse5 + T(3)*ddLxi_v*xi) + cse0*cse10*(T(2)*xv + T(2)) + T(3)*cse1*cse10*dpr*(pr)*(pr))/std::pow(xi + T(1), T(3));
+            const T cse5 = cse3*(-cse2 + cse3*(T(6)*cse4 - T(3)/T(2)*ddLxi_v)) + T(1);
+            R = (cse0*cse1*(-cse2 + cse3*(T(12)*cse4 - T(3)*ddLxi_v)) + cse0*cse5*(T(2)*xv + T(2)) + T(3)*cse1*cse5*dpr*(pr)*(pr))/std::pow(xi + T(1), T(3));
           } break;
           case 1: {
             const T cse0 = (pr)*(pr)*(pr);
             const T cse1 = std::pow(xv + T(1), T(2));
-            const T cse2 = T(6)*dLxi_v;
-            const T cse3 = T(3)*dLxi_v;
-            const T cse4 = -cse3*(xi)*(xi) - cse3*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv;
-            R = (cse0*cse1*(cse2*xi - cse2*xv + T(1)) + cse0*cse4*(T(2)*xv + T(2)) + T(3)*cse1*cse4*dpr*(pr)*(pr))/std::pow(xi + T(1), T(3));
+            const T cse2 = -xi + xv;
+            const T cse3 = cse2*dLxi_v;
+            const T cse4 = cse2*(T(1) - T(3)*cse3);
+            R = (cse0*cse1*(T(1) - T(6)*cse3) + cse0*cse4*(T(2)*xv + T(2)) + T(3)*cse1*cse4*dpr*(pr)*(pr))/std::pow(xi + T(1), T(3));
           } break;
           case 2: {
-            const T cse0 = (pr)*(pr)*(pr);
-            const T cse1 = std::pow(xv + T(1), T(2));
-            const T cse2 = (T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv);
-            R = (cse0*cse1*(-xi + xv) + cse0*cse2*(T(2)*xv + T(2)) + T(3)*cse1*cse2*dpr*(pr)*(pr))/std::pow(xi + T(1), T(3));
+            const T cse0 = std::pow(xv + T(1), T(2));
+            const T cse1 = -xi + xv;
+            const T cse2 = cse1*(pr)*(pr)*(pr);
+            const T cse3 = -T(1)/T(2)*xi + (T(1)/T(2))*xv;
+            R = (T(3)*cse0*cse1*cse3*dpr*(pr)*(pr) + cse0*cse2 + cse2*cse3*(T(2)*xv + T(2)))/std::pow(xi + T(1), T(3));
           } break;
           }
           break;
@@ -187,43 +175,42 @@ void eval_hip2_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
           switch (kind) {
           case 0: {
             const T cse0 = (pr)*(pr)*(pr);
-            const T cse1 = (dLxi_v)*(dLxi_v);
-            const T cse2 = std::pow(xv + T(1), T(2));
-            const T cse3 = T(3)*cse2;
+            const T cse1 = std::pow(xv + T(1), T(2));
+            const T cse2 = (dLxi_v)*(dLxi_v);
+            const T cse3 = T(12)*cse2 - T(3)*ddLxi_v;
             const T cse4 = T(4)*xv + T(4);
             const T cse5 = T(3)*dLxi_v;
-            const T cse6 = T(3)*ddLxi_v*xv;
-            const T cse7 = T(12)*cse1*xi;
-            const T cse8 = T(12)*cse1*xv - cse5 - cse6 - cse7 + T(3)*ddLxi_v*xi;
-            const T cse9 = dpr*(pr)*(pr);
-            const T cse10 = (xi)*(xi);
-            const T cse11 = (T(3)/T(2))*ddLxi_v;
-            const T cse12 = (xv)*(xv);
-            const T cse13 = T(6)*cse1;
-            const T cse14 = -cse10*cse11 + cse10*cse13 - cse11*cse12 + cse12*cse13 + cse5*xi - cse5*xv + cse6*xi - cse7*xv + T(1);
-            R = (T(2)*cse0*cse14 + cse0*cse3*(T(4)*cse1 - ddLxi_v) + cse0*cse4*cse8 + cse14*cse3*pr*(ddpr*pr + T(2)*(dpr)*(dpr)) + T(3)*cse14*cse4*cse9 + T(6)*cse2*cse8*cse9)/std::pow(xi + T(1), T(3));
+            const T cse6 = -xi + xv;
+            const T cse7 = cse3*cse6 - cse5;
+            const T cse8 = dpr*(pr)*(pr);
+            const T cse9 = cse6*(-cse5 + cse6*(T(6)*cse2 - T(3)/T(2)*ddLxi_v)) + T(1);
+            const T cse10 = T(3)*cse9;
+            R = (cse0*cse1*cse3 + cse0*cse4*cse7 + T(2)*cse0*cse9 + cse1*cse10*pr*(ddpr*pr + T(2)*(dpr)*(dpr)) + T(6)*cse1*cse7*cse8 + cse10*cse4*cse8)/std::pow(xi + T(1), T(3));
           } break;
           case 1: {
             const T cse0 = (pr)*(pr)*(pr);
             const T cse1 = std::pow(xv + T(1), T(2));
-            const T cse2 = T(6)*dLxi_v;
+            const T cse2 = T(6)*cse1;
             const T cse3 = T(4)*xv + T(4);
-            const T cse4 = cse2*xi - cse2*xv + T(1);
-            const T cse5 = dpr*(pr)*(pr);
-            const T cse6 = T(3)*dLxi_v;
-            const T cse7 = -cse6*(xi)*(xi) - cse6*(xv)*(xv) + T(6)*dLxi_v*xi*xv - xi + xv;
-            const T cse8 = T(3)*cse7;
-            R = (-cse0*cse1*cse2 + cse0*cse3*cse4 + T(2)*cse0*cse7 + T(6)*cse1*cse4*cse5 + cse1*cse8*pr*(ddpr*pr + T(2)*(dpr)*(dpr)) + cse3*cse5*cse8)/std::pow(xi + T(1), T(3));
+            const T cse4 = -xi + xv;
+            const T cse5 = cse4*dLxi_v;
+            const T cse6 = T(1) - T(6)*cse5;
+            const T cse7 = cse4*(T(1) - T(3)*cse5);
+            const T cse8 = dpr*(pr)*(pr);
+            const T cse9 = T(3)*cse7;
+            R = (-cse0*cse2*dLxi_v + cse0*cse3*cse6 + T(2)*cse0*cse7 + cse1*cse9*pr*(ddpr*pr + T(2)*(dpr)*(dpr)) + cse2*cse6*cse8 + cse3*cse8*cse9)/std::pow(xi + T(1), T(3));
           } break;
           case 2: {
             const T cse0 = (pr)*(pr)*(pr);
             const T cse1 = std::pow(xv + T(1), T(2));
-            const T cse2 = -xi + xv;
-            const T cse3 = T(4)*xv + T(4);
-            const T cse4 = dpr*(pr)*(pr);
-            const T cse5 = (T(1)/T(2))*(xi)*(xi) - xi*xv + (T(1)/T(2))*(xv)*(xv);
-            const T cse6 = T(3)*cse5;
-            R = (cse0*cse1 + cse0*cse2*cse3 + T(2)*cse0*cse5 + T(6)*cse1*cse2*cse4 + cse1*cse6*pr*(ddpr*pr + T(2)*(dpr)*(dpr)) + cse3*cse4*cse6)/std::pow(xi + T(1), T(3));
+            const T cse2 = T(4)*xv + T(4);
+            const T cse3 = -xi + xv;
+            const T cse4 = cse0*cse3;
+            const T cse5 = cse1*cse3;
+            const T cse6 = dpr*(pr)*(pr);
+            const T cse7 = -T(1)/T(2)*xi + (T(1)/T(2))*xv;
+            const T cse8 = T(3)*cse7;
+            R = (cse0*cse1 + cse2*cse3*cse6*cse8 + cse2*cse4 + T(2)*cse4*cse7 + T(6)*cse5*cse6 + cse5*cse8*pr*(ddpr*pr + T(2)*(dpr)*(dpr)))/std::pow(xi + T(1), T(3));
           } break;
           }
           break;

--- a/libhelfem/include/HIP3Basis_eval.h
+++ b/libhelfem/include/HIP3Basis_eval.h
@@ -11,12 +11,11 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#ifndef HELFEM_FEM_HIP3BASIS_EVAL_H
-#define HELFEM_FEM_HIP3BASIS_EVAL_H
+#ifndef LIB1DFEM_HIP3BASIS_EVAL_H
+#define LIB1DFEM_HIP3BASIS_EVAL_H
 
 #include <types.h>
 #include <LIPBasis_eval.h>
-#include <cmath>
 #include <sstream>
 #include <stdexcept>
 
@@ -62,45 +61,19 @@ case (0): {
       const T ddLxi_v = lipxi2(fi);
       const T d3Lxi_v = lipxi3(fi);
       {
-        const T cse0 = T(4)*dLxi_v;
-        const T cse1 = xi*xv;
-        const T cse2 = (xi)*(xi)*(xi);
-        const T cse3 = (T(2)/T(3))*d3Lxi_v;
-        const T cse4 = (xv)*(xv)*(xv);
-        const T cse5 = (xi)*(xi);
-        const T cse6 = T(2)*ddLxi_v;
-        const T cse7 = (xv)*(xv);
-        const T cse8 = T(2)*d3Lxi_v;
-        const T cse9 = cse7*xi;
-        const T cse10 = cse5*xv;
-        const T cse11 = dLxi_v*ddLxi_v;
-        const T cse12 = T(10)*cse11;
-        const T cse13 = (dLxi_v)*(dLxi_v);
-        const T cse14 = T(10)*cse13;
-        const T cse15 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-        const T cse16 = T(20)*cse15;
-        const T cse17 = T(30)*cse11;
-        const T cse18 = T(60)*cse15;
-        dnf(ix, 4*fi + 0) = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv - T(20)*cse1*cse13 + T(4)*cse1*ddLxi_v + cse10*cse17 - cse10*cse18 - cse10*cse8 - cse12*cse2 + cse12*cse4 + cse14*cse5 + cse14*cse7 + cse16*cse2 - cse16*cse4 - cse17*cse9 + cse18*cse9 + cse2*cse3 - cse3*cse4 - cse5*cse6 - cse6*cse7 + cse8*cse9 + T(1));
+        const T cse0 = -xi + xv;
+        dnf(ix, 4*fi + 0) = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*(cse0*(cse0*(-T(2)/T(3)*d3Lxi_v - T(20)*(dLxi_v)*(dLxi_v)*(dLxi_v) + T(10)*dLxi_v*ddLxi_v) + T(10)*(dLxi_v)*(dLxi_v) - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1));
       }
       {
-        const T cse0 = (xi)*(xi);
-        const T cse1 = T(4)*dLxi_v;
-        const T cse2 = (xv)*(xv);
-        const T cse3 = (xi)*(xi)*(xi);
-        const T cse4 = (xv)*(xv)*(xv);
-        const T cse5 = (dLxi_v)*(dLxi_v);
-        dnf(ix, 4*fi + 1) = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0*cse1 + T(30)*cse0*cse5*xv - T(6)*cse0*ddLxi_v*xv - cse1*cse2 - T(30)*cse2*cse5*xi + T(6)*cse2*ddLxi_v*xi - T(10)*cse3*cse5 + T(2)*cse3*ddLxi_v + T(10)*cse4*cse5 - T(2)*cse4*ddLxi_v + T(8)*dLxi_v*xi*xv - xi + xv);
+        const T cse0 = -xi + xv;
+        dnf(ix, 4*fi + 1) = (Lx)*(Lx)*(Lx)*(Lx)*cse0*(cse0*(cse0*(T(10)*(dLxi_v)*(dLxi_v) - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1));
       }
       {
-        const T cse0 = (xi)*(xi);
-        const T cse1 = (xv)*(xv);
-        const T cse2 = T(2)*dLxi_v;
-        const T cse3 = T(6)*dLxi_v;
-        dnf(ix, 4*fi + 2) = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0*cse3*xv + (T(1)/T(2))*cse0 + cse1*cse3*xi + (T(1)/T(2))*cse1 + cse2*(xi)*(xi)*(xi) - cse2*(xv)*(xv)*(xv) - xi*xv);
+        const T cse0 = -xi + xv;
+        dnf(ix, 4*fi + 2) = (Lx)*(Lx)*(Lx)*(Lx)*(cse0)*(cse0)*(-T(2)*cse0*dLxi_v + T(1)/T(2));
       }
       {
-        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx)*(-T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(2))*(xi)*(xi)*xv - T(1)/T(2)*xi*(xv)*(xv) + (T(1)/T(6))*(xv)*(xv)*(xv));
+        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx)*std::pow(-xi + xv, T(2))*(-T(1)/T(6)*xi + (T(1)/T(6))*xv);
       }
       dnf(ix, 4*fi + 1) *= element_length;
       dnf(ix, 4*fi + 2) *= element_length * element_length;
@@ -125,57 +98,24 @@ case (1): {
       const T d3Lxi_v = lipxi3(fi);
       {
         const T cse0 = T(4)*dLxi_v;
-        const T cse1 = T(4)*ddLxi_v*xv;
-        const T cse2 = (xi)*(xi);
-        const T cse3 = T(2)*d3Lxi_v;
-        const T cse4 = cse2*cse3;
-        const T cse5 = (xv)*(xv);
-        const T cse6 = cse3*cse5;
-        const T cse7 = (dLxi_v)*(dLxi_v);
-        const T cse8 = T(20)*cse7*xi;
-        const T cse9 = dLxi_v*ddLxi_v;
-        const T cse10 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-        const T cse11 = T(60)*cse10;
-        const T cse12 = cse11*cse2;
-        const T cse13 = cse11*cse5;
-        const T cse14 = (xi)*(xi)*(xi);
-        const T cse15 = (T(2)/T(3))*d3Lxi_v;
-        const T cse16 = (xv)*(xv)*(xv);
-        const T cse17 = T(2)*ddLxi_v;
-        const T cse18 = T(10)*cse9;
-        const T cse19 = T(10)*cse7;
-        const T cse20 = T(20)*cse10;
-        const T cse21 = T(30)*cse9;
-        dnf(ix, 4*fi + 0) = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0 - cse1 + T(120)*cse10*xi*xv - cse12 - cse13 + T(30)*cse2*dLxi_v*ddLxi_v - cse4 + T(30)*cse5*dLxi_v*ddLxi_v - cse6 + T(20)*cse7*xv - cse8 - T(60)*cse9*xi*xv + T(4)*d3Lxi_v*xi*xv + T(4)*ddLxi_v*xi) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(cse0*xi - cse0*xv + cse1*xi - cse12*xv + cse13*xi + cse14*cse15 - cse14*cse18 + cse14*cse20 - cse15*cse16 + cse16*cse18 - cse16*cse20 - cse17*cse2 - cse17*cse5 + cse19*cse2 + cse19*cse5 + cse2*cse21*xv - cse21*cse5*xi - cse4*xv + cse6*xi - cse8*xv + T(1));
+        const T cse1 = -xi + xv;
+        const T cse2 = (dLxi_v)*(dLxi_v);
+        const T cse3 = (dLxi_v)*(dLxi_v)*(dLxi_v);
+        dnf(ix, 4*fi + 0) = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0 + cse1*(cse1*(-T(60)*cse3 - T(2)*d3Lxi_v + T(30)*dLxi_v*ddLxi_v) + T(20)*cse2 - T(4)*ddLxi_v)) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(cse1*(-cse0 + cse1*(cse1*(-T(20)*cse3 - T(2)/T(3)*d3Lxi_v + T(10)*dLxi_v*ddLxi_v) + T(10)*cse2 - T(2)*ddLxi_v)) + T(1));
       }
       {
-        const T cse0 = T(8)*dLxi_v;
-        const T cse1 = xi*xv;
-        const T cse2 = (xi)*(xi);
-        const T cse3 = T(6)*ddLxi_v;
-        const T cse4 = cse2*cse3;
-        const T cse5 = (xv)*(xv);
-        const T cse6 = (dLxi_v)*(dLxi_v);
-        const T cse7 = T(30)*cse6;
-        const T cse8 = cse5*cse7;
-        const T cse9 = T(4)*dLxi_v;
-        const T cse10 = (xi)*(xi)*(xi);
-        const T cse11 = (xv)*(xv)*(xv);
-        dnf(ix, 4*fi + 1) = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv - T(60)*cse1*cse6 + T(12)*cse1*ddLxi_v + cse2*cse7 - cse3*cse5 - cse4 + cse8 + T(1)) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(-T(10)*cse10*cse6 + T(2)*cse10*ddLxi_v + T(10)*cse11*cse6 - T(2)*cse11*ddLxi_v + T(30)*cse2*cse6*xv - cse2*cse9 - cse4*xv - cse5*cse9 + T(6)*cse5*ddLxi_v*xi - cse8*xi + T(8)*dLxi_v*xi*xv - xi + xv);
+        const T cse0 = -xi + xv;
+        const T cse1 = (dLxi_v)*(dLxi_v);
+        dnf(ix, 4*fi + 1) = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*(cse0*(T(30)*cse1 - T(6)*ddLxi_v) - T(8)*dLxi_v) + T(1)) + T(4)*(Lx)*(Lx)*(Lx)*cse0*dLx*(cse0*(cse0*(T(10)*cse1 - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1));
       }
       {
-        const T cse0 = (xi)*(xi);
-        const T cse1 = T(6)*dLxi_v;
-        const T cse2 = cse0*cse1;
-        const T cse3 = (xv)*(xv);
-        const T cse4 = cse1*cse3;
-        const T cse5 = T(2)*dLxi_v;
-        dnf(ix, 4*fi + 2) = (Lx)*(Lx)*(Lx)*(Lx)*(-cse2 - cse4 + T(12)*dLxi_v*xi*xv - xi + xv) + T(4)*(Lx)*(Lx)*(Lx)*dLx*((T(1)/T(2))*cse0 - cse2*xv + (T(1)/T(2))*cse3 + cse4*xi + cse5*(xi)*(xi)*(xi) - cse5*(xv)*(xv)*(xv) - xi*xv);
+        const T cse0 = -xi + xv;
+        const T cse1 = cse0*dLxi_v;
+        dnf(ix, 4*fi + 2) = (Lx)*(Lx)*(Lx)*(Lx)*cse0*(T(1) - T(6)*cse1) + T(4)*(Lx)*(Lx)*(Lx)*(cse0)*(cse0)*dLx*(T(1)/T(2) - T(2)*cse1);
       }
       {
-        const T cse0 = (xi)*(xi);
-        const T cse1 = (T(1)/T(2))*(xv)*(xv);
-        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx)*((T(1)/T(2))*cse0 + cse1 - xi*xv) + T(4)*(Lx)*(Lx)*(Lx)*dLx*((T(1)/T(2))*cse0*xv - cse1*xi - T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv)*(xv));
+        const T cse0 = -xi + xv;
+        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx)*cse0*(-T(1)/T(2)*xi + (T(1)/T(2))*xv) + T(4)*(Lx)*(Lx)*(Lx)*(cse0)*(cse0)*dLx*(-T(1)/T(6)*xi + (T(1)/T(6))*xv);
       }
       dnf(ix, 4*fi + 1) *= element_length;
       dnf(ix, 4*fi + 2) *= element_length * element_length;
@@ -202,61 +142,27 @@ case (2): {
       const T ddLxi_v = lipxi2(fi);
       const T d3Lxi_v = lipxi3(fi);
       {
-        const T cse0 = d3Lxi_v*xi;
-        const T cse1 = d3Lxi_v*xv;
+        const T cse0 = -xi + xv;
+        const T cse1 = (dLxi_v)*(dLxi_v)*(dLxi_v);
         const T cse2 = (dLxi_v)*(dLxi_v);
-        const T cse3 = dLxi_v*ddLxi_v;
-        const T cse4 = T(15)*cse3;
-        const T cse5 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-        const T cse6 = T(30)*cse5;
-        const T cse7 = T(4)*dLxi_v;
-        const T cse8 = T(4)*ddLxi_v*xv;
-        const T cse9 = (xi)*(xi);
-        const T cse10 = T(2)*d3Lxi_v;
-        const T cse11 = (xv)*(xv);
-        const T cse12 = T(20)*cse2*xi;
-        const T cse13 = T(60)*cse5;
-        const T cse14 = cse13*cse9;
-        const T cse15 = cse11*cse13;
-        const T cse16 = (xi)*(xi)*(xi);
-        const T cse17 = (T(2)/T(3))*d3Lxi_v;
-        const T cse18 = (xv)*(xv)*(xv);
-        const T cse19 = T(2)*ddLxi_v;
-        const T cse20 = T(10)*cse3;
-        const T cse21 = T(10)*cse2;
-        const T cse22 = T(20)*cse5;
-        const T cse23 = T(30)*cse3;
-        dnf(ix, 4*fi + 0) = T(4)*(Lx)*(Lx)*(Lx)*(Lx)*(cse0 - cse1 + T(5)*cse2 - cse4*xi + cse4*xv + cse6*xi - cse6*xv - ddLxi_v) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(-cse10*cse11 - cse10*cse9 + T(30)*cse11*dLxi_v*ddLxi_v - cse12 - cse14 - cse15 + T(20)*cse2*xv - T(60)*cse3*xi*xv + T(120)*cse5*xi*xv - cse7 - cse8 + T(30)*cse9*dLxi_v*ddLxi_v + T(4)*d3Lxi_v*xi*xv + T(4)*ddLxi_v*xi) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*(T(2)*cse0*cse11 - T(2)*cse1*cse9 - cse11*cse19 + cse11*cse21 - cse11*cse23*xi - cse12*xv - cse14*xv + cse15*xi + cse16*cse17 - cse16*cse20 + cse16*cse22 - cse17*cse18 + cse18*cse20 - cse18*cse22 - cse19*cse9 + cse21*cse9 + cse23*cse9*xv + cse7*xi - cse7*xv + cse8*xi + T(1));
+        const T cse3 = T(20)*cse2 - T(4)*ddLxi_v;
+        const T cse4 = T(4)*dLxi_v;
+        dnf(ix, 4*fi + 0) = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*(-T(120)*cse1 - T(4)*d3Lxi_v + T(60)*dLxi_v*ddLxi_v) + cse3) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(cse0*(cse0*(-T(60)*cse1 - T(2)*d3Lxi_v + T(30)*dLxi_v*ddLxi_v) + cse3) - cse4) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*(cse0*(cse0*(cse0*(-T(20)*cse1 - T(2)/T(3)*d3Lxi_v + T(10)*dLxi_v*ddLxi_v) + T(10)*cse2 - T(2)*ddLxi_v) - cse4) + T(1));
       }
       {
-        const T cse0 = (dLxi_v)*(dLxi_v);
-        const T cse1 = T(8)*dLxi_v;
-        const T cse2 = xi*xv;
-        const T cse3 = (xi)*(xi);
-        const T cse4 = T(6)*ddLxi_v;
-        const T cse5 = cse3*cse4;
-        const T cse6 = (xv)*(xv);
-        const T cse7 = T(30)*cse0;
-        const T cse8 = cse6*cse7;
-        const T cse9 = T(4)*dLxi_v;
-        const T cse10 = (xi)*(xi)*(xi);
-        const T cse11 = (xv)*(xv)*(xv);
-        dnf(ix, 4*fi + 1) = T(4)*(Lx)*(Lx)*(Lx)*(Lx)*(-T(15)*cse0*xi + T(15)*cse0*xv - T(2)*dLxi_v + T(3)*ddLxi_v*xi - T(3)*ddLxi_v*xv) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(-T(60)*cse0*cse2 + cse1*xi - cse1*xv + T(12)*cse2*ddLxi_v + cse3*cse7 - cse4*cse6 - cse5 + cse8 + T(1)) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*(-T(10)*cse0*cse10 + T(10)*cse0*cse11 + T(30)*cse0*cse3*xv + T(2)*cse10*ddLxi_v - T(2)*cse11*ddLxi_v - cse3*cse9 - cse5*xv - cse6*cse9 + T(6)*cse6*ddLxi_v*xi - cse8*xi + T(8)*dLxi_v*xi*xv - xi + xv);
+        const T cse0 = T(8)*dLxi_v;
+        const T cse1 = -xi + xv;
+        const T cse2 = (dLxi_v)*(dLxi_v);
+        dnf(ix, 4*fi + 1) = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0 + cse1*(T(60)*cse2 - T(12)*ddLxi_v)) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(cse1*(-cse0 + cse1*(T(30)*cse2 - T(6)*ddLxi_v)) + T(1)) + T(4)*(Lx)*(Lx)*cse1*(Lx*ddLx + T(3)*(dLx)*(dLx))*(cse1*(cse1*(T(10)*cse2 - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1));
       }
       {
-        const T cse0 = T(12)*dLxi_v;
-        const T cse1 = (xi)*(xi);
-        const T cse2 = T(6)*dLxi_v;
-        const T cse3 = cse1*cse2;
-        const T cse4 = (xv)*(xv);
-        const T cse5 = cse2*cse4;
-        const T cse6 = T(2)*dLxi_v;
-        dnf(ix, 4*fi + 2) = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv + T(1)) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(-cse3 - cse5 + T(12)*dLxi_v*xi*xv - xi + xv) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*((T(1)/T(2))*cse1 - cse3*xv + (T(1)/T(2))*cse4 + cse5*xi + cse6*(xi)*(xi)*(xi) - cse6*(xv)*(xv)*(xv) - xi*xv);
+        const T cse0 = -xi + xv;
+        const T cse1 = cse0*dLxi_v;
+        dnf(ix, 4*fi + 2) = (Lx)*(Lx)*(Lx)*(Lx)*(T(1) - T(12)*cse1) + T(8)*(Lx)*(Lx)*(Lx)*cse0*dLx*(T(1) - T(6)*cse1) + T(4)*(Lx)*(Lx)*(cse0)*(cse0)*(T(1)/T(2) - T(2)*cse1)*(Lx*ddLx + T(3)*(dLx)*(dLx));
       }
       {
-        const T cse0 = (xi)*(xi);
-        const T cse1 = (T(1)/T(2))*(xv)*(xv);
-        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx)*(-xi + xv) + T(8)*(Lx)*(Lx)*(Lx)*dLx*((T(1)/T(2))*cse0 + cse1 - xi*xv) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*((T(1)/T(2))*cse0*xv - cse1*xi - T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv)*(xv));
+        const T cse0 = -xi + xv;
+        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx)*cse0 + T(8)*(Lx)*(Lx)*(Lx)*cse0*dLx*(-T(1)/T(2)*xi + (T(1)/T(2))*xv) + T(4)*(Lx)*(Lx)*(cse0)*(cse0)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv)*(Lx*ddLx + T(3)*(dLx)*(dLx));
       }
       dnf(ix, 4*fi + 1) *= element_length;
       dnf(ix, 4*fi + 2) *= element_length * element_length;
@@ -287,68 +193,38 @@ case (3): {
       const T d3Lxi_v = lipxi3(fi);
       {
         const T cse0 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-        const T cse1 = T(30)*cse0;
-        const T cse2 = d3Lxi_v*xi;
-        const T cse3 = d3Lxi_v*xv;
-        const T cse4 = (dLxi_v)*(dLxi_v);
-        const T cse5 = dLxi_v*ddLxi_v;
-        const T cse6 = T(15)*cse5;
-        const T cse7 = (Lx)*(Lx);
-        const T cse8 = Lx*ddLx;
-        const T cse9 = T(4)*dLxi_v;
-        const T cse10 = T(4)*ddLxi_v*xv;
-        const T cse11 = (xi)*(xi);
-        const T cse12 = T(2)*d3Lxi_v;
-        const T cse13 = (xv)*(xv);
-        const T cse14 = T(20)*cse4*xi;
-        const T cse15 = T(60)*cse0;
-        const T cse16 = cse11*cse15;
-        const T cse17 = cse13*cse15;
-        const T cse18 = (xi)*(xi)*(xi);
-        const T cse19 = (T(2)/T(3))*d3Lxi_v;
-        const T cse20 = (xv)*(xv)*(xv);
-        const T cse21 = T(2)*ddLxi_v;
-        const T cse22 = T(10)*cse5;
-        const T cse23 = T(10)*cse4;
-        const T cse24 = T(20)*cse0;
-        const T cse25 = T(30)*cse5;
-        dnf(ix, 4*fi + 0) = T(4)*(Lx)*(Lx)*(Lx)*(Lx)*(-cse1 - d3Lxi_v + T(15)*dLxi_v*ddLxi_v) + T(48)*(Lx)*(Lx)*(Lx)*dLx*(cse1*xi - cse1*xv + cse2 - cse3 + T(5)*cse4 - cse6*xi + cse6*xv - ddLxi_v) + T(4)*Lx*(cse7*d3Lx + T(9)*cse8*dLx + T(6)*(dLx)*(dLx)*(dLx))*(cse10*xi - cse11*cse21 + cse11*cse23 + cse11*cse25*xv - T(2)*cse11*cse3 + T(2)*cse13*cse2 - cse13*cse21 + cse13*cse23 - cse13*cse25*xi - cse14*xv - cse16*xv + cse17*xi + cse18*cse19 - cse18*cse22 + cse18*cse24 - cse19*cse20 + cse20*cse22 - cse20*cse24 + cse9*xi - cse9*xv + T(1)) + T(12)*cse7*(cse8 + T(3)*(dLx)*(dLx))*(T(120)*cse0*xi*xv - cse10 - cse11*cse12 + T(30)*cse11*dLxi_v*ddLxi_v - cse12*cse13 + T(30)*cse13*dLxi_v*ddLxi_v - cse14 - cse16 - cse17 + T(20)*cse4*xv - T(60)*cse5*xi*xv - cse9 + T(4)*d3Lxi_v*xi*xv + T(4)*ddLxi_v*xi);
+        const T cse1 = -T(120)*cse0 - T(4)*d3Lxi_v + T(60)*dLxi_v*ddLxi_v;
+        const T cse2 = -xi + xv;
+        const T cse3 = (dLxi_v)*(dLxi_v);
+        const T cse4 = T(20)*cse3 - T(4)*ddLxi_v;
+        const T cse5 = (Lx)*(Lx);
+        const T cse6 = Lx*ddLx;
+        const T cse7 = T(4)*dLxi_v;
+        dnf(ix, 4*fi + 0) = (Lx)*(Lx)*(Lx)*(Lx)*cse1 + T(12)*(Lx)*(Lx)*(Lx)*dLx*(cse1*cse2 + cse4) + T(4)*Lx*(cse2*(cse2*(cse2*(-T(20)*cse0 - T(2)/T(3)*d3Lxi_v + T(10)*dLxi_v*ddLxi_v) + T(10)*cse3 - T(2)*ddLxi_v) - cse7) + T(1))*(cse5*d3Lx + T(9)*cse6*dLx + T(6)*(dLx)*(dLx)*(dLx)) + T(12)*cse5*(cse6 + T(3)*(dLx)*(dLx))*(cse2*(cse2*(-T(60)*cse0 - T(2)*d3Lxi_v + T(30)*dLxi_v*ddLxi_v) + cse4) - cse7);
       }
       {
         const T cse0 = (dLxi_v)*(dLxi_v);
-        const T cse1 = (Lx)*(Lx);
-        const T cse2 = Lx*ddLx;
-        const T cse3 = T(8)*dLxi_v;
-        const T cse4 = xi*xv;
-        const T cse5 = (xi)*(xi);
-        const T cse6 = T(6)*ddLxi_v;
-        const T cse7 = cse5*cse6;
-        const T cse8 = (xv)*(xv);
-        const T cse9 = T(30)*cse0;
-        const T cse10 = cse8*cse9;
-        const T cse11 = T(4)*dLxi_v;
-        const T cse12 = (xi)*(xi)*(xi);
-        const T cse13 = (xv)*(xv)*(xv);
-        dnf(ix, 4*fi + 1) = T(12)*(Lx)*(Lx)*(Lx)*(Lx)*(T(5)*cse0 - ddLxi_v) + T(48)*(Lx)*(Lx)*(Lx)*dLx*(-T(15)*cse0*xi + T(15)*cse0*xv - T(2)*dLxi_v + T(3)*ddLxi_v*xi - T(3)*ddLxi_v*xv) + T(4)*Lx*(cse1*d3Lx + T(9)*cse2*dLx + T(6)*(dLx)*(dLx)*(dLx))*(-T(10)*cse0*cse12 + T(10)*cse0*cse13 + T(30)*cse0*cse5*xv - cse10*xi - cse11*cse5 - cse11*cse8 + T(2)*cse12*ddLxi_v - T(2)*cse13*ddLxi_v - cse7*xv + T(6)*cse8*ddLxi_v*xi + T(8)*dLxi_v*xi*xv - xi + xv) + T(12)*cse1*(cse2 + T(3)*(dLx)*(dLx))*(-T(60)*cse0*cse4 + cse10 + cse3*xi - cse3*xv + T(12)*cse4*ddLxi_v + cse5*cse9 - cse6*cse8 - cse7 + T(1));
+        const T cse1 = T(60)*cse0 - T(12)*ddLxi_v;
+        const T cse2 = T(8)*dLxi_v;
+        const T cse3 = -xi + xv;
+        const T cse4 = (Lx)*(Lx);
+        const T cse5 = Lx*ddLx;
+        dnf(ix, 4*fi + 1) = (Lx)*(Lx)*(Lx)*(Lx)*cse1 + T(12)*(Lx)*(Lx)*(Lx)*dLx*(cse1*cse3 - cse2) + T(4)*Lx*cse3*(cse3*(cse3*(T(10)*cse0 - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1))*(cse4*d3Lx + T(9)*cse5*dLx + T(6)*(dLx)*(dLx)*(dLx)) + T(12)*cse4*(cse5 + T(3)*(dLx)*(dLx))*(cse3*(-cse2 + cse3*(T(30)*cse0 - T(6)*ddLxi_v)) + T(1));
       }
       {
         const T cse0 = T(12)*dLxi_v;
-        const T cse1 = (Lx)*(Lx);
-        const T cse2 = Lx*ddLx;
-        const T cse3 = (xi)*(xi);
-        const T cse4 = T(6)*dLxi_v;
-        const T cse5 = cse3*cse4;
-        const T cse6 = (xv)*(xv);
-        const T cse7 = cse4*cse6;
-        const T cse8 = T(2)*dLxi_v;
-        dnf(ix, 4*fi + 2) = -(Lx)*(Lx)*(Lx)*(Lx)*cse0 + T(12)*(Lx)*(Lx)*(Lx)*dLx*(cse0*xi - cse0*xv + T(1)) + T(4)*Lx*(cse1*d3Lx + T(9)*cse2*dLx + T(6)*(dLx)*(dLx)*(dLx))*((T(1)/T(2))*cse3 - cse5*xv + (T(1)/T(2))*cse6 + cse7*xi + cse8*(xi)*(xi)*(xi) - cse8*(xv)*(xv)*(xv) - xi*xv) + T(12)*cse1*(cse2 + T(3)*(dLx)*(dLx))*(-cse5 - cse7 + T(12)*dLxi_v*xi*xv - xi + xv);
+        const T cse1 = -xi + xv;
+        const T cse2 = (Lx)*(Lx);
+        const T cse3 = Lx*ddLx;
+        const T cse4 = cse1*dLxi_v;
+        dnf(ix, 4*fi + 2) = -(Lx)*(Lx)*(Lx)*(Lx)*cse0 + T(12)*(Lx)*(Lx)*(Lx)*dLx*(-cse0*cse1 + T(1)) + T(4)*Lx*(cse1)*(cse1)*(T(1)/T(2) - T(2)*cse4)*(cse2*d3Lx + T(9)*cse3*dLx + T(6)*(dLx)*(dLx)*(dLx)) + T(12)*cse1*cse2*(T(1) - T(6)*cse4)*(cse3 + T(3)*(dLx)*(dLx));
       }
       {
-        const T cse0 = (Lx)*(Lx);
-        const T cse1 = Lx*ddLx;
-        const T cse2 = (xi)*(xi);
-        const T cse3 = (T(1)/T(2))*(xv)*(xv);
-        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx) + T(12)*(Lx)*(Lx)*(Lx)*dLx*(-xi + xv) + T(4)*Lx*(cse0*d3Lx + T(9)*cse1*dLx + T(6)*(dLx)*(dLx)*(dLx))*((T(1)/T(2))*cse2*xv - cse3*xi - T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv)*(xv)) + T(12)*cse0*(cse1 + T(3)*(dLx)*(dLx))*((T(1)/T(2))*cse2 + cse3 - xi*xv);
+        const T cse0 = -xi + xv;
+        const T cse1 = T(12)*cse0;
+        const T cse2 = (Lx)*(Lx);
+        const T cse3 = Lx*ddLx;
+        dnf(ix, 4*fi + 3) = (Lx)*(Lx)*(Lx)*(Lx) + (Lx)*(Lx)*(Lx)*cse1*dLx + T(4)*Lx*(cse0)*(cse0)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv)*(cse2*d3Lx + T(9)*cse3*dLx + T(6)*(dLx)*(dLx)*(dLx)) + cse1*cse2*(cse3 + T(3)*(dLx)*(dLx))*(-T(1)/T(2)*xi + (T(1)/T(2))*xv);
       }
       dnf(ix, 4*fi + 1) *= element_length;
       dnf(ix, 4*fi + 2) *= element_length * element_length;
@@ -383,79 +259,47 @@ case (4): {
       {
         const T cse0 = (Lx)*(Lx)*(Lx);
         const T cse1 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-        const T cse2 = T(30)*cse1;
+        const T cse2 = -T(120)*cse1 - T(4)*d3Lxi_v + T(60)*dLxi_v*ddLxi_v;
         const T cse3 = (Lx)*(Lx);
         const T cse4 = Lx*ddLx;
         const T cse5 = (dLx)*(dLx);
-        const T cse6 = d3Lxi_v*xi;
-        const T cse7 = d3Lxi_v*xv;
-        const T cse8 = (dLxi_v)*(dLxi_v);
-        const T cse9 = dLxi_v*ddLxi_v;
-        const T cse10 = T(15)*cse9;
-        const T cse11 = cse3*d3Lx;
-        const T cse12 = T(4)*dLxi_v;
-        const T cse13 = T(4)*ddLxi_v*xv;
-        const T cse14 = (xi)*(xi);
-        const T cse15 = T(2)*d3Lxi_v;
-        const T cse16 = (xv)*(xv);
-        const T cse17 = T(20)*cse8*xi;
-        const T cse18 = T(60)*cse1;
-        const T cse19 = cse14*cse18;
-        const T cse20 = cse16*cse18;
-        const T cse21 = (xi)*(xi)*(xi);
-        const T cse22 = (T(2)/T(3))*d3Lxi_v;
-        const T cse23 = (xv)*(xv)*(xv);
-        const T cse24 = T(2)*ddLxi_v;
-        const T cse25 = T(10)*cse9;
-        const T cse26 = T(10)*cse8;
-        const T cse27 = T(20)*cse1;
-        const T cse28 = T(30)*cse9;
-        dnf(ix, 4*fi + 0) = T(16)*Lx*(cse11 + T(9)*cse4*dLx + T(6)*(dLx)*(dLx)*(dLx))*(T(120)*cse1*xi*xv - cse12 - cse13 - cse14*cse15 + T(30)*cse14*dLxi_v*ddLxi_v - cse15*cse16 + T(30)*cse16*dLxi_v*ddLxi_v - cse17 - cse19 - cse20 + T(20)*cse8*xv - T(60)*cse9*xi*xv + T(4)*d3Lxi_v*xi*xv + T(4)*ddLxi_v*xi) + T(64)*cse0*dLx*(-cse2 - d3Lxi_v + T(15)*dLxi_v*ddLxi_v) + T(96)*cse3*(cse4 + T(3)*cse5)*(-cse10*xi + cse10*xv + cse2*xi - cse2*xv + cse6 - cse7 + T(5)*cse8 - ddLxi_v) + (T(4)*cse0*d4Lx + T(48)*cse11*dLx + T(36)*cse3*(ddLx)*(ddLx) + T(144)*cse4*cse5 + T(24)*(dLx)*(dLx)*(dLx)*(dLx))*(cse12*xi - cse12*xv + cse13*xi - cse14*cse24 + cse14*cse26 + cse14*cse28*xv - T(2)*cse14*cse7 - cse16*cse24 + cse16*cse26 - cse16*cse28*xi + T(2)*cse16*cse6 - cse17*xv - cse19*xv + cse20*xi + cse21*cse22 - cse21*cse25 + cse21*cse27 - cse22*cse23 + cse23*cse25 - cse23*cse27 + T(1));
+        const T cse6 = -xi + xv;
+        const T cse7 = (dLxi_v)*(dLxi_v);
+        const T cse8 = T(20)*cse7 - T(4)*ddLxi_v;
+        const T cse9 = cse3*d3Lx;
+        const T cse10 = T(4)*dLxi_v;
+        dnf(ix, 4*fi + 0) = T(16)*Lx*(-cse10 + cse6*(cse6*(-T(60)*cse1 - T(2)*d3Lxi_v + T(30)*dLxi_v*ddLxi_v) + cse8))*(T(9)*cse4*dLx + cse9 + T(6)*(dLx)*(dLx)*(dLx)) + T(16)*cse0*cse2*dLx + T(24)*cse3*(cse4 + T(3)*cse5)*(cse2*cse6 + cse8) + (cse6*(-cse10 + cse6*(cse6*(-T(20)*cse1 - T(2)/T(3)*d3Lxi_v + T(10)*dLxi_v*ddLxi_v) + T(10)*cse7 - T(2)*ddLxi_v)) + T(1))*(T(4)*cse0*d4Lx + T(36)*cse3*(ddLx)*(ddLx) + T(144)*cse4*cse5 + T(48)*cse9*dLx + T(24)*(dLx)*(dLx)*(dLx)*(dLx));
       }
       {
         const T cse0 = (Lx)*(Lx)*(Lx);
         const T cse1 = (dLxi_v)*(dLxi_v);
-        const T cse2 = (Lx)*(Lx);
+        const T cse2 = T(60)*cse1 - T(12)*ddLxi_v;
+        const T cse3 = (Lx)*(Lx);
+        const T cse4 = Lx*ddLx;
+        const T cse5 = (dLx)*(dLx);
+        const T cse6 = T(8)*dLxi_v;
+        const T cse7 = -xi + xv;
+        const T cse8 = cse3*d3Lx;
+        dnf(ix, 4*fi + 1) = T(16)*Lx*(cse7*(-cse6 + cse7*(T(30)*cse1 - T(6)*ddLxi_v)) + T(1))*(T(9)*cse4*dLx + cse8 + T(6)*(dLx)*(dLx)*(dLx)) + T(16)*cse0*cse2*dLx + T(24)*cse3*(cse4 + T(3)*cse5)*(cse2*cse7 - cse6) + cse7*(cse7*(cse7*(T(10)*cse1 - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1))*(T(4)*cse0*d4Lx + T(36)*cse3*(ddLx)*(ddLx) + T(144)*cse4*cse5 + T(48)*cse8*dLx + T(24)*(dLx)*(dLx)*(dLx)*(dLx));
+      }
+      {
+        const T cse0 = (Lx)*(Lx)*(Lx);
+        const T cse1 = (Lx)*(Lx);
+        const T cse2 = Lx*ddLx;
+        const T cse3 = (dLx)*(dLx);
+        const T cse4 = -xi + xv;
+        const T cse5 = cse4*dLxi_v;
+        const T cse6 = cse1*d3Lx;
+        dnf(ix, 4*fi + 2) = T(16)*Lx*cse4*(T(1) - T(6)*cse5)*(T(9)*cse2*dLx + cse6 + T(6)*(dLx)*(dLx)*(dLx)) - T(192)*cse0*dLx*dLxi_v + T(24)*cse1*(T(1) - T(12)*cse5)*(cse2 + T(3)*cse3) + (cse4)*(cse4)*(T(1)/T(2) - T(2)*cse5)*(T(4)*cse0*d4Lx + T(36)*cse1*(ddLx)*(ddLx) + T(144)*cse2*cse3 + T(48)*cse6*dLx + T(24)*(dLx)*(dLx)*(dLx)*(dLx));
+      }
+      {
+        const T cse0 = (Lx)*(Lx)*(Lx);
+        const T cse1 = (Lx)*(Lx);
+        const T cse2 = -xi + xv;
         const T cse3 = Lx*ddLx;
         const T cse4 = (dLx)*(dLx);
-        const T cse5 = cse2*d3Lx;
-        const T cse6 = T(8)*dLxi_v;
-        const T cse7 = xi*xv;
-        const T cse8 = (xi)*(xi);
-        const T cse9 = T(6)*ddLxi_v;
-        const T cse10 = cse8*cse9;
-        const T cse11 = (xv)*(xv);
-        const T cse12 = T(30)*cse1;
-        const T cse13 = cse11*cse12;
-        const T cse14 = T(4)*dLxi_v;
-        const T cse15 = (xi)*(xi)*(xi);
-        const T cse16 = (xv)*(xv)*(xv);
-        dnf(ix, 4*fi + 1) = T(16)*Lx*(T(9)*cse3*dLx + cse5 + T(6)*(dLx)*(dLx)*(dLx))*(-T(60)*cse1*cse7 - cse10 - cse11*cse9 + cse12*cse8 + cse13 + cse6*xi - cse6*xv + T(12)*cse7*ddLxi_v + T(1)) + T(192)*cse0*dLx*(T(5)*cse1 - ddLxi_v) + T(96)*cse2*(cse3 + T(3)*cse4)*(-T(15)*cse1*xi + T(15)*cse1*xv - T(2)*dLxi_v + T(3)*ddLxi_v*xi - T(3)*ddLxi_v*xv) + (T(4)*cse0*d4Lx + T(36)*cse2*(ddLx)*(ddLx) + T(144)*cse3*cse4 + T(48)*cse5*dLx + T(24)*(dLx)*(dLx)*(dLx)*(dLx))*(-T(10)*cse1*cse15 + T(10)*cse1*cse16 + T(30)*cse1*cse8*xv - cse10*xv - cse11*cse14 + T(6)*cse11*ddLxi_v*xi - cse13*xi - cse14*cse8 + T(2)*cse15*ddLxi_v - T(2)*cse16*ddLxi_v + T(8)*dLxi_v*xi*xv - xi + xv);
-      }
-      {
-        const T cse0 = (Lx)*(Lx)*(Lx);
-        const T cse1 = (Lx)*(Lx);
-        const T cse2 = Lx*ddLx;
-        const T cse3 = (dLx)*(dLx);
-        const T cse4 = T(12)*dLxi_v;
         const T cse5 = cse1*d3Lx;
-        const T cse6 = (xi)*(xi);
-        const T cse7 = T(6)*dLxi_v;
-        const T cse8 = cse6*cse7;
-        const T cse9 = (xv)*(xv);
-        const T cse10 = cse7*cse9;
-        const T cse11 = T(2)*dLxi_v;
-        dnf(ix, 4*fi + 2) = T(16)*Lx*(T(9)*cse2*dLx + cse5 + T(6)*(dLx)*(dLx)*(dLx))*(-cse10 - cse8 + T(12)*dLxi_v*xi*xv - xi + xv) - T(192)*cse0*dLx*dLxi_v + T(24)*cse1*(cse2 + T(3)*cse3)*(cse4*xi - cse4*xv + T(1)) + (T(4)*cse0*d4Lx + T(36)*cse1*(ddLx)*(ddLx) + T(144)*cse2*cse3 + T(48)*cse5*dLx + T(24)*(dLx)*(dLx)*(dLx)*(dLx))*(cse10*xi + cse11*(xi)*(xi)*(xi) - cse11*(xv)*(xv)*(xv) + (T(1)/T(2))*cse6 - cse8*xv + (T(1)/T(2))*cse9 - xi*xv);
-      }
-      {
-        const T cse0 = (Lx)*(Lx)*(Lx);
-        const T cse1 = (Lx)*(Lx);
-        const T cse2 = Lx*ddLx;
-        const T cse3 = (dLx)*(dLx);
-        const T cse4 = (xi)*(xi);
-        const T cse5 = (T(1)/T(2))*(xv)*(xv);
-        const T cse6 = cse1*d3Lx;
-        dnf(ix, 4*fi + 3) = T(16)*Lx*((T(1)/T(2))*cse4 + cse5 - xi*xv)*(T(9)*cse2*dLx + cse6 + T(6)*(dLx)*(dLx)*(dLx)) + T(16)*cse0*dLx + T(24)*cse1*(cse2 + T(3)*cse3)*(-xi + xv) + ((T(1)/T(2))*cse4*xv - cse5*xi - T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv)*(xv))*(T(4)*cse0*d4Lx + T(36)*cse1*(ddLx)*(ddLx) + T(144)*cse2*cse3 + T(48)*cse6*dLx + T(24)*(dLx)*(dLx)*(dLx)*(dLx));
+        dnf(ix, 4*fi + 3) = T(16)*Lx*cse2*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*(T(9)*cse3*dLx + cse5 + T(6)*(dLx)*(dLx)*(dLx)) + T(16)*cse0*dLx + T(24)*cse1*cse2*(cse3 + T(3)*cse4) + (cse2)*(cse2)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv)*(T(4)*cse0*d4Lx + T(36)*cse1*(ddLx)*(ddLx) + T(144)*cse3*cse4 + T(48)*cse5*dLx + T(24)*(dLx)*(dLx)*(dLx)*(dLx));
       }
       dnf(ix, 4*fi + 1) *= element_length;
       dnf(ix, 4*fi + 2) *= element_length * element_length;
@@ -495,85 +339,53 @@ case (5): {
         const T cse1 = Lx*ddLx;
         const T cse2 = (dLx)*(dLx);
         const T cse3 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-        const T cse4 = T(30)*cse3;
+        const T cse4 = -T(120)*cse3 - T(4)*d3Lxi_v + T(60)*dLxi_v*ddLxi_v;
         const T cse5 = (dLx)*(dLx)*(dLx);
         const T cse6 = cse0*d3Lx;
-        const T cse7 = d3Lxi_v*xi;
-        const T cse8 = d3Lxi_v*xv;
-        const T cse9 = (dLxi_v)*(dLxi_v);
-        const T cse10 = dLxi_v*ddLxi_v;
-        const T cse11 = T(15)*cse10;
-        const T cse12 = (Lx)*(Lx)*(Lx);
-        const T cse13 = (ddLx)*(ddLx);
-        const T cse14 = T(4)*dLxi_v;
-        const T cse15 = T(4)*ddLxi_v*xv;
-        const T cse16 = (xi)*(xi);
-        const T cse17 = T(2)*d3Lxi_v;
-        const T cse18 = (xv)*(xv);
-        const T cse19 = T(20)*cse9*xi;
-        const T cse20 = T(60)*cse3;
-        const T cse21 = cse16*cse20;
-        const T cse22 = cse18*cse20;
-        const T cse23 = (xi)*(xi)*(xi);
-        const T cse24 = (T(2)/T(3))*d3Lxi_v;
-        const T cse25 = (xv)*(xv)*(xv);
-        const T cse26 = T(2)*ddLxi_v;
-        const T cse27 = T(10)*cse10;
-        const T cse28 = T(10)*cse9;
-        const T cse29 = T(20)*cse3;
-        const T cse30 = T(30)*cse10;
-        dnf(ix, 4*fi + 0) = T(160)*Lx*(T(9)*cse1*dLx + T(6)*cse5 + cse6)*(-cse11*xi + cse11*xv + cse4*xi - cse4*xv + cse7 - cse8 + T(5)*cse9 - ddLxi_v) + T(160)*cse0*(cse1 + T(3)*cse2)*(-cse4 - d3Lxi_v + T(15)*dLxi_v*ddLxi_v) + (T(180)*cse0*cse13 + T(720)*cse1*cse2 + T(20)*cse12*d4Lx + T(240)*cse6*dLx + T(120)*(dLx)*(dLx)*(dLx)*(dLx))*(-T(60)*cse10*xi*xv - cse14 - cse15 - cse16*cse17 + T(30)*cse16*dLxi_v*ddLxi_v - cse17*cse18 + T(30)*cse18*dLxi_v*ddLxi_v - cse19 - cse21 - cse22 + T(120)*cse3*xi*xv + T(20)*cse9*xv + T(4)*d3Lxi_v*xi*xv + T(4)*ddLxi_v*xi) + (T(360)*Lx*cse13*dLx + T(240)*Lx*cse2*d3Lx + T(60)*cse0*d4Lx*dLx + T(4)*cse12*d5Lx + T(240)*cse5*ddLx + T(120)*cse6*ddLx)*(cse14*xi - cse14*xv + cse15*xi - cse16*cse26 + cse16*cse28 + cse16*cse30*xv - T(2)*cse16*cse8 - cse18*cse26 + cse18*cse28 - cse18*cse30*xi + T(2)*cse18*cse7 - cse19*xv - cse21*xv + cse22*xi + cse23*cse24 - cse23*cse27 + cse23*cse29 - cse24*cse25 + cse25*cse27 - cse25*cse29 + T(1));
+        const T cse7 = -xi + xv;
+        const T cse8 = (dLxi_v)*(dLxi_v);
+        const T cse9 = T(20)*cse8 - T(4)*ddLxi_v;
+        const T cse10 = (Lx)*(Lx)*(Lx);
+        const T cse11 = (ddLx)*(ddLx);
+        const T cse12 = T(4)*dLxi_v;
+        dnf(ix, 4*fi + 0) = T(40)*Lx*(cse4*cse7 + cse9)*(T(9)*cse1*dLx + T(6)*cse5 + cse6) + T(40)*cse0*cse4*(cse1 + T(3)*cse2) + (-cse12 + cse7*(cse7*(-T(60)*cse3 - T(2)*d3Lxi_v + T(30)*dLxi_v*ddLxi_v) + cse9))*(T(180)*cse0*cse11 + T(720)*cse1*cse2 + T(20)*cse10*d4Lx + T(240)*cse6*dLx + T(120)*(dLx)*(dLx)*(dLx)*(dLx)) + (cse7*(-cse12 + cse7*(cse7*(-T(20)*cse3 - T(2)/T(3)*d3Lxi_v + T(10)*dLxi_v*ddLxi_v) + T(10)*cse8 - T(2)*ddLxi_v)) + T(1))*(T(360)*Lx*cse11*dLx + T(240)*Lx*cse2*d3Lx + T(60)*cse0*d4Lx*dLx + T(4)*cse10*d5Lx + T(240)*cse5*ddLx + T(120)*cse6*ddLx);
       }
       {
         const T cse0 = (Lx)*(Lx);
         const T cse1 = (dLxi_v)*(dLxi_v);
-        const T cse2 = Lx*ddLx;
-        const T cse3 = (dLx)*(dLx);
+        const T cse2 = T(60)*cse1 - T(12)*ddLxi_v;
+        const T cse3 = Lx*ddLx;
+        const T cse4 = (dLx)*(dLx);
+        const T cse5 = (dLx)*(dLx)*(dLx);
+        const T cse6 = cse0*d3Lx;
+        const T cse7 = T(8)*dLxi_v;
+        const T cse8 = -xi + xv;
+        const T cse9 = (Lx)*(Lx)*(Lx);
+        const T cse10 = (ddLx)*(ddLx);
+        dnf(ix, 4*fi + 1) = T(40)*Lx*(cse2*cse8 - cse7)*(T(9)*cse3*dLx + T(6)*cse5 + cse6) + T(40)*cse0*cse2*(cse3 + T(3)*cse4) + cse8*(cse8*(cse8*(T(10)*cse1 - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1))*(T(360)*Lx*cse10*dLx + T(240)*Lx*cse4*d3Lx + T(60)*cse0*d4Lx*dLx + T(240)*cse5*ddLx + T(120)*cse6*ddLx + T(4)*cse9*d5Lx) + (cse8*(-cse7 + cse8*(T(30)*cse1 - T(6)*ddLxi_v)) + T(1))*(T(180)*cse0*cse10 + T(720)*cse3*cse4 + T(240)*cse6*dLx + T(20)*cse9*d4Lx + T(120)*(dLx)*(dLx)*(dLx)*(dLx));
+      }
+      {
+        const T cse0 = (Lx)*(Lx);
+        const T cse1 = Lx*ddLx;
+        const T cse2 = (dLx)*(dLx);
+        const T cse3 = -xi + xv;
+        const T cse4 = cse3*dLxi_v;
+        const T cse5 = (dLx)*(dLx)*(dLx);
+        const T cse6 = cse0*d3Lx;
+        const T cse7 = (Lx)*(Lx)*(Lx);
+        const T cse8 = (ddLx)*(ddLx);
+        dnf(ix, 4*fi + 2) = T(40)*Lx*(T(1) - T(12)*cse4)*(T(9)*cse1*dLx + T(6)*cse5 + cse6) - T(480)*cse0*dLxi_v*(cse1 + T(3)*cse2) + (cse3)*(cse3)*(T(1)/T(2) - T(2)*cse4)*(T(240)*Lx*cse2*d3Lx + T(360)*Lx*cse8*dLx + T(60)*cse0*d4Lx*dLx + T(240)*cse5*ddLx + T(120)*cse6*ddLx + T(4)*cse7*d5Lx) + cse3*(T(1) - T(6)*cse4)*(T(180)*cse0*cse8 + T(720)*cse1*cse2 + T(240)*cse6*dLx + T(20)*cse7*d4Lx + T(120)*(dLx)*(dLx)*(dLx)*(dLx));
+      }
+      {
+        const T cse0 = (Lx)*(Lx);
+        const T cse1 = Lx*ddLx;
+        const T cse2 = (dLx)*(dLx);
+        const T cse3 = -xi + xv;
         const T cse4 = (dLx)*(dLx)*(dLx);
         const T cse5 = cse0*d3Lx;
         const T cse6 = (Lx)*(Lx)*(Lx);
         const T cse7 = (ddLx)*(ddLx);
-        const T cse8 = T(8)*dLxi_v;
-        const T cse9 = xi*xv;
-        const T cse10 = (xi)*(xi);
-        const T cse11 = T(6)*ddLxi_v;
-        const T cse12 = cse10*cse11;
-        const T cse13 = (xv)*(xv);
-        const T cse14 = T(30)*cse1;
-        const T cse15 = cse13*cse14;
-        const T cse16 = T(4)*dLxi_v;
-        const T cse17 = (xi)*(xi)*(xi);
-        const T cse18 = (xv)*(xv)*(xv);
-        dnf(ix, 4*fi + 1) = T(160)*Lx*(T(9)*cse2*dLx + T(6)*cse4 + cse5)*(-T(15)*cse1*xi + T(15)*cse1*xv - T(2)*dLxi_v + T(3)*ddLxi_v*xi - T(3)*ddLxi_v*xv) + T(480)*cse0*(T(5)*cse1 - ddLxi_v)*(cse2 + T(3)*cse3) + (T(180)*cse0*cse7 + T(720)*cse2*cse3 + T(240)*cse5*dLx + T(20)*cse6*d4Lx + T(120)*(dLx)*(dLx)*(dLx)*(dLx))*(-T(60)*cse1*cse9 + cse10*cse14 - cse11*cse13 - cse12 + cse15 + cse8*xi - cse8*xv + T(12)*cse9*ddLxi_v + T(1)) + (T(240)*Lx*cse3*d3Lx + T(360)*Lx*cse7*dLx + T(60)*cse0*d4Lx*dLx + T(240)*cse4*ddLx + T(120)*cse5*ddLx + T(4)*cse6*d5Lx)*(T(30)*cse1*cse10*xv - T(10)*cse1*cse17 + T(10)*cse1*cse18 - cse10*cse16 - cse12*xv - cse13*cse16 + T(6)*cse13*ddLxi_v*xi - cse15*xi + T(2)*cse17*ddLxi_v - T(2)*cse18*ddLxi_v + T(8)*dLxi_v*xi*xv - xi + xv);
-      }
-      {
-        const T cse0 = (Lx)*(Lx);
-        const T cse1 = Lx*ddLx;
-        const T cse2 = (dLx)*(dLx);
-        const T cse3 = T(12)*dLxi_v;
-        const T cse4 = (dLx)*(dLx)*(dLx);
-        const T cse5 = cse0*d3Lx;
-        const T cse6 = (xi)*(xi);
-        const T cse7 = T(6)*dLxi_v;
-        const T cse8 = cse6*cse7;
-        const T cse9 = (xv)*(xv);
-        const T cse10 = cse7*cse9;
-        const T cse11 = (Lx)*(Lx)*(Lx);
-        const T cse12 = (ddLx)*(ddLx);
-        const T cse13 = T(2)*dLxi_v;
-        dnf(ix, 4*fi + 2) = T(40)*Lx*(T(9)*cse1*dLx + T(6)*cse4 + cse5)*(cse3*xi - cse3*xv + T(1)) - T(480)*cse0*dLxi_v*(cse1 + T(3)*cse2) + (-cse10 - cse8 + T(12)*dLxi_v*xi*xv - xi + xv)*(T(180)*cse0*cse12 + T(720)*cse1*cse2 + T(20)*cse11*d4Lx + T(240)*cse5*dLx + T(120)*(dLx)*(dLx)*(dLx)*(dLx)) + (T(360)*Lx*cse12*dLx + T(240)*Lx*cse2*d3Lx + T(60)*cse0*d4Lx*dLx + T(4)*cse11*d5Lx + T(240)*cse4*ddLx + T(120)*cse5*ddLx)*(cse10*xi + cse13*(xi)*(xi)*(xi) - cse13*(xv)*(xv)*(xv) + (T(1)/T(2))*cse6 - cse8*xv + (T(1)/T(2))*cse9 - xi*xv);
-      }
-      {
-        const T cse0 = (Lx)*(Lx);
-        const T cse1 = Lx*ddLx;
-        const T cse2 = (dLx)*(dLx);
-        const T cse3 = (dLx)*(dLx)*(dLx);
-        const T cse4 = cse0*d3Lx;
-        const T cse5 = (xi)*(xi);
-        const T cse6 = (T(1)/T(2))*(xv)*(xv);
-        const T cse7 = (Lx)*(Lx)*(Lx);
-        const T cse8 = (ddLx)*(ddLx);
-        dnf(ix, 4*fi + 3) = T(40)*Lx*(-xi + xv)*(T(9)*cse1*dLx + T(6)*cse3 + cse4) + T(40)*cse0*(cse1 + T(3)*cse2) + ((T(1)/T(2))*cse5 + cse6 - xi*xv)*(T(180)*cse0*cse8 + T(720)*cse1*cse2 + T(240)*cse4*dLx + T(20)*cse7*d4Lx + T(120)*(dLx)*(dLx)*(dLx)*(dLx)) + ((T(1)/T(2))*cse5*xv - cse6*xi - T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv)*(xv))*(T(240)*Lx*cse2*d3Lx + T(360)*Lx*cse8*dLx + T(60)*cse0*d4Lx*dLx + T(240)*cse3*ddLx + T(120)*cse4*ddLx + T(4)*cse7*d5Lx);
+        dnf(ix, 4*fi + 3) = T(40)*Lx*cse3*(T(9)*cse1*dLx + T(6)*cse4 + cse5) + T(40)*cse0*(cse1 + T(3)*cse2) + (cse3)*(cse3)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv)*(T(240)*Lx*cse2*d3Lx + T(360)*Lx*cse7*dLx + T(60)*cse0*d4Lx*dLx + T(240)*cse4*ddLx + T(120)*cse5*ddLx + T(4)*cse6*d5Lx) + cse3*(-T(1)/T(2)*xi + (T(1)/T(2))*xv)*(T(180)*cse0*cse7 + T(720)*cse1*cse2 + T(240)*cse5*dLx + T(20)*cse6*d4Lx + T(120)*(dLx)*(dLx)*(dLx)*(dLx));
       }
       dnf(ix, 4*fi + 1) *= element_length;
       dnf(ix, 4*fi + 2) *= element_length * element_length;

--- a/libhelfem/include/HIP3Basis_over_r.h
+++ b/libhelfem/include/HIP3Basis_over_r.h
@@ -11,8 +11,8 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#ifndef HELFEM_FEM_HIP3BASIS_OVER_R_H
-#define HELFEM_FEM_HIP3BASIS_OVER_R_H
+#ifndef LIB1DFEM_HIP3BASIS_OVER_R_H
+#define LIB1DFEM_HIP3BASIS_OVER_R_H
 
 #include <types.h>
 #include <LIPBasis_eval.h>
@@ -93,21 +93,15 @@ void eval_hip3_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
         case 0:
           switch (kind) {
           case 1: {
-            const T cse0 = T(4)*dLxi_v;
-            const T cse1 = xi*xv;
-            const T cse2 = (xi)*(xi);
-            const T cse3 = T(2)*ddLxi_v;
-            const T cse4 = (xv)*(xv);
-            const T cse5 = (dLxi_v)*(dLxi_v);
-            const T cse6 = T(10)*cse5;
-            R = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv - T(20)*cse1*cse5 + T(4)*cse1*ddLxi_v - cse2*cse3 + cse2*cse6 - cse3*cse4 + cse4*cse6 + T(1));
+            const T cse0 = -xi + xv;
+            R = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*(cse0*(T(10)*(dLxi_v)*(dLxi_v) - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1));
           } break;
           case 2: {
-            const T cse0 = T(2)*dLxi_v;
-            R = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0*(xi)*(xi) - cse0*(xv)*(xv) + T(4)*dLxi_v*xi*xv - T(1)/T(2)*xi + (T(1)/T(2))*xv);
+            const T cse0 = -xi + xv;
+            R = (Lx)*(Lx)*(Lx)*(Lx)*cse0*(-T(2)*cse0*dLxi_v + T(1)/T(2));
           } break;
           case 3: {
-            R = (Lx)*(Lx)*(Lx)*(Lx)*((T(1)/T(6))*(xi)*(xi) - T(1)/T(3)*xi*xv + (T(1)/T(6))*(xv)*(xv));
+            R = (Lx)*(Lx)*(Lx)*(Lx)*(-xi + xv)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv);
           } break;
           }
           break;
@@ -115,23 +109,17 @@ void eval_hip3_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
           switch (kind) {
           case 1: {
             const T cse0 = T(4)*dLxi_v;
-            const T cse1 = T(4)*ddLxi_v*xv;
+            const T cse1 = -xi + xv;
             const T cse2 = (dLxi_v)*(dLxi_v);
-            const T cse3 = T(20)*cse2*xi;
-            const T cse4 = (xi)*(xi);
-            const T cse5 = T(2)*ddLxi_v;
-            const T cse6 = (xv)*(xv);
-            const T cse7 = T(10)*cse2;
-            R = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0 - cse1 + T(20)*cse2*xv - cse3 + T(4)*ddLxi_v*xi) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(cse0*xi - cse0*xv + cse1*xi - cse3*xv - cse4*cse5 + cse4*cse7 - cse5*cse6 + cse6*cse7 + T(1));
+            R = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0 + cse1*(T(20)*cse2 - T(4)*ddLxi_v)) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(cse1*(-cse0 + cse1*(T(10)*cse2 - T(2)*ddLxi_v)) + T(1));
           } break;
           case 2: {
-            const T cse0 = T(4)*dLxi_v;
-            const T cse1 = T(2)*dLxi_v;
-            R = (Lx)*(Lx)*(Lx)*(Lx)*(cse0*xi - cse0*xv + T(1)/T(2)) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(-cse1*(xi)*(xi) - cse1*(xv)*(xv) + T(4)*dLxi_v*xi*xv - T(1)/T(2)*xi + (T(1)/T(2))*xv);
+            const T cse0 = -xi + xv;
+            const T cse1 = cse0*dLxi_v;
+            R = (Lx)*(Lx)*(Lx)*(Lx)*(T(1)/T(2) - T(4)*cse1) + T(4)*(Lx)*(Lx)*(Lx)*cse0*dLx*(T(1)/T(2) - T(2)*cse1);
           } break;
           case 3: {
-            const T cse0 = (T(1)/T(3))*xi;
-            R = (Lx)*(Lx)*(Lx)*(Lx)*(-cse0 + (T(1)/T(3))*xv) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(-cse0*xv + (T(1)/T(6))*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv));
+            R = (Lx)*(Lx)*(Lx)*(Lx)*(-T(1)/T(3)*xi + (T(1)/T(3))*xv) + T(4)*(Lx)*(Lx)*(Lx)*dLx*(-xi + xv)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv);
           } break;
           }
           break;
@@ -139,23 +127,18 @@ void eval_hip3_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
           switch (kind) {
           case 1: {
             const T cse0 = (dLxi_v)*(dLxi_v);
-            const T cse1 = T(4)*dLxi_v;
-            const T cse2 = T(4)*ddLxi_v*xv;
-            const T cse3 = T(20)*cse0*xi;
-            const T cse4 = (xi)*(xi);
-            const T cse5 = T(2)*ddLxi_v;
-            const T cse6 = (xv)*(xv);
-            const T cse7 = T(10)*cse0;
-            R = T(4)*(Lx)*(Lx)*(Lx)*(Lx)*(T(5)*cse0 - ddLxi_v) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(T(20)*cse0*xv - cse1 - cse2 - cse3 + T(4)*ddLxi_v*xi) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*(cse1*xi - cse1*xv + cse2*xi - cse3*xv - cse4*cse5 + cse4*cse7 - cse5*cse6 + cse6*cse7 + T(1));
+            const T cse1 = T(20)*cse0 - T(4)*ddLxi_v;
+            const T cse2 = T(4)*dLxi_v;
+            const T cse3 = -xi + xv;
+            R = (Lx)*(Lx)*(Lx)*(Lx)*cse1 + T(8)*(Lx)*(Lx)*(Lx)*dLx*(cse1*cse3 - cse2) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*(cse3*(-cse2 + cse3*(T(10)*cse0 - T(2)*ddLxi_v)) + T(1));
           } break;
           case 2: {
             const T cse0 = T(4)*dLxi_v;
-            const T cse1 = T(2)*dLxi_v;
-            R = -(Lx)*(Lx)*(Lx)*(Lx)*cse0 + T(8)*(Lx)*(Lx)*(Lx)*dLx*(cse0*xi - cse0*xv + T(1)/T(2)) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*(-cse1*(xi)*(xi) - cse1*(xv)*(xv) + T(4)*dLxi_v*xi*xv - T(1)/T(2)*xi + (T(1)/T(2))*xv);
+            const T cse1 = -xi + xv;
+            R = -(Lx)*(Lx)*(Lx)*(Lx)*cse0 + T(8)*(Lx)*(Lx)*(Lx)*dLx*(-cse0*cse1 + T(1)/T(2)) + T(4)*(Lx)*(Lx)*cse1*(Lx*ddLx + T(3)*(dLx)*(dLx))*(-T(2)*cse1*dLxi_v + T(1)/T(2));
           } break;
           case 3: {
-            const T cse0 = (T(1)/T(3))*xi;
-            R = (T(1)/T(3))*(Lx)*(Lx)*(Lx)*(Lx) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(-cse0 + (T(1)/T(3))*xv) + T(4)*(Lx)*(Lx)*(Lx*ddLx + T(3)*(dLx)*(dLx))*(-cse0*xv + (T(1)/T(6))*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv));
+            R = (T(1)/T(3))*(Lx)*(Lx)*(Lx)*(Lx) + T(8)*(Lx)*(Lx)*(Lx)*dLx*(-T(1)/T(3)*xi + (T(1)/T(3))*xv) + T(4)*(Lx)*(Lx)*(-xi + xv)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv)*(Lx*ddLx + T(3)*(dLx)*(dLx));
           } break;
           }
           break;
@@ -171,45 +154,19 @@ void eval_hip3_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
         case 0:
           switch (kind) {
           case 0: {
-            const T cse0 = T(4)*dLxi_v;
-            const T cse1 = xi*xv;
-            const T cse2 = (xi)*(xi)*(xi);
-            const T cse3 = (T(2)/T(3))*d3Lxi_v;
-            const T cse4 = (xv)*(xv)*(xv);
-            const T cse5 = (xi)*(xi);
-            const T cse6 = T(2)*ddLxi_v;
-            const T cse7 = (xv)*(xv);
-            const T cse8 = T(2)*d3Lxi_v;
-            const T cse9 = cse7*xi;
-            const T cse10 = cse5*xv;
-            const T cse11 = dLxi_v*ddLxi_v;
-            const T cse12 = T(10)*cse11;
-            const T cse13 = (dLxi_v)*(dLxi_v);
-            const T cse14 = T(10)*cse13;
-            const T cse15 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-            const T cse16 = T(20)*cse15;
-            const T cse17 = T(30)*cse11;
-            const T cse18 = T(60)*cse15;
-            R = (pr)*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(3))*(cse0*xi - cse0*xv - T(20)*cse1*cse13 + T(4)*cse1*ddLxi_v + cse10*cse17 - cse10*cse18 - cse10*cse8 - cse12*cse2 + cse12*cse4 + cse14*cse5 + cse14*cse7 + cse16*cse2 - cse16*cse4 - cse17*cse9 + cse18*cse9 + cse2*cse3 - cse3*cse4 - cse5*cse6 - cse6*cse7 + cse8*cse9 + T(1))/std::pow(xi + T(1), T(4));
+            const T cse0 = -xi + xv;
+            R = (pr)*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(3))*(cse0*(cse0*(cse0*(-T(2)/T(3)*d3Lxi_v - T(20)*(dLxi_v)*(dLxi_v)*(dLxi_v) + T(10)*dLxi_v*ddLxi_v) + T(10)*(dLxi_v)*(dLxi_v) - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1))/std::pow(xi + T(1), T(4));
           } break;
           case 1: {
-            const T cse0 = (xi)*(xi);
-            const T cse1 = T(4)*dLxi_v;
-            const T cse2 = (xv)*(xv);
-            const T cse3 = (xi)*(xi)*(xi);
-            const T cse4 = (xv)*(xv)*(xv);
-            const T cse5 = (dLxi_v)*(dLxi_v);
-            R = (pr)*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(3))*(-cse0*cse1 + T(30)*cse0*cse5*xv - T(6)*cse0*ddLxi_v*xv - cse1*cse2 - T(30)*cse2*cse5*xi + T(6)*cse2*ddLxi_v*xi - T(10)*cse3*cse5 + T(2)*cse3*ddLxi_v + T(10)*cse4*cse5 - T(2)*cse4*ddLxi_v + T(8)*dLxi_v*xi*xv - xi + xv)/std::pow(xi + T(1), T(4));
+            const T cse0 = -xi + xv;
+            R = cse0*(pr)*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(3))*(cse0*(cse0*(T(10)*(dLxi_v)*(dLxi_v) - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1))/std::pow(xi + T(1), T(4));
           } break;
           case 2: {
-            const T cse0 = (xi)*(xi);
-            const T cse1 = (xv)*(xv);
-            const T cse2 = T(2)*dLxi_v;
-            const T cse3 = T(6)*dLxi_v;
-            R = (pr)*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(3))*(-cse0*cse3*xv + (T(1)/T(2))*cse0 + cse1*cse3*xi + (T(1)/T(2))*cse1 + cse2*(xi)*(xi)*(xi) - cse2*(xv)*(xv)*(xv) - xi*xv)/std::pow(xi + T(1), T(4));
+            const T cse0 = -xi + xv;
+            R = (cse0)*(cse0)*(pr)*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(3))*(-T(2)*cse0*dLxi_v + T(1)/T(2))/std::pow(xi + T(1), T(4));
           } break;
           case 3: {
-            R = (pr)*(pr)*(pr)*(pr)*std::pow(xv + T(1), T(3))*(-T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(2))*(xi)*(xi)*xv - T(1)/T(2)*xi*(xv)*(xv) + (T(1)/T(6))*(xv)*(xv)*(xv))/std::pow(xi + T(1), T(4));
+            R = (pr)*(pr)*(pr)*(pr)*std::pow(-xi + xv, T(2))*(-T(1)/T(6)*xi + (T(1)/T(6))*xv)*std::pow(xv + T(1), T(3))/std::pow(xi + T(1), T(4));
           } break;
           }
           break;
@@ -220,70 +177,37 @@ void eval_hip3_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
             const T cse1 = xv + T(1);
             const T cse2 = (cse1)*(cse1)*(cse1);
             const T cse3 = T(4)*dLxi_v;
-            const T cse4 = T(4)*ddLxi_v*xv;
-            const T cse5 = (xi)*(xi);
-            const T cse6 = T(2)*d3Lxi_v;
-            const T cse7 = cse5*cse6;
-            const T cse8 = (xv)*(xv);
-            const T cse9 = cse6*cse8;
-            const T cse10 = (dLxi_v)*(dLxi_v);
-            const T cse11 = T(20)*cse10*xi;
-            const T cse12 = dLxi_v*ddLxi_v;
-            const T cse13 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-            const T cse14 = T(60)*cse13;
-            const T cse15 = cse14*cse5;
-            const T cse16 = cse14*cse8;
-            const T cse17 = (xi)*(xi)*(xi);
-            const T cse18 = (T(2)/T(3))*d3Lxi_v;
-            const T cse19 = (xv)*(xv)*(xv);
-            const T cse20 = T(2)*ddLxi_v;
-            const T cse21 = T(10)*cse12;
-            const T cse22 = T(10)*cse10;
-            const T cse23 = T(20)*cse13;
-            const T cse24 = T(30)*cse12;
-            const T cse25 = -cse11*xv - cse15*xv + cse16*xi + cse17*cse18 - cse17*cse21 + cse17*cse23 - cse18*cse19 + cse19*cse21 - cse19*cse23 - cse20*cse5 - cse20*cse8 + cse22*cse5 + cse22*cse8 + cse24*cse5*xv - cse24*cse8*xi + cse3*xi - cse3*xv + cse4*xi - cse7*xv + cse9*xi + T(1);
-            R = (T(3)*cse0*(cse1)*(cse1)*cse25 + cse0*cse2*(T(20)*cse10*xv - cse11 - T(60)*cse12*xi*xv + T(120)*cse13*xi*xv - cse15 - cse16 - cse3 - cse4 + T(30)*cse5*dLxi_v*ddLxi_v - cse7 + T(30)*cse8*dLxi_v*ddLxi_v - cse9 + T(4)*d3Lxi_v*xi*xv + T(4)*ddLxi_v*xi) + T(4)*cse2*cse25*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
+            const T cse4 = -xi + xv;
+            const T cse5 = (dLxi_v)*(dLxi_v);
+            const T cse6 = (dLxi_v)*(dLxi_v)*(dLxi_v);
+            const T cse7 = cse4*(-cse3 + cse4*(cse4*(-T(20)*cse6 - T(2)/T(3)*d3Lxi_v + T(10)*dLxi_v*ddLxi_v) + T(10)*cse5 - T(2)*ddLxi_v)) + T(1);
+            R = (T(3)*cse0*(cse1)*(cse1)*cse7 + cse0*cse2*(-cse3 + cse4*(cse4*(-T(60)*cse6 - T(2)*d3Lxi_v + T(30)*dLxi_v*ddLxi_v) + T(20)*cse5 - T(4)*ddLxi_v)) + T(4)*cse2*cse7*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
           } break;
           case 1: {
             const T cse0 = (pr)*(pr)*(pr)*(pr);
             const T cse1 = xv + T(1);
             const T cse2 = (cse1)*(cse1)*(cse1);
-            const T cse3 = T(8)*dLxi_v;
-            const T cse4 = xi*xv;
-            const T cse5 = (xi)*(xi);
-            const T cse6 = T(6)*ddLxi_v;
-            const T cse7 = cse5*cse6;
-            const T cse8 = (xv)*(xv);
-            const T cse9 = (dLxi_v)*(dLxi_v);
-            const T cse10 = T(30)*cse9;
-            const T cse11 = cse10*cse8;
-            const T cse12 = T(4)*dLxi_v;
-            const T cse13 = (xi)*(xi)*(xi);
-            const T cse14 = (xv)*(xv)*(xv);
-            const T cse15 = -cse11*xi - cse12*cse5 - cse12*cse8 - T(10)*cse13*cse9 + T(2)*cse13*ddLxi_v + T(10)*cse14*cse9 - T(2)*cse14*ddLxi_v + T(30)*cse5*cse9*xv - cse7*xv + T(6)*cse8*ddLxi_v*xi + T(8)*dLxi_v*xi*xv - xi + xv;
-            R = (T(3)*cse0*(cse1)*(cse1)*cse15 + cse0*cse2*(cse10*cse5 + cse11 + cse3*xi - cse3*xv - T(60)*cse4*cse9 + T(12)*cse4*ddLxi_v - cse6*cse8 - cse7 + T(1)) + T(4)*cse15*cse2*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
+            const T cse3 = -xi + xv;
+            const T cse4 = (dLxi_v)*(dLxi_v);
+            const T cse5 = cse3*(cse3*(cse3*(T(10)*cse4 - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1));
+            R = (T(3)*cse0*(cse1)*(cse1)*cse5 + cse0*cse2*(cse3*(cse3*(T(30)*cse4 - T(6)*ddLxi_v) - T(8)*dLxi_v) + T(1)) + T(4)*cse2*cse5*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
           } break;
           case 2: {
             const T cse0 = (pr)*(pr)*(pr)*(pr);
-            const T cse1 = xv + T(1);
-            const T cse2 = (cse1)*(cse1)*(cse1);
-            const T cse3 = (xi)*(xi);
-            const T cse4 = T(6)*dLxi_v;
-            const T cse5 = cse3*cse4;
-            const T cse6 = (xv)*(xv);
-            const T cse7 = cse4*cse6;
-            const T cse8 = T(2)*dLxi_v;
-            const T cse9 = (T(1)/T(2))*cse3 - cse5*xv + (T(1)/T(2))*cse6 + cse7*xi + cse8*(xi)*(xi)*(xi) - cse8*(xv)*(xv)*(xv) - xi*xv;
-            R = (T(3)*cse0*(cse1)*(cse1)*cse9 + cse0*cse2*(-cse5 - cse7 + T(12)*dLxi_v*xi*xv - xi + xv) + T(4)*cse2*cse9*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
+            const T cse1 = -xi + xv;
+            const T cse2 = xv + T(1);
+            const T cse3 = (cse2)*(cse2)*(cse2);
+            const T cse4 = cse1*dLxi_v;
+            const T cse5 = (cse1)*(cse1)*(T(1)/T(2) - T(2)*cse4);
+            R = (cse0*cse1*cse3*(T(1) - T(6)*cse4) + T(3)*cse0*(cse2)*(cse2)*cse5 + T(4)*cse3*cse5*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
           } break;
           case 3: {
             const T cse0 = (pr)*(pr)*(pr)*(pr);
-            const T cse1 = xv + T(1);
-            const T cse2 = (cse1)*(cse1)*(cse1);
-            const T cse3 = (xi)*(xi);
-            const T cse4 = (T(1)/T(2))*(xv)*(xv);
-            const T cse5 = (T(1)/T(2))*cse3*xv - cse4*xi - T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv)*(xv);
-            R = (T(3)*cse0*(cse1)*(cse1)*cse5 + cse0*cse2*((T(1)/T(2))*cse3 + cse4 - xi*xv) + T(4)*cse2*cse5*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
+            const T cse1 = -xi + xv;
+            const T cse2 = xv + T(1);
+            const T cse3 = (cse2)*(cse2)*(cse2);
+            const T cse4 = (cse1)*(cse1)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv);
+            R = (cse0*cse1*cse3*(-T(1)/T(2)*xi + (T(1)/T(2))*xv) + T(3)*cse0*(cse2)*(cse2)*cse4 + T(4)*cse3*cse4*dpr*(pr)*(pr)*(pr))/std::pow(xi + T(1), T(4));
           } break;
           }
           break;
@@ -291,94 +215,58 @@ void eval_hip3_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
           switch (kind) {
           case 0: {
             const T cse0 = (pr)*(pr)*(pr)*(pr);
-            const T cse1 = d3Lxi_v*xi;
-            const T cse2 = d3Lxi_v*xv;
-            const T cse3 = (dLxi_v)*(dLxi_v);
-            const T cse4 = dLxi_v*ddLxi_v;
-            const T cse5 = T(15)*cse4;
-            const T cse6 = (dLxi_v)*(dLxi_v)*(dLxi_v);
-            const T cse7 = T(30)*cse6;
-            const T cse8 = xv + T(1);
-            const T cse9 = (cse8)*(cse8)*(cse8);
-            const T cse10 = T(4)*cse9;
-            const T cse11 = (cse8)*(cse8);
-            const T cse12 = T(4)*dLxi_v;
-            const T cse13 = T(4)*ddLxi_v*xv;
-            const T cse14 = (xi)*(xi);
-            const T cse15 = T(2)*d3Lxi_v;
-            const T cse16 = (xv)*(xv);
-            const T cse17 = T(20)*cse3*xi;
-            const T cse18 = T(60)*cse6;
-            const T cse19 = cse14*cse18;
-            const T cse20 = cse16*cse18;
-            const T cse21 = -cse12 - cse13 - cse14*cse15 + T(30)*cse14*dLxi_v*ddLxi_v - cse15*cse16 + T(30)*cse16*dLxi_v*ddLxi_v - cse17 - cse19 - cse20 + T(20)*cse3*xv - T(60)*cse4*xi*xv + T(120)*cse6*xi*xv + T(4)*d3Lxi_v*xi*xv + T(4)*ddLxi_v*xi;
-            const T cse22 = T(6)*cse0;
-            const T cse23 = dpr*(pr)*(pr)*(pr);
-            const T cse24 = (xi)*(xi)*(xi);
-            const T cse25 = (T(2)/T(3))*d3Lxi_v;
-            const T cse26 = (xv)*(xv)*(xv);
-            const T cse27 = T(2)*ddLxi_v;
-            const T cse28 = T(10)*cse4;
-            const T cse29 = T(10)*cse3;
-            const T cse30 = T(20)*cse6;
-            const T cse31 = T(30)*cse4;
-            const T cse32 = T(2)*cse1*cse16 + cse12*xi - cse12*xv + cse13*xi - T(2)*cse14*cse2 - cse14*cse27 + cse14*cse29 + cse14*cse31*xv - cse16*cse27 + cse16*cse29 - cse16*cse31*xi - cse17*xv - cse19*xv + cse20*xi + cse24*cse25 - cse24*cse28 + cse24*cse30 - cse25*cse26 + cse26*cse28 - cse26*cse30 + T(1);
-            R = (cse0*cse10*(cse1 - cse2 + T(5)*cse3 - cse5*xi + cse5*xv + cse7*xi - cse7*xv - ddLxi_v) + cse10*cse32*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)) + cse11*cse21*cse22 + T(24)*cse11*cse23*cse32 + T(8)*cse21*cse23*cse9 + cse22*cse32*cse8)/std::pow(xi + T(1), T(4));
+            const T cse1 = xv + T(1);
+            const T cse2 = (cse1)*(cse1)*(cse1);
+            const T cse3 = -xi + xv;
+            const T cse4 = (dLxi_v)*(dLxi_v)*(dLxi_v);
+            const T cse5 = (dLxi_v)*(dLxi_v);
+            const T cse6 = T(20)*cse5 - T(4)*ddLxi_v;
+            const T cse7 = (cse1)*(cse1);
+            const T cse8 = T(4)*dLxi_v;
+            const T cse9 = cse3*(cse3*(-T(60)*cse4 - T(2)*d3Lxi_v + T(30)*dLxi_v*ddLxi_v) + cse6) - cse8;
+            const T cse10 = T(6)*cse0;
+            const T cse11 = dpr*(pr)*(pr)*(pr);
+            const T cse12 = cse3*(cse3*(cse3*(-T(20)*cse4 - T(2)/T(3)*d3Lxi_v + T(10)*dLxi_v*ddLxi_v) + T(10)*cse5 - T(2)*ddLxi_v) - cse8) + T(1);
+            R = (cse0*cse2*(cse3*(-T(120)*cse4 - T(4)*d3Lxi_v + T(60)*dLxi_v*ddLxi_v) + cse6) + cse1*cse10*cse12 + cse10*cse7*cse9 + T(24)*cse11*cse12*cse7 + T(8)*cse11*cse2*cse9 + T(4)*cse12*cse2*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)))/std::pow(xi + T(1), T(4));
           } break;
           case 1: {
             const T cse0 = (pr)*(pr)*(pr)*(pr);
-            const T cse1 = (dLxi_v)*(dLxi_v);
-            const T cse2 = xv + T(1);
-            const T cse3 = (cse2)*(cse2)*(cse2);
-            const T cse4 = T(4)*cse3;
-            const T cse5 = (cse2)*(cse2);
-            const T cse6 = T(8)*dLxi_v;
-            const T cse7 = xi*xv;
-            const T cse8 = (xi)*(xi);
-            const T cse9 = T(6)*ddLxi_v;
-            const T cse10 = cse8*cse9;
-            const T cse11 = (xv)*(xv);
-            const T cse12 = T(30)*cse1;
-            const T cse13 = cse11*cse12;
-            const T cse14 = -T(60)*cse1*cse7 - cse10 - cse11*cse9 + cse12*cse8 + cse13 + cse6*xi - cse6*xv + T(12)*cse7*ddLxi_v + T(1);
-            const T cse15 = T(6)*cse0;
-            const T cse16 = dpr*(pr)*(pr)*(pr);
-            const T cse17 = T(4)*dLxi_v;
-            const T cse18 = (xi)*(xi)*(xi);
-            const T cse19 = (xv)*(xv)*(xv);
-            const T cse20 = -T(10)*cse1*cse18 + T(10)*cse1*cse19 + T(30)*cse1*cse8*xv - cse10*xv - cse11*cse17 + T(6)*cse11*ddLxi_v*xi - cse13*xi - cse17*cse8 + T(2)*cse18*ddLxi_v - T(2)*cse19*ddLxi_v + T(8)*dLxi_v*xi*xv - xi + xv;
-            R = (cse0*cse4*(-T(15)*cse1*xi + T(15)*cse1*xv - T(2)*dLxi_v + T(3)*ddLxi_v*xi - T(3)*ddLxi_v*xv) + cse14*cse15*cse5 + T(8)*cse14*cse16*cse3 + cse15*cse2*cse20 + T(24)*cse16*cse20*cse5 + cse20*cse4*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)))/std::pow(xi + T(1), T(4));
+            const T cse1 = xv + T(1);
+            const T cse2 = (cse1)*(cse1)*(cse1);
+            const T cse3 = T(8)*dLxi_v;
+            const T cse4 = -xi + xv;
+            const T cse5 = (dLxi_v)*(dLxi_v);
+            const T cse6 = (cse1)*(cse1);
+            const T cse7 = cse4*(-cse3 + cse4*(T(30)*cse5 - T(6)*ddLxi_v)) + T(1);
+            const T cse8 = T(6)*cse0;
+            const T cse9 = dpr*(pr)*(pr)*(pr);
+            const T cse10 = cse4*(cse4*(cse4*(T(10)*cse5 - T(2)*ddLxi_v) - T(4)*dLxi_v) + T(1));
+            R = (cse0*cse2*(-cse3 + cse4*(T(60)*cse5 - T(12)*ddLxi_v)) + cse1*cse10*cse8 + T(4)*cse10*cse2*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)) + T(24)*cse10*cse6*cse9 + T(8)*cse2*cse7*cse9 + cse6*cse7*cse8)/std::pow(xi + T(1), T(4));
           } break;
           case 2: {
             const T cse0 = (pr)*(pr)*(pr)*(pr);
             const T cse1 = xv + T(1);
             const T cse2 = (cse1)*(cse1)*(cse1);
-            const T cse3 = T(12)*dLxi_v;
-            const T cse4 = (cse1)*(cse1);
-            const T cse5 = (xi)*(xi);
-            const T cse6 = T(6)*dLxi_v;
-            const T cse7 = cse5*cse6;
-            const T cse8 = (xv)*(xv);
-            const T cse9 = cse6*cse8;
-            const T cse10 = -cse7 - cse9 + T(12)*dLxi_v*xi*xv - xi + xv;
-            const T cse11 = T(6)*cse0;
-            const T cse12 = dpr*(pr)*(pr)*(pr);
-            const T cse13 = T(2)*dLxi_v;
-            const T cse14 = cse13*(xi)*(xi)*(xi) - cse13*(xv)*(xv)*(xv) + (T(1)/T(2))*cse5 - cse7*xv + (T(1)/T(2))*cse8 + cse9*xi - xi*xv;
-            R = (cse0*cse2*(cse3*xi - cse3*xv + T(1)) + cse1*cse11*cse14 + cse10*cse11*cse4 + T(8)*cse10*cse12*cse2 + T(24)*cse12*cse14*cse4 + T(4)*cse14*cse2*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)))/std::pow(xi + T(1), T(4));
+            const T cse3 = -xi + xv;
+            const T cse4 = cse3*dLxi_v;
+            const T cse5 = (cse1)*(cse1);
+            const T cse6 = T(6)*cse0;
+            const T cse7 = cse3*(T(1) - T(6)*cse4);
+            const T cse8 = (cse3)*(cse3)*(T(1)/T(2) - T(2)*cse4);
+            const T cse9 = dpr*(pr)*(pr)*(pr);
+            R = (cse0*cse2*(T(1) - T(12)*cse4) + cse1*cse6*cse8 + T(8)*cse2*cse7*cse9 + T(4)*cse2*cse8*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)) + cse5*cse6*cse7 + T(24)*cse5*cse8*cse9)/std::pow(xi + T(1), T(4));
           } break;
           case 3: {
-            const T cse0 = (pr)*(pr)*(pr)*(pr);
-            const T cse1 = xv + T(1);
-            const T cse2 = (cse1)*(cse1)*(cse1);
-            const T cse3 = (cse1)*(cse1);
-            const T cse4 = (xi)*(xi);
-            const T cse5 = (T(1)/T(2))*(xv)*(xv);
-            const T cse6 = (T(1)/T(2))*cse4 + cse5 - xi*xv;
-            const T cse7 = T(6)*cse0;
+            const T cse0 = xv + T(1);
+            const T cse1 = (cse0)*(cse0)*(cse0);
+            const T cse2 = (pr)*(pr)*(pr)*(pr);
+            const T cse3 = -xi + xv;
+            const T cse4 = cse2*cse3;
+            const T cse5 = (cse0)*(cse0);
+            const T cse6 = -T(1)/T(2)*xi + (T(1)/T(2))*xv;
+            const T cse7 = (cse3)*(cse3)*(-T(1)/T(6)*xi + (T(1)/T(6))*xv);
             const T cse8 = dpr*(pr)*(pr)*(pr);
-            const T cse9 = (T(1)/T(2))*cse4*xv - cse5*xi - T(1)/T(6)*(xi)*(xi)*(xi) + (T(1)/T(6))*(xv)*(xv)*(xv);
-            R = (cse0*cse2*(-xi + xv) + cse1*cse7*cse9 + T(8)*cse2*cse6*cse8 + T(4)*cse2*cse9*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)) + cse3*cse6*cse7 + T(24)*cse3*cse8*cse9)/std::pow(xi + T(1), T(4));
+            R = (T(6)*cse0*cse2*cse7 + T(8)*cse1*cse3*cse6*cse8 + cse1*cse4 + T(4)*cse1*cse7*(pr)*(pr)*(ddpr*pr + T(3)*(dpr)*(dpr)) + T(6)*cse4*cse5*cse6 + T(24)*cse5*cse7*cse8)/std::pow(xi + T(1), T(4));
           } break;
           }
           break;

--- a/libhelfem/include/HIPBasis_eval.h
+++ b/libhelfem/include/HIPBasis_eval.h
@@ -11,12 +11,11 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#ifndef HELFEM_FEM_HIPBASIS_EVAL_H
-#define HELFEM_FEM_HIPBASIS_EVAL_H
+#ifndef LIB1DFEM_HIPBASIS_EVAL_H
+#define LIB1DFEM_HIPBASIS_EVAL_H
 
 #include <types.h>
 #include <LIPBasis_eval.h>
-#include <cmath>
 #include <sstream>
 #include <stdexcept>
 
@@ -56,8 +55,7 @@ case (0): {
       const T Lx = Lx_all(ix, fi);
       const T dLxi_v = lipxi(fi);
       {
-        const T cse0 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = (Lx)*(Lx)*(cse0*xi - cse0*xv + T(1));
+        dnf(ix, 2*fi + 0) = (Lx)*(Lx)*(-T(2)*dLxi_v*(-xi + xv) + T(1));
       }
       {
         dnf(ix, 2*fi + 1) = (Lx)*(Lx)*(-xi + xv);
@@ -81,7 +79,7 @@ case (1): {
       const T dLxi_v = lipxi(fi);
       {
         const T cse0 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -(Lx)*(Lx)*cse0 + T(2)*Lx*dLx*(cse0*xi - cse0*xv + T(1));
+        dnf(ix, 2*fi + 0) = -(Lx)*(Lx)*cse0 + T(2)*Lx*dLx*(-cse0*(-xi + xv) + T(1));
       }
       {
         dnf(ix, 2*fi + 1) = (Lx)*(Lx) + T(2)*Lx*dLx*(-xi + xv);
@@ -107,8 +105,7 @@ case (2): {
       const T ddLx = ddLx_all(ix, fi);
       const T dLxi_v = lipxi(fi);
       {
-        const T cse0 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -T(8)*Lx*dLx*dLxi_v + (T(2)*Lx*ddLx + T(2)*(dLx)*(dLx))*(cse0*xi - cse0*xv + T(1));
+        dnf(ix, 2*fi + 0) = -T(8)*Lx*dLx*dLxi_v + (T(2)*Lx*ddLx + T(2)*(dLx)*(dLx))*(-T(2)*dLxi_v*(-xi + xv) + T(1));
       }
       {
         dnf(ix, 2*fi + 1) = T(4)*Lx*dLx + (-xi + xv)*(T(2)*Lx*ddLx + T(2)*(dLx)*(dLx));
@@ -139,7 +136,7 @@ case (3): {
       {
         const T cse0 = T(6)*ddLx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(6)*(dLx)*(dLx)) + (T(2)*Lx*d3Lx + cse0*dLx)*(cse1*xi - cse1*xv + T(1));
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(6)*(dLx)*(dLx)) + (T(2)*Lx*d3Lx + cse0*dLx)*(-cse1*(-xi + xv) + T(1));
       }
       {
         const T cse0 = T(6)*ddLx;
@@ -174,7 +171,7 @@ case (4): {
       {
         const T cse0 = T(8)*d3Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(24)*dLx*ddLx) + (T(2)*Lx*d4Lx + cse0*dLx + T(6)*(ddLx)*(ddLx))*(cse1*xi - cse1*xv + T(1));
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(24)*dLx*ddLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d4Lx + cse0*dLx + T(6)*(ddLx)*(ddLx));
       }
       {
         const T cse0 = T(8)*d3Lx;
@@ -212,7 +209,7 @@ case (5): {
       {
         const T cse0 = T(10)*d4Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(40)*d3Lx*dLx + T(30)*(ddLx)*(ddLx)) + (T(2)*Lx*d5Lx + cse0*dLx + T(20)*d3Lx*ddLx)*(cse1*xi - cse1*xv + T(1));
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(40)*d3Lx*dLx + T(30)*(ddLx)*(ddLx)) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d5Lx + cse0*dLx + T(20)*d3Lx*ddLx);
       }
       {
         const T cse0 = T(10)*d4Lx;
@@ -253,7 +250,7 @@ case (6): {
       {
         const T cse0 = T(12)*d5Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(120)*d3Lx*ddLx + T(60)*d4Lx*dLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d6Lx + cse0*dLx + T(20)*(d3Lx)*(d3Lx) + T(30)*d4Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(120)*d3Lx*ddLx + T(60)*d4Lx*dLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d6Lx + cse0*dLx + T(20)*(d3Lx)*(d3Lx) + T(30)*d4Lx*ddLx);
       }
       {
         const T cse0 = T(12)*d5Lx;
@@ -297,7 +294,7 @@ case (7): {
       {
         const T cse0 = T(14)*d6Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(140)*(d3Lx)*(d3Lx) + T(210)*d4Lx*ddLx + T(84)*d5Lx*dLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d7Lx + cse0*dLx + T(70)*d3Lx*d4Lx + T(42)*d5Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(140)*(d3Lx)*(d3Lx) + T(210)*d4Lx*ddLx + T(84)*d5Lx*dLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d7Lx + cse0*dLx + T(70)*d3Lx*d4Lx + T(42)*d5Lx*ddLx);
       }
       {
         const T cse0 = T(14)*d6Lx;
@@ -344,7 +341,7 @@ case (8): {
       {
         const T cse0 = T(16)*d7Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(560)*d3Lx*d4Lx + T(336)*d5Lx*ddLx + T(112)*d6Lx*dLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d8Lx + cse0*dLx + T(112)*d3Lx*d5Lx + T(70)*(d4Lx)*(d4Lx) + T(56)*d6Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(560)*d3Lx*d4Lx + T(336)*d5Lx*ddLx + T(112)*d6Lx*dLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d8Lx + cse0*dLx + T(112)*d3Lx*d5Lx + T(70)*(d4Lx)*(d4Lx) + T(56)*d6Lx*ddLx);
       }
       {
         const T cse0 = T(16)*d7Lx;
@@ -394,7 +391,7 @@ case (9): {
       {
         const T cse0 = T(18)*d8Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1008)*d3Lx*d5Lx + T(630)*(d4Lx)*(d4Lx) + T(504)*d6Lx*ddLx + T(144)*d7Lx*dLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d9Lx + cse0*dLx + T(168)*d3Lx*d6Lx + T(252)*d4Lx*d5Lx + T(72)*d7Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1008)*d3Lx*d5Lx + T(630)*(d4Lx)*(d4Lx) + T(504)*d6Lx*ddLx + T(144)*d7Lx*dLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d9Lx + cse0*dLx + T(168)*d3Lx*d6Lx + T(252)*d4Lx*d5Lx + T(72)*d7Lx*ddLx);
       }
       {
         const T cse0 = T(18)*d8Lx;
@@ -447,7 +444,7 @@ case (10): {
       {
         const T cse0 = T(20)*d9Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1680)*d3Lx*d6Lx + T(2520)*d4Lx*d5Lx + T(720)*d7Lx*ddLx + T(180)*d8Lx*dLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d10Lx + cse0*dLx + T(240)*d3Lx*d7Lx + T(420)*d4Lx*d6Lx + T(252)*(d5Lx)*(d5Lx) + T(90)*d8Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1680)*d3Lx*d6Lx + T(2520)*d4Lx*d5Lx + T(720)*d7Lx*ddLx + T(180)*d8Lx*dLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d10Lx + cse0*dLx + T(240)*d3Lx*d7Lx + T(420)*d4Lx*d6Lx + T(252)*(d5Lx)*(d5Lx) + T(90)*d8Lx*ddLx);
       }
       {
         const T cse0 = T(20)*d9Lx;
@@ -503,7 +500,7 @@ case (11): {
       {
         const T cse0 = T(22)*d10Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(2640)*d3Lx*d7Lx + T(4620)*d4Lx*d6Lx + T(2772)*(d5Lx)*(d5Lx) + T(990)*d8Lx*ddLx + T(220)*d9Lx*dLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d11Lx + cse0*dLx + T(330)*d3Lx*d8Lx + T(660)*d4Lx*d7Lx + T(924)*d5Lx*d6Lx + T(110)*d9Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(2640)*d3Lx*d7Lx + T(4620)*d4Lx*d6Lx + T(2772)*(d5Lx)*(d5Lx) + T(990)*d8Lx*ddLx + T(220)*d9Lx*dLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d11Lx + cse0*dLx + T(330)*d3Lx*d8Lx + T(660)*d4Lx*d7Lx + T(924)*d5Lx*d6Lx + T(110)*d9Lx*ddLx);
       }
       {
         const T cse0 = T(22)*d10Lx;
@@ -562,7 +559,7 @@ case (12): {
       {
         const T cse0 = T(24)*d11Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(264)*d10Lx*dLx + T(3960)*d3Lx*d8Lx + T(7920)*d4Lx*d7Lx + T(11088)*d5Lx*d6Lx + T(1320)*d9Lx*ddLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d12Lx + cse0*dLx + T(132)*d10Lx*ddLx + T(440)*d3Lx*d9Lx + T(990)*d4Lx*d8Lx + T(1584)*d5Lx*d7Lx + T(924)*(d6Lx)*(d6Lx));
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(264)*d10Lx*dLx + T(3960)*d3Lx*d8Lx + T(7920)*d4Lx*d7Lx + T(11088)*d5Lx*d6Lx + T(1320)*d9Lx*ddLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d12Lx + cse0*dLx + T(132)*d10Lx*ddLx + T(440)*d3Lx*d9Lx + T(990)*d4Lx*d8Lx + T(1584)*d5Lx*d7Lx + T(924)*(d6Lx)*(d6Lx));
       }
       {
         const T cse0 = T(24)*d11Lx;
@@ -624,7 +621,7 @@ case (13): {
       {
         const T cse0 = T(26)*d12Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1716)*d10Lx*ddLx + T(312)*d11Lx*dLx + T(5720)*d3Lx*d9Lx + T(12870)*d4Lx*d8Lx + T(20592)*d5Lx*d7Lx + T(12012)*(d6Lx)*(d6Lx)) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d13Lx + cse0*dLx + T(572)*d10Lx*d3Lx + T(156)*d11Lx*ddLx + T(1430)*d4Lx*d9Lx + T(2574)*d5Lx*d8Lx + T(3432)*d6Lx*d7Lx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1716)*d10Lx*ddLx + T(312)*d11Lx*dLx + T(5720)*d3Lx*d9Lx + T(12870)*d4Lx*d8Lx + T(20592)*d5Lx*d7Lx + T(12012)*(d6Lx)*(d6Lx)) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d13Lx + cse0*dLx + T(572)*d10Lx*d3Lx + T(156)*d11Lx*ddLx + T(1430)*d4Lx*d9Lx + T(2574)*d5Lx*d8Lx + T(3432)*d6Lx*d7Lx);
       }
       {
         const T cse0 = T(26)*d12Lx;
@@ -689,7 +686,7 @@ case (14): {
       {
         const T cse0 = T(28)*d13Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(8008)*d10Lx*d3Lx + T(2184)*d11Lx*ddLx + T(364)*d12Lx*dLx + T(20020)*d4Lx*d9Lx + T(36036)*d5Lx*d8Lx + T(48048)*d6Lx*d7Lx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d14Lx + cse0*dLx + T(2002)*d10Lx*d4Lx + T(728)*d11Lx*d3Lx + T(182)*d12Lx*ddLx + T(4004)*d5Lx*d9Lx + T(6006)*d6Lx*d8Lx + T(3432)*(d7Lx)*(d7Lx));
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(8008)*d10Lx*d3Lx + T(2184)*d11Lx*ddLx + T(364)*d12Lx*dLx + T(20020)*d4Lx*d9Lx + T(36036)*d5Lx*d8Lx + T(48048)*d6Lx*d7Lx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d14Lx + cse0*dLx + T(2002)*d10Lx*d4Lx + T(728)*d11Lx*d3Lx + T(182)*d12Lx*ddLx + T(4004)*d5Lx*d9Lx + T(6006)*d6Lx*d8Lx + T(3432)*(d7Lx)*(d7Lx));
       }
       {
         const T cse0 = T(28)*d13Lx;
@@ -757,7 +754,7 @@ case (15): {
       {
         const T cse0 = T(30)*d14Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(30030)*d10Lx*d4Lx + T(10920)*d11Lx*d3Lx + T(2730)*d12Lx*ddLx + T(420)*d13Lx*dLx + T(60060)*d5Lx*d9Lx + T(90090)*d6Lx*d8Lx + T(51480)*(d7Lx)*(d7Lx)) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d15Lx + cse0*dLx + T(6006)*d10Lx*d5Lx + T(2730)*d11Lx*d4Lx + T(910)*d12Lx*d3Lx + T(210)*d13Lx*ddLx + T(10010)*d6Lx*d9Lx + T(12870)*d7Lx*d8Lx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(30030)*d10Lx*d4Lx + T(10920)*d11Lx*d3Lx + T(2730)*d12Lx*ddLx + T(420)*d13Lx*dLx + T(60060)*d5Lx*d9Lx + T(90090)*d6Lx*d8Lx + T(51480)*(d7Lx)*(d7Lx)) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d15Lx + cse0*dLx + T(6006)*d10Lx*d5Lx + T(2730)*d11Lx*d4Lx + T(910)*d12Lx*d3Lx + T(210)*d13Lx*ddLx + T(10010)*d6Lx*d9Lx + T(12870)*d7Lx*d8Lx);
       }
       {
         const T cse0 = T(30)*d14Lx;
@@ -828,7 +825,7 @@ case (16): {
       {
         const T cse0 = T(32)*d15Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(96096)*d10Lx*d5Lx + T(43680)*d11Lx*d4Lx + T(14560)*d12Lx*d3Lx + T(3360)*d13Lx*ddLx + T(480)*d14Lx*dLx + T(160160)*d6Lx*d9Lx + T(205920)*d7Lx*d8Lx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d16Lx + cse0*dLx + T(16016)*d10Lx*d6Lx + T(8736)*d11Lx*d5Lx + T(3640)*d12Lx*d4Lx + T(1120)*d13Lx*d3Lx + T(240)*d14Lx*ddLx + T(22880)*d7Lx*d9Lx + T(12870)*(d8Lx)*(d8Lx));
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(96096)*d10Lx*d5Lx + T(43680)*d11Lx*d4Lx + T(14560)*d12Lx*d3Lx + T(3360)*d13Lx*ddLx + T(480)*d14Lx*dLx + T(160160)*d6Lx*d9Lx + T(205920)*d7Lx*d8Lx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d16Lx + cse0*dLx + T(16016)*d10Lx*d6Lx + T(8736)*d11Lx*d5Lx + T(3640)*d12Lx*d4Lx + T(1120)*d13Lx*d3Lx + T(240)*d14Lx*ddLx + T(22880)*d7Lx*d9Lx + T(12870)*(d8Lx)*(d8Lx));
       }
       {
         const T cse0 = T(32)*d15Lx;
@@ -902,7 +899,7 @@ case (17): {
       {
         const T cse0 = T(34)*d16Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(272272)*d10Lx*d6Lx + T(148512)*d11Lx*d5Lx + T(61880)*d12Lx*d4Lx + T(19040)*d13Lx*d3Lx + T(4080)*d14Lx*ddLx + T(544)*d15Lx*dLx + T(388960)*d7Lx*d9Lx + T(218790)*(d8Lx)*(d8Lx)) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d17Lx + cse0*dLx + T(38896)*d10Lx*d7Lx + T(24752)*d11Lx*d6Lx + T(12376)*d12Lx*d5Lx + T(4760)*d13Lx*d4Lx + T(1360)*d14Lx*d3Lx + T(272)*d15Lx*ddLx + T(48620)*d8Lx*d9Lx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(272272)*d10Lx*d6Lx + T(148512)*d11Lx*d5Lx + T(61880)*d12Lx*d4Lx + T(19040)*d13Lx*d3Lx + T(4080)*d14Lx*ddLx + T(544)*d15Lx*dLx + T(388960)*d7Lx*d9Lx + T(218790)*(d8Lx)*(d8Lx)) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d17Lx + cse0*dLx + T(38896)*d10Lx*d7Lx + T(24752)*d11Lx*d6Lx + T(12376)*d12Lx*d5Lx + T(4760)*d13Lx*d4Lx + T(1360)*d14Lx*d3Lx + T(272)*d15Lx*ddLx + T(48620)*d8Lx*d9Lx);
       }
       {
         const T cse0 = T(34)*d16Lx;
@@ -979,7 +976,7 @@ case (18): {
       {
         const T cse0 = T(36)*d17Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(700128)*d10Lx*d7Lx + T(445536)*d11Lx*d6Lx + T(222768)*d12Lx*d5Lx + T(85680)*d13Lx*d4Lx + T(24480)*d14Lx*d3Lx + T(4896)*d15Lx*ddLx + T(612)*d16Lx*dLx + T(875160)*d8Lx*d9Lx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d18Lx + cse0*dLx + T(87516)*d10Lx*d8Lx + T(63648)*d11Lx*d7Lx + T(37128)*d12Lx*d6Lx + T(17136)*d13Lx*d5Lx + T(6120)*d14Lx*d4Lx + T(1632)*d15Lx*d3Lx + T(306)*d16Lx*ddLx + T(48620)*(d9Lx)*(d9Lx));
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(700128)*d10Lx*d7Lx + T(445536)*d11Lx*d6Lx + T(222768)*d12Lx*d5Lx + T(85680)*d13Lx*d4Lx + T(24480)*d14Lx*d3Lx + T(4896)*d15Lx*ddLx + T(612)*d16Lx*dLx + T(875160)*d8Lx*d9Lx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d18Lx + cse0*dLx + T(87516)*d10Lx*d8Lx + T(63648)*d11Lx*d7Lx + T(37128)*d12Lx*d6Lx + T(17136)*d13Lx*d5Lx + T(6120)*d14Lx*d4Lx + T(1632)*d15Lx*d3Lx + T(306)*d16Lx*ddLx + T(48620)*(d9Lx)*(d9Lx));
       }
       {
         const T cse0 = T(36)*d17Lx;
@@ -1059,7 +1056,7 @@ case (19): {
       {
         const T cse0 = T(38)*d18Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1662804)*d10Lx*d8Lx + T(1209312)*d11Lx*d7Lx + T(705432)*d12Lx*d6Lx + T(325584)*d13Lx*d5Lx + T(116280)*d14Lx*d4Lx + T(31008)*d15Lx*d3Lx + T(5814)*d16Lx*ddLx + T(684)*d17Lx*dLx + T(923780)*(d9Lx)*(d9Lx)) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d19Lx + cse0*dLx + T(184756)*d10Lx*d9Lx + T(151164)*d11Lx*d8Lx + T(100776)*d12Lx*d7Lx + T(54264)*d13Lx*d6Lx + T(23256)*d14Lx*d5Lx + T(7752)*d15Lx*d4Lx + T(1938)*d16Lx*d3Lx + T(342)*d17Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(1662804)*d10Lx*d8Lx + T(1209312)*d11Lx*d7Lx + T(705432)*d12Lx*d6Lx + T(325584)*d13Lx*d5Lx + T(116280)*d14Lx*d4Lx + T(31008)*d15Lx*d3Lx + T(5814)*d16Lx*ddLx + T(684)*d17Lx*dLx + T(923780)*(d9Lx)*(d9Lx)) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d19Lx + cse0*dLx + T(184756)*d10Lx*d9Lx + T(151164)*d11Lx*d8Lx + T(100776)*d12Lx*d7Lx + T(54264)*d13Lx*d6Lx + T(23256)*d14Lx*d5Lx + T(7752)*d15Lx*d4Lx + T(1938)*d16Lx*d3Lx + T(342)*d17Lx*ddLx);
       }
       {
         const T cse0 = T(38)*d18Lx;
@@ -1142,7 +1139,7 @@ case (20): {
       {
         const T cse0 = T(40)*d19Lx;
         const T cse1 = T(2)*dLxi_v;
-        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(3695120)*d10Lx*d9Lx + T(3023280)*d11Lx*d8Lx + T(2015520)*d12Lx*d7Lx + T(1085280)*d13Lx*d6Lx + T(465120)*d14Lx*d5Lx + T(155040)*d15Lx*d4Lx + T(38760)*d16Lx*d3Lx + T(6840)*d17Lx*ddLx + T(760)*d18Lx*dLx) + (cse1*xi - cse1*xv + T(1))*(T(2)*Lx*d20Lx + cse0*dLx + T(184756)*(d10Lx)*(d10Lx) + T(335920)*d11Lx*d9Lx + T(251940)*d12Lx*d8Lx + T(155040)*d13Lx*d7Lx + T(77520)*d14Lx*d6Lx + T(31008)*d15Lx*d5Lx + T(9690)*d16Lx*d4Lx + T(2280)*d17Lx*d3Lx + T(380)*d18Lx*ddLx);
+        dnf(ix, 2*fi + 0) = -cse1*(Lx*cse0 + T(3695120)*d10Lx*d9Lx + T(3023280)*d11Lx*d8Lx + T(2015520)*d12Lx*d7Lx + T(1085280)*d13Lx*d6Lx + T(465120)*d14Lx*d5Lx + T(155040)*d15Lx*d4Lx + T(38760)*d16Lx*d3Lx + T(6840)*d17Lx*ddLx + T(760)*d18Lx*dLx) + (-cse1*(-xi + xv) + T(1))*(T(2)*Lx*d20Lx + cse0*dLx + T(184756)*(d10Lx)*(d10Lx) + T(335920)*d11Lx*d9Lx + T(251940)*d12Lx*d8Lx + T(155040)*d13Lx*d7Lx + T(77520)*d14Lx*d6Lx + T(31008)*d15Lx*d5Lx + T(9690)*d16Lx*d4Lx + T(2280)*d17Lx*d3Lx + T(380)*d18Lx*ddLx);
       }
       {
         const T cse0 = T(40)*d19Lx;

--- a/libhelfem/include/HIPBasis_over_r.h
+++ b/libhelfem/include/HIPBasis_over_r.h
@@ -11,8 +11,8 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#ifndef HELFEM_FEM_HIPBASIS_OVER_R_H
-#define HELFEM_FEM_HIPBASIS_OVER_R_H
+#ifndef LIB1DFEM_HIPBASIS_OVER_R_H
+#define LIB1DFEM_HIPBASIS_OVER_R_H
 
 #include <types.h>
 #include <LIPBasis_eval.h>
@@ -119,8 +119,7 @@ void eval_hip_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
         case 0:
           switch (kind) {
           case 0: {
-            const T cse0 = T(2)*dLxi_v;
-            R = (pr)*(pr)*(xv + T(1))*(cse0*xi - cse0*xv + T(1))/std::pow(xi + T(1), T(2));
+            R = (pr)*(pr)*(xv + T(1))*(-T(2)*dLxi_v*(-xi + xv) + T(1))/std::pow(xi + T(1), T(2));
           } break;
           case 1: {
             R = (pr)*(pr)*(-xi + xv)*(xv + T(1))/std::pow(xi + T(1), T(2));
@@ -133,7 +132,7 @@ void eval_hip_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
             const T cse0 = (pr)*(pr);
             const T cse1 = xv + T(1);
             const T cse2 = T(2)*dLxi_v;
-            const T cse3 = cse2*xi - cse2*xv + T(1);
+            const T cse3 = -cse2*(-xi + xv) + T(1);
             R = (-cse0*cse1*cse2 + cse0*cse3 + T(2)*cse1*cse3*dpr*pr)/std::pow(xi + T(1), T(2));
           } break;
           case 1: {
@@ -148,9 +147,8 @@ void eval_hip_prim_over_r(const Vec<T> & x, const Vec<T> & x0,
           switch (kind) {
           case 0: {
             const T cse0 = T(4)*dLxi_v;
-            const T cse1 = T(2)*xv;
-            const T cse2 = -cse1*dLxi_v + T(2)*dLxi_v*xi + T(1);
-            R = (-cse0*dpr*pr*(cse1 + T(2)) - cse0*(pr)*(pr) + T(4)*cse2*dpr*pr + cse2*(xv + T(1))*(T(2)*ddpr*pr + T(2)*(dpr)*(dpr)))/std::pow(xi + T(1), T(2));
+            const T cse1 = -T(2)*dLxi_v*(-xi + xv) + T(1);
+            R = (-cse0*dpr*pr*(T(2)*xv + T(2)) - cse0*(pr)*(pr) + T(4)*cse1*dpr*pr + cse1*(xv + T(1))*(T(2)*ddpr*pr + T(2)*(dpr)*(dpr)))/std::pow(xi + T(1), T(2));
           } break;
           case 1: {
             const T cse0 = -xi + xv;

--- a/libhelfem/src/generate_hip_family_code.py
+++ b/libhelfem/src/generate_hip_family_code.py
@@ -153,7 +153,18 @@ def P_deriv_at_node(r):
 # ---------------------------------------------------------------------
 Pn = [P_deriv_at_node(r) for r in range(NDER + 1)]   # P^{(r)}(0)
 
-q = []
+# q_j is kept as a COEFFICIENT LIST in t = xv - xi, never as an expanded
+# polynomial. sp.expand(qj) here was the accuracy bug of the whole family:
+# expanding q into monomials of xv and xi separately hands the evaluator
+# sums of large terms cancelling to O(1), and the interpolation conditions
+# then hold only to the size of those terms times eps. Measured on the
+# reference element (scaling 1), the residual of the 3rd-derivative
+# condition was 9.7e-10 at 5 nodes and 7.0e-08 at 7 nodes -- against
+# ~1e-12 for the better-conditioned HIP2 -- and the FE derivative scaling
+# (1/s)^j then amplified that into continuity-check failures on any
+# graded grid. Same lesson as the over_r deflation below, which already
+# says so in its comment; the plain evaluator just never got the memo.
+qc = []                            # qc[j][a] = coefficient of t^a in q_j
 for j in range(NSHAPE):
     c = sp.symbols(f"c0:{NDER+1}")
     eqs = []
@@ -161,8 +172,22 @@ for j in range(NSHAPE):
         lhs = sum(sp.binomial(k, a) * Pn[k - a] * sp.factorial(a) * c[a] for a in range(k + 1))
         eqs.append(sp.Eq(sp.expand(lhs), 1 if k == j else 0))
     sol = sp.solve(eqs, c, dict=True)[0]
-    qj = sum(sp.simplify(sol[c[a]]) * t**a for a in range(NDER + 1))
-    q.append(sp.expand(qj))
+    qc.append([sp.simplify(sol[c[a]]) for a in range(NDER + 1)])
+
+def _horner_t(coeffs):
+    """sum_a coeffs[a] * t^a as a Horner nest in t, unexpanded. cse then
+    pulls xv - xi out once and every intermediate stays O(coefficient)."""
+    expr = sp.Integer(0)
+    for ca in reversed(coeffs):
+        expr = ca + t * expr
+    return expr
+
+def q_deriv(j, r):
+    """r-th xv-derivative of q_j (dt/dxv = 1), coefficient-wise."""
+    if r >= len(qc[j]):
+        return sp.Integer(0)
+    return _horner_t([sp.factorial(a + r) / sp.factorial(a) * qc[j][a + r]
+                      for a in range(len(qc[j]) - r)])
 
 # ---------------------------------------------------------------------
 # h_{i,j}^{(n)} = sum_a C(n,a) * (L^m)^{(a)} * q_j^{(n-a)}   (Leibniz)
@@ -177,7 +202,7 @@ def shape_deriv(j, n):
     keeps every intermediate small."""
     total = 0
     for a in range(n + 1):
-        total += sp.binomial(n, a) * deriv_of_L_power_factored(M, a) * sp.diff(q[j], xv, n - a)
+        total += sp.binomial(n, a) * deriv_of_L_power_factored(M, a) * q_deriv(j, n - a)
     return total
 
 # =====================================================================
@@ -236,20 +261,34 @@ def leibniz(factors_derivs, n):
         total += term
     return total
 
-# qtil_j = q_j / t   for the node-0 shapes that survive (j >= 1)
-qtil = [None] + [sp.simplify(sp.cancel(q[j] / t)) for j in range(1, NSHAPE)]
+# qtil_j = q_j / t for the node-0 shapes that survive (j >= 1). In
+# coefficients the division is a shift -- q_j(0) = c_0 = 0 exactly for
+# j >= 1 (the k = 0 interpolation condition with P(0) = 1), which is
+# asserted rather than assumed. sp.cancel(q/t) on the old expanded q
+# returned an EXPANDED quotient, quietly reintroducing into the over_r
+# path the very cancellation its emitter is documented to avoid.
+for _j in range(1, NSHAPE):
+    assert sp.simplify(qc[_j][0]) == 0, f"q_{_j}(0) != 0"
+
+def qtil_deriv(j, r):
+    """r-th xv-derivative of q_j / t, coefficient-wise, Horner in t."""
+    coeffs = qc[j][1:]
+    if r >= len(coeffs):
+        return sp.Integer(0)
+    return _horner_t([sp.factorial(a + r) / sp.factorial(a) * coeffs[a + r]
+                      for a in range(len(coeffs) - r)])
 
 def over_r_node0(j, n):
     """d^n/dx^n [ L_0^m * qtil_j ]  -- node 0, surviving shapes j >= 1."""
     return leibniz([lambda k: deriv_of_sym_power(LX, M, k),
-                    lambda k: sp.diff(qtil[j], xv, k)], n)
+                    lambda k: qtil_deriv(j, k)], n)
 
 def over_r_nodei(j, n):
     """d^n/dx^n [ (x+1)^(m-1) * (p_red/(xi+1))^m * q_j ]  -- nodes i >= 1."""
     inv = 1 / (xi + 1)**M
     return inv * leibniz([lambda k: sp.diff(xp1**(M - 1), xv, k),
                           lambda k: deriv_of_sym_power(PR, M, k),
-                          lambda k: sp.diff(q[j], xv, k)], n)
+                          lambda k: q_deriv(j, k)], n)
 
 # ---------------------------------------------------------------------
 # C++ emission


### PR DESCRIPTION
Fixes the HIP3 continuity failure (task 63) at its root, and improves the accuracy of the whole analytic Hermite family.

## The bug

The generator expanded the fix-up polynomial q_j(t), t = x − x_i, into monomials of x and x_i — `sp.expand(qj)` at construction, and `sp.cancel(q/t)` returning an expanded quotient into the `over_r` path. This contradicts the generator's own design note, which documents (with measurement) that expanding these products is exactly what makes the deflation cancel. The emitted code computed algebraically-O(1) values as sums of L‴-sized terms, so the Hermite interpolation conditions held only to ~term-size × eps, and the FE derivative scaling (1/s)ʲ amplified that into `check_bf_continuity` failures on any graded grid: **primbas=9 was unusable beyond two elements.**

## The fix

q_j lives as a coefficient list, differentiated coefficient-wise, emitted as a Horner nest in t; `cse` pulls `x − x_i` out once and every intermediate stays O(coefficient). The c₀ = 0 divisibility that `cancel` established is asserted instead. All six generated headers regenerated with their recorded parameters — and come out ~300 lines smaller.

## Measured

Interpolation-condition residuals on the reference element (scaling 1):

| | deriv 2 | deriv 3 |
|---|---|---|
| HIP3, 5 nodes | 1.9e-10 → **0** | 9.7e-10 → **7.1e-15** |
| HIP3, 7 nodes | 1.3e-08 → **0** | 7.0e-08 → **2.9e-11** |
| HIP2, 6 nodes | 1.5e-12 → 1.7e-13 | |

Derivatives 0–1 are now exactly zero for all families.

## Verification

- `primbas=9 nnodes=5` passes continuity at nelem = 2..12 (previously failed from 3 up), and at nnodes 5–8 on the narrow grid (previously failed at 7–8).
- **N/TPSS at the task-62 killer grid** (`lmax=15,13 nelem=8`) runs on HIP3: first DIIS error 1.10e-04 (LIP: 7.11e+02), noise floor 1.0e-08 Eh (LIP: 285 Eh), converges to −54.6161726848. The Hermite family agrees internally to 4e-9 and with the converged atomic value to 6e-7.
- ctest unit tier 6/6, including `over_r_test` on the regenerated deflation code.
- ci tier: 45/45 of the cases runnable at the harness timeout (the 4 exceptions are the WIP grid branch's 2700 s cases against a 900 s timeout — unrelated lineage, not this change).

## For the pending default-basis decision (task 62)

HIP3's overlap condition number at the N grid is **1.9e6** against ~4e2 for LIP. The third-order family is now *correct*, but much worse conditioned — which argues for HIP1 (8 nodes) or HIP2 (6 nodes) as the meta-GGA default, not HIP3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)