### PR TITLE
API unification, part 1: eval_psi_dnf consolidation + atomdb hygiene

### DIFF
--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -319,6 +319,17 @@ namespace helfem {
         void fill_quadrature_cache(bool need_df = false, bool need_lf = false) const;
 
         /// Evaluate basis functions at quadrature points (Eigen return).
+        /// d^n/dr^n of psi = B(r)/r for every basis function, at the
+        /// reference points x of element iel. ONE implementation for
+        /// every order: the first element uses the analytic (x+1)
+        /// deflation (eval_over_r), and iel > 0 the quotient rule in
+        /// Horner form,
+        ///   d^n [B/r] = ( ... (c_0 B invr + c_1 B') invr + ... + c_n B^(n) ) invr,
+        ///   c_k = (-1)^(n-k) n! / k!,
+        /// which reproduces the former per-order get_bf/get_df/get_lf
+        /// groupings exactly; those are now one-line calls of this.
+        helfem::Mat<T> eval_psi_dnf(const helfem::Vec<T> & x, int n, size_t iel) const;
+
         helfem::Mat<T> get_bf(size_t iel) const;
         /// Evaluate basis functions at given points (Phase 5.24: Eigen input + return).
         helfem::Mat<T> get_bf(const helfem::Vec<T> & x, size_t iel) const;

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -866,15 +866,53 @@ namespace helfem {
       }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::get_bf(const helfem::Vec<T> & x, size_t iel) const {
+      helfem::Mat<T> FEMRadialBasisT<T>::eval_psi_dnf(const helfem::Vec<T> & x, int n, size_t iel) const {
         if (iel == 0)
-          return fem.eval_over_r(x, 0, iel);
-        helfem::Mat<T> val = fem.eval_dnf(x, 0, iel);
+          return fem.eval_over_r(x, n, iel);
+        if (n == 0) {
+          // Plain division, matching the historical get_bf exactly.
+          helfem::Mat<T> val = fem.eval_dnf(x, 0, iel);
+          const helfem::Vec<T> r = fem.eval_coord(x, iel);
+          for (Eigen::Index ifun = 0; ifun < val.cols(); ++ifun)
+            for (Eigen::Index ir = 0; ir < val.rows(); ++ir)
+              val(ir, ifun) /= r(ir);
+          return val;
+        }
+        // Quotient rule for d^n/dr^n [B/r], Horner in 1/r. The
+        // coefficients c_k = (-1)^(n-k) n!/k! give, for n = 1 and 2,
+        // exactly the groupings the per-order routines used:
+        //   n=1: (-f invr + d) invr
+        //   n=2: ((2 f invr - 2 d) invr + l) invr
+        std::vector<helfem::Mat<T>> B(n + 1);
+        for (int k = 0; k <= n; k++)
+          B[k] = fem.eval_dnf(x, k, iel);
+        std::vector<T> c(n + 1);
+        {
+          T nfac = T(1);
+          for (int k = 2; k <= n; k++) nfac *= T(k);
+          T kfac = T(1);
+          for (int k = 0; k <= n; k++) {
+            if (k >= 2) kfac *= T(k);
+            c[k] = nfac / kfac;
+            if ((n - k) % 2) c[k] = -c[k];
+          }
+        }
         const helfem::Vec<T> r = fem.eval_coord(x, iel);
-        for (Eigen::Index ifun = 0; ifun < val.cols(); ++ifun)
-          for (Eigen::Index ir = 0; ir < val.rows(); ++ir)
-            val(ir, ifun) /= r(ir);
-        return val;
+        helfem::Mat<T> out(B[0].rows(), B[0].cols());
+        for (Eigen::Index ifun = 0; ifun < out.cols(); ++ifun)
+          for (Eigen::Index ir = 0; ir < out.rows(); ++ir) {
+            const T invr = T(1) / r(ir);
+            T acc = c[0] * B[0](ir, ifun);
+            for (int k = 1; k <= n; k++)
+              acc = acc * invr + c[k] * B[k](ir, ifun);
+            out(ir, ifun) = acc * invr;
+          }
+        return out;
+      }
+
+      template <typename T>
+      helfem::Mat<T> FEMRadialBasisT<T>::get_bf(const helfem::Vec<T> & x, size_t iel) const {
+        return eval_psi_dnf(x, 0, iel);
       }
 
       template <typename T>
@@ -886,18 +924,7 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::get_df(const helfem::Vec<T> & x, size_t iel) const {
-        if (iel == 0)
-          return fem.eval_over_r(x, 1, iel);
-        helfem::Mat<T> fval = fem.eval_dnf(x, 0, iel);
-        helfem::Mat<T> dval = fem.eval_dnf(x, 1, iel);
-        const helfem::Vec<T> r = fem.eval_coord(x, iel);
-        helfem::Mat<T> der(fval.rows(), fval.cols());
-        for (Eigen::Index ifun = 0; ifun < der.cols(); ++ifun)
-          for (Eigen::Index ir = 0; ir < der.rows(); ++ir) {
-            const T invr = T(1) / r(ir);
-            der(ir, ifun) = (-fval(ir, ifun) * invr + dval(ir, ifun)) * invr;
-          }
-        return der;
+        return eval_psi_dnf(x, 1, iel);
       }
 
       template <typename T>
@@ -909,20 +936,7 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::get_lf(const helfem::Vec<T> & x, size_t iel) const {
-        if (iel == 0)
-          return fem.eval_over_r(x, 2, iel);
-        helfem::Mat<T> fval = fem.eval_dnf(x, 0, iel);
-        helfem::Mat<T> dval = fem.eval_dnf(x, 1, iel);
-        helfem::Mat<T> lval = fem.eval_dnf(x, 2, iel);
-        const helfem::Vec<T> r = fem.eval_coord(x, iel);
-        helfem::Mat<T> lapl(fval.rows(), fval.cols());
-        for (Eigen::Index ifun = 0; ifun < lapl.cols(); ++ifun)
-          for (Eigen::Index ir = 0; ir < lapl.rows(); ++ir) {
-            const T invr = T(1) / r(ir);
-            lapl(ir, ifun) = ((T(2) * fval(ir, ifun) * invr - T(2) * dval(ir, ifun)) * invr
-                              + lval(ir, ifun)) * invr;
-          }
-        return lapl;
+        return eval_psi_dnf(x, 2, iel);
       }
 
       template <typename T>

--- a/src/general/atomdb.h
+++ b/src/general/atomdb.h
@@ -96,14 +96,14 @@ namespace helfem {
       /// functionals are asked for and reused afterwards.
       mutable std::shared_ptr<XCFunctionals> xc_;
 
-    public:
       /// Integral over the part of element iel between the reference
       /// coordinates xa and xb, of the radial charge distribution
       /// 4 pi r^2 rho(r) (over_r = false) or of it divided by r
       /// (over_r = true). These are the two halves of the multipole
       /// expansion of 1/r_>, restricted to the element the evaluation
       /// point falls in; everything outside is already summed into
-      /// Qbelow_ and Mabove_.
+      /// Qbelow_ and Mabove_. Implementation detail of the evaluators
+      /// below; nothing outside this class uses it.
       double partial_integral(size_t iel, double xa, double xb, bool over_r) const;
 
     public:


### PR DESCRIPTION
First slice of the API unification agreed from the 2026-08-13 audit. Parts 2–3 (the bare `X()` accessor convention and the `X_` member convention) follow separately — they are large mechanical renames that deserve their own reviewable diffs.

## eval consolidation

`get_bf`, `get_df`, `get_lf` were three separate implementations of the same thing — d^n/dr^n of ψ = B(r)/r, each spelling out its own quotient-rule combination with the analytic first-element deflation. They are now one-line calls of a single `eval_psi_dnf(x, n, iel)`, valid for **any** n.

Bit-compatibility was engineered rather than hoped for: the general routine evaluates the quotient rule in Horner form with c_k = (−1)^(n−k)·n!/k!, which reproduces the per-order groupings exactly — `(−f·invr + d)·invr` at n=1, `((2f·invr − 2d)·invr + l)·invr` at n=2 — and n=0 keeps the plain division. Verified: unit tier 8/8, spot suite references bit-identical.

(The atomic `TwoDBasis::eval_df(iel,cth,phi,dr,dθ,dφ)` returns gradient *components*, not an n-th derivative — different concept, unchanged.)

## atomdb hygiene

The duplicate `public:` sections collapse to one; `partial_integral` — the multipole implementation detail — is now private (nothing outside the class called it).

Per the audit decisions: NAORadialBasis's protected members are deliberately untouched (external codes subclass it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)