### PR TITLE
API unification, part 2: bare accessors and underscored members (FEM core)

### DIFF
--- a/libhelfem/include/FiniteElementBasis.h
+++ b/libhelfem/include/FiniteElementBasis.h
@@ -35,24 +35,24 @@ namespace helfem {
     class FiniteElementBasisT {
     protected:
       /// Polynomial basis
-      std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> poly;
+      std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> poly_;
 
       /// Element boundary values
       // Phase 5.5: members migrated to Eigen.
-      helfem::Vec<T> bval;
+      helfem::Vec<T> bval_;
       /// Zero out function at left end?
-      bool zero_func_left;
+      bool zero_func_left_;
       /// Zero out derivative at left end?
-      bool zero_deriv_left;
+      bool zero_deriv_left_;
       /// Zero out function at right end?
-      bool zero_func_right;
+      bool zero_func_right_;
       /// Zero out derivatives at right end?
-      bool zero_deriv_right;
+      bool zero_deriv_right_;
 
       /// First basis function in element
-      helfem::IVec first_func_in_element;
+      helfem::IVec first_func_in_element_;
       /// Last basis function in element
-      helfem::IVec last_func_in_element;
+      helfem::IVec last_func_in_element_;
       /// Update the above list of basis functions
       void update_bf_list();
 
@@ -65,7 +65,7 @@ namespace helfem {
     public:
       /// Dummy constructor
       FiniteElementBasisT();
-      /// Constructor. Phase 5.26: bval is Eigen at the public boundary
+      /// Constructor. Phase 5.26: bval_ is Eigen at the public boundary
       /// (matches the internal helfem::Vec<T> storage introduced in
       /// Phase 5.5).
       FiniteElementBasisT(const std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> &poly,
@@ -77,18 +77,18 @@ namespace helfem {
       void add_boundary(T r);
 
       /// Get the polynomial basis
-      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>>  get_poly() const;
+      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>>  poly() const;
       /// Get basis functions in element
       std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>>
-      get_basis(size_t iel) const;
+      basis(size_t iel) const;
 
       /// Get the numerical id of the polynomial basis
-      int get_poly_id() const;
+      int poly_id() const;
       /// Get the number of nodes in the polynomial basis
-      int get_poly_nnodes() const;
+      int poly_nnodes() const;
 
       /// Get the element boundaries
-      helfem::Vec<T> get_bval() const;
+      helfem::Vec<T> bval() const;
       /// Element begins at
       T element_begin(size_t iel) const;
       /// Element ends at
@@ -118,16 +118,16 @@ namespace helfem {
       T scaling_factor(size_t iel) const;
 
       /// Get the consecutive index range of the basis functions in the element
-      void get_idx(size_t iel, size_t &ifirst, size_t &ilast) const;
+      void idx(size_t iel, size_t &ifirst, size_t &ilast) const;
 
       /// Get maximum possible number of primitives
-      size_t get_max_nprim() const;
+      size_t max_nprim() const;
       /// Get number of functions in element
-      size_t get_nprim(size_t iel) const;
+      size_t nprim(size_t iel) const;
       /// Get number of basis functions
-      size_t get_nbf() const;
+      size_t nbf() const;
       /// Get number of elements
-      size_t get_nelem() const;
+      size_t nelem() const;
 
       /// Evaluate nth derivative
       /// Evaluate the n-th derivative of the basis functions in element iel.

--- a/libhelfem/include/HIP2Basis.h
+++ b/libhelfem/include/HIP2Basis.h
@@ -42,19 +42,19 @@ class HIP2BasisT : public LIPBasisT<T> {
   Vec<T> lipxi2;
 
  public:
-  /// id_ is just an identifier echoed via get_id(); the libhelfem
+  /// id is just an identifier echoed via id(); the libhelfem
   /// factory passes the primbas value (8 for HIP2).
-  HIP2BasisT(const Vec<T> & x, int id_ = 8) : LIPBasisT<T>(x, id_) {
+  HIP2BasisT(const Vec<T> & x, int id = 8) : LIPBasisT<T>(x, id) {
     // Three overlapping functions per node (value + 1st deriv + 2nd deriv).
-    this->noverlap = 3;
-    this->nprim    = 3 * static_cast<int>(this->x0.size());
-    this->enabled  = IVec::LinSpaced(this->nprim, 0, this->nprim - 1);
-    this->nnodes   = static_cast<int>(this->x0.size());
+    this->noverlap_ = 3;
+    this->nprim_    = 3 * static_cast<int>(this->x0_.size());
+    this->enabled_  = IVec::LinSpaced(this->nprim_, 0, this->nprim_ - 1);
+    this->nnodes_   = static_cast<int>(this->x0_.size());
 
     // L_i'(x_i) and L_i''(x_i) at every node, via the existing LIP evaluator.
     Mat<T> dlip, ddlip;
-    detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dlip,  1);
-    detail::eval_lip_prim_dnf<T>(this->x0, this->x0, ddlip, 2);
+    detail::eval_lip_prim_dnf<T>(this->x0_, this->x0_, dlip,  1);
+    detail::eval_lip_prim_dnf<T>(this->x0_, this->x0_, ddlip, 2);
     lipxi  = dlip.diagonal();
     lipxi2 = ddlip.diagonal();
   }
@@ -67,7 +67,7 @@ class HIP2BasisT : public LIPBasisT<T> {
 
   void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
-    detail::eval_hip2_prim_dnf<T>(x, this->x0, lipxi, lipxi2, dnf, n,
+    detail::eval_hip2_prim_dnf<T>(x, this->x0_, lipxi, lipxi2, dnf, n,
                                   element_length);
   }
 
@@ -79,8 +79,8 @@ class HIP2BasisT : public LIPBasisT<T> {
   ///   func=false, deriv=true  : drop the two derivative interpolants
   ///   func=false, deriv=false : drop nothing
   void drop_first(bool func, bool deriv) override {
-    const IVec first(this->enabled.segment(0, (2) - (0) + 1));
-    const IVec rest(this->enabled.segment(3, (this->enabled.size() - (3) + 1) - 1));
+    const IVec first(this->enabled_.segment(0, (2) - (0) + 1));
+    const IVec rest(this->enabled_.segment(3, (this->enabled_.size() - (3) + 1) - 1));
     IVec keep;
     keep.resize((func ? 0 : 1) + (deriv ? 0 : 2) + rest.size());
     Eigen::Index idx = 0;
@@ -88,12 +88,12 @@ class HIP2BasisT : public LIPBasisT<T> {
     if (!deriv) { keep(idx++) = first(1); keep(idx++) = first(2); }
     if (rest.size())
       keep.segment(idx, (idx + rest.size() - (idx) + 1) - 1) = rest;
-    this->enabled = keep;
+    this->enabled_ = keep;
   }
 
   void drop_last(bool func, bool deriv) override {
-    const IVec head(this->enabled.segment(0, (this->enabled.size() - (0) + 1) - 4));
-    const IVec last(this->enabled.segment(this->enabled.size() - 3, (this->enabled.size() - (this->enabled.size() - 3) + 1) - 1));
+    const IVec head(this->enabled_.segment(0, (this->enabled_.size() - (0) + 1) - 4));
+    const IVec last(this->enabled_.segment(this->enabled_.size() - 3, (this->enabled_.size() - (this->enabled_.size() - 3) + 1) - 1));
     IVec keep;
     keep.resize(head.size() + (func ? 0 : 1) + (deriv ? 0 : 2));
     Eigen::Index idx = 0;
@@ -103,7 +103,7 @@ class HIP2BasisT : public LIPBasisT<T> {
     }
     if (!func)  keep(idx++) = last(0);
     if (!deriv) { keep(idx++) = last(1); keep(idx++) = last(2); }
-    this->enabled = keep;
+    this->enabled_ = keep;
   }
 
   // Pull the base's 3-arg eval_over_r overload back into scope.
@@ -114,7 +114,7 @@ class HIP2BasisT : public LIPBasisT<T> {
   /// drop_first(zero_func=true, zero_deriv=false) was called so the
   /// value-shape at node 0 is dropped (it has B(-1) != 0).
   ///
-  /// Derivations (with e = element_length = scaling_factor, x_i = x0(node),
+  /// Derivations (with e = element_length = scaling_factor, x_i = x0_(node),
   /// p1 = L_i'(x_i), p2 = L_i''(x_i), p = L_0(x) for node 0 or
   /// p = L_i^{(0)}(x) for i >= 1 with L_i = ((x+1)/(x_i+1)) L_i^{(0)}):
   ///
@@ -132,7 +132,7 @@ class HIP2BasisT : public LIPBasisT<T> {
                    T element_length) const override {
     // All of the deflation maths is generated -- see
     // libhelfem/src/generate_hip_family_code.py --order 2 --over-r
-    detail::eval_hip2_prim_over_r<T>(x, this->x0, lipxi, lipxi2, this->enabled,
+    detail::eval_hip2_prim_over_r<T>(x, this->x0_, lipxi, lipxi2, this->enabled_,
                                       dnf_over_r, n, element_length);
   }
 };

--- a/libhelfem/include/HIP3Basis.h
+++ b/libhelfem/include/HIP3Basis.h
@@ -39,18 +39,18 @@ class HIP3BasisT : public LIPBasisT<T> {
   Vec<T> lipxi, lipxi2, lipxi3;
 
  public:
-  /// id_ is the primbas value echoed via get_id() (typically 9 for HIP3).
-  HIP3BasisT(const Vec<T> & x, int id_ = 9) : LIPBasisT<T>(x, id_) {
+  /// id is the primbas value echoed via id() (typically 9 for HIP3).
+  HIP3BasisT(const Vec<T> & x, int id = 9) : LIPBasisT<T>(x, id) {
     // Four overlapping functions per node (value + 1st + 2nd + 3rd deriv).
-    this->noverlap = 4;
-    this->nprim    = 4 * static_cast<int>(this->x0.size());
-    this->enabled  = IVec::LinSpaced(this->nprim, 0, this->nprim - 1);
-    this->nnodes   = static_cast<int>(this->x0.size());
+    this->noverlap_ = 4;
+    this->nprim_    = 4 * static_cast<int>(this->x0_.size());
+    this->enabled_  = IVec::LinSpaced(this->nprim_, 0, this->nprim_ - 1);
+    this->nnodes_   = static_cast<int>(this->x0_.size());
 
     Mat<T> dlip, ddlip, dddlip;
-    detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dlip,   1);
-    detail::eval_lip_prim_dnf<T>(this->x0, this->x0, ddlip,  2);
-    detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dddlip, 3);
+    detail::eval_lip_prim_dnf<T>(this->x0_, this->x0_, dlip,   1);
+    detail::eval_lip_prim_dnf<T>(this->x0_, this->x0_, ddlip,  2);
+    detail::eval_lip_prim_dnf<T>(this->x0_, this->x0_, dddlip, 3);
     lipxi  = dlip.diagonal();
     lipxi2 = ddlip.diagonal();
     lipxi3 = dddlip.diagonal();
@@ -64,7 +64,7 @@ class HIP3BasisT : public LIPBasisT<T> {
 
   void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
-    detail::eval_hip3_prim_dnf<T>(x, this->x0, lipxi, lipxi2, lipxi3, dnf, n,
+    detail::eval_hip3_prim_dnf<T>(x, this->x0_, lipxi, lipxi2, lipxi3, dnf, n,
                                   element_length);
   }
 
@@ -75,8 +75,8 @@ class HIP3BasisT : public LIPBasisT<T> {
   ///   func=false, deriv=true  : drop only the three derivative interpolants
   ///   func=false, deriv=false : drop nothing
   void drop_first(bool func, bool deriv) override {
-    const IVec first(this->enabled.segment(0, (3) - (0) + 1));
-    const IVec rest(this->enabled.segment(4, (this->enabled.size() - (4) + 1) - 1));
+    const IVec first(this->enabled_.segment(0, (3) - (0) + 1));
+    const IVec rest(this->enabled_.segment(4, (this->enabled_.size() - (4) + 1) - 1));
     IVec keep;
     keep.resize((func ? 0 : 1) + (deriv ? 0 : 3) + rest.size());
     Eigen::Index idx = 0;
@@ -84,12 +84,12 @@ class HIP3BasisT : public LIPBasisT<T> {
     if (!deriv) { keep(idx++) = first(1); keep(idx++) = first(2); keep(idx++) = first(3); }
     if (rest.size())
       keep.segment(idx, (idx + rest.size() - (idx) + 1) - 1) = rest;
-    this->enabled = keep;
+    this->enabled_ = keep;
   }
 
   void drop_last(bool func, bool deriv) override {
-    const IVec head(this->enabled.segment(0, (this->enabled.size() - (0) + 1) - 5));
-    const IVec last(this->enabled.segment(this->enabled.size() - 4, (this->enabled.size() - (this->enabled.size() - 4) + 1) - 1));
+    const IVec head(this->enabled_.segment(0, (this->enabled_.size() - (0) + 1) - 5));
+    const IVec last(this->enabled_.segment(this->enabled_.size() - 4, (this->enabled_.size() - (this->enabled_.size() - 4) + 1) - 1));
     IVec keep;
     keep.resize(head.size() + (func ? 0 : 1) + (deriv ? 0 : 3));
     Eigen::Index idx = 0;
@@ -99,7 +99,7 @@ class HIP3BasisT : public LIPBasisT<T> {
     }
     if (!func)  keep(idx++) = last(0);
     if (!deriv) { keep(idx++) = last(1); keep(idx++) = last(2); keep(idx++) = last(3); }
-    this->enabled = keep;
+    this->enabled_ = keep;
   }
 
   // Pull the base's 3-arg eval_over_r overload back into scope.
@@ -132,7 +132,7 @@ class HIP3BasisT : public LIPBasisT<T> {
                    T element_length) const override {
     // All of the deflation maths is generated -- see
     // libhelfem/src/generate_hip_family_code.py --order 3 --over-r
-    detail::eval_hip3_prim_over_r<T>(x, this->x0, lipxi, lipxi2, lipxi3, this->enabled,
+    detail::eval_hip3_prim_over_r<T>(x, this->x0_, lipxi, lipxi2, lipxi3, this->enabled_,
                                       dnf_over_r, n, element_length);
   }
 };

--- a/libhelfem/include/HIPBasis.h
+++ b/libhelfem/include/HIPBasis.h
@@ -33,16 +33,16 @@ class HIPBasisT : public LIPBasisT<T> {
   Vec<T> lipxi;
 
  public:
-  HIPBasisT(const Vec<T> & x, int id_ = 5) : LIPBasisT<T>(x, id_) {
+  HIPBasisT(const Vec<T> & x, int id = 5) : LIPBasisT<T>(x, id) {
     // Two overlapping functions: function + derivative
-    this->noverlap = 2;
-    this->nprim    = 2 * static_cast<int>(this->x0.size());
-    this->enabled  = IVec::LinSpaced(this->nprim, 0, this->nprim - 1);
-    this->nnodes   = static_cast<int>(this->x0.size());
+    this->noverlap_ = 2;
+    this->nprim_    = 2 * static_cast<int>(this->x0_.size());
+    this->enabled_  = IVec::LinSpaced(this->nprim_, 0, this->nprim_ - 1);
+    this->nnodes_   = static_cast<int>(this->x0_.size());
 
     // L'_i(x_i): use the LIP-derivative evaluator at the node positions.
     Mat<T> dlip;
-    detail::eval_lip_prim_dnf<T>(this->x0, this->x0, dlip, 1);
+    detail::eval_lip_prim_dnf<T>(this->x0_, this->x0_, dlip, 1);
     lipxi = dlip.diagonal();
   }
 
@@ -54,35 +54,35 @@ class HIPBasisT : public LIPBasisT<T> {
 
   void drop_first(bool func, bool deriv) override {
     if (func && deriv) {
-      this->enabled = this->enabled.segment(2, this->enabled.size() - 2).eval();
+      this->enabled_ = this->enabled_.segment(2, this->enabled_.size() - 2).eval();
     } else if (func) {
-      this->enabled = this->enabled.segment(1, this->enabled.size() - 1).eval();
+      this->enabled_ = this->enabled_.segment(1, this->enabled_.size() - 1).eval();
     } else if (deriv) {
-      IVec new_enabled(this->enabled.size() - 1);
-      new_enabled(0) = this->enabled(0);
+      IVec new_enabled(this->enabled_.size() - 1);
+      new_enabled(0) = this->enabled_(0);
       new_enabled.segment(1, new_enabled.size() - 1)
-          = this->enabled.segment(2, this->enabled.size() - 2);
-      this->enabled = new_enabled;
+          = this->enabled_.segment(2, this->enabled_.size() - 2);
+      this->enabled_ = new_enabled;
     }
   }
 
   void drop_last(bool func, bool deriv) override {
     if (func && deriv) {
-      this->enabled = this->enabled.segment(0, this->enabled.size() - 2).eval();
+      this->enabled_ = this->enabled_.segment(0, this->enabled_.size() - 2).eval();
     } else if (deriv) {
-      this->enabled = this->enabled.segment(0, this->enabled.size() - 1).eval();
+      this->enabled_ = this->enabled_.segment(0, this->enabled_.size() - 1).eval();
     } else {
-      IVec new_enabled(this->enabled.size() - 1);
-      new_enabled.segment(0, this->enabled.size() - 2)
-          = this->enabled.segment(0, this->enabled.size() - 2);
-      new_enabled(this->enabled.size() - 2) = this->enabled(this->enabled.size() - 1);
-      this->enabled = new_enabled;
+      IVec new_enabled(this->enabled_.size() - 1);
+      new_enabled.segment(0, this->enabled_.size() - 2)
+          = this->enabled_.segment(0, this->enabled_.size() - 2);
+      new_enabled(this->enabled_.size() - 2) = this->enabled_(this->enabled_.size() - 1);
+      this->enabled_ = new_enabled;
     }
   }
 
   void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
-    detail::eval_hip_prim_dnf<T>(x, this->x0, lipxi, dnf, n, element_length);
+    detail::eval_hip_prim_dnf<T>(x, this->x0_, lipxi, dnf, n, element_length);
   }
 
   // Pull the base's 3-arg matrix-returning eval_over_r overload back into
@@ -96,7 +96,7 @@ class HIPBasisT : public LIPBasisT<T> {
                    T element_length) const override {
     // All of the deflation maths is generated -- see
     // libhelfem/src/generate_hip_family_code.py --order 1 --over-r
-    detail::eval_hip_prim_over_r<T>(x, this->x0, lipxi, this->enabled,
+    detail::eval_hip_prim_over_r<T>(x, this->x0_, lipxi, this->enabled_,
                                       dnf_over_r, n, element_length);
   }
 };

--- a/libhelfem/include/LIPBasis.h
+++ b/libhelfem/include/LIPBasis.h
@@ -26,32 +26,32 @@ namespace helfem {
 namespace polynomial_basis {
 
 /// Lagrange interpolating polynomial basis on the reference element [-1, 1]
-/// with caller-supplied control nodes x0 (must include the endpoints).
+/// with caller-supplied control nodes x0_ (must include the endpoints).
 /// Templated on the scalar type T. Phase 5.2: Eigen-typed.
 template <typename T>
 class LIPBasisT : public PolynomialBasisT<T> {
  protected:
   /// Control nodes (sorted ascending; must span the reference element).
-  Vec<T> x0;
+  Vec<T> x0_;
 
  public:
   LIPBasisT() = default;
 
-  LIPBasisT(const Vec<T> & x, int id_ = 4) {
-    x0 = x;
-    std::sort(x0.data(), x0.data() + x0.size());
+  LIPBasisT(const Vec<T> & x, int id = 4) {
+    x0_ = x;
+    std::sort(x0_.data(), x0_.data() + x0_.size());
 
     const T sqrteps = std::sqrt(std::numeric_limits<T>::epsilon());
-    if (std::abs(x0(0) + T(1)) >= sqrteps)
+    if (std::abs(x0_(0) + T(1)) >= sqrteps)
       throw std::logic_error("LIP leftmost node is not at -1!\n");
-    if (std::abs(x0(x0.size() - 1) - T(1)) >= sqrteps)
+    if (std::abs(x0_(x0_.size() - 1) - T(1)) >= sqrteps)
       throw std::logic_error("LIP rightmost node is not at -1!\n");
 
-    this->noverlap = 1;
-    this->nprim    = static_cast<int>(x0.size());
-    this->enabled  = IVec::LinSpaced(x0.size(), 0, x0.size() - 1);
-    this->id       = id_;
-    this->nnodes   = static_cast<int>(this->enabled.size());
+    this->noverlap_ = 1;
+    this->nprim_    = static_cast<int>(x0_.size());
+    this->enabled_  = IVec::LinSpaced(x0_.size(), 0, x0_.size() - 1);
+    this->id_       = id;
+    this->nnodes_   = static_cast<int>(this->enabled_.size());
   }
 
   ~LIPBasisT() override = default;
@@ -63,18 +63,18 @@ class LIPBasisT : public PolynomialBasisT<T> {
   void drop_first(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.segment(1, this->enabled.size() - 1).eval();
+      this->enabled_ = this->enabled_.segment(1, this->enabled_.size() - 1).eval();
   }
   void drop_last(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.segment(0, this->enabled.size() - 1).eval();
+      this->enabled_ = this->enabled_.segment(0, this->enabled_.size() - 1).eval();
   }
 
   void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                      T element_length) const override {
     (void)element_length;
-    detail::eval_lip_prim_dnf<T>(x, x0, dnf, n);
+    detail::eval_lip_prim_dnf<T>(x, x0_, dnf, n);
   }
 
   // Pull the base's 3-arg matrix-returning eval_over_r overload back into
@@ -86,31 +86,31 @@ class LIPBasisT : public PolynomialBasisT<T> {
   /// the v1 code for the deflation derivation.
   void eval_over_r(const Vec<T> & x, Mat<T> & dnf_over_r, int n,
                    T element_length) const override {
-    if (this->enabled.size() == 0)
+    if (this->enabled_.size() == 0)
       throw std::logic_error("eval_over_r: no surviving basis functions.\n");
-    if (this->enabled(0) == 0)
+    if (this->enabled_(0) == 0)
       throw std::logic_error(
           "eval_over_r requires drop_first(func=true) on LIPBasisT: the shape "
           "function at x=-1 has B(-1) != 0 and B/r is singular at the origin.\n");
 
-    const Vec<T> x0_reduced = x0.segment(1, x0.size() - 1);
+    const Vec<T> x0_reduced = x0_.segment(1, x0_.size() - 1);
     Mat<T> dnf_reduced;
     detail::eval_lip_prim_dnf<T>(x, x0_reduced, dnf_reduced, n);
     // dnf_reduced column j_red ∈ [0, n-2] corresponds to full index j_full = j_red + 1.
 
     const T scale = T(1) / std::pow(element_length, n + 1);
-    dnf_over_r.resize(x.size(), this->enabled.size());
-    for (Eigen::Index k = 0; k < this->enabled.size(); ++k) {
-      const Eigen::Index i_full = this->enabled(k);
+    dnf_over_r.resize(x.size(), this->enabled_.size());
+    for (Eigen::Index k = 0; k < this->enabled_.size(); ++k) {
+      const Eigen::Index i_full = this->enabled_(k);
       const Eigen::Index i_red  = i_full - 1;
-      const T denom = x0(i_full) + T(1);
+      const T denom = x0_(i_full) + T(1);
       for (Eigen::Index ix = 0; ix < x.size(); ++ix) {
         dnf_over_r(ix, k) = scale * dnf_reduced(ix, i_red) / denom;
       }
     }
   }
 
-  Vec<T> get_nodes() const override { return x0; }
+  Vec<T> nodes() const override { return x0_; }
 };
 
 } // namespace polynomial_basis

--- a/libhelfem/include/LegendreBasis.h
+++ b/libhelfem/include/LegendreBasis.h
@@ -44,7 +44,7 @@ class LegendreBasisT : public PolynomialBasisT<T> {
   }
 
  public:
-  LegendreBasisT(int n_nodes, int id_ = 3) {
+  LegendreBasisT(int n_nodes, int id = 3) {
     lmax = n_nodes - 1;
     Tmat = Mat<T>::Zero(lmax + 1, lmax + 1);
     // First shape function: (P_0 - P_1) / 2
@@ -59,11 +59,11 @@ class LegendreBasisT : public PolynomialBasisT<T> {
       Tmat(j + 1, j) = sqfac;
       Tmat(j - 1, j) = -sqfac;
     }
-    this->noverlap = 1;
-    this->nprim    = static_cast<int>(Tmat.cols());
-    this->nnodes   = static_cast<int>(Tmat.cols());
-    this->enabled  = IVec::LinSpaced(Tmat.cols(), 0, Tmat.cols() - 1);
-    this->id       = id_;
+    this->noverlap_ = 1;
+    this->nprim_    = static_cast<int>(Tmat.cols());
+    this->nnodes_   = static_cast<int>(Tmat.cols());
+    this->enabled_  = IVec::LinSpaced(Tmat.cols(), 0, Tmat.cols() - 1);
+    this->id_       = id;
   }
 
   ~LegendreBasisT() override = default;
@@ -75,12 +75,12 @@ class LegendreBasisT : public PolynomialBasisT<T> {
   void drop_first(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.segment(1, this->enabled.size() - 1).eval();
+      this->enabled_ = this->enabled_.segment(1, this->enabled_.size() - 1).eval();
   }
   void drop_last(bool func, bool deriv) override {
     (void)deriv;
     if (func)
-      this->enabled = this->enabled.segment(0, this->enabled.size() - 1).eval();
+      this->enabled_ = this->enabled_.segment(0, this->enabled_.size() - 1).eval();
   }
 
   void eval_prim_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
@@ -112,9 +112,9 @@ class LegendreBasisT : public PolynomialBasisT<T> {
           << " not implemented (only 0, 1, 2 supported).\n";
       throw std::logic_error(oss.str());
     }
-    if (this->enabled.size() == 0)
+    if (this->enabled_.size() == 0)
       throw std::logic_error("LegendreBasisT::eval_over_r: no surviving basis functions.\n");
-    if (this->enabled(0) == 0)
+    if (this->enabled_(0) == 0)
       throw std::logic_error(
           "LegendreBasisT::eval_over_r requires drop_first(zero_func=true): "
           "the value-shape (1-x)/2 has B(-1)=1 and B/r is singular at the origin.\n");
@@ -145,9 +145,9 @@ class LegendreBasisT : public PolynomialBasisT<T> {
     const T inv_e   = T(1) / element_length;
     const T chain_n = std::pow(inv_e, n);
 
-    dnf_over_r.resize(x.size(), this->enabled.size());
-    for (Eigen::Index k = 0; k < this->enabled.size(); ++k) {
-      const Eigen::Index j = this->enabled(k);
+    dnf_over_r.resize(x.size(), this->enabled_.size());
+    for (Eigen::Index k = 0; k < this->enabled_.size(); ++k) {
+      const Eigen::Index j = this->enabled_(k);
       if (j == static_cast<Eigen::Index>(lmax)) {
         // Last shape: R(r) = 1/(2 e); derivatives vanish.
         const T val0 = T(1) / (T(2) * element_length);

--- a/libhelfem/include/PolynomialBasis.h
+++ b/libhelfem/include/PolynomialBasis.h
@@ -45,14 +45,14 @@ namespace helfem {
     using LegendreBasis   = LegendreBasisT<double>;
 
     /// Factory: construct a primitive polynomial basis by ID.
-    PolynomialBasis * get_basis(int primbas, int Nnodes);
+    PolynomialBasis * make_basis(int primbas, int Nnodes);
 
     /// Same factory, templated on the scalar type. The concrete bases
     /// (LegendreBasisT<T>, LIPBasisT<T>, HIPBasisT<T>) and lobatto_compute<T>
     /// were already generic; this just stops the factory from pinning double.
     template<typename T>
     helfem::polynomial_basis::PolynomialBasisT<T> *
-    get_basis_T(int primbas, int Nnodes) {
+    make_basis_T(int primbas, int Nnodes) {
       namespace pb = helfem::polynomial_basis;
       if(Nnodes < 2)
         throw std::logic_error("Can't have finite element basis with less than two nodes per element.\n");

--- a/libhelfem/include/PolynomialBasisT.h
+++ b/libhelfem/include/PolynomialBasisT.h
@@ -27,22 +27,22 @@ namespace polynomial_basis {
 /// Abstract template for a primitive polynomial basis defined on the
 /// reference element [-1, 1]. Concrete subclasses (LIPBasisT, HIPBasisT,
 /// GeneralHIPBasis, LegendreBasisT) implement eval_prim_dnf, copy,
-/// drop_first, drop_last and may override get_nodes.
+/// drop_first, drop_last and may override nodes.
 ///
 /// Templated on the scalar type T.
 template <typename T>
 class PolynomialBasisT {
  protected:
   /// Number of primitive functions
-  int nprim = 0;
-  /// List of enabled functions (column indices into the primitive set).
-  IVec enabled;
+  int nprim_ = 0;
+  /// List of enabled_ functions (column indices into the primitive set).
+  IVec enabled_;
   /// Number of overlapping functions (between adjacent elements)
-  int noverlap = 0;
+  int noverlap_ = 0;
   /// Identifier (used by factories and downstream metadata)
-  int id = 0;
+  int id_ = 0;
   /// Number of nodes
-  int nnodes = 0;
+  int nnodes_ = 0;
 
   /// Evaluate nth derivatives of primitive polynomials at given points.
   /// Default throws -- concrete subclasses must override.
@@ -60,22 +60,22 @@ class PolynomialBasisT {
   /// Polymorphic clone.
   virtual PolynomialBasisT * copy() const = 0;
 
-  int get_nprim()    const { return nprim; }
-  int get_nbf()      const { return static_cast<int>(enabled.size()); }
-  int get_noverlap() const { return noverlap; }
-  int get_id()       const { return id; }
-  int get_nnodes()   const { return nnodes; }
+  int nprim()    const { return nprim_; }
+  int nbf()      const { return static_cast<int>(enabled_.size()); }
+  int noverlap() const { return noverlap_; }
+  int id()       const { return id_; }
+  int nnodes()   const { return nnodes_; }
 
   /// Default node set is the reference element boundary {-1, +1};
   /// concrete subclasses (LIP/HIP) override with the actual node set.
-  virtual Vec<T> get_nodes() const {
+  virtual Vec<T> nodes() const {
     Vec<T> n(2);
     n(0) = T(-1);
     n(1) = T(1);
     return n;
   }
 
-  IVec get_enabled() const { return enabled; }
+  IVec enabled() const { return enabled_; }
 
   /// Drop first function(s); zero_deriv: also set derivatives to zero.
   virtual void drop_first(bool zero_func, bool zero_deriv) = 0;
@@ -83,14 +83,14 @@ class PolynomialBasisT {
   virtual void drop_last(bool zero_func, bool zero_deriv) = 0;
 
   /// Evaluate nth derivatives of polynomials at given points; applies the
-  /// element_length^-n chain-rule scaling and restricts to enabled
+  /// element_length^-n chain-rule scaling and restricts to enabled_
   /// functions.
   void eval_dnf(const Vec<T> & x, Mat<T> & dnf, int n,
                 T element_length) const {
     Mat<T> prim;
     eval_prim_dnf(x, prim, n, element_length);
-    // Column subset using Eigen 3.4 indexing: prim(all, enabled).
-    dnf = prim(Eigen::all, enabled) / std::pow(element_length, n);
+    // Column subset using Eigen 3.4 indexing: prim(all, enabled_).
+    dnf = prim(Eigen::all, enabled_) / std::pow(element_length, n);
   }
 
   Mat<T> eval_dnf(const Vec<T> & x, int n, T element_length) const {
@@ -99,7 +99,7 @@ class PolynomialBasisT {
     return dnf;
   }
 
-  /// Evaluate n-th derivative (w.r.t. r) of B_u(r)/r for every enabled
+  /// Evaluate n-th derivative (w.r.t. r) of B_u(r)/r for every enabled_
   /// shape function on the FIRST element [0, element_length], where x is in
   /// reference coords [-1, +1] and r = (element_length/2) * (x+1).
   ///

--- a/libhelfem/include/RadialBasis.h
+++ b/libhelfem/include/RadialBasis.h
@@ -78,11 +78,11 @@ namespace helfem {
       class FEMRadialBasisT : public RadialBasisT<T> {
         /// Quadrature points
         // Phase 5.6: quadrature node/weight members migrated to Eigen.
-        helfem::Vec<T> xq;
+        helfem::Vec<T> xq_;
         /// Quadrature weights
-        helfem::Vec<T> wq;
+        helfem::Vec<T> wq_;
         /// Finite element basis
-        polynomial_basis::FiniteElementBasisT<T> fem;
+        polynomial_basis::FiniteElementBasisT<T> fem_;
 
         /// Quadrature-node values of the basis functions and of their
         /// first two derivatives, indexed by element. Filled on demand by
@@ -90,9 +90,9 @@ namespace helfem {
         /// the get_*(iel) overloads fall back to evaluating. Mutable
         /// because filling them changes nothing an observer can see --
         /// the values are a pure function of the element index.
-        mutable std::vector<helfem::Mat<T>> bfq_cache;
-        mutable std::vector<helfem::Mat<T>> dfq_cache;
-        mutable std::vector<helfem::Mat<T>> lfq_cache;
+        mutable std::vector<helfem::Mat<T>> bfq_cache_;
+        mutable std::vector<helfem::Mat<T>> dfq_cache_;
+        mutable std::vector<helfem::Mat<T>> lfq_cache_;
 
         /// Starting Gauss-Chebyshev order for the auto-converging
         /// two-electron primitives. Seeded from the requested n_quad so the
@@ -112,23 +112,23 @@ namespace helfem {
         void add_boundary(T r);
 
         /// Get polynomial basis
-        std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> get_poly() const;
+        std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> poly() const;
         /// Get the underlying FE basis (read-only).
-        const polynomial_basis::FiniteElementBasisT<T> & get_fem() const { return fem; }
+        const polynomial_basis::FiniteElementBasisT<T> & fem() const { return fem_; }
 
         /// Get number of quadrature points
-        int get_nquad() const;
+        int nquad() const;
         /// Get quadrature points (Phase 5.20: Eigen at the public boundary).
-        helfem::Vec<T> get_xq() const;
+        helfem::Vec<T> xq() const;
         /// Get boundary values (Phase 5.20: Eigen at the public boundary).
-        helfem::Vec<T> get_bval() const;
+        helfem::Vec<T> bval() const;
         /// Get polynomial basis identifier
-        int get_poly_id() const;
+        int poly_id() const;
         /// Get number of nodes in polynomial basis
-        int get_poly_nnodes() const;
+        int poly_nnodes() const;
 
         /// Get number of overlapping functions
-        size_t get_noverlap() const;
+        size_t noverlap() const;
         /// Number of basis functions
         size_t Nbf() const override;
         /// Number of primitive functions in element
@@ -139,7 +139,7 @@ namespace helfem {
         /// Number of elements
         size_t Nel() const;
         /// Get function indices
-        void get_idx(size_t iel, size_t &ifirst, size_t &ilast) const;
+        void idx(size_t iel, size_t &ifirst, size_t &ilast) const;
 
         /// Compute radial matrix elements <r^n> in element (overlap is n=0,
         /// nuclear is n=-1). Eigen-typed (Phase 2a migration).
@@ -308,7 +308,7 @@ namespace helfem {
         /// table lookups.
         ///
         /// The values depend only on the element index -- the nodes are
-        /// the fixed rule `xq` -- so recomputing them, as the DFT grid
+        /// the fixed rule `xq_` -- so recomputing them, as the DFT grid
         /// did on every Fock build, is pure repetition: it cost ~11% of
         /// an atom-in-jellium run. Nel * Nquad * (nnodes+1) doubles per
         /// requested order, a few MB even for a large grid.
@@ -326,38 +326,38 @@ namespace helfem {
         /// Horner form,
         ///   d^n [B/r] = ( ... (c_0 B invr + c_1 B') invr + ... + c_n B^(n) ) invr,
         ///   c_k = (-1)^(n-k) n! / k!,
-        /// which reproduces the former per-order get_bf/get_df/get_lf
+        /// which reproduces the former per-order bf/df/lf
         /// groupings exactly; those are now one-line calls of this.
         helfem::Mat<T> eval_psi_dnf(const helfem::Vec<T> & x, int n, size_t iel) const;
 
-        helfem::Mat<T> get_bf(size_t iel) const;
+        helfem::Mat<T> bf(size_t iel) const;
         /// Evaluate basis functions at given points (Phase 5.24: Eigen input + return).
-        helfem::Mat<T> get_bf(const helfem::Vec<T> & x, size_t iel) const;
+        helfem::Mat<T> bf(const helfem::Vec<T> & x, size_t iel) const;
         /// Evaluate derivatives of basis functions at quadrature points (Eigen return).
-        helfem::Mat<T> get_df(size_t iel) const;
+        helfem::Mat<T> df(size_t iel) const;
         /// Evaluate derivatives of basis functions at given points
         /// (Phase 5.24: Eigen input + return).
-        helfem::Mat<T> get_df(const helfem::Vec<T> & x, size_t iel) const;
+        helfem::Mat<T> df(const helfem::Vec<T> & x, size_t iel) const;
         /// Evaluate second derivatives of basis functions at quadrature points (Eigen return).
-        helfem::Mat<T> get_lf(size_t iel) const;
+        helfem::Mat<T> lf(size_t iel) const;
         /// Evaluate second derivatives of basis functions at given points
         /// (Phase 5.24: Eigen input + return).
-        helfem::Mat<T> get_lf(const helfem::Vec<T> & x, size_t iel) const;
+        helfem::Mat<T> lf(const helfem::Vec<T> & x, size_t iel) const;
         /// Evaluate orbitals at a given point (Phase 5.23: Eigen-typed).
         helfem::Vec<T> eval_orbs(const helfem::Mat<T> & C, T r) const override;
 
         /// Get quadrature weights in element.
-        helfem::Vec<T> get_wrad(size_t iel) const;
+        helfem::Vec<T> wrad(size_t iel) const;
         /// Get quadrature weights in element from user-supplied weight
         /// vector (Phase 5.25: Eigen input + return).
-        helfem::Vec<T> get_wrad(const helfem::Vec<T> & w, size_t iel) const;
+        helfem::Vec<T> wrad(const helfem::Vec<T> & w, size_t iel) const;
         /// Get r values at quadrature points in element.
-        helfem::Vec<T> get_r(size_t iel) const;
+        helfem::Vec<T> r(size_t iel) const;
         /// Get r values at user-supplied x points in element
         /// (Phase 5.25: Eigen input + return).
-        helfem::Vec<T> get_r(const helfem::Vec<T> & x, size_t iel) const;
+        helfem::Vec<T> r(const helfem::Vec<T> & x, size_t iel) const;
 	/// Get r value
-        T get_r(T x, size_t iel) const;
+        T r(T x, size_t iel) const;
 
         /// Evaluate nuclear density (Phase 5.22: Eigen-typed argument).
         T nuclear_density(const helfem::Mat<T> &P) const;

--- a/libhelfem/include/helfem.source.h
+++ b/libhelfem/include/helfem.source.h
@@ -70,7 +70,7 @@ namespace helfem {
 namespace helfem {
   namespace polynomial_basis {
     /// Get the wanted basis
-    PolynomialBasis *get_basis(int primbas, int Nnodes);
+    PolynomialBasis *basis(int primbas, int Nnodes);
   } // namespace polynomial_basis
 } // namespace helfem
 

--- a/libhelfem/src/FiniteElementBasis.cpp
+++ b/libhelfem/src/FiniteElementBasis.cpp
@@ -32,12 +32,12 @@ namespace helfem {
     }
 
     template<typename T>
-    FiniteElementBasisT<T>::FiniteElementBasisT(const std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> & poly_,
-                                           const helfem::Vec<T> &bval_, bool zero_func_left_, bool zero_deriv_left_, bool zero_func_right_, bool zero_deriv_right_) : zero_func_left(zero_func_left_), zero_deriv_left(zero_deriv_left_), zero_func_right(zero_func_right_), zero_deriv_right(zero_deriv_right_) {
+    FiniteElementBasisT<T>::FiniteElementBasisT(const std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> & poly,
+                                           const helfem::Vec<T> &bval, bool zero_func_left, bool zero_deriv_left, bool zero_func_right, bool zero_deriv_right) : zero_func_left_(zero_func_left), zero_deriv_left_(zero_deriv_left), zero_func_right_(zero_func_right), zero_deriv_right_(zero_deriv_right) {
       // Phase 5.26: bval is Eigen at both the public boundary and the
       // internal storage; direct assignment, no bridge.
-      bval = bval_;
-      poly = std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>>(poly_->copy());
+      bval_ = bval;
+      poly_ = std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>>(poly->copy());
       // Update list of basis functions
       update_bf_list();
       // Check that basis functions are continuous
@@ -50,27 +50,27 @@ namespace helfem {
 
     template<typename T>
     void FiniteElementBasisT<T>::update_bf_list() {
-      if (bval.size() == 0)
+      if (bval_.size() == 0)
         throw std::logic_error("Can't update basis function list since there are no elements!\n");
 
       // Form list of element boundaries
-      first_func_in_element = helfem::IVec::Zero(bval.size() - 1);
-      last_func_in_element  = helfem::IVec::Zero(bval.size() - 1);
-      for (Eigen::Index iel = 0; iel < first_func_in_element.size(); ++iel) {
-        first_func_in_element(iel) = (iel == 0) ? 0
-            : last_func_in_element(iel - 1) - poly->get_noverlap() + 1;
-        last_func_in_element(iel) = first_func_in_element(iel) + basis_indices(iel).size() - 1;
+      first_func_in_element_ = helfem::IVec::Zero(bval_.size() - 1);
+      last_func_in_element_  = helfem::IVec::Zero(bval_.size() - 1);
+      for (Eigen::Index iel = 0; iel < first_func_in_element_.size(); ++iel) {
+        first_func_in_element_(iel) = (iel == 0) ? 0
+            : last_func_in_element_(iel - 1) - poly_->noverlap() + 1;
+        last_func_in_element_(iel) = first_func_in_element_(iel) + basis_indices(iel).size() - 1;
       }
     }
 
     template<typename T>
     void FiniteElementBasisT<T>::check_bf_continuity() const {
-      if(get_nelem()==1)
+      if(nelem()==1)
         return;
-      int noverlap(poly->get_noverlap());
+      int noverlap(poly_->noverlap());
 
-      helfem::Vec<T> dnorm(get_nelem()-1);
-      for(size_t iel=0; iel+1<get_nelem(); iel++) {
+      helfem::Vec<T> dnorm(nelem()-1);
+      for(size_t iel=0; iel+1<nelem(); iel++) {
         // Points that correspond to lh and rh elements
         helfem::Vec<T> xlh(1), xrh(1);
         xlh(0) = 1.0;
@@ -155,29 +155,29 @@ namespace helfem {
     }
 
     template<typename T>
-    void FiniteElementBasisT<T>::get_idx(size_t iel, size_t &ifirst, size_t &ilast) const {
-      ifirst = first_func_in_element[iel];
-      ilast = last_func_in_element[iel];
+    void FiniteElementBasisT<T>::idx(size_t iel, size_t &ifirst, size_t &ilast) const {
+      ifirst = first_func_in_element_[iel];
+      ilast = last_func_in_element_[iel];
     }
 
     template<typename T>
     void FiniteElementBasisT<T>::add_boundary(T r) {
-      // Check that r is not in bval
-      for (Eigen::Index i = 0; i < bval.size(); ++i)
-        if (bval(i) == r)
+      // Check that r is not in bval_
+      for (Eigen::Index i = 0; i < bval_.size(); ++i)
+        if (bval_(i) == r)
           return;
 
       // Append + sort
-      helfem::Vec<T> newbval(bval.size() + 1);
-      newbval.head(bval.size()) = bval;
-      newbval(bval.size()) = r;
+      helfem::Vec<T> newbval(bval_.size() + 1);
+      newbval.head(bval_.size()) = bval_;
+      newbval(bval_.size()) = r;
       std::sort(newbval.data(), newbval.data() + newbval.size());
-      bval = newbval;
+      bval_ = newbval;
       update_bf_list();
     }
 
     template<typename T>
-    std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> FiniteElementBasisT<T>::get_poly() const { return std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>>(poly->copy()); }
+    std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> FiniteElementBasisT<T>::poly() const { return std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>>(poly_->copy()); }
 
     template<typename T>
     T FiniteElementBasisT<T>::scaling_factor(size_t iel) const {
@@ -187,32 +187,32 @@ namespace helfem {
 
     template<typename T>
     T FiniteElementBasisT<T>::element_length(size_t iel) const {
-      if(iel>=get_nelem()) {
+      if(iel>=nelem()) {
         std::ostringstream oss;
-        oss << "Trying to access length of element " << iel << " but only have " << get_nelem() << "!\n";
+        oss << "Trying to access length of element " << iel << " but only have " << nelem() << "!\n";
         throw std::logic_error(oss.str());
       }
-      return bval(iel+1)-bval(iel);
+      return bval_(iel+1)-bval_(iel);
     }
 
     template<typename T>
     T FiniteElementBasisT<T>::element_begin(size_t iel) const {
-      if(iel>=get_nelem()) {
+      if(iel>=nelem()) {
         std::ostringstream oss;
-        oss << "Trying to access length of element " << iel << " but only have " << get_nelem() << "!\n";
+        oss << "Trying to access length of element " << iel << " but only have " << nelem() << "!\n";
         throw std::logic_error(oss.str());
       }
-      return bval(iel);
+      return bval_(iel);
     }
 
     template<typename T>
     T FiniteElementBasisT<T>::element_end(size_t iel) const {
-      if(iel>=get_nelem()) {
+      if(iel>=nelem()) {
         std::ostringstream oss;
-        oss << "Trying to access length of element " << iel << " but only have " << get_nelem() << "!\n";
+        oss << "Trying to access length of element " << iel << " but only have " << nelem() << "!\n";
         throw std::logic_error(oss.str());
       }
-      return bval(iel+1);
+      return bval_(iel+1);
     }
 
     template<typename T>
@@ -224,7 +224,7 @@ namespace helfem {
     size_t FiniteElementBasisT<T>::find_element(T x) const {
       // Find the element x is in
       size_t element_left = 0;
-      size_t element_right = get_nelem()-1;
+      size_t element_right = nelem()-1;
 
       if(x <= element_end(element_left))
         return element_left;
@@ -244,9 +244,9 @@ namespace helfem {
     }
 
     template<typename T>
-    helfem::Vec<T> FiniteElementBasisT<T>::get_bval() const {
-      // Phase 5.5: bval is now native Eigen; direct return.
-      return bval;
+    helfem::Vec<T> FiniteElementBasisT<T>::bval() const {
+      // Phase 5.5: bval_ is now native Eigen; direct return.
+      return bval_;
     }
 
     template<typename T>
@@ -261,16 +261,16 @@ namespace helfem {
 
     template<typename T>
     helfem::Vec<T> FiniteElementBasisT<T>::eval_coord(const helfem::Vec<T> & x) const {
-      helfem::Vec<T> r(get_nelem() * x.size());
-      for (size_t iel = 0; iel < get_nelem(); ++iel)
+      helfem::Vec<T> r(nelem() * x.size());
+      for (size_t iel = 0; iel < nelem(); ++iel)
         r.segment(iel * x.size(), x.size()) = eval_coord(x, iel);
       return r;
     }
 
     template<typename T>
     helfem::Vec<T> FiniteElementBasisT<T>::eval_weights(const helfem::Vec<T> & w) const {
-      helfem::Vec<T> wr(get_nelem() * w.size());
-      for (size_t iel = 0; iel < get_nelem(); ++iel)
+      helfem::Vec<T> wr(nelem() * w.size());
+      for (size_t iel = 0; iel < nelem(); ++iel)
         wr.segment(iel * w.size(), w.size()) = w * scaling_factor(iel);
       return wr;
     }
@@ -284,54 +284,54 @@ namespace helfem {
     }
 
     template<typename T>
-    int FiniteElementBasisT<T>::get_poly_id() const {
-      return poly->get_id();
+    int FiniteElementBasisT<T>::poly_id() const {
+      return poly_->id();
     }
 
     template<typename T>
-    int FiniteElementBasisT<T>::get_poly_nnodes() const {
-      return poly->get_nnodes();
+    int FiniteElementBasisT<T>::poly_nnodes() const {
+      return poly_->nnodes();
     }
 
     template<typename T>
     helfem::IVec FiniteElementBasisT<T>::basis_indices(size_t iel) const {
       // Phase 5.5: native Eigen pass-through.
-      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(get_basis(iel));
-      return p->get_enabled();
+      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(basis(iel));
+      return p->enabled();
     }
 
     template<typename T>
     std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>>
-    FiniteElementBasisT<T>::get_basis(size_t iel) const {
-      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(poly->copy());
+    FiniteElementBasisT<T>::basis(size_t iel) const {
+      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(poly_->copy());
       if (iel == 0)
-        p->drop_first(zero_func_left, zero_deriv_left);
-      if (iel == bval.size() - 2)
-        p->drop_last(zero_func_right, zero_deriv_right);
+        p->drop_first(zero_func_left_, zero_deriv_left_);
+      if (iel == bval_.size() - 2)
+        p->drop_last(zero_func_right_, zero_deriv_right_);
 
       return p;
     }
 
     template<typename T>
-    size_t FiniteElementBasisT<T>::get_nbf() const {
-      if (last_func_in_element.size() == 0)
+    size_t FiniteElementBasisT<T>::nbf() const {
+      if (last_func_in_element_.size() == 0)
         throw std::logic_error("Basis function list has not been filled\n");
-      return static_cast<size_t>(last_func_in_element(last_func_in_element.size() - 1) + 1);
+      return static_cast<size_t>(last_func_in_element_(last_func_in_element_.size() - 1) + 1);
     }
 
     template<typename T>
-    size_t FiniteElementBasisT<T>::get_nelem() const {
-      return bval.size() - 1;
+    size_t FiniteElementBasisT<T>::nelem() const {
+      return bval_.size() - 1;
     }
 
     template<typename T>
-    size_t FiniteElementBasisT<T>::get_max_nprim() const {
-      return poly->get_nprim();
+    size_t FiniteElementBasisT<T>::max_nprim() const {
+      return poly_->nprim();
     }
 
     template<typename T>
-    size_t FiniteElementBasisT<T>::get_nprim(size_t iel) const {
-      return get_basis(iel)->get_nbf();
+    size_t FiniteElementBasisT<T>::nprim(size_t iel) const {
+      return basis(iel)->nbf();
     }
 
     // Phase 5.3: eval_* migrated to Eigen; internal primitive-basis call no longer
@@ -341,7 +341,7 @@ namespace helfem {
     void FiniteElementBasisT<T>::eval_dnf(const helfem::Vec<T> & x, helfem::Mat<T> & dnf, int n, size_t iel) const {
       // helfem::Vec<T> == Vec<double>, same for Matrix; no
       // conversion needed.
-      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(get_basis(iel));
+      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(basis(iel));
       p->eval_dnf(x, dnf, n, scaling_factor(iel));
     }
 
@@ -361,7 +361,7 @@ namespace helfem {
             " element " << iel << " starts at " << (double) element_begin(iel) << ".\n";
         throw std::logic_error(oss.str());
       }
-      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(get_basis(iel));
+      std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(basis(iel));
       helfem::Mat<T> dnf_over_r;
       p->eval_over_r(x, dnf_over_r, n, scaling_factor(iel));
       return dnf_over_r;
@@ -369,11 +369,11 @@ namespace helfem {
 
     template<typename T>
     helfem::Mat<T> FiniteElementBasisT<T>::eval_dnf(const helfem::Vec<T> & x, int n) const {
-      helfem::Mat<T> f(get_nelem() * x.size(), get_nbf());
+      helfem::Mat<T> f(nelem() * x.size(), nbf());
       f.setZero();
-      for (size_t iel = 0; iel < get_nelem(); ++iel) {
-        const Eigen::Index ifirst = static_cast<Eigen::Index>(first_func_in_element(iel));
-        const Eigen::Index ilast  = static_cast<Eigen::Index>(last_func_in_element(iel));
+      for (size_t iel = 0; iel < nelem(); ++iel) {
+        const Eigen::Index ifirst = static_cast<Eigen::Index>(first_func_in_element_(iel));
+        const Eigen::Index ilast  = static_cast<Eigen::Index>(last_func_in_element_(iel));
         f.block(iel * x.size(), ifirst, x.size(), ilast - ifirst + 1) = eval_dnf(x, n, iel);
       }
       return f;
@@ -385,19 +385,19 @@ namespace helfem {
     template<typename T>
     helfem::Mat<T> FiniteElementBasisT<T>::matrix_element(const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_lh, const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval_rh, const helfem::Vec<T> & xq, const helfem::Vec<T> & wq, const std::function<T(T)> & f) const {
       // Compute matrix elements in parallel
-      std::vector<helfem::Mat<T>> matel(get_nelem());
+      std::vector<helfem::Mat<T>> matel(nelem());
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t iel = 0; iel < get_nelem(); ++iel) {
+      for (size_t iel = 0; iel < nelem(); ++iel) {
         matel[iel] = matrix_element(iel, eval_lh, eval_rh, xq, wq, f);
       }
 
-      const Eigen::Index N = static_cast<Eigen::Index>(get_nbf());
+      const Eigen::Index N = static_cast<Eigen::Index>(nbf());
       helfem::Mat<T> M = helfem::Mat<T>::Zero(N, N);
-      for (size_t iel = 0; iel < get_nelem(); ++iel) {
+      for (size_t iel = 0; iel < nelem(); ++iel) {
         size_t ifirst, ilast;
-        get_idx(iel, ifirst, ilast);
+        idx(iel, ifirst, ilast);
         M.block((Eigen::Index) ifirst, (Eigen::Index) ifirst,
                 ilast - ifirst + 1, ilast - ifirst + 1) += matel[iel];
       }
@@ -406,18 +406,18 @@ namespace helfem {
 
     template<typename T>
     helfem::Vec<T> FiniteElementBasisT<T>::vector_element(const std::function<helfem::Mat<T>(helfem::Vec<T>,size_t)> & eval, const helfem::Vec<T> & xq, const helfem::Vec<T> & wq, const std::function<T(T)> & f) const {
-      std::vector<helfem::Vec<T>> vecel(get_nelem());
+      std::vector<helfem::Vec<T>> vecel(nelem());
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t iel = 0; iel < get_nelem(); ++iel) {
+      for (size_t iel = 0; iel < nelem(); ++iel) {
         vecel[iel] = vector_element(iel, eval, xq, wq, f);
       }
 
-      helfem::Vec<T> V = helfem::Vec<T>::Zero(get_nbf());
-      for (size_t iel = 0; iel < get_nelem(); ++iel) {
+      helfem::Vec<T> V = helfem::Vec<T>::Zero(nbf());
+      for (size_t iel = 0; iel < nelem(); ++iel) {
         size_t ifirst, ilast;
-        get_idx(iel, ifirst, ilast);
+        idx(iel, ifirst, ilast);
         V.segment((Eigen::Index) ifirst, ilast - ifirst + 1) += vecel[iel];
       }
       return V;
@@ -580,7 +580,7 @@ namespace helfem {
       // n that already integrates B*B*(polynomial f) exactly; the refine loop
       // then confirms (polynomial case) or extends (non-polynomial f). Using an
       // upper bound on the basis degree only affects speed, never correctness.
-      const int basisdeg = std::max(0, poly->get_noverlap() * poly->get_nnodes() - 1);
+      const int basisdeg = std::max(0, poly_->noverlap() * poly_->nnodes() - 1);
       const int fdeg     = std::max(0, poly_degree_f);
       const int deg      = 2 * basisdeg + fdeg;
       const int nmax     = 512;
@@ -610,18 +610,18 @@ namespace helfem {
         const std::function<T(T)> & f,
         const std::vector<T> & breakpoints,
         int poly_degree_f) const {
-      std::vector<helfem::Mat<T>> matel(get_nelem());
+      std::vector<helfem::Mat<T>> matel(nelem());
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t iel = 0; iel < get_nelem(); ++iel)
+      for (size_t iel = 0; iel < nelem(); ++iel)
         matel[iel] = matrix_element_auto(iel, eval_lh, eval_rh, f, breakpoints, poly_degree_f);
 
-      const Eigen::Index N = static_cast<Eigen::Index>(get_nbf());
+      const Eigen::Index N = static_cast<Eigen::Index>(nbf());
       helfem::Mat<T> M = helfem::Mat<T>::Zero(N, N);
-      for (size_t iel = 0; iel < get_nelem(); ++iel) {
+      for (size_t iel = 0; iel < nelem(); ++iel) {
         size_t ifirst, ilast;
-        get_idx(iel, ifirst, ilast);
+        idx(iel, ifirst, ilast);
         M.block((Eigen::Index) ifirst, (Eigen::Index) ifirst,
                 ilast - ifirst + 1, ilast - ifirst + 1) += matel[iel];
       }
@@ -677,7 +677,7 @@ namespace helfem {
     template<typename T>
     void FiniteElementBasisT<T>::print(const std::string & str) const {
       printf("%s",str.c_str());
-      printf("bval has %lld entries\n", (long long) bval.size());
+      printf("bval_ has %lld entries\n", (long long) bval_.size());
     }
 
     // Explicit instantiations. Everything below libhelfem was already generic;

--- a/libhelfem/src/PolynomialBasis.cpp
+++ b/libhelfem/src/PolynomialBasis.cpp
@@ -29,7 +29,7 @@
 
 namespace helfem {
   namespace polynomial_basis {
-    PolynomialBasis * get_basis(int primbas, int Nnodes) {
+    PolynomialBasis * make_basis(int primbas, int Nnodes) {
       if(Nnodes<2)
         throw std::logic_error("Can't have finite element basis with less than two nodes per element.\n");
 

--- a/libhelfem/src/RadialBasis.cpp
+++ b/libhelfem/src/RadialBasis.cpp
@@ -166,7 +166,7 @@ namespace helfem {
       int FEMRadialBasisT<T>::twoe_nstart() const {
         // Seed from the requested --nquad so the common case converges in
         // 1-2 refinement steps; the loop is what guarantees the accuracy.
-        int n = (int) xq.size();
+        int n = (int) xq_.size();
         if (n < 5) n = 5;
         if (n > twoe_nmax) n = twoe_nmax;
         return n;
@@ -176,14 +176,14 @@ namespace helfem {
       FEMRadialBasisT<T>::FEMRadialBasisT() {}
 
       template <typename T>
-      FEMRadialBasisT<T>::FEMRadialBasisT(const polynomial_basis::FiniteElementBasisT<T> & fem_, int n_quad) : fem(fem_) {
-        helfem::chebyshev::chebyshev<T>(n_quad, xq, wq);
-        for (Eigen::Index i = 0; i < xq.size(); ++i) {
+      FEMRadialBasisT<T>::FEMRadialBasisT(const polynomial_basis::FiniteElementBasisT<T> & fem, int n_quad) : fem_(fem) {
+        helfem::chebyshev::chebyshev<T>(n_quad, xq_, wq_);
+        for (Eigen::Index i = 0; i < xq_.size(); ++i) {
           // Format the T value at its own precision (no truncation to double).
-          if (!std::isfinite(xq(i)))
-            printf("xq[%lld]=%s\n", (long long) i, helfem::io::fmt_sci(xq(i)).c_str());
-          if (!std::isfinite(wq(i)))
-            printf("wq[%lld]=%s\n", (long long) i, helfem::io::fmt_sci(wq(i)).c_str());
+          if (!std::isfinite(xq_(i)))
+            printf("xq_[%lld]=%s\n", (long long) i, helfem::io::fmt_sci(xq_(i)).c_str());
+          if (!std::isfinite(wq_(i)))
+            printf("wq_[%lld]=%s\n", (long long) i, helfem::io::fmt_sci(wq_(i)).c_str());
         }
       }
 
@@ -191,55 +191,55 @@ namespace helfem {
       FEMRadialBasisT<T>::~FEMRadialBasisT() {}
 
       template <typename T>
-      int FEMRadialBasisT<T>::get_nquad() const {
-        return (int) xq.size();
+      int FEMRadialBasisT<T>::nquad() const {
+        return (int) xq_.size();
       }
 
       template <typename T>
-      helfem::Vec<T> FEMRadialBasisT<T>::get_xq() const {
-        // Phase 5.20: xq storage is Eigen; return it directly at the public boundary.
-        return xq;
+      helfem::Vec<T> FEMRadialBasisT<T>::xq() const {
+        // Phase 5.20: xq_ storage is Eigen; return it directly at the public boundary.
+        return xq_;
       }
 
       template <typename T>
       size_t FEMRadialBasisT<T>::Nbf() const {
-        return fem.get_nbf();
+        return fem_.nbf();
       }
 
       template <typename T>
       size_t FEMRadialBasisT<T>::Nel() const {
-        return fem.get_nelem();
+        return fem_.nelem();
       }
 
       template <typename T>
       size_t FEMRadialBasisT<T>::Nprim(size_t iel) const {
-        return fem.get_nprim(iel);
+        return fem_.nprim(iel);
       }
 
       template <typename T>
       size_t FEMRadialBasisT<T>::max_Nprim() const {
-        return fem.get_max_nprim();
+        return fem_.max_nprim();
       }
 
       template <typename T>
-      void FEMRadialBasisT<T>::get_idx(size_t iel, size_t &ifirst, size_t &ilast) const {
-        fem.get_idx(iel, ifirst, ilast);
+      void FEMRadialBasisT<T>::idx(size_t iel, size_t &ifirst, size_t &ilast) const {
+        fem_.idx(iel, ifirst, ilast);
       }
 
       template <typename T>
-      helfem::Vec<T> FEMRadialBasisT<T>::get_bval() const {
-        // Phase 5.20: fem.get_bval() is Eigen; return directly.
-        return fem.get_bval();
+      helfem::Vec<T> FEMRadialBasisT<T>::bval() const {
+        // Phase 5.20: fem_.bval() is Eigen; return directly.
+        return fem_.bval();
       }
 
       template <typename T>
-      int FEMRadialBasisT<T>::get_poly_id() const {
-        return fem.get_poly_id();
+      int FEMRadialBasisT<T>::poly_id() const {
+        return fem_.poly_id();
       }
 
       template <typename T>
-      int FEMRadialBasisT<T>::get_poly_nnodes() const {
-        return fem.get_poly_nnodes();
+      int FEMRadialBasisT<T>::poly_nnodes() const {
+        return fem_.poly_nnodes();
       }
 
       template <typename T>
@@ -262,22 +262,22 @@ namespace helfem {
         using BK = typename FEMRadialBasisT<T>::BasisKind;
         switch (k) {
           case BK::B0: return [rb](helfem::Vec<T> x, size_t iel) {
-            return rb->get_fem().eval_dnf(x, 0, iel);
+            return rb->fem().eval_dnf(x, 0, iel);
           };
           case BK::B1: return [rb](helfem::Vec<T> x, size_t iel) {
-            return rb->get_fem().eval_dnf(x, 1, iel);
+            return rb->fem().eval_dnf(x, 1, iel);
           };
           case BK::B2: return [rb](helfem::Vec<T> x, size_t iel) {
-            return rb->get_fem().eval_dnf(x, 2, iel);
+            return rb->fem().eval_dnf(x, 2, iel);
           };
           case BK::R0: return [rb](helfem::Vec<T> x, size_t iel) {
-            return rb->get_bf(x, iel);
+            return rb->bf(x, iel);
           };
           case BK::R1: return [rb](helfem::Vec<T> x, size_t iel) {
-            return rb->get_df(x, iel);
+            return rb->df(x, iel);
           };
           case BK::R2: return [rb](helfem::Vec<T> x, size_t iel) {
-            return rb->get_lf(x, iel);
+            return rb->lf(x, iel);
           };
         }
         throw std::logic_error("FEMRadialBasisT::matrix_element: unknown BasisKind\n");
@@ -291,7 +291,7 @@ namespace helfem {
         auto lhs = make_evaluator<T>(this, bra);
         auto rhs = make_evaluator<T>(this, ket);
         // Phase 2: FE basis auto-converges its own quadrature to eps(T).
-        return fem.matrix_element_auto(iel, lhs, rhs, weight, breakpoints, poly_degree_f);
+        return fem_.matrix_element_auto(iel, lhs, rhs, weight, breakpoints, poly_degree_f);
       }
 
       template <typename T>
@@ -302,7 +302,7 @@ namespace helfem {
         auto lhs = make_evaluator<T>(this, bra);
         auto rhs = make_evaluator<T>(this, ket);
         // Phase 2: FE basis auto-converges its own quadrature to eps(T).
-        return fem.matrix_element_auto(lhs, rhs, weight, breakpoints, poly_degree_f);
+        return fem_.matrix_element_auto(lhs, rhs, weight, breakpoints, poly_degree_f);
       }
 
       template <typename T>
@@ -313,7 +313,7 @@ namespace helfem {
         auto lhs = make_evaluator<T>(this, bra);
         auto rhs = make_evaluator<T>(this, ket);
         // Phase 2: auto-converge over the reference sub-range [x_left,x_right].
-        return fem.matrix_element_auto(iel, lhs, rhs, weight,
+        return fem_.matrix_element_auto(iel, lhs, rhs, weight,
                                        std::vector<T>(), -1, x_left, x_right);
       }
 
@@ -357,13 +357,13 @@ namespace helfem {
           BasisKind bra, BasisKind ket,
           const std::function<T(T)> & weight) const {
         // List overlapping (iel, jel) element pairs.
-        std::vector<std::vector<size_t>> overlap(fem.get_nelem());
-        for (size_t iel = 0; iel < fem.get_nelem(); ++iel) {
-          const T istart = fem.element_begin(iel);
-          const T iend   = fem.element_end(iel);
-          for (size_t jel = 0; jel < rh.fem.get_nelem(); ++jel) {
-            const T jstart = rh.fem.element_begin(jel);
-            const T jend   = rh.fem.element_end(jel);
+        std::vector<std::vector<size_t>> overlap(fem_.nelem());
+        for (size_t iel = 0; iel < fem_.nelem(); ++iel) {
+          const T istart = fem_.element_begin(iel);
+          const T iend   = fem_.element_end(iel);
+          for (size_t jel = 0; jel < rh.fem_.nelem(); ++jel) {
+            const T jstart = rh.fem_.element_begin(jel);
+            const T jend   = rh.fem_.element_end(jel);
             if ((jstart >= istart && jstart < iend) ||
                 (istart >= jstart && istart < jend))
               overlap[iel].push_back(jel);
@@ -374,19 +374,19 @@ namespace helfem {
         // whole (Nbf x rh.Nbf) matrix is stable to 8*eps(T). The shape does
         // not depend on the order, so the comparison is well defined. Seeded
         // from a rule sized for the finer of the two bases.
-        const int nstart = std::max({(int) xq.size(), (int) rh.xq.size(), 5});
+        const int nstart = std::max({(int) xq_.size(), (int) rh.xq_.size(), 5});
         return converge_rule<T>(
             [&](int n) {
               helfem::Vec<T> xproj, wproj;
               helfem::lobatto::lobatto_compute<T>(n, xproj, wproj);
 
               helfem::Mat<T> S = helfem::Mat<T>::Zero(Nbf(), rh.Nbf());
-              for (size_t iel = 0; iel < fem.get_nelem(); ++iel) {
+              for (size_t iel = 0; iel < fem_.nelem(); ++iel) {
                 for (size_t jel : overlap[iel]) {
-                  const T intstart = std::max(fem.element_begin(iel),
-                                              rh.fem.element_begin(jel));
-                  const T intend   = std::min(fem.element_end(iel),
-                                              rh.fem.element_end(jel));
+                  const T intstart = std::max(fem_.element_begin(iel),
+                                              rh.fem_.element_begin(jel));
+                  const T intend   = std::min(fem_.element_end(iel),
+                                              rh.fem_.element_end(jel));
                   const T intmid   = T(0.5) * (intend + intstart);
                   const T intlen   = T(0.5) * (intend - intstart);
 
@@ -399,19 +399,19 @@ namespace helfem {
                       (helfem::Vec<T>::Constant(xproj.size(), intmid) + intlen * xproj)
                           .cwiseMax(intstart).cwiseMin(intend);
 
-                  const helfem::Vec<T> xi = fem.eval_prim(r, iel);
-                  const helfem::Vec<T> xj = rh.fem.eval_prim(r, jel);
+                  const helfem::Vec<T> xi = fem_.eval_prim(r, iel);
+                  const helfem::Vec<T> xj = rh.fem_.eval_prim(r, jel);
 
                   helfem::Vec<T> wtot = wproj * intlen;
                   if (weight)
                     for (Eigen::Index i = 0; i < r.size(); ++i)
                       wtot(i) *= weight(r(i));
 
-                  const helfem::Mat<T> ifunc = eval_B_at<T>(fem,    xi, iel, bra);
-                  const helfem::Mat<T> jfunc = eval_B_at<T>(rh.fem, xj, jel, ket);
+                  const helfem::Mat<T> ifunc = eval_B_at<T>(fem_,    xi, iel, bra);
+                  const helfem::Mat<T> jfunc = eval_B_at<T>(rh.fem_, xj, jel, ket);
 
-                  size_t ifirst, ilast; get_idx(iel, ifirst, ilast);
-                  size_t jfirst, jlast; rh.get_idx(jel, jfirst, jlast);
+                  size_t ifirst, ilast; idx(iel, ifirst, ilast);
+                  size_t jfirst, jlast; rh.idx(jel, jfirst, jlast);
                   const Eigen::Index Ni = ilast - ifirst + 1;
                   const Eigen::Index Nj = jlast - jfirst + 1;
                   // ifunc^T * diag(wtot) * jfunc = (ifunc^T * wtot.asDiagonal()) * jfunc.
@@ -595,7 +595,7 @@ namespace helfem {
 	    throw std::logic_error("Junquera confinement potential requires N >= 1!");
 	  if(V<=0)
 	    throw std::logic_error("Cannot have attractive Junquera potential!\n");
-	  return junq_confinement(iel, N, V, get_bval().maxCoeff(), shift_pot);
+	  return junq_confinement(iel, N, V, bval().maxCoeff(), shift_pot);
 	} else
 	  throw std::logic_error("Case not implemented!\n");
       }
@@ -614,8 +614,8 @@ namespace helfem {
         // algebraically and grinds to the order cap.
         return matrix_element(iel, BasisKind::B0, BasisKind::B0,
                               [model](T r){ return model->V(r); },
-                              model->breakpoints(fem.element_begin(iel),
-                                                 fem.element_end(iel)));
+                              model->breakpoints(fem_.element_begin(iel),
+                                                 fem_.element_end(iel)));
       }
 
       template <typename T>
@@ -627,11 +627,11 @@ namespace helfem {
         // <r^L> * Rhalf^{-L-1}. The comparison operators were inverted in
         // an earlier migration, which for r>Rhalf elements evaluated
         // <r^L> out to Rmax (~40^L) and blew up the SCF; restored here.
-        if (fem.element_begin(iel) >= Rhalf) {
+        if (fem_.element_begin(iel) >= Rhalf) {
           return -std::sqrt(T(4) * utils::pi<T>() / T(2 * L + 1)) *
                   radial_integral(-L - 1, iel) *
                   std::pow(Rhalf, L);
-        } else if (fem.element_end(iel) <= Rhalf) {
+        } else if (fem_.element_end(iel) <= Rhalf) {
           return -std::sqrt(T(4) * utils::pi<T>() / T(2 * L + 1)) *
                   radial_integral(L, iel) *
                   std::pow(Rhalf, -L - 1);
@@ -642,13 +642,13 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::twoe_integral(int L, size_t iel) const {
-        T Rmin(fem.element_begin(iel));
-        T Rmax(fem.element_end(iel));
+        T Rmin(fem_.element_begin(iel));
+        T Rmax(fem_.element_end(iel));
 
         // Integral by auto-converging quadrature: the rule order is refined
         // internally until the block is stable to 8*eps(T), so the accuracy
         // follows T and not the caller's --nquad.
-        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> p(fem.get_basis(iel));
+        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> p(fem_.basis(iel));
         helfem::Mat<T> tei = converge_rule<T>(
             [&](int n) {
               helfem::Vec<T> x, w;
@@ -725,11 +725,11 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::yukawa_integral(int L, T lambda, size_t iel) const {
-        T Rmin(fem.element_begin(iel));
-        T Rmax(fem.element_end(iel));
+        T Rmin(fem_.element_begin(iel));
+        T Rmax(fem_.element_end(iel));
 
         // Integral by auto-converging quadrature (see converge_rule above).
-        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> p(fem.get_basis(iel));
+        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasisT<T>> p(fem_.basis(iel));
         return converge_rule<T>(
             [&](int n) {
               helfem::Vec<T> x, w;
@@ -762,7 +762,7 @@ namespace helfem {
         // rule so a single erfc call uses one consistent order.
         //
         // Number of quadrature points
-        size_t Nq = (size_t) xq.size();
+        size_t Nq = (size_t) xq_.size();
         // Number of subintervals
         size_t Nint;
 
@@ -781,9 +781,9 @@ namespace helfem {
         // Phase 5.8: local scratch is now native Eigen.
         helfem::Vec<T> xi, wi;
         helfem::chebyshev::chebyshev<T>((int) Nq, xi, wi);
-        helfem::Mat<T> ibf = fem.eval_dnf(xi, 0, iel);
-        const T Rmini = fem.element_begin(iel);
-        const T Rmaxi = fem.element_end(iel);
+        helfem::Mat<T> ibf = fem_.eval_dnf(xi, 0, iel);
+        const T Rmini = fem_.element_begin(iel);
+        const T Rmaxi = fem_.element_end(iel);
 
         // Rh quadrature points: Nint copies of xi, mapped to subintervals.
         helfem::Vec<T> xk(Nq * Nint), wk(Nq * Nint);
@@ -796,9 +796,9 @@ namespace helfem {
               = helfem::Vec<T>::Constant((Eigen::Index) Nq, imid) + xi * ilen;
           wk.segment((Eigen::Index)(ii * Nq), (Eigen::Index) Nq) = wi * ilen;
         }
-        const helfem::Mat<T> kbf = fem.eval_dnf(xk, 0, kel);
-        const T Rmink = fem.element_begin(kel);
-        const T Rmaxk = fem.element_end(kel);
+        const helfem::Mat<T> kbf = fem_.eval_dnf(xk, 0, kel);
+        const T Rmink = fem_.element_begin(kel);
+        const T Rmaxk = fem_.element_end(kel);
 
         helfem::Mat<T> tei = quadrature::erfc_integral<T>(
             Rmini, Rmaxi, ibf, xi, wi,
@@ -812,54 +812,54 @@ namespace helfem {
 
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::spherical_potential(size_t iel) const {
-        T Rmin(fem.element_begin(iel));
-        T Rmax(fem.element_end(iel));
+        T Rmin(fem_.element_begin(iel));
+        T Rmax(fem_.element_end(iel));
 
         // Integral by quadrature
-        std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(fem.get_basis(iel));
-        return quadrature::spherical_potential<T>(Rmin, Rmax, xq, wq, p);
+        std::shared_ptr<helfem::polynomial_basis::PolynomialBasisT<T>> p(fem_.basis(iel));
+        return quadrature::spherical_potential<T>(Rmin, Rmax, xq_, wq_, p);
       }
 
       template <typename T>
       void FEMRadialBasisT<T>::fill_quadrature_cache(bool need_df, bool need_lf) const {
-        const size_t Nel = fem.get_nelem();
-        if (bfq_cache.size() != Nel) bfq_cache.assign(Nel, helfem::Mat<T>());
-        if (dfq_cache.size() != Nel) dfq_cache.assign(Nel, helfem::Mat<T>());
-        if (lfq_cache.size() != Nel) lfq_cache.assign(Nel, helfem::Mat<T>());
+        const size_t Nel = fem_.nelem();
+        if (bfq_cache_.size() != Nel) bfq_cache_.assign(Nel, helfem::Mat<T>());
+        if (dfq_cache_.size() != Nel) dfq_cache_.assign(Nel, helfem::Mat<T>());
+        if (lfq_cache_.size() != Nel) lfq_cache_.assign(Nel, helfem::Mat<T>());
         for (size_t iel = 0; iel < Nel; ++iel) {
-          if (!bfq_cache[iel].size()) bfq_cache[iel] = get_bf(xq, iel);
-          if (need_df && !dfq_cache[iel].size()) dfq_cache[iel] = get_df(xq, iel);
-          if (need_lf && !lfq_cache[iel].size()) lfq_cache[iel] = get_lf(xq, iel);
+          if (!bfq_cache_[iel].size()) bfq_cache_[iel] = bf(xq_, iel);
+          if (need_df && !dfq_cache_[iel].size()) dfq_cache_[iel] = df(xq_, iel);
+          if (need_lf && !lfq_cache_[iel].size()) lfq_cache_[iel] = lf(xq_, iel);
         }
       }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::get_bf(size_t iel) const {
-        if (iel < bfq_cache.size() && bfq_cache[iel].size())
-          return bfq_cache[iel];
-        return get_bf(xq, iel);
+      helfem::Mat<T> FEMRadialBasisT<T>::bf(size_t iel) const {
+        if (iel < bfq_cache_.size() && bfq_cache_[iel].size())
+          return bfq_cache_[iel];
+        return bf(xq_, iel);
       }
 
-      // get_taylor() has been removed in favour of fem.eval_over_r().
+      // get_taylor() has been removed in favour of fem_.eval_over_r().
 
       template <typename T>
       helfem::Vec<T> FEMRadialBasisT<T>::eval_orbs(const helfem::Mat<T> & C, T r) const {
-        if(r > fem.element_end(fem.get_nelem()-1)) {
+        if(r > fem_.element_end(fem_.nelem()-1)) {
           // Wave function is zero beyond the practical infinity.
           return helfem::Vec<T>::Zero(C.cols());
         }
         // Find the element and evaluate the primitive coordinate.
-        const size_t iel = fem.find_element(r);
+        const size_t iel = fem_.find_element(r);
         helfem::Vec<T> r_e(1); r_e(0) = r;
-        const helfem::Vec<T> xe = fem.eval_prim(r_e, iel);
+        const helfem::Vec<T> xe = fem_.eval_prim(r_e, iel);
 
         // Basis functions in the element -- Eigen throughout after Phase 5.24.
-        const helfem::Mat<T> val = get_bf(xe, iel);
+        const helfem::Mat<T> val = bf(xe, iel);
 
         // Slice C over the element's basis-function index range and
         // return the row-vector product transposed to a column.
         size_t ifirst, ilast;
-        get_idx(iel, ifirst, ilast);
+        idx(iel, ifirst, ilast);
         const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
         const helfem::Mat<T> Csub = C.block(ifirst, 0, n, C.cols());
         return (val * Csub).transpose();
@@ -868,11 +868,11 @@ namespace helfem {
       template <typename T>
       helfem::Mat<T> FEMRadialBasisT<T>::eval_psi_dnf(const helfem::Vec<T> & x, int n, size_t iel) const {
         if (iel == 0)
-          return fem.eval_over_r(x, n, iel);
+          return fem_.eval_over_r(x, n, iel);
         if (n == 0) {
-          // Plain division, matching the historical get_bf exactly.
-          helfem::Mat<T> val = fem.eval_dnf(x, 0, iel);
-          const helfem::Vec<T> r = fem.eval_coord(x, iel);
+          // Plain division, matching the historical bf exactly.
+          helfem::Mat<T> val = fem_.eval_dnf(x, 0, iel);
+          const helfem::Vec<T> r = fem_.eval_coord(x, iel);
           for (Eigen::Index ifun = 0; ifun < val.cols(); ++ifun)
             for (Eigen::Index ir = 0; ir < val.rows(); ++ir)
               val(ir, ifun) /= r(ir);
@@ -885,7 +885,7 @@ namespace helfem {
         //   n=2: ((2 f invr - 2 d) invr + l) invr
         std::vector<helfem::Mat<T>> B(n + 1);
         for (int k = 0; k <= n; k++)
-          B[k] = fem.eval_dnf(x, k, iel);
+          B[k] = fem_.eval_dnf(x, k, iel);
         std::vector<T> c(n + 1);
         {
           T nfac = T(1);
@@ -897,7 +897,7 @@ namespace helfem {
             if ((n - k) % 2) c[k] = -c[k];
           }
         }
-        const helfem::Vec<T> r = fem.eval_coord(x, iel);
+        const helfem::Vec<T> r = fem_.eval_coord(x, iel);
         helfem::Mat<T> out(B[0].rows(), B[0].cols());
         for (Eigen::Index ifun = 0; ifun < out.cols(); ++ifun)
           for (Eigen::Index ir = 0; ir < out.rows(); ++ir) {
@@ -911,57 +911,57 @@ namespace helfem {
       }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::get_bf(const helfem::Vec<T> & x, size_t iel) const {
+      helfem::Mat<T> FEMRadialBasisT<T>::bf(const helfem::Vec<T> & x, size_t iel) const {
         return eval_psi_dnf(x, 0, iel);
       }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::get_df(size_t iel) const {
-        if (iel < dfq_cache.size() && dfq_cache[iel].size())
-          return dfq_cache[iel];
-        return get_df(xq, iel);
+      helfem::Mat<T> FEMRadialBasisT<T>::df(size_t iel) const {
+        if (iel < dfq_cache_.size() && dfq_cache_[iel].size())
+          return dfq_cache_[iel];
+        return df(xq_, iel);
       }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::get_df(const helfem::Vec<T> & x, size_t iel) const {
+      helfem::Mat<T> FEMRadialBasisT<T>::df(const helfem::Vec<T> & x, size_t iel) const {
         return eval_psi_dnf(x, 1, iel);
       }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::get_lf(size_t iel) const {
-        if (iel < lfq_cache.size() && lfq_cache[iel].size())
-          return lfq_cache[iel];
-        return get_lf(xq, iel);
+      helfem::Mat<T> FEMRadialBasisT<T>::lf(size_t iel) const {
+        if (iel < lfq_cache_.size() && lfq_cache_[iel].size())
+          return lfq_cache_[iel];
+        return lf(xq_, iel);
       }
 
       template <typename T>
-      helfem::Mat<T> FEMRadialBasisT<T>::get_lf(const helfem::Vec<T> & x, size_t iel) const {
+      helfem::Mat<T> FEMRadialBasisT<T>::lf(const helfem::Vec<T> & x, size_t iel) const {
         return eval_psi_dnf(x, 2, iel);
       }
 
       template <typename T>
-      helfem::Vec<T> FEMRadialBasisT<T>::get_wrad(size_t iel) const {
-        return get_wrad(wq, iel);
+      helfem::Vec<T> FEMRadialBasisT<T>::wrad(size_t iel) const {
+        return wrad(wq_, iel);
       }
 
       template <typename T>
-      helfem::Vec<T> FEMRadialBasisT<T>::get_wrad(const helfem::Vec<T> & w, size_t iel) const {
-        return fem.scaling_factor(iel) * w;
+      helfem::Vec<T> FEMRadialBasisT<T>::wrad(const helfem::Vec<T> & w, size_t iel) const {
+        return fem_.scaling_factor(iel) * w;
       }
 
       template <typename T>
-      helfem::Vec<T> FEMRadialBasisT<T>::get_r(size_t iel) const {
-        return get_r(xq, iel);
+      helfem::Vec<T> FEMRadialBasisT<T>::r(size_t iel) const {
+        return r(xq_, iel);
       }
 
       template <typename T>
-      helfem::Vec<T> FEMRadialBasisT<T>::get_r(const helfem::Vec<T> & x, size_t iel) const {
-        return fem.eval_coord(x, iel);
+      helfem::Vec<T> FEMRadialBasisT<T>::r(const helfem::Vec<T> & x, size_t iel) const {
+        return fem_.eval_coord(x, iel);
       }
 
       template <typename T>
-      T FEMRadialBasisT<T>::get_r(T x, size_t iel) const {
-        return fem.eval_coord(x, iel);
+      T FEMRadialBasisT<T>::r(T x, size_t iel) const {
+        return fem_.eval_coord(x, iel);
       }
 
       // Nuclear coordinate: primitive basis polynomials belong to [-1,1],
@@ -979,10 +979,10 @@ namespace helfem {
           throw std::logic_error("nuclear_density expects a radial density matrix\n");
 
         // Derivative at nucleus.
-        const helfem::Mat<T> der = fem.eval_dnf(nuclear_x<T>(), 1, (size_t) 0);
+        const helfem::Mat<T> der = fem_.eval_dnf(nuclear_x<T>(), 1, (size_t) 0);
         // First-element radial index range.
         size_t ifirst, ilast;
-        get_idx(0, ifirst, ilast);
+        idx(0, ifirst, ilast);
         const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
         // Density submatrix.
         const helfem::Mat<T> Psub = Prad.block(ifirst, ifirst, n, n);
@@ -997,10 +997,10 @@ namespace helfem {
           throw std::logic_error("nuclear_density_gradient expects a radial density matrix\n");
 
         const helfem::Vec<T> xn = nuclear_x<T>();
-        const helfem::Mat<T> der  = fem.eval_dnf(xn, 1, (size_t) 0);
-        const helfem::Mat<T> lapl = fem.eval_dnf(xn, 2, (size_t) 0);
+        const helfem::Mat<T> der  = fem_.eval_dnf(xn, 1, (size_t) 0);
+        const helfem::Mat<T> lapl = fem_.eval_dnf(xn, 2, (size_t) 0);
         size_t ifirst, ilast;
-        get_idx(0, ifirst, ilast);
+        idx(0, ifirst, ilast);
         const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
         const helfem::Mat<T> Psub = Prad.block(ifirst, ifirst, n, n);
         // P_uv B_u'(0) B_v''(0) -- one number.
@@ -1009,9 +1009,9 @@ namespace helfem {
 
       template <typename T>
       helfem::RowVec<T> FEMRadialBasisT<T>::nuclear_orbital(const helfem::Mat<T> &C) const {
-        const helfem::Mat<T> der = fem.eval_dnf(nuclear_x<T>(), 1, (size_t) 0);
+        const helfem::Mat<T> der = fem_.eval_dnf(nuclear_x<T>(), 1, (size_t) 0);
         size_t ifirst, ilast;
-        get_idx(0, ifirst, ilast);
+        idx(0, ifirst, ilast);
         const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
         const helfem::Mat<T> Csub = C.block(ifirst, 0, n, C.cols());
         // C_ui B_u'(0) -- row vector of length C.cols().

--- a/libhelfem/src/quadrature.cpp
+++ b/libhelfem/src/quadrature.cpp
@@ -83,7 +83,7 @@ namespace helfem {
       const T rlen = T(0.5) * (rmax - rmin);
       const Vec<T> r = Vec<T>::Constant(x.size(), rmid) + rlen * x;
 
-      const int nbf = poly->get_nbf();
+      const int nbf = poly->nbf();
       Mat<T> inner(x.size(), nbf * nbf);
       // Row 0: integral from rmin to r(0). With an endpoint-including rule
       // (Gauss-Lobatto) r(0) == rmin and the segment is empty; skip the
@@ -256,7 +256,7 @@ namespace helfem {
       const T rlen = T(0.5) * (rmax - rmin);
       const Vec<T> r = Vec<T>::Constant(x.size(), rmid) + rlen * x;
 
-      const int nbf = poly->get_nbf();
+      const int nbf = poly->nbf();
       Mat<T> zero     = Mat<T>::Zero(nbf * nbf, x.size());
       Mat<T> minusone = Mat<T>::Zero(nbf * nbf, x.size());
 

--- a/libhelfemqc/include/CoulombExchangeFE.h
+++ b/libhelfemqc/include/CoulombExchangeFE.h
@@ -314,7 +314,7 @@ namespace helfem {
         helfem::Mat<T> J_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
-          radial.get_idx(jel, jfirst, jlast);
+          radial.idx(jel, jfirst, jlast);
           const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
           const helfem::Mat<T> Psub =
               P_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj);
@@ -327,14 +327,14 @@ namespace helfem {
           const T jbig   = (jel > 0) ? T((r_big(jel) * Psub).trace()) : T(0);
           for (size_t iel = 0; iel < jel; ++iel) {
             size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
+            radial.idx(iel, ifirst, ilast);
             const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
             J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
                 += jbig * r_small(iel);
           }
           for (size_t iel = jel + 1; iel < Nel; ++iel) {
             size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
+            radial.idx(iel, ifirst, ilast);
             const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
             J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
                 += jsmall * r_big(iel);
@@ -362,11 +362,11 @@ namespace helfem {
         helfem::Mat<T> K_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
-          radial.get_idx(iel, ifirst, ilast);
+          radial.idx(iel, ifirst, ilast);
           const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
           for (size_t jel = 0; jel < Nel; ++jel) {
             size_t jfirst, jlast;
-            radial.get_idx(jel, jfirst, jlast);
+            radial.idx(jel, jfirst, jlast);
             const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
             if (iel == jel) {
               const helfem::Mat<T> Psub =
@@ -404,11 +404,11 @@ namespace helfem {
         helfem::Mat<T> K_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
-          radial.get_idx(iel, ifirst, ilast);
+          radial.idx(iel, ifirst, ilast);
           const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
           for (size_t jel = 0; jel < Nel; ++jel) {
             size_t jfirst, jlast;
-            radial.get_idx(jel, jfirst, jlast);
+            radial.idx(jel, jfirst, jlast);
             const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
             const helfem::Mat<T> Psub =
                 P_E.block((Eigen::Index) ifirst, (Eigen::Index) jfirst, Ni, Nj);
@@ -442,7 +442,7 @@ namespace helfem {
         helfem::Mat<T> J_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t jel = 0; jel < Nel; ++jel) {
           size_t jfirst, jlast;
-          radial.get_idx(jel, jfirst, jlast);
+          radial.idx(jel, jfirst, jlast);
           const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
           const helfem::Mat<T> Psub =
               P_E.block((Eigen::Index) jfirst, (Eigen::Index) jfirst, Nj, Nj);
@@ -455,14 +455,14 @@ namespace helfem {
           const T jbig   = (jel > 0) ? T((r_big(jel) * Psub).trace()) : T(0);
           for (size_t iel = 0; iel < jel; ++iel) {
             size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
+            radial.idx(iel, ifirst, ilast);
             const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
             J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
                 += jbig * r_small(iel);
           }
           for (size_t iel = jel + 1; iel < Nel; ++iel) {
             size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
+            radial.idx(iel, ifirst, ilast);
             const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
             J_E.block((Eigen::Index) ifirst, (Eigen::Index) ifirst, Ni, Ni)
                 += jsmall * r_big(iel);
@@ -494,11 +494,11 @@ namespace helfem {
         helfem::Mat<T> K_E = helfem::Mat<T>::Zero(Nrad, Nrad);
         for (size_t iel = 0; iel < Nel; ++iel) {
           size_t ifirst, ilast;
-          radial.get_idx(iel, ifirst, ilast);
+          radial.idx(iel, ifirst, ilast);
           const Eigen::Index Ni = (Eigen::Index)(ilast - ifirst + 1);
           for (size_t jel = 0; jel < Nel; ++jel) {
             size_t jfirst, jlast;
-            radial.get_idx(jel, jfirst, jlast);
+            radial.idx(jel, jfirst, jlast);
             const Eigen::Index Nj = (Eigen::Index)(jlast - jfirst + 1);
             if (iel == jel) {
               // Factored in-element K via the J-ordered Cholesky factor:
@@ -578,7 +578,7 @@ namespace helfem {
         auto kt = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_ktei[iel].size() == 0) {
             size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
+            radial.idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
             scratch_ktei[iel] = utils::exchange_tei<T>(
                 detail_fe_2e::in_element_tei<T>(radial, L, iel, false, T(0)),
@@ -634,7 +634,7 @@ namespace helfem {
         auto kt = [&](size_t iel) -> const helfem::Mat<T> & {
           if (scratch_ktei[iel].size() == 0) {
             size_t ifirst, ilast;
-            radial.get_idx(iel, ifirst, ilast);
+            radial.idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
             scratch_ktei[iel] = utils::exchange_tei<T>(
                 detail_fe_2e::in_element_tei<T>(radial, L, iel, true, lambda),

--- a/libhelfemqc/include/GTO.h
+++ b/libhelfemqc/include/GTO.h
@@ -127,16 +127,16 @@ namespace helfem {
         for (int k = 0; k <= nelem; ++k)
           bval(k) = r_max * (std::exp(2.0 * k / nelem) - 1.0) / denom;
         auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-            polynomial_basis::get_basis(/*primbas=*/4, nnodes));
+            polynomial_basis::make_basis(/*primbas=*/4, nnodes));
         polynomial_basis::FiniteElementBasis fem(poly, bval,
             /*zero_func_left*/true,  /*zero_deriv_left*/false,
             /*zero_func_right*/true, /*zero_deriv_right*/false);
-        atomic::basis::FEMRadialBasis radial(fem, 5 * poly->get_nbf());
+        atomic::basis::FEMRadialBasis radial(fem, 5 * poly->nbf());
         const helfem::Matrix S = radial.overlap();
         // Quadrature points + weights for the projection integrals.
         helfem::Vector xq, wq;
         helfem::chebyshev::chebyshev<double>(
-            5 * poly->get_nbf(), xq, wq);
+            5 * poly->nbf(), xq, wq);
         helfem::Matrix C = helfem::Matrix::Zero(S.rows(), basis.size());
         // Overlap is symmetric positive definite -- one LDLT solves all.
         Eigen::LDLT<helfem::Matrix> S_ldlt(S);

--- a/libhelfemqc/include/STO.h
+++ b/libhelfemqc/include/STO.h
@@ -152,16 +152,16 @@ namespace helfem {
         // u(0) = u(r_max) = 0 for STOs (vanishes at origin since u = r * R
         // with R(0) finite; vanishes at r_max by construction).
         auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-            polynomial_basis::get_basis(/*primbas=*/4, nnodes));
+            polynomial_basis::make_basis(/*primbas=*/4, nnodes));
         polynomial_basis::FiniteElementBasis fem(poly, bval,
             /*zero_func_left*/true,  /*zero_deriv_left*/false,
             /*zero_func_right*/true, /*zero_deriv_right*/false);
-        atomic::basis::FEMRadialBasis radial(fem, 5 * poly->get_nbf());
+        atomic::basis::FEMRadialBasis radial(fem, 5 * poly->nbf());
         const helfem::Matrix S = radial.overlap();
         // Quadrature points + weights for the projection integrals.
         helfem::Vector xq, wq;
         helfem::chebyshev::chebyshev<double>(
-            5 * poly->get_nbf(), xq, wq);
+            5 * poly->nbf(), xq, wq);
         // Project each STO onto the FE basis: c = S^{-1} <u_i, u_STO>.
         helfem::Matrix C = helfem::Matrix::Zero(S.rows(), basis.size());
         // Overlap is symmetric positive definite; a single LDLT solves

--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -47,8 +47,8 @@ namespace helfem {
       // is a double-only C library), and none is on the Fock path. Rather than
       // split the class they are compiled for every T and guarded: at
       // T = double they are exactly the code they always were, and at any
-      // other T they throw. (The quadrature-point accessors get_bval /
-      // get_wrad / get_r are now precision-generic helfem::Vec<T> and need no
+      // other T they throw. (The quadrature-point accessors bval /
+      // wrad / r are now precision-generic helfem::Vec<T> and need no
       // guard.)
       namespace {
         [[noreturn]] void double_only(const char *what) {
@@ -138,23 +138,23 @@ namespace helfem {
       }
 
       template <typename T>
-      int TwoDBasisT<T>::get_nquad() const {
-        return radial_.get_nquad();
+      int TwoDBasisT<T>::nquad() const {
+        return radial_.nquad();
       }
 
       template <typename T>
-      helfem::Vec<T> TwoDBasisT<T>::get_bval() const {
-        return radial_.get_bval();
+      helfem::Vec<T> TwoDBasisT<T>::bval() const {
+        return radial_.bval();
       }
 
       template <typename T>
-      int TwoDBasisT<T>::get_poly_id() const {
-        return radial_.get_poly_id();
+      int TwoDBasisT<T>::poly_id() const {
+        return radial_.poly_id();
       }
 
       template <typename T>
-      int TwoDBasisT<T>::get_poly_nnodes() const {
-        return radial_.get_poly_nnodes();
+      int TwoDBasisT<T>::poly_nnodes() const {
+        return radial_.poly_nnodes();
       }
 
       template <typename T>
@@ -626,7 +626,7 @@ namespace helfem {
           helfem::Mat<T> D = helfem::Mat<T>::Zero(Nrad_e, Nrad_e);
           for (size_t iel = 0; iel < Nel; ++iel) {
             size_t ifirst, ilast;
-            radial_.get_idx(iel, ifirst, ilast);
+            radial_.idx(iel, ifirst, ilast);
             const size_t Ni = ilast - ifirst + 1;
             for (size_t j_loc = 0; j_loc < Ni; ++j_loc) {
               for (size_t i_loc = 0; i_loc <= j_loc; ++i_loc) {
@@ -1139,7 +1139,7 @@ namespace helfem {
             sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
           // Evaluate radial functions
-          helfem::Matrix rad(radial_.get_bf(iel));
+          helfem::Matrix rad(radial_.bf(iel));
 
           // Form supermatrix
           Eigen::MatrixXcd bf(rad.rows(),lval.size()*rad.cols());
@@ -1162,8 +1162,8 @@ namespace helfem {
             sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
           // Evaluate radial functions
-          helfem::Matrix frad(radial_.get_bf(iel));
-          helfem::Matrix drad(radial_.get_df(iel));
+          helfem::Matrix frad(radial_.bf(iel));
+          helfem::Matrix drad(radial_.df(iel));
 
           // Form supermatrices
           dr=Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*frad.cols());
@@ -1213,10 +1213,10 @@ namespace helfem {
             sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
           // Evaluate radial functions
-          helfem::Vector r(radial_.get_r(iel));
-          helfem::Matrix frad(radial_.get_bf(iel));
-          helfem::Matrix drad(radial_.get_df(iel));
-          helfem::Matrix lrad(radial_.get_lf(iel));
+          helfem::Vector r(radial_.r(iel));
+          helfem::Matrix frad(radial_.bf(iel));
+          helfem::Matrix drad(radial_.df(iel));
+          helfem::Matrix lrad(radial_.lf(iel));
 
           // Form supermatrix
           Eigen::MatrixXcd lf(Eigen::MatrixXcd::Zero(frad.rows(),lval.size()*frad.cols()));
@@ -1238,7 +1238,7 @@ namespace helfem {
       std::vector<Eigen::Index> TwoDBasisT<T>::bf_list(size_t iel) const {
         // Radial functions in element
         size_t ifirst, ilast;
-        radial_.get_idx(iel,ifirst,ilast);
+        radial_.idx(iel,ifirst,ilast);
         // Number of radial functions in element
         size_t Nr(ilast-ifirst+1);
 
@@ -1263,18 +1263,18 @@ namespace helfem {
       std::pair<size_t, size_t>
       TwoDBasisT<T>::radial_element_range(size_t iel) const {
         size_t ifirst, ilast;
-        radial_.get_idx(iel, ifirst, ilast);
+        radial_.idx(iel, ifirst, ilast);
         return {ifirst, ilast};
       }
 
       template <typename T>
-      helfem::Vec<T> TwoDBasisT<T>::get_wrad(size_t iel) const {
-        return radial_.get_wrad(iel);
+      helfem::Vec<T> TwoDBasisT<T>::wrad(size_t iel) const {
+        return radial_.wrad(iel);
       }
 
       template <typename T>
-      helfem::Vec<T> TwoDBasisT<T>::get_r(size_t iel) const {
-        return radial_.get_r(iel);
+      helfem::Vec<T> TwoDBasisT<T>::r(size_t iel) const {
+        return radial_.r(iel);
       }
 
       template class TwoDBasisT<double>;

--- a/src/atomic/TwoDBasis.h
+++ b/src/atomic/TwoDBasis.h
@@ -44,8 +44,8 @@ namespace helfem {
       ///     the analysis binaries -- eval_bf / eval_df / eval_lf (which return
       ///     Eigen::MatrixXcd and go through the double-only ::spherical_harmonics).
       ///     These are compiled for every T but THROW unless T = double; they
-      ///     are not on the Fock path. (The quadrature-point accessors get_bval
-      ///     / get_wrad / get_r are precision-generic helfem::Vec<T>.)
+      ///     are not on the Fock path. (The quadrature-point accessors bval
+      ///     / wrad / r are precision-generic helfem::Vec<T>.)
       /// The angular-index bookkeeping (get_lval / m_indices / get_sym_idx,
       /// Eigen::VectorXi / std::vector<Eigen::Index>) is integer-valued, hence
       /// precision-free, and is shared by all instantiations unchanged.
@@ -168,19 +168,19 @@ namespace helfem {
         /// The underlying radial FEM basis. Public so that library
         /// consumers (the installed helfem/atomic/TwoDBasis.h is the
         /// libatomscf-facing surface) can reach the quadrature grid:
-        /// get_r(iel) gives the radii, get_wrad(iel) the weights and
-        /// get_bval() the element boundaries, without this class having
+        /// r(iel) gives the radii, wrad(iel) the weights and
+        /// bval() the element boundaries, without this class having
         /// to mirror each accessor.
         const FEMRadialBasisT<T> & radial() const { return radial_; }
 
         /// Get number of quadrature points
-        int get_nquad() const;
+        int nquad() const;
         /// Get boundary values
-        helfem::Vec<T> get_bval() const;
+        helfem::Vec<T> bval() const;
         /// Get polynomial basis identifier
-        int get_poly_id() const;
+        int poly_id() const;
         /// Get number of nodes in polynomial
-        int get_poly_nnodes() const;
+        int poly_nnodes() const;
         /// Is derivative zeroed at infinity?
         int get_zeroder() const;
 
@@ -285,9 +285,9 @@ namespace helfem {
         /// quantities.
         std::pair<size_t, size_t> radial_element_range(size_t iel) const;
         /// Get radial quadrature weights
-        helfem::Vec<T> get_wrad(size_t iel) const;
+        helfem::Vec<T> wrad(size_t iel) const;
         /// Get r values
-        helfem::Vec<T> get_r(size_t iel) const;
+        helfem::Vec<T> r(size_t iel) const;
       };
 
       /// The double instantiation, which every existing caller uses.

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -473,8 +473,8 @@ namespace helfem {
         const Eigen::Index nbf=(Eigen::Index) bf_ind.size();
 
         // Get radii and radial weights
-        helfem::Vector r(basp->get_r(iel));
-        helfem::Vector wrad(basp->get_wrad(iel));
+        helfem::Vector r(basp->r(iel));
+        helfem::Vector wrad(basp->wrad(iel));
         const Eigen::Index nrad=wrad.size();
         const Eigen::Index nang=wang.size();
 

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -243,9 +243,9 @@ int main(int argc, char **argv) {
     is_range_separated(x_func, rs_erfc, rs_yukawa);
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
-  if (Nquad == 0) Nquad = 5 * poly->get_nbf();
-  else if (Nquad < 2 * poly->get_nbf())
+      polynomial_basis::make_basis(primbas, Nnodes));
+  if (Nquad == 0) Nquad = 5 * poly->nbf();
+  else if (Nquad < 2 * poly->nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
 
   // Nuclear-nuclear repulsion from the off-centre charges: Z(centre)<->Zl,

--- a/src/atomic/precision.cpp
+++ b/src/atomic/precision.cpp
@@ -131,8 +131,8 @@ namespace {
 
     // --- Basis -------------------------------------------------------------
     auto poly = std::shared_ptr<const pb::PolynomialBasisT<T>>(
-        polynomial_basis::get_basis_T<T>(primbas, Nnodes));
-    const int Nquad = 5 * poly->get_nbf();
+        polynomial_basis::make_basis_T<T>(primbas, Nnodes));
+    const int Nquad = 5 * poly->nbf();
 
     // Element boundaries: computed in double and cast up, so that every
     // precision solves the SAME variational problem and the columns below

--- a/src/atomic/teirank.cpp
+++ b/src/atomic/teirank.cpp
@@ -64,8 +64,8 @@ int main(int argc, char **argv) {
   const double tol = parser.get<double>("tol");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
-  const int Nquad = 5 * poly->get_nbf();
+      polynomial_basis::make_basis(primbas, Nnodes));
+  const int Nquad = 5 * poly->nbf();
 
   const helfem::Vector bval = atomic::basis::normal_grid(Nelem, Rmax, 4, 1.0);
   polynomial_basis::FiniteElementBasis fem(poly, bval,

--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -89,12 +89,12 @@ int main(int argc, char **argv) {
   chkpt.write("nelb",0);
 
   // Get primitive basis
-  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::get_basis(primbas,Nnodes)));
+  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::make_basis(primbas,Nnodes)));
 
   if(Nquad==0)
     // Set default value
-    Nquad=5*poly->get_nbf();
-  else if(Nquad<2*poly->get_nbf())
+    Nquad=5*poly->nbf();
+  else if(Nquad<2*poly->nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
 
   printf("Using %i point quadrature rule.\n",Nquad);

--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -203,56 +203,56 @@ namespace helfem {
       RadialBasis::RadialBasis() {
       }
 
-      RadialBasis::RadialBasis(const polynomial_basis::FiniteElementBasis & fem_, int n_quad) : fem(fem_) {
+      RadialBasis::RadialBasis(const polynomial_basis::FiniteElementBasis & fem, int n_quad) : fem_(fem) {
         // Get quadrature rule
-        chebyshev::chebyshev<double>(n_quad,xq,wq);
-        for(Eigen::Index i=0;i<xq.size();i++) {
-          if(!std::isfinite(xq[i]))
-            printf("xq[%i]=%e\n",(int) i, xq[i]);
-          if(!std::isfinite(wq[i]))
-            printf("wq[%i]=%e\n",(int) i, wq[i]);
+        chebyshev::chebyshev<double>(n_quad,xq_,wq_);
+        for(Eigen::Index i=0;i<xq_.size();i++) {
+          if(!std::isfinite(xq_[i]))
+            printf("xq_[%i]=%e\n",(int) i, xq_[i]);
+          if(!std::isfinite(wq_[i]))
+            printf("wq_[%i]=%e\n",(int) i, wq_[i]);
         }
       }
 
       RadialBasis::~RadialBasis() {
       }
 
-      int RadialBasis::get_nquad() const {
-        return (int) xq.size();
+      int RadialBasis::nquad() const {
+        return (int) xq_.size();
       }
 
-      helfem::Vector RadialBasis::get_bval() const {
-        return fem.get_bval();
+      helfem::Vector RadialBasis::bval() const {
+        return fem_.bval();
       }
 
-      int RadialBasis::get_poly_id() const {
-        return fem.get_poly_id();
+      int RadialBasis::poly_id() const {
+        return fem_.poly_id();
       }
 
-      int RadialBasis::get_poly_nnodes() const {
-        return fem.get_poly_nnodes();
+      int RadialBasis::poly_nnodes() const {
+        return fem_.poly_nnodes();
       }
 
       size_t RadialBasis::Nel() const {
         // Number of elements is
-        return fem.get_nelem();
+        return fem_.nelem();
       }
 
       size_t RadialBasis::Nbf() const {
         // Number of basis functions is Nbf*Nel - (Nel-1)*Noverlap - Noverlap
-        return fem.get_nbf();
+        return fem_.nbf();
       }
 
       size_t RadialBasis::Nprim(size_t iel) const {
-	return fem.get_nprim(iel);
+	return fem_.nprim(iel);
       }
 
       size_t RadialBasis::max_Nprim() const {
-        return fem.get_max_nprim();
+        return fem_.max_nprim();
       }
 
-      void RadialBasis::get_idx(size_t iel, size_t & ifirst, size_t & ilast) const {
-        fem.get_idx(iel, ifirst, ilast);
+      void RadialBasis::idx(size_t iel, size_t & ifirst, size_t & ilast) const {
+        fem_.idx(iel, ifirst, ilast);
       }
 
       helfem::Matrix RadialBasis::radial_integral(int m, int n) const {
@@ -274,21 +274,21 @@ namespace helfem {
             [&](int nq) {
               helfem::Vector x, w;
               lobatto::lobatto_compute<double>(nq, x, w);
-              return fem.matrix_element(false, false, x, w, chsh);
+              return fem_.matrix_element(false, false, x, w, chsh);
             },
-            std::max((int) xq.size(), 5), "radial_integral");
+            std::max((int) xq_.size(), 5), "radial_integral");
       }
 
       helfem::Matrix RadialBasis::overlap(const RadialBasis & rh, int n) const {
         // Find element pairs that share any mu range (independent of the
         // quadrature order).
-        std::vector<std::vector<size_t>> overlap(fem.get_nelem());
-        for(size_t iel=0;iel<fem.get_nelem();iel++) {
-          double istart(fem.element_begin(iel));
-          double iend(fem.element_end(iel));
-          for(size_t jel=0;jel<rh.fem.get_nelem();jel++) {
-            double jstart(rh.fem.element_begin(jel));
-            double jend(rh.fem.element_end(jel));
+        std::vector<std::vector<size_t>> overlap(fem_.nelem());
+        for(size_t iel=0;iel<fem_.nelem();iel++) {
+          double istart(fem_.element_begin(iel));
+          double iend(fem_.element_end(iel));
+          for(size_t jel=0;jel<rh.fem_.nelem();jel++) {
+            double jstart(rh.fem_.element_begin(jel));
+            double jend(rh.fem_.element_end(jel));
             if((jstart >= istart && jstart<iend) || (istart >= jstart && istart < jend))
               overlap[iel].push_back(jel);
           }
@@ -306,14 +306,14 @@ namespace helfem {
               lobatto::lobatto_compute<double>(nq, xproj, wproj);
 
               helfem::Matrix S(helfem::Matrix::Zero(Nbf(), rh.Nbf()));
-              for(size_t iel=0;iel<fem.get_nelem();iel++) {
+              for(size_t iel=0;iel<fem_.nelem();iel++) {
                 for(size_t jj=0;jj<overlap[iel].size();jj++) {
                   size_t jel=overlap[iel][jj];
                   // FE-side element ranges.
-                  double imin(fem.element_begin(iel));
-                  double imax(fem.element_end(iel));
-                  double jmin(rh.fem.element_begin(jel));
-                  double jmax(rh.fem.element_end(jel));
+                  double imin(fem_.element_begin(iel));
+                  double imax(fem_.element_end(iel));
+                  double jmin(rh.fem_.element_begin(jel));
+                  double jmax(rh.fem_.element_end(jel));
                   // Shared range.
                   double intstart(std::max(imin, jmin));
                   double intend(std::min(imax, jmax));
@@ -327,26 +327,26 @@ namespace helfem {
                   // boundaries of one basis and interior to the other.
                   helfem::Vector mu((intmid*helfem::Vector::Ones(xproj.size())+intlen*xproj)
                                         .cwiseMax(intstart).cwiseMin(intend));
-                  helfem::Vector xi(fem.eval_prim(mu, iel));
-                  helfem::Vector xj(rh.fem.eval_prim(mu, jel));
+                  helfem::Vector xi(fem_.eval_prim(mu, iel));
+                  helfem::Vector xj(rh.fem_.eval_prim(mu, jel));
 
                   size_t ifirst, ilast;
-                  get_idx(iel, ifirst, ilast);
+                  idx(iel, ifirst, ilast);
                   size_t jfirst, jlast;
-                  rh.get_idx(jel, jfirst, jlast);
+                  rh.idx(jel, jfirst, jlast);
 
                   helfem::Vector wtot(wproj*intlen);
                   wtot.array() *= mu.array().sinh();
                   if(n!=0) wtot.array() *= mu.array().cosh().pow((double) n);
-                  helfem::Matrix ibf(fem.eval_dnf(xi, 0, iel));
-                  helfem::Matrix jbf(rh.fem.eval_dnf(xj, 0, jel));
+                  helfem::Matrix ibf(fem_.eval_dnf(xi, 0, iel));
+                  helfem::Matrix jbf(rh.fem_.eval_dnf(xj, 0, jel));
                   helfem::Matrix s(ibf.transpose()*wtot.asDiagonal()*jbf);
                   S.block(ifirst, jfirst, ilast-ifirst+1, jlast-jfirst+1) += s;
                 }
               }
               return S;
             },
-            std::max({(int) xq.size(), (int) rh.xq.size(), 5}), "overlap");
+            std::max({(int) xq_.size(), (int) rh.xq_.size(), 5}), "overlap");
       }
 
       helfem::Matrix RadialBasis::Plm_integral(int k, size_t iel, int L, int M, quadrature::MLegendreCache & leg) const {
@@ -369,9 +369,9 @@ namespace helfem {
             [&](int n) {
               helfem::Vector x, w;
               chebyshev::chebyshev<double>(n, x, w);
-              return fem.matrix_element(iel, false, false, x, w, Plm);
+              return fem_.matrix_element(iel, false, false, x, w, Plm);
             },
-            std::max((int) xq.size(), 5), "Plm_integral", nullptr, true);
+            std::max((int) xq_.size(), 5), "Plm_integral", nullptr, true);
       }
 
       helfem::Matrix RadialBasis::Qlm_integral(int k, size_t iel, int L, int M, quadrature::MLegendreCache & leg) const {
@@ -388,9 +388,9 @@ namespace helfem {
             [&](int n) {
               helfem::Vector x, w;
               chebyshev::chebyshev<double>(n, x, w);
-              return fem.matrix_element(iel, false, false, x, w, Qlm);
+              return fem_.matrix_element(iel, false, false, x, w, Qlm);
             },
-            std::max((int) xq.size(), 5), "Qlm_integral", nullptr, true);
+            std::max((int) xq_.size(), 5), "Qlm_integral", nullptr, true);
       }
 
       helfem::Matrix RadialBasis::kinetic() const {
@@ -402,36 +402,36 @@ namespace helfem {
             [&](int nq) {
               helfem::Vector x, w;
               lobatto::lobatto_compute<double>(nq, x, w);
-              return fem.matrix_element(true, true, x, w, sinhmu);
+              return fem_.matrix_element(true, true, x, w, sinhmu);
             },
-            std::max((int) xq.size(), 5), "kinetic");
+            std::max((int) xq_.size(), 5), "kinetic");
       }
 
       helfem::Matrix RadialBasis::twoe_integral(int alpha, int beta, size_t iel, int L, int M, quadrature::MLegendreCache & leg) const {
-        double mumin=fem.element_begin(iel);
-        double mumax=fem.element_end(iel);
+        double mumin=fem_.element_begin(iel);
+        double mumax=fem_.element_end(iel);
 
         // Integral by quadrature
-        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
-        helfem::Matrix tei(quadrature::twoe_integral(mumin,mumax,alpha,beta,xq,wq,p,L,M,leg));
+        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> p(fem_.basis(iel));
+        helfem::Matrix tei(quadrature::twoe_integral(mumin,mumax,alpha,beta,xq_,wq_,p,L,M,leg));
 
         return tei;
       }
 
       quadrature::TwoElectronElement RadialBasis::twoe_element(size_t iel) const {
         // Build at the stored quadrature order.
-        return twoe_element(iel, (int) xq.size());
+        return twoe_element(iel, (int) xq_.size());
       }
 
       quadrature::TwoElectronElement RadialBasis::twoe_element(size_t iel, int n) const {
         // Build at a specified Gauss-Chebyshev order: a fresh n-point rule
-        // instead of the stored (xq, wq). This is what lets compute_tei refine
+        // instead of the stored (xq_, wq_). This is what lets compute_tei refine
         // the in-element two-electron kernel until it is converged to
         // eps(double).
         helfem::Vector x, w;
         chebyshev::chebyshev<double>(n, x, w);
-        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> p(fem.get_basis(iel));
-        return quadrature::twoe_element(fem.element_begin(iel), fem.element_end(iel), x, w, p);
+        std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis> p(fem_.basis(iel));
+        return quadrature::twoe_element(fem_.element_begin(iel), fem_.element_end(iel), x, w, p);
       }
 
       helfem::Matrix RadialBasis::twoe_integral(int alpha, int beta, const quadrature::TwoElectronElement & el, int L, int M, quadrature::MLegendreCache & leg) const {
@@ -440,33 +440,33 @@ namespace helfem {
 
       helfem::Vector RadialBasis::get_chmu_quad() const {
         // Quadrature points for normal integrals
-        helfem::Vector muq(fem.get_nelem()*xq.size()*(xq.size()+1));
+        helfem::Vector muq(fem_.nelem()*xq_.size()*(xq_.size()+1));
         size_t ioff=0;
 
-        for(size_t iel=0;iel<fem.get_nelem();iel++) {
+        for(size_t iel=0;iel<fem_.nelem();iel++) {
           // Element ranges from
-          double mumin0=fem.element_begin(iel);
-          double mumax0=fem.element_end(iel);
+          double mumin0=fem_.element_begin(iel);
+          double mumax0=fem_.element_end(iel);
 
           // Midpoint is at
           double mumid0(0.5*(mumax0+mumin0));
           // and half-length of interval is
           double mulen0(0.5*(mumax0-mumin0));
           // mu values are then
-          helfem::Vector mu0(mumid0*helfem::Vector::Ones(xq.size())+mulen0*xq);
+          helfem::Vector mu0(mumid0*helfem::Vector::Ones(xq_.size())+mulen0*xq_);
 
           // Store values
           muq.segment(ioff,mu0.size())=mu0;
           ioff+=mu0.size();
 
           // Subintervals for in-element two-electron integrals
-          for(Eigen::Index isub=0;isub<xq.size();isub++) {
+          for(Eigen::Index isub=0;isub<xq_.size();isub++) {
             double mumin = (isub==0) ? mumin0 : mu0(isub-1);
             double mumax = mu0(isub);
 
             double mumid(0.5*(mumax+mumin));
             double mulen(0.5*(mumax-mumin));
-            helfem::Vector mu(mumid*helfem::Vector::Ones(xq.size())+mulen*xq);
+            helfem::Vector mu(mumid*helfem::Vector::Ones(xq_.size())+mulen*xq_);
             muq.segment(ioff,mu.size())=mu;
             ioff+=mu.size();
           }
@@ -477,29 +477,29 @@ namespace helfem {
         return muq.array().cosh().matrix();
       }
 
-      helfem::Matrix RadialBasis::get_bf(size_t iel) const {
-        return get_bf(iel, xq);
+      helfem::Matrix RadialBasis::bf(size_t iel) const {
+        return bf(iel, xq_);
       }
 
-      helfem::Matrix RadialBasis::get_bf(size_t iel, const helfem::Vector & x) const {
-        return fem.eval_dnf(x, 0, iel);
+      helfem::Matrix RadialBasis::bf(size_t iel, const helfem::Vector & x) const {
+        return fem_.eval_dnf(x, 0, iel);
       }
 
-      helfem::Matrix RadialBasis::get_df(size_t iel) const {
-        return fem.eval_dnf(xq, 1, iel);
+      helfem::Matrix RadialBasis::df(size_t iel) const {
+        return fem_.eval_dnf(xq_, 1, iel);
       }
 
       helfem::Matrix RadialBasis::get_d2f(size_t iel) const {
-        return fem.eval_dnf(xq, 2, iel);
+        return fem_.eval_dnf(xq_, 2, iel);
       }
 
-      helfem::Vector RadialBasis::get_wrad(size_t iel) const {
+      helfem::Vector RadialBasis::wrad(size_t iel) const {
         // This is just the radial rule, no r^2 factor included here
-        return fem.scaling_factor(iel)*wq;
+        return fem_.scaling_factor(iel)*wq_;
       }
 
-      helfem::Vector RadialBasis::get_r(size_t iel) const {
-        return fem.eval_coord(xq, iel);
+      helfem::Vector RadialBasis::r(size_t iel) const {
+        return fem_.eval_coord(xq_, iel);
       }
 
       void lm_to_l_m(const Eigen::VectorXi & lmax, Eigen::VectorXi & lval, Eigen::VectorXi & mval) {
@@ -533,8 +533,8 @@ namespace helfem {
         bool zero_deriv_left=false;
         bool zero_func_right=true;
         bool zero_deriv_right=true;
-        polynomial_basis::FiniteElementBasis fem(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
-        radial=RadialBasis(fem, n_quad);
+        polynomial_basis::FiniteElementBasis fem_(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
+        radial=RadialBasis(fem_, n_quad);
         // Angular basis.
         lval=lval_;
         mval=mval_;
@@ -669,25 +669,25 @@ namespace helfem {
         return mval;
       }
 
-      int TwoDBasis::get_nquad() const {
-        return radial.get_nquad();
+      int TwoDBasis::nquad() const {
+        return radial.nquad();
       }
 
-      helfem::Vector TwoDBasis::get_bval() const {
-        return radial.get_bval();
+      helfem::Vector TwoDBasis::bval() const {
+        return radial.bval();
       }
 
       double TwoDBasis::get_mumax() const {
-        helfem::Vector bval(radial.get_bval());
+        helfem::Vector bval(radial.bval());
         return bval(bval.size()-1);
       }
 
-      int TwoDBasis::get_poly_id() const {
-        return radial.get_poly_id();
+      int TwoDBasis::poly_id() const {
+        return radial.poly_id();
       }
 
-      int TwoDBasis::get_poly_nnodes() const {
-        return radial.get_poly_nnodes();
+      int TwoDBasis::poly_nnodes() const {
+        return radial.poly_nnodes();
       }
 
       size_t TwoDBasis::Ndummy() const {
@@ -1334,7 +1334,7 @@ namespace helfem {
       int TwoDBasis::converged_twoe_order(size_t iel) const {
         // Seed the refinement from the requested --nquad so the common case
         // converges in 1-2 steps; the loop, not the seed, sets the accuracy.
-        int nstart = radial.get_nquad();
+        int nstart = radial.nquad();
         if(nstart < 5) nstart = 5;
         if(nstart > twoe_nmax) nstart = twoe_nmax;
 
@@ -1697,7 +1697,7 @@ namespace helfem {
           // Loop over input elements
           for(size_t jel=0;jel<Nel;jel++) {
             size_t jfirst, jlast;
-            radial.get_idx(jel,jfirst,jlast);
+            radial.idx(jel,jfirst,jlast);
             size_t Nj(jlast-jfirst+1);
 
             // Get density submatrices
@@ -1715,7 +1715,7 @@ namespace helfem {
             double ifac2(-jbig0 + jbig2);
             for(size_t iel=0;iel<jel;iel++) {
               size_t ifirst, ilast;
-              radial.get_idx(iel,ifirst,ilast);
+              radial.idx(iel,ifirst,ilast);
               size_t Ni(ilast-ifirst+1);
 
               const helfem::Matrix & iint0=disjoint_P0[ilm*Nel+iel];
@@ -1729,7 +1729,7 @@ namespace helfem {
             ifac2=-jsmall0 + jsmall2;
             for(size_t iel=jel+1;iel<Nel;iel++) {
               size_t ifirst, ilast;
-              radial.get_idx(iel,ifirst,ilast);
+              radial.idx(iel,ifirst,ilast);
               size_t Ni(ilast-ifirst+1);
 
               const helfem::Matrix & iint0=disjoint_Q0[ilm*Nel+iel];
@@ -1967,12 +1967,12 @@ namespace helfem {
               // Loop over elements: output
               for(size_t iel=0;iel<Nel;iel++) {
                 size_t ifirst, ilast;
-                radial.get_idx(iel,ifirst,ilast);
+                radial.idx(iel,ifirst,ilast);
 
                 // Input
                 for(size_t jel=0;jel<Nel;jel++) {
                   size_t jfirst, jlast;
-                  radial.get_idx(jel,jfirst,jlast);
+                  radial.idx(jel,jfirst,jlast);
 
                   // Number of functions in the two elements
                   size_t Ni(ilast-ifirst+1);
@@ -2124,7 +2124,7 @@ namespace helfem {
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
         // Evaluate radial functions (single quadrature point, 1 x Nc row)
-        const helfem::Matrix rad(radial.get_bf(iel).row(irad));
+        const helfem::Matrix rad(radial.bf(iel).row(irad));
         const Eigen::Index Nc = rad.cols();
 
         // Form supermatrix. sph(i) is complex, rad is real -> cast rad.
@@ -2136,7 +2136,7 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m) const {
-        return eval_bf(iel, irad, cth, m, radial.get_bf(iel));
+        return eval_bf(iel, irad, cth, m, radial.bf(iel));
       }
 
       helfem::Matrix TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m, const helfem::Matrix & rad_all) const {
@@ -2165,7 +2165,7 @@ namespace helfem {
 
       Eigen::VectorXcd TwoDBasis::eval_bf(double mu, double cth, double phi) const {
 	// Find out which element mu belongs to
-	const helfem::Vector bval(radial.get_bval());
+	const helfem::Vector bval(radial.bval());
 	Eigen::Index iel;
 	for(iel=0;iel<bval.size()-1;iel++)
 	  if(bval(iel)<=mu && mu<=bval(iel+1))
@@ -2185,11 +2185,11 @@ namespace helfem {
         for(size_t i=0;i<(size_t) lval.size();i++)
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
         // Evaluate radial functions (1 x Nc row)
-        const helfem::Matrix rad(radial.get_bf(iel,x));
+        const helfem::Matrix rad(radial.bf(iel,x));
 
 	// Get indices of radial functions
 	size_t ifirst, ilast;
-        radial.get_idx(iel,ifirst,ilast);
+        radial.idx(iel,ifirst,ilast);
 
         // Form supermatrix. arma used trans() on a real matrix = plain
         // transpose; sph(i) is complex so cast the transposed radial row.
@@ -2208,8 +2208,8 @@ namespace helfem {
           sph(i)=::spherical_harmonics(lval(i),mval(i),cth,phi);
 
         // Evaluate radial functions (single quadrature point, 1 x Nc rows)
-        const helfem::Matrix frad(radial.get_bf(iel).row(irad));
-        const helfem::Matrix drad(radial.get_df(iel).row(irad));
+        const helfem::Matrix frad(radial.bf(iel).row(irad));
+        const helfem::Matrix drad(radial.df(iel).row(irad));
         const Eigen::Index Nc = frad.cols();
 
         // Form supermatrices
@@ -2271,8 +2271,8 @@ namespace helfem {
         }
 
         // Radial functions and their derivatives at the single radial point
-        const helfem::Matrix frad(radial.get_bf(iel).row(irad));
-        const helfem::Matrix drad(radial.get_df(iel).row(irad));
+        const helfem::Matrix frad(radial.bf(iel).row(irad));
+        const helfem::Matrix drad(radial.df(iel).row(irad));
         const Eigen::Index Nc = frad.cols();
 
         dr = helfem::Matrix::Zero(frad.rows(),flist.size()*Nc);
@@ -2292,7 +2292,7 @@ namespace helfem {
             flist.push_back(i);
 
         // Geometry at this (mu, nu) point
-        const double mu(radial.get_r(iel)(irad));
+        const double mu(radial.r(iel)(irad));
         const double shmu(std::sinh(mu)), chmu(std::cosh(mu));
         // sin^2(nu), written to avoid cancellation near |cth| = 1
         const double sth2(std::max((1.0-cth)*(1.0+cth), 0.0));
@@ -2304,8 +2304,8 @@ namespace helfem {
         const double m2_sh2((shmu>0.0) ? (m*m)/(shmu*shmu) : 0.0);
 
         // Radial functions and their first two mu derivatives (1 x Nc rows)
-        const helfem::Matrix frad(radial.get_bf(iel).row(irad));
-        const helfem::Matrix drad(radial.get_df(iel).row(irad));
+        const helfem::Matrix frad(radial.bf(iel).row(irad));
+        const helfem::Matrix drad(radial.df(iel).row(irad));
         const helfem::Matrix d2rad(radial.get_d2f(iel).row(irad));
         const Eigen::Index Nc = frad.cols();
 
@@ -2356,7 +2356,7 @@ namespace helfem {
       std::vector<Eigen::Index> TwoDBasis::bf_list_dummy(size_t iel) const {
         // Radial functions in element
         size_t ifirst, ilast;
-        radial.get_idx(iel,ifirst,ilast);
+        radial.idx(iel,ifirst,ilast);
         // Number of radial functions in element
         size_t Nr(ilast-ifirst+1);
 
@@ -2379,7 +2379,7 @@ namespace helfem {
       std::vector<Eigen::Index> TwoDBasis::bf_list_dummy(size_t iel, int m) const {
         // Radial functions in element
         size_t ifirst, ilast;
-        radial.get_idx(iel,ifirst,ilast);
+        radial.idx(iel,ifirst,ilast);
         // Number of radial functions in element
         size_t Nr(ilast-ifirst+1);
 
@@ -2401,23 +2401,23 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::get_rad_bf(size_t iel) const {
-        return radial.get_bf(iel);
+        return radial.bf(iel);
       }
 
       helfem::Matrix TwoDBasis::get_rad_df(size_t iel) const {
-        return radial.get_df(iel);
+        return radial.df(iel);
       }
 
       helfem::Matrix TwoDBasis::get_rad_d2f(size_t iel) const {
         return radial.get_d2f(iel);
       }
 
-      helfem::Vector TwoDBasis::get_wrad(size_t iel) const {
-        return radial.get_wrad(iel);
+      helfem::Vector TwoDBasis::wrad(size_t iel) const {
+        return radial.wrad(iel);
       }
 
-      helfem::Vector TwoDBasis::get_r(size_t iel) const {
-        return radial.get_r(iel);
+      helfem::Vector TwoDBasis::r(size_t iel) const {
+        return radial.r(iel);
       }
 
     }

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -26,11 +26,11 @@ namespace helfem {
       /// Radial basis set
       class RadialBasis {
         /// Quadrature points
-        helfem::Vector xq;
+        helfem::Vector xq_;
         /// Quadrature weights
-        helfem::Vector wq;
+        helfem::Vector wq_;
         /// Finite element basis
-        polynomial_basis::FiniteElementBasis fem;
+        polynomial_basis::FiniteElementBasis fem_;
 
       public:
         /// Dummy constructor
@@ -41,16 +41,16 @@ namespace helfem {
         ~RadialBasis();
 
         /// Get number of quadrature points
-        int get_nquad() const;
+        int nquad() const;
         /// Get boundary values
-        helfem::Vector get_bval() const;
+        helfem::Vector bval() const;
         /// Get polynomial basis identifier
-        int get_poly_id() const;
+        int poly_id() const;
         /// Get number of nodes in polynomial
-        int get_poly_nnodes() const;
+        int poly_nnodes() const;
 
         /// Get number of overlapping functions
-        size_t get_noverlap() const;
+        size_t noverlap() const;
         /// Number of basis functions
         size_t Nbf() const;
         /// Number of primitive functions in element
@@ -61,7 +61,7 @@ namespace helfem {
         /// Number of elements
         size_t Nel() const;
         /// Get function indices
-        void get_idx(size_t iel, size_t & ifirst, size_t & ilast) const;
+        void idx(size_t iel, size_t & ifirst, size_t & ilast) const;
 
         /// Compute radial matrix elements
         helfem::Matrix radial_integral(int m, int n) const;
@@ -89,7 +89,7 @@ namespace helfem {
         quadrature::TwoElectronElement twoe_element(size_t iel) const;
         /// Build the element-only two-electron data at a SPECIFIED
         /// Gauss-Chebyshev order n, using a fresh n-point rule instead of the
-        /// stored (xq, wq). Used by compute_tei's auto-convergence refinement,
+        /// stored (xq_, wq_). Used by compute_tei's auto-convergence refinement,
         /// which rebuilds the element at rising n until the in-element kernel
         /// stops changing to eps(double).
         quadrature::TwoElectronElement twoe_element(size_t iel, int n) const;
@@ -99,17 +99,17 @@ namespace helfem {
         /// Get quadrature points
         helfem::Vector get_chmu_quad() const;
         /// Evaluate basis functions at quadrature points
-        helfem::Matrix get_bf(size_t iel) const;
+        helfem::Matrix bf(size_t iel) const;
         /// Evaluate basis functions at wanted point in [-1,1]
-        helfem::Matrix get_bf(size_t iel, const helfem::Vector & x) const;
+        helfem::Matrix bf(size_t iel, const helfem::Vector & x) const;
         /// Evaluate derivatives of basis functions at quadrature points
-        helfem::Matrix get_df(size_t iel) const;
+        helfem::Matrix df(size_t iel) const;
         /// Evaluate second derivatives of basis functions at quadrature points
         helfem::Matrix get_d2f(size_t iel) const;
         /// Get quadrature weights
-        helfem::Vector get_wrad(size_t iel) const;
+        helfem::Vector wrad(size_t iel) const;
         /// Get r values
-        helfem::Vector get_r(size_t iel) const;
+        helfem::Vector r(size_t iel) const;
       };
 
       /// L, |M| index type
@@ -236,15 +236,15 @@ namespace helfem {
         Eigen::VectorXi get_mval() const;
 
         /// Get number of quadrature points
-        int get_nquad() const;
+        int nquad() const;
         /// Get boundary values
-        helfem::Vector get_bval() const;
+        helfem::Vector bval() const;
 	/// Get maximum mu value
 	double get_mumax() const;
         /// Get polynomial basis identifier
-        int get_poly_id() const;
+        int poly_id() const;
         /// Get polynomial basis order
-        int get_poly_nnodes() const;
+        int poly_nnodes() const;
 
         /// Get indices of real basis functions
         std::vector<Eigen::Index> pure_indices() const;
@@ -417,9 +417,9 @@ namespace helfem {
         /// Get number of radial elements
         size_t get_rad_Nel() const;
         /// Get radial quadrature weights
-        helfem::Vector get_wrad(size_t iel) const;
+        helfem::Vector wrad(size_t iel) const;
         /// Get r values
-        helfem::Vector get_r(size_t iel) const;
+        helfem::Vector r(size_t iel) const;
         /// Get radial basis functions at the quadrature points of element iel
         /// (rows = radial points, cols = element primitives)
         helfem::Matrix get_rad_bf(size_t iel) const;

--- a/src/diatomic/corebasis.cpp
+++ b/src/diatomic/corebasis.cpp
@@ -239,7 +239,7 @@ int main(int argc, char **argv) {
   printf("Determining basis set for %s-%s at distance %e with Rmax=%e.\n",element_symbols[Z1].c_str(),element_symbols[Z2].c_str(),Rbond,Rmax);
 
   // Get primitive basis
-  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::get_basis(primbas,Nnodes)));
+  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::make_basis(primbas,Nnodes)));
 
   if(Nquad==0)
     // Set default value

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
 
   // Process defaults
   if(nquad<=0)
-    nquad=5*basis.get_poly_nnodes();
+    nquad=5*basis.poly_nnodes();
   if(lang<=0)
     lang=4*basis.get_lval().maxCoeff()+12;
   if(mang<=0)
@@ -90,8 +90,8 @@ int main(int argc, char **argv) {
   // mu array
   std::vector<helfem::Vector> mu(basis.get_rad_Nel()), wmu(basis.get_rad_Nel());
   for(size_t iel=0;iel<mu.size();iel++) {
-    mu[iel]=basis.get_r(iel);
-    wmu[iel]=basis.get_wrad(iel);
+    mu[iel]=basis.r(iel);
+    wmu[iel]=basis.wrad(iel);
   }
 
   size_t Nradpts=mu.size()*mu[0].size();

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -418,8 +418,8 @@ namespace helfem {
         // Get radial weights. Only do one radial quadrature point at a
         // time, since this is an easy way to save a lot of memory.
         helfem::Vector wrad(1), r(1);
-        wrad(0)=basp->get_wrad(iel)(irad);
-        r(0)=basp->get_r(iel)(irad);
+        wrad(0)=basp->wrad(iel)(irad);
+        r(0)=basp->r(iel)(irad);
 
         double Rhalf(basp->get_Rhalf());
 
@@ -545,7 +545,7 @@ namespace helfem {
           const helfem::Matrix P_exp(basp->expand_boundaries(P_e));
 
           for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+            for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
               grid.compute_bf(iel,irad);
               grid.update_density(P_exp);
               nel+=grid.compute_Nel();
@@ -588,7 +588,7 @@ namespace helfem {
           const helfem::Matrix Pb_exp(basp->expand_boundaries(Pb_e));
 
           for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-            for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+            for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
               grid.compute_bf(iel,irad);
               grid.update_density(Pa_exp,Pb_exp);
               nel+=grid.compute_Nel();

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -88,8 +88,8 @@ namespace helfem {
         const Eigen::Index nang = cth.size();
         const bool need_df = do_grad || do_tau || do_lapl;
 
-        const double r0    = basp->get_r(iel)(irad);
-        const double wr    = basp->get_wrad(iel)(irad);
+        const double r0    = basp->r(iel)(irad);
+        const double wr    = basp->wrad(iel)(irad);
         const double Rhalf = basp->get_Rhalf();
         const double shmu  = std::sinh(r0);
 
@@ -682,7 +682,7 @@ namespace helfem {
           grid.check_grad_tau_lapl(x_func, c_func);
 
           for (size_t iel = 0; iel < basp->get_rad_Nel(); iel++) {
-            for (size_t irad = 0; irad < (size_t) basp->get_r(iel).size(); irad++) {
+            for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++) {
               grid.compute_bf(iel, irad);
               grid.update_density(P);
               nel  += grid.compute_Nel();
@@ -713,7 +713,7 @@ namespace helfem {
           grid.check_grad_tau_lapl(x_func, c_func);
 
           for (size_t iel = 0; iel < basp->get_rad_Nel(); iel++) {
-            for (size_t irad = 0; irad < (size_t) basp->get_r(iel).size(); irad++) {
+            for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++) {
               grid.compute_bf(iel, irad);
               grid.update_density(Pa, Pb);
               nel  += grid.compute_Nel();

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -191,9 +191,9 @@ int main(int argc, char **argv) {
     throw std::logic_error("Range-separated hybrids not yet supported in diatomic_ooo (needs omega wiring).\n");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
-  if (Nquad == 0) Nquad = 5 * poly->get_nbf();
-  else if (Nquad < 2 * poly->get_nbf())
+      polynomial_basis::make_basis(primbas, Nnodes));
+  if (Nquad == 0) Nquad = 5 * poly->nbf();
+  else if (Nquad < 2 * poly->nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
 
   Eigen::VectorXi lmmax;

--- a/src/diatomic/projection_test.cpp
+++ b/src/diatomic/projection_test.cpp
@@ -76,8 +76,8 @@ int main(int argc, char **argv) {
   const double thresh = parser.get<double>("thresh");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
-  const int Nquad = 5 * poly->get_nbf();
+      polynomial_basis::make_basis(primbas, Nnodes));
+  const int Nquad = 5 * poly->nbf();
 
   const Eigen::VectorXi lmmax = Eigen::VectorXi::Constant(mmax + 1, lmax);
   Eigen::VectorXi lval, mval;

--- a/src/diatomic/purem_test.cpp
+++ b/src/diatomic/purem_test.cpp
@@ -113,8 +113,8 @@ int main(int argc, char **argv) {
   const int primbas = parser.get<int>("primbas");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
-  const int Nquad = 5 * poly->get_nbf();
+      polynomial_basis::make_basis(primbas, Nnodes));
+  const int Nquad = 5 * poly->nbf();
 
   const Eigen::VectorXi lmmax = Eigen::VectorXi::Constant(mmax + 1, lmax);
   Eigen::VectorXi lval, mval;
@@ -182,12 +182,12 @@ int main(int argc, char **argv) {
     for (int m = 0; m <= std::min(mmax, 2); m++) {
       // A radial point comfortably inside the second element, and a few nu
       const size_t iel = std::min<size_t>(1, basis.get_rad_Nel() - 1);
-      const helfem::Vector rr(basis.get_r(iel));
+      const helfem::Vector rr(basis.r(iel));
       // The FEM basis is only C0 across element boundaries -- the second
       // derivative jumps -- so a finite-difference stencil must not step out
       // of the element. Gauss-Lobatto points cluster at the edges, so skip
       // any radial point within `edge` of a boundary.
-      const helfem::Vector bv(basis.get_bval());
+      const helfem::Vector bv(basis.bval());
       const double edge = 100.0 * 1e-4;
       for (size_t irad = 0; irad < (size_t) rr.size(); irad += 7) {
         const double mu = rr(irad);

--- a/src/diatomic/quadrature.cpp
+++ b/src/diatomic/quadrature.cpp
@@ -78,7 +78,7 @@ namespace helfem {
         helfem::Vector mu = mumid*helfem::Vector::Ones(x.size()) + mulen*x;
 
         // Compute the "inner" integrals as function of r.
-        helfem::Matrix inner(x.size(), (Eigen::Index) std::pow(poly->get_nbf(),2));
+        helfem::Matrix inner(x.size(), (Eigen::Index) std::pow(poly->nbf(),2));
         inner.row(0)=twoe_inner_integral_wrk(mumin, mu(0), mumin, mumax, l, x, wx, poly, L, M, tab).transpose();
         // Every subinterval uses a fresh nquad points!
         for(Eigen::Index ip=1;ip<x.size();ip++)

--- a/src/diatomic/teirank.cpp
+++ b/src/diatomic/teirank.cpp
@@ -63,8 +63,8 @@ int main(int argc, char **argv) {
   const int mmax = parser.get<int>("mmax");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
-  const int Nquad = 5 * poly->get_nbf();
+      polynomial_basis::make_basis(primbas, Nnodes));
+  const int Nquad = 5 * poly->nbf();
 
   const Eigen::VectorXi lmmax = Eigen::VectorXi::Constant(mmax + 1, lmax);
   Eigen::VectorXi lval, mval;
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
 
   diatomic::basis::TwoDBasis basis(7, 7, Rhalf, poly, Nquad, bval, lval, mval);
 
-  const int nprim = (int) poly->get_nbf();
+  const int nprim = (int) poly->nbf();
   const int n = nprim * nprim;
   printf("nnodes = %i -> Nprim = %i, Nprim^2 = %i, nquad = %i\n",
          Nnodes, nprim, n, Nquad);

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -168,9 +168,9 @@ namespace helfem {
         // Get radial weights. Only do one radial quadrature point at a
         // time, since this is an easy way to save a lot of memory.
         r=helfem::Vector::Zero(1);
-        r(0)=basp->get_r(iel)(irad);
+        r(0)=basp->r(iel)(irad);
         wrad=helfem::Vector::Zero(1);
-        wrad(0)=basp->get_wrad(iel)(irad);
+        wrad(0)=basp->wrad(iel)(irad);
 
         double Rhalf(basp->get_Rhalf());
 
@@ -383,7 +383,7 @@ namespace helfem {
 
           for(size_t im=0;im<muni.size();im++) {
             for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-              for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+              for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
                 grid.compute_bf(iel,irad,muni[im]);
                 grid.model_potential(p1, p2);
                 grid.eval_pot(H);
@@ -410,7 +410,7 @@ namespace helfem {
 
         TwoDGridWorker grid(basp, lang);
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.ao_projection(compute_ao, p);
             grid.multiply_Plm(l, m, p);
@@ -431,7 +431,7 @@ namespace helfem {
 
         TwoDGridWorker grid(basp, lang);
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.ao_projection(compute_ao, p);
             grid.multiply_Plm(l, m, p);
@@ -446,7 +446,7 @@ namespace helfem {
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.gto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -462,7 +462,7 @@ namespace helfem {
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.gto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -478,7 +478,7 @@ namespace helfem {
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.sto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -494,7 +494,7 @@ namespace helfem {
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.sto(l, expn, p);
             grid.multiply_Plm(l, m, p);
@@ -538,7 +538,7 @@ namespace helfem {
         TwoDGridWorker grid(basp,lang);
 
         for(size_t iel=0;iel<basp->get_rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->get_r(iel).size();irad++) {
+          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
             grid.compute_bf(iel,irad,m);
             grid.ao_projection(eval_ao, p);
             grid.multiply_Plm(l, m, p);
@@ -568,8 +568,8 @@ namespace helfem {
         constexpr double dftthr = 1e-12;
 
         auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-            polynomial_basis::get_basis(primbas, Nnodes));
-        const int Nquad = 5 * poly->get_nbf();
+            polynomial_basis::make_basis(primbas, Nnodes));
+        const int Nquad = 5 * poly->nbf();
 
         auto lmax_for_Z = [](int Z){
           for (int l = 3; l >= 0; --l)

--- a/src/general/atomdb.cpp
+++ b/src/general/atomdb.cpp
@@ -75,7 +75,7 @@ namespace helfem {
     static const atomic::basis::FEMRadialBasis & shared_basis() {
       static const atomic::basis::FEMRadialBasis basis = []() {
         std::shared_ptr<const polynomial_basis::PolynomialBasis> poly(
-            polynomial_basis::get_basis(data::primbas, data::nnodes));
+            polynomial_basis::make_basis(data::primbas, data::nnodes));
         // Matches sadatom::basis::TwoDBasis: the function vanishes at the
         // origin and at the practical infinity, its derivative is free.
         polynomial_basis::FiniteElementBasis fem(poly, element_boundaries(), true,
@@ -105,7 +105,7 @@ namespace helfem {
       helfem::Vector qel(Nel), mel(Nel);
       for (size_t iel = 0; iel < Nel; iel++) {
         size_t ifirst, ilast;
-        radial_.get_idx(iel, ifirst, ilast);
+        radial_.idx(iel, ifirst, ilast);
         Psub_[iel] = P.block(ifirst, ifirst, ilast - ifirst + 1, ilast - ifirst + 1);
         qel(iel) = partial_integral(iel, -1.0, 1.0, false);
         mel(iel) = partial_integral(iel, -1.0, 1.0, true);
@@ -120,7 +120,7 @@ namespace helfem {
         Mabove_(iel) = Mabove_(iel + 1) + mel(iel + 1);
 
       Ntot_ = qel.sum();
-      Rmax_ = radial_.get_fem().element_end(Nel - 1);
+      Rmax_ = radial_.fem().element_end(Nel - 1);
     }
 
     int Atom::charge() const { return Z_; }
@@ -151,14 +151,14 @@ namespace helfem {
       if (n <= 0 || r <= 0.0 || r > Rmax_)
         return out;
       double xprim;
-      const size_t iel = locate(radial_.get_fem(), r, xprim);
+      const size_t iel = locate(radial_.fem(), r, xprim);
       helfem::Vector x(1);
       x(0) = xprim;
-      // get_bf returns B(r)/r, so contracting it with the stored
+      // bf returns B(r)/r, so contracting it with the stored
       // coefficients gives the radial function R(r) itself, not r*R(r).
-      const helfem::Matrix bf = radial_.get_bf(x, iel);
+      const helfem::Matrix bf = radial_.bf(x, iel);
       size_t ifirst, ilast;
-      radial_.get_idx(iel, ifirst, ilast);
+      radial_.idx(iel, ifirst, ilast);
       const helfem::Matrix C = coefficients(Z_, l);
       out = (bf * C.block(ifirst, 0, ilast - ifirst + 1, n)).transpose();
       return out;
@@ -168,11 +168,11 @@ namespace helfem {
       if (r <= 0.0 || r > Rmax_)
         return 0.0;
       double xprim;
-      const size_t iel = locate(radial_.get_fem(), r, xprim);
+      const size_t iel = locate(radial_.fem(), r, xprim);
       helfem::Vector x(1);
       x(0) = xprim;
-      // get_bf returns B(r)/r, so the contraction is 4 pi rho directly.
-      const helfem::Matrix bf = radial_.get_bf(x, iel);
+      // bf returns B(r)/r, so the contraction is 4 pi rho directly.
+      const helfem::Matrix bf = radial_.bf(x, iel);
       return r * r * (bf * Psub_[iel] * bf.transpose())(0, 0);
     }
 
@@ -185,11 +185,11 @@ namespace helfem {
       if (r <= 0.0 || r > Rmax_)
         return 0.0;
       double xprim;
-      const size_t iel = locate(radial_.get_fem(), r, xprim);
+      const size_t iel = locate(radial_.fem(), r, xprim);
       helfem::Vector x(1);
       x(0) = xprim;
-      const helfem::Matrix bf = radial_.get_bf(x, iel);
-      const helfem::Matrix df = radial_.get_df(x, iel);
+      const helfem::Matrix bf = radial_.bf(x, iel);
+      const helfem::Matrix df = radial_.df(x, iel);
       // d/dr sum_ij P_ij R_i R_j = 2 sum_ij P_ij R_i R_j', P symmetric.
       return 2.0 * (bf * Psub_[iel] * df.transpose())(0, 0) / (4.0 * M_PI);
     }
@@ -198,12 +198,12 @@ namespace helfem {
       if (r <= 0.0 || r > Rmax_)
         return 0.0;
       double xprim;
-      const size_t iel = locate(radial_.get_fem(), r, xprim);
+      const size_t iel = locate(radial_.fem(), r, xprim);
       helfem::Vector x(1);
       x(0) = xprim;
-      const helfem::Matrix bf = radial_.get_bf(x, iel);
-      const helfem::Matrix df = radial_.get_df(x, iel);
-      const helfem::Matrix lf = radial_.get_lf(x, iel);
+      const helfem::Matrix bf = radial_.bf(x, iel);
+      const helfem::Matrix df = radial_.df(x, iel);
+      const helfem::Matrix lf = radial_.lf(x, iel);
       // rho'' + 2 rho' / r, with rho'' = 2 (R' P R' + R P R'').
       const double d2 = 2.0 * ((df * Psub_[iel] * df.transpose())(0, 0) +
                                (bf * Psub_[iel] * lf.transpose())(0, 0));
@@ -236,7 +236,7 @@ namespace helfem {
       const double half_sub = 0.5 * (xb - xa);
       if (half_sub <= 0.0)
         return 0.0;
-      const polynomial_basis::FiniteElementBasis & fem = radial_.get_fem();
+      const polynomial_basis::FiniteElementBasis & fem = radial_.fem();
 
       const helfem::Vector & xq = in_element_rule().first;
       const helfem::Vector & wq = in_element_rule().second;
@@ -249,11 +249,11 @@ namespace helfem {
       // tracing it against the density matrix afterwards computes 400
       // matrix elements to extract one number; the integrand we actually
       // want is the scalar sum_ij P_ij R_i(r) R_j(r).
-      const helfem::Matrix bf = radial_.get_bf(xi, iel);
+      const helfem::Matrix bf = radial_.bf(xi, iel);
       const helfem::Vector quad =
           ((bf * Psub_[iel]).array() * bf.array()).rowwise().sum();
 
-      // get_bf gives R = B/r, so the quadratic form is 4 pi rho. The
+      // bf gives R = B/r, so the quadratic form is 4 pi rho. The
       // weight is r^2 for the charge and r for the 1/r moment -- written
       // as a multiplication rather than a division so that r = 0, which
       // the innermost element reaches, needs no special case.
@@ -271,7 +271,7 @@ namespace helfem {
       if (r >= Rmax_)
         return nelectrons();
       double xprim;
-      const size_t iel = locate(radial_.get_fem(), r, xprim);
+      const size_t iel = locate(radial_.fem(), r, xprim);
       return Qbelow_(iel) + partial_integral(iel, -1.0, xprim, false);
     }
 
@@ -281,7 +281,7 @@ namespace helfem {
       if (r >= Rmax_)
         return nelectrons();
       double xprim;
-      const size_t iel = locate(radial_.get_fem(), r, xprim);
+      const size_t iel = locate(radial_.fem(), r, xprim);
       // r * V_H(r) = Q(<r) + r * integral_{r'>r} rho(r') / r' dV.
       const double Qin = Qbelow_(iel) + partial_integral(iel, -1.0, xprim, false);
       const double Mout = Mabove_(iel) + partial_integral(iel, xprim, 1.0, true);

--- a/src/general/atomdb_dump.cpp
+++ b/src/general/atomdb_dump.cpp
@@ -55,8 +55,8 @@ int main(void) {
   r.push_back(0.0);
   w.push_back(0.0);
   for (size_t iel = 0; iel < rb.Nel(); iel++) {
-    const helfem::Vector ri = rb.get_r(iel);
-    const helfem::Vector wi = rb.get_wrad(iel);
+    const helfem::Vector ri = rb.r(iel);
+    const helfem::Vector wi = rb.wrad(iel);
     for (Eigen::Index ip = 0; ip < ri.size(); ip++) {
       r.push_back(ri(ip));
       w.push_back(wi(ip));

--- a/src/general/atomdb_test.cpp
+++ b/src/general/atomdb_test.cpp
@@ -139,7 +139,7 @@ int main(void) {
   {
     printf("\nExchange-correlation screening vs. the grid implementation:\n");
     std::shared_ptr<const polynomial_basis::PolynomialBasis> poly(
-        polynomial_basis::get_basis(atomdb::data::primbas, atomdb::data::nnodes));
+        polynomial_basis::make_basis(atomdb::data::primbas, atomdb::data::nnodes));
     const helfem::Vector bv(atomdb::element_boundaries());
     sadatom::basis::TwoDBasis tdb(1, modelpotential::POINT_NUCLEUS, 0.0, poly, false,
                                   atomdb::data::nquad, bv, atomdb::lmax());
@@ -180,7 +180,7 @@ int main(void) {
 
   // The stored orbitals must reproduce the stored density:
   //   rho(r) = sum_l sum_n occ_nl R_nl(r)^2 / (4 pi)
-  // This pins the normalization convention of Atom::orbitals -- get_bf
+  // This pins the normalization convention of Atom::orbitals -- bf
   // returns B(r)/r, so the contraction is R(r) and not r*R(r) -- so that
   // a projected guess does not have to rediscover it, and gets it wrong
   // by a factor of r if it does.

--- a/src/general/checkpoint.cpp
+++ b/src/general/checkpoint.cpp
@@ -550,14 +550,14 @@ void Checkpoint::write(const helfem::atomic::basis::TwoDBasis & basis) {
   write("Zl",basis.get_Zl());
   write("Zr",basis.get_Zr());
   write("Rhalf",basis.get_Rhalf());
-  write("bval",basis.get_bval());
+  write("bval",basis.bval());
 
   write("finitenuc",basis.get_nuclear_model());
   write("Rrms",basis.get_nuclear_size());
 
-  write("n_quad",basis.get_nquad());
-  write("poly_id",basis.get_poly_id());
-  write("poly_nnodes",basis.get_poly_nnodes());
+  write("n_quad",basis.nquad());
+  write("poly_id",basis.poly_id());
+  write("poly_nnodes",basis.poly_nnodes());
   write("zeroder",basis.get_zeroder());
 
   // get_lval/get_mval are Eigen::VectorXi; stored as N x 1 int matrices.
@@ -610,7 +610,7 @@ void Checkpoint::read(helfem::atomic::basis::TwoDBasis & basis) {
   read("lval", lval);
   read("mval", mval);
 
-  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(poly_id,poly_nnodes)));
+  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::make_basis(poly_id,poly_nnodes)));
   basis=helfem::atomic::basis::TwoDBasis(Z, (helfem::modelpotential::nuclear_model_t) finitenuc, Rrms, poly, zeroder, n_quad, bval, lval.col(0), mval.col(0), Zl, Zr, Rhalf);
   
   if(cl) close();
@@ -631,11 +631,11 @@ void Checkpoint::write(const helfem::diatomic::basis::TwoDBasis & basis) {
   write("Z1",basis.get_Z1());
   write("Z2",basis.get_Z2());
   write("Rhalf",basis.get_Rhalf());
-  write("bval",basis.get_bval());
+  write("bval",basis.bval());
 
-  write("n_quad",basis.get_nquad());
-  write("poly_id",basis.get_poly_id());
-  write("poly_nnodes",basis.get_poly_nnodes());
+  write("n_quad",basis.nquad());
+  write("poly_id",basis.poly_id());
+  write("poly_nnodes",basis.poly_nnodes());
 
   // get_lval/get_mval are Eigen::VectorXi; stored as N x 1 int matrices.
   write("lval",Eigen::MatrixXi(basis.get_lval()));
@@ -679,7 +679,7 @@ void Checkpoint::read(helfem::diatomic::basis::TwoDBasis & basis) {
   read("lval", lval);
   read("mval", mval);
 
-  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(poly_id,poly_nnodes)));
+  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::make_basis(poly_id,poly_nnodes)));
   basis=helfem::diatomic::basis::TwoDBasis(Z1, Z2, Rhalf, poly, n_quad, bval, lval.col(0), mval.col(0));
   
   if(cl) close();

--- a/src/general/over_r_test.cpp
+++ b/src/general/over_r_test.cpp
@@ -55,7 +55,7 @@ namespace {
 
     std::shared_ptr<pb::PolynomialBasisT<T>> poly;
     try {
-      poly.reset(polynomial_basis::get_basis_T<T>(b.primbas, Nnodes));
+      poly.reset(polynomial_basis::make_basis_T<T>(b.primbas, Nnodes));
     } catch (const std::exception &e) {
       printf("  %-10s SKIPPED (%s)\n", b.name, "not constructible");
       return 0;
@@ -130,7 +130,7 @@ namespace {
     {
       namespace pbq = helfem::polynomial_basis;
       std::shared_ptr<pbq::PolynomialBasisT<_Float128>> polyq(
-          polynomial_basis::get_basis_T<_Float128>(b.primbas, Nnodes));
+          polynomial_basis::make_basis_T<_Float128>(b.primbas, Nnodes));
       polyq->drop_first(true, false);
 
       for (int sI = 1; sI <= 160; sI++) {

--- a/src/general/radial_block_helper.h
+++ b/src/general/radial_block_helper.h
@@ -23,12 +23,12 @@ namespace helfem {
   // Assemble a block-diagonal radial matrix by summing per-element
   // contributions. Kernel is a callable (size_t iel) -> helfem::Matrix
   // returning the per-element block; the block is placed into
-  // rows/cols [ifirst .. ilast] as returned by radial.get_idx(iel).
+  // rows/cols [ifirst .. ilast] as returned by radial.idx(iel).
   //
   // Replaces the copy-pasted pattern:
   //   for (size_t iel = 0; iel < radial.Nel(); ++iel) {
   //     size_t ifirst, ilast;
-  //     radial.get_idx(iel, ifirst, ilast);
+  //     radial.idx(iel, ifirst, ilast);
   //     M.submat(ifirst, ifirst, ilast, ilast) += radial.foo(iel);
   //   }
   // that appears ~13 times across src/atomic/TwoDBasis.cpp and
@@ -46,7 +46,7 @@ namespace helfem {
     helfem::Mat<T> M = helfem::Mat<T>::Zero(Nrad, Nrad);
     for (size_t iel = 0; iel < radial.Nel(); ++iel) {
       size_t ifirst, ilast;
-      radial.get_idx(iel, ifirst, ilast);
+      radial.idx(iel, ifirst, ilast);
       const Eigen::Index n = static_cast<Eigen::Index>(ilast - ifirst + 1);
       M.block(static_cast<Eigen::Index>(ifirst),
                static_cast<Eigen::Index>(ifirst), n, n) += kernel(iel);

--- a/src/harmonic/main.cpp
+++ b/src/harmonic/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
   printf("Using %i point quadrature rule.\n", Nquad);
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
+      polynomial_basis::make_basis(primbas, Nnodes));
 
   // Radial grid: linspace(-xmax, xmax, Nelem+1) on helfem::Vector.
   const helfem::Vector r = helfem::Vector::LinSpaced(Nelem + 1, -xmax, xmax);
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
   io::write_raw_ascii("bf.dat", bf);
   io::write_raw_ascii("dbf.dat", dbf);
 
-  const size_t Nbf = fem.get_nbf();
+  const size_t Nbf = fem.nbf();
   printf("Basis set contains %i functions\n", (int) Nbf);
 
   const helfem::Matrix S = overlap  (fem, xq, wq);

--- a/src/harmonic/morse.cpp
+++ b/src/harmonic/morse.cpp
@@ -71,9 +71,9 @@ int main(int argc, char **argv) {
   std::string save = parser.get<std::string>("save");
 
   // Get polynomial basis
-  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::get_basis(primbas, Nnodes)));
+  auto poly(std::shared_ptr<const helfem::polynomial_basis::PolynomialBasis>(helfem::polynomial_basis::make_basis(primbas, Nnodes)));
   if(Nquad<0)
-    Nquad=5*poly->get_nbf();
+    Nquad=5*poly->nbf();
 
   // Radial grid
   helfem::Vector r(helfem::Vector::LinSpaced(Nelem+1,0.0,rmax));
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
   helfem::Vector xq, wq;
   chebyshev::chebyshev<double>(Nquad,xq,wq);
 
-  size_t Nbf(fem.get_nbf());
+  size_t Nbf(fem.nbf());
   printf("Basis set contains %i functions\n",(int) Nbf);
 
   // Form overlap matrix

--- a/src/harmonic/precision.cpp
+++ b/src/harmonic/precision.cpp
@@ -34,7 +34,7 @@
 // not by the basis -- which is the whole argument for templating on the scalar.
 //
 // Nothing here is a special-cased "high precision path": FiniteElementBasisT<T>
-// and get_basis_T<T> are the ordinary production classes, instantiated at a
+// and make_basis_T<T> are the ordinary production classes, instantiated at a
 // different T. Everything below them (PolynomialBasisT<T>, LIPBasisT<T>,
 // lobatto_compute<T>) was already generic.
 
@@ -64,7 +64,7 @@ namespace {
     namespace pb = helfem::polynomial_basis;
 
     auto poly = std::shared_ptr<const pb::PolynomialBasisT<T>>(
-        polynomial_basis::get_basis_T<T>(primbas, Nnodes));
+        polynomial_basis::make_basis_T<T>(primbas, Nnodes));
 
     const helfem::Vec<T> r =
         helfem::Vec<T>::LinSpaced(Nelem + 1, T(-xmax), T(xmax));

--- a/src/harmonic/softcoulomb.cpp
+++ b/src/harmonic/softcoulomb.cpp
@@ -91,8 +91,8 @@ int main(int argc, char **argv) {
     printf("Using potential V(x) = -Z / sqrt( (x-x0)^2 + alpha^2 )\n");
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
-  if (Nquad < 0) Nquad = 5 * poly->get_nbf();
+      polynomial_basis::make_basis(primbas, Nnodes));
+  if (Nquad < 0) Nquad = 5 * poly->nbf();
 
   const helfem::Vector x = helfem::Vector::LinSpaced(Nelem + 1, -xmax, xmax);
 
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
   helfem::Vector xq, wq;
   helfem::chebyshev::chebyshev<double>(Nquad, xq, wq);
 
-  const size_t Nbf = fem.get_nbf();
+  const size_t Nbf = fem.nbf();
   printf("Basis set contains %i functions\n", (int) Nbf);
 
   const helfem::Matrix S = overlap(fem, xq, wq);

--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -84,12 +84,12 @@ int main(int argc, char **argv) {
   bool zeroder=false;
 
   // Get primitive basis
-  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::get_basis(primbas,Nnodes)));
+  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::make_basis(primbas,Nnodes)));
 
   if(Nquad==0)
     // Set default value
-    Nquad=5*poly->get_nbf();
-  else if(Nquad<2*poly->get_nbf())
+    Nquad=5*poly->nbf();
+  else if(Nquad<2*poly->nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
   // Order of quadrature rule
   printf("Using %i point quadrature rule.\n",Nquad);
@@ -126,13 +126,13 @@ int main(int argc, char **argv) {
 
     // Evaluate orbitals on the quadrature grid.
     const Eigen::Index Ncols = C.cols();
-    const Eigen::Index Npts  = radial.get_bf(0).rows();
+    const Eigen::Index Npts  = radial.bf(0).rows();
     helfem::Matrix Cv = helfem::Matrix::Zero(radial.Nel() * Npts, Ncols);
     for (size_t iel = 0; iel < radial.Nel(); ++iel) {
       size_t ifirst, ilast;
-      radial.get_idx(iel, ifirst, ilast);
+      radial.idx(iel, ifirst, ilast);
       const helfem::Matrix Csub = C.middleRows(ifirst, ilast - ifirst + 1);
-      const helfem::Matrix bf   = radial.get_bf(iel);
+      const helfem::Matrix bf   = radial.bf(iel);
       Cv.middleRows(iel * Npts, Npts) = bf * Csub;
     }
 
@@ -146,12 +146,12 @@ int main(int argc, char **argv) {
 
   // Concatenate per-element radii and quadrature weights into flat
   // vectors and write them to the checkpoint.
-  const Eigen::Index Npts = radial.get_r(0).size();
+  const Eigen::Index Npts = radial.r(0).size();
   helfem::Vector radii   = helfem::Vector::Zero(radial.Nel() * Npts);
   helfem::Vector weights = helfem::Vector::Zero(radial.Nel() * Npts);
   for (size_t iel = 0; iel < radial.Nel(); ++iel) {
-    radii  .segment(iel * Npts, Npts) = radial.get_r   (iel);
-    weights.segment(iel * Npts, Npts) = radial.get_wrad(iel);
+    radii  .segment(iel * Npts, Npts) = radial.r   (iel);
+    weights.segment(iel * Npts, Npts) = radial.wrad(iel);
   }
 
   chkpt.write("r",  radii);

--- a/src/sadatom/aij.cpp
+++ b/src/sadatom/aij.cpp
@@ -137,12 +137,12 @@ int main(int argc, char **argv) {
   }
 
   // Get primitive basis
-  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::get_basis(primbas,Nnodes)));
+  auto poly(std::shared_ptr<const polynomial_basis::PolynomialBasis>(polynomial_basis::make_basis(primbas,Nnodes)));
 
   if(Nquad==0)
     // Set default value
-    Nquad=5*poly->get_nbf();
-  else if(Nquad<2*poly->get_nbf())
+    Nquad=5*poly->nbf();
+  else if(Nquad<2*poly->nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
   // Order of quadrature rule
   if(verbosity >= 1)

--- a/src/sadatom/basis.cpp
+++ b/src/sadatom/basis.cpp
@@ -434,21 +434,21 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::eval_bf(size_t iel) const {
-        return radial.get_bf(iel);
+        return radial.bf(iel);
       }
 
       helfem::Matrix TwoDBasis::eval_df(size_t iel) const {
-        return radial.get_df(iel);
+        return radial.df(iel);
       }
 
       helfem::Matrix TwoDBasis::eval_lf(size_t iel) const {
-        return radial.get_lf(iel);
+        return radial.lf(iel);
       }
 
       std::vector<Eigen::Index> TwoDBasis::bf_list(size_t iel) const {
         // Radial functions in element
         size_t ifirst, ilast;
-        radial.get_idx(iel,ifirst,ilast);
+        radial.idx(iel,ifirst,ilast);
         // Number of radial functions in element
         size_t Nr(ilast-ifirst+1);
 
@@ -468,12 +468,12 @@ namespace helfem {
         return radial.Nel();
       }
 
-      helfem::Vector TwoDBasis::get_wrad(size_t iel) const {
-        return radial.get_wrad(iel);
+      helfem::Vector TwoDBasis::wrad(size_t iel) const {
+        return radial.wrad(iel);
       }
 
-      helfem::Vector TwoDBasis::get_r(size_t iel) const {
-        return radial.get_r(iel);
+      helfem::Vector TwoDBasis::r(size_t iel) const {
+        return radial.r(iel);
       }
 
       double TwoDBasis::nuclear_density(const helfem::Matrix & P) const {
@@ -487,7 +487,7 @@ namespace helfem {
         std::vector<helfem::Vector> w(radial.Nel());
         size_t ntot=1;
         for(size_t iel=0;iel<radial.Nel();iel++) {
-          w[iel]=radial.get_wrad(iel);
+          w[iel]=radial.wrad(iel);
           ntot+=w[iel].size();
         }
         helfem::Vector wt = helfem::Vector::Zero(ntot);
@@ -508,7 +508,7 @@ namespace helfem {
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Radial functions in element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
           // Density matrix
           helfem::Matrix Psub(Prad.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
           helfem::Matrix zm(radial.radial_integral(0,iel));
@@ -526,12 +526,12 @@ namespace helfem {
         // Form potential
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Initialize potential
-          r[iel]=radial.get_r(iel);
+          r[iel]=radial.r(iel);
           V[iel]=helfem::Vector::Zero(r[iel].size());
 
           // Get the density in the element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
           const helfem::Matrix Psub(Prad.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
           const helfem::Vector Pv(Eigen::Map<const helfem::Vector>(Psub.data(), Psub.size()));
 
@@ -564,7 +564,7 @@ namespace helfem {
       helfem::Vector TwoDBasis::radii() const {
         std::vector<helfem::Vector> r(radial.Nel());
         for(size_t iel=0;iel<radial.Nel();iel++) {
-          r[iel]=radial.get_r(iel);
+          r[iel]=radial.r(iel);
         }
 
         size_t Npts=r[0].size();
@@ -601,10 +601,10 @@ namespace helfem {
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Radial functions in element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
           // Density matrix
           helfem::Matrix Csub(C.middleRows(ifirst,ilast-ifirst+1));
-          helfem::Matrix bf(radial.get_bf(iel));
+          helfem::Matrix bf(radial.bf(iel));
 
           c[iel]=bf*Csub;
         }
@@ -632,10 +632,10 @@ namespace helfem {
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Radial functions in element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
           // Density matrix
           helfem::Matrix Csub(C.middleRows(ifirst,ilast-ifirst+1));
-          helfem::Matrix bf(radial.get_df(iel));
+          helfem::Matrix bf(radial.df(iel));
 
           c[iel]=bf*Csub;
         }
@@ -659,10 +659,10 @@ namespace helfem {
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Radial functions in element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
           // Density matrix
           helfem::Matrix Csub(C.middleRows(ifirst,ilast-ifirst+1));
-          helfem::Matrix bf(radial.get_lf(iel));
+          helfem::Matrix bf(radial.lf(iel));
 
           c[iel]=bf*Csub;
         }
@@ -684,21 +684,21 @@ namespace helfem {
       helfem::Vector TwoDBasis::electron_density(const helfem::Vector & x, size_t iel, const helfem::Matrix & Prad, bool rsqweight) const {
         // Radial functions in element
         size_t ifirst, ilast;
-        radial.get_idx(iel,ifirst,ilast);
+        radial.idx(iel,ifirst,ilast);
         // Density matrix
         helfem::Matrix Psub(Prad.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
-        helfem::Matrix bf(radial.get_bf(x, iel));
+        helfem::Matrix bf(radial.bf(x, iel));
 
         helfem::Vector density = (bf*Psub*bf.transpose()).diagonal();
         if(rsqweight) {
-          const helfem::Vector rr = radial.get_r(x, iel);
+          const helfem::Vector rr = radial.r(x, iel);
           density.array() *= rr.array().square();
         }
         return density;
       }
 
       helfem::Vector TwoDBasis::electron_density(size_t iel, const helfem::Matrix & Prad, bool rsqweight) const {
-        return electron_density(radial.get_xq(), iel, Prad, rsqweight);
+        return electron_density(radial.xq(), iel, Prad, rsqweight);
       }
 
       helfem::Vector TwoDBasis::electron_density(const helfem::Matrix & Prad, bool rsqweight) const {
@@ -727,7 +727,7 @@ namespace helfem {
         }
 
         // Quadrature points
-        helfem::Vector xq = radial.get_xq();
+        helfem::Vector xq = radial.xq();
 
         // Find the element with the maximum density
         Eigen::Index iel;
@@ -778,7 +778,7 @@ namespace helfem {
             throw std::logic_error(oss.str());
           }
           // Position of maximum is
-          rmax = radial.get_r(cen, iel)(0);
+          rmax = radial.r(cen, iel)(0);
         }
 
         return rmax;
@@ -807,7 +807,7 @@ namespace helfem {
         // Now find the position in the element where the density is = vdw_threshold.
         // Evaluate the difference in density from the threshold value.
         // Quadrature points
-        helfem::Vector xq = radial.get_xq();
+        helfem::Vector xq = radial.xq();
         helfem::Vector diff = angfac*electron_density(xq, iel, Prad, rsqweight);
         diff-=vdw_threshold*helfem::Vector::Ones(diff.size());
         diff=diff.cwiseAbs();
@@ -854,7 +854,7 @@ namespace helfem {
           // Coordinate is
           helfem::Vector cen=((a+b)/2);
           // Position of maximum is
-          rvdw = radial.get_r(cen, iel)(0);
+          rvdw = radial.r(cen, iel)(0);
         }
 
         return rvdw;
@@ -866,7 +866,7 @@ namespace helfem {
 	for(size_t iel=0;iel<radial.Nel();iel++) {
 	  // Radial functions in element
 	  size_t ifirst, ilast;
-	  radial.get_idx(iel,ifirst,ilast);
+	  radial.idx(iel,ifirst,ilast);
 	  // Density matrix
 	  helfem::Matrix Psub(Prad.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
 	  // Overlap matrix (Phase 2a: overlap(iel) returns helfem::Matrix).
@@ -886,7 +886,7 @@ namespace helfem {
 
 	// Radial functions in element
 	size_t ifirst, ilast;
-	radial.get_idx(ielement,ifirst,ilast);
+	radial.idx(ielement,ifirst,ilast);
 	// Density matrix within the element
 	helfem::Matrix Psub(Prad.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
 
@@ -906,7 +906,7 @@ namespace helfem {
 	    break;
 	}
 
-	return radial.get_r(m, ielement);
+	return radial.r(m, ielement);
       }
 
       helfem::Vector TwoDBasis::electron_density_gradient(const helfem::Matrix & Prad) const {
@@ -914,11 +914,11 @@ namespace helfem {
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Radial functions in element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
           // Density matrix
           helfem::Matrix Psub(Prad.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
-          helfem::Matrix bf(radial.get_bf(iel));
-          helfem::Matrix df(radial.get_df(iel));
+          helfem::Matrix bf(radial.bf(iel));
+          helfem::Matrix df(radial.df(iel));
 
           d[iel]=2.0*(bf*Psub*df.transpose()).diagonal();
         }
@@ -942,13 +942,13 @@ namespace helfem {
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Radial functions in element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
           // Density matrix
           helfem::Matrix Psub(Prad.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
-          helfem::Matrix bf(radial.get_bf(iel));
-          helfem::Matrix df(radial.get_df(iel));
-          helfem::Matrix lf(radial.get_lf(iel));
-          helfem::Vector r(radial.get_r(iel));
+          helfem::Matrix bf(radial.bf(iel));
+          helfem::Matrix df(radial.df(iel));
+          helfem::Matrix lf(radial.lf(iel));
+          helfem::Vector r(radial.r(iel));
 
           // Laplacian is df^2/dr^2 + 2/r df/dr
           helfem::Vector lap = 2.0*((df*Psub*df.transpose()).diagonal() + (bf*Psub*lf.transpose()).diagonal());
@@ -980,19 +980,19 @@ namespace helfem {
         for(size_t iel=0;iel<radial.Nel();iel++) {
           // Radial functions in element
           size_t ifirst, ilast;
-          radial.get_idx(iel,ifirst,ilast);
+          radial.idx(iel,ifirst,ilast);
 
           // Radii
-          helfem::Vector r(radial.get_r(iel));
+          helfem::Vector r(radial.r(iel));
 
           // Density matrix
           helfem::Matrix Psub(P.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
           helfem::Matrix Psubl(Pl.block(ifirst,ifirst,ilast-ifirst+1,ilast-ifirst+1));
 
           // Basis function
-          helfem::Matrix bf(radial.get_bf(iel));
+          helfem::Matrix bf(radial.bf(iel));
           // Basis function derivative
-          helfem::Matrix bf_rho(radial.get_df(iel));
+          helfem::Matrix bf_rho(radial.df(iel));
 
           helfem::Vector term1((bf_rho * Psub * bf_rho.transpose()).diagonal());
           helfem::Vector term2((bf * Psubl * bf.transpose()).diagonal());

--- a/src/sadatom/basis.h
+++ b/src/sadatom/basis.h
@@ -134,9 +134,9 @@ namespace helfem {
         /// Get number of radial elements
         size_t get_rad_Nel() const;
         /// Get radial quadrature weights
-        helfem::Vector get_wrad(size_t iel) const;
+        helfem::Vector wrad(size_t iel) const;
         /// Get r values
-        helfem::Vector get_r(size_t iel) const;
+        helfem::Vector r(size_t iel) const;
 
         /// Electron density at nucleus
         double nuclear_density(const helfem::Matrix & P) const;

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -466,9 +466,9 @@ namespace helfem {
         bf_ind = basp->bf_list(iel);
 
         // Get radii
-        r = basp->get_r(iel);
+        r = basp->r(iel);
         // Get radial weights
-        wrad = basp->get_wrad(iel);
+        wrad = basp->wrad(iel);
 
         // Update total weights
         wtot = 4.0*M_PI * wrad.array() * r.array().square();

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -121,8 +121,8 @@ static helfem::Matrix ao_completeness_profile(
   for (int l = 0; l <= lmax; l++) {
     helfem::Matrix ao_projection = helfem::Matrix::Zero(expn.size(), basis.Nbf());
     for (size_t iel = 0; iel < basis.get_rad_Nel(); iel++) {
-      const helfem::Vector r  = basis.get_r(iel);
-      const helfem::Vector wr = basis.get_wrad(iel);
+      const helfem::Vector r  = basis.r(iel);
+      const helfem::Vector wr = basis.wrad(iel);
       const helfem::Matrix ao = eval_ao(l, r);          // (npts x nexp)
       const helfem::Matrix bf = basis.eval_bf(iel);     // (npts x nbf_el)
       const std::vector<Eigen::Index> bfl = basis.bf_list(iel);
@@ -156,8 +156,8 @@ static helfem::Matrix ao_importance_profile(
     const helfem::Matrix Cocc = C[l].leftCols(nocc);
     helfem::Matrix ao_projection = helfem::Matrix::Zero(nocc, expn.size());
     for (size_t iel = 0; iel < basis.get_rad_Nel(); iel++) {
-      const helfem::Vector r  = basis.get_r(iel);
-      const helfem::Vector wr = basis.get_wrad(iel);
+      const helfem::Vector r  = basis.r(iel);
+      const helfem::Vector wr = basis.wrad(iel);
       const helfem::Matrix ao = eval_ao(l, r);
       const helfem::Matrix bf = basis.eval_bf(iel);
       const std::vector<Eigen::Index> bfl = basis.bf_list(iel);
@@ -313,11 +313,11 @@ int main(int argc, char **argv) {
     printf("nela=%d nelb=%d\n", nela, nelb);
 
   auto poly = std::shared_ptr<const polynomial_basis::PolynomialBasis>(
-      polynomial_basis::get_basis(primbas, Nnodes));
+      polynomial_basis::make_basis(primbas, Nnodes));
 
   if (Nquad == 0)
-    Nquad = 5 * poly->get_nbf();
-  else if (Nquad < 2 * poly->get_nbf())
+    Nquad = 5 * poly->nbf();
+  else if (Nquad < 2 * poly->nbf())
     throw std::logic_error("Insufficient radial quadrature.\n");
   if (verbosity >= 1)
     printf("Using %i point quadrature rule.\n", Nquad);

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -427,7 +427,7 @@ namespace helfem {
           // Reconstruct the old polynomial basis so the reassembled
           // FE basis matches the checkpoint's Nbf exactly.
           std::shared_ptr<const polynomial_basis::PolynomialBasis> old_poly(
-              polynomial_basis::get_basis(old_primbas, old_nnodes));
+              polynomial_basis::make_basis(old_primbas, old_nnodes));
           sadatom::basis::TwoDBasis oldbasis(old_Z, modelpotential::POINT_NUCLEUS,
                                               0.0, old_poly, opts.zeroder,
                                               old_Nquad, old_bval, old_lmax);
@@ -617,8 +617,8 @@ namespace helfem {
           Checkpoint savechk(opts.save_file, /*writemode=*/true);
           savechk.write("sadatom_Z",       opts.Z);
           savechk.write("sadatom_lmax",    opts.lmax);
-          savechk.write("sadatom_primbas", opts.poly->get_id());
-          savechk.write("sadatom_nnodes",  opts.poly->get_nnodes());
+          savechk.write("sadatom_primbas", opts.poly->id());
+          savechk.write("sadatom_nnodes",  opts.poly->nnodes());
           savechk.write("sadatom_Nquad",   opts.Nquad);
           savechk.write("sadatom_bval", opts.bval);
 


### PR DESCRIPTION
Second slice of the API unification (follows #316). One-time convention change, agreed in the audit: accessors lose the `get_` prefix, class data members take a trailing underscore.

## What is renamed

The FEM-core accessor family, in one sweep across all three layers since the names are shared by `FEMRadialBasisT`, `FiniteElementBasisT`, `PolynomialBasisT`, the diatomic/sadatom radial bases and the drivers (~730 tokens, 53 files):

| old | new |
|---|---|
| `get_bf/get_df/get_lf` | `bf()/df()/lf()` |
| `get_r/get_wrad/get_idx` | `r()/wrad()/idx()` |
| `get_bval/get_xq/get_nquad` | `bval()/xq()/nquad()` |
| `get_poly/get_poly_id/get_poly_nnodes/get_fem` | bare |
| `get_nelem/get_nbf/get_nprim/get_max_nprim/get_noverlap` | bare |
| `get_id/get_nnodes/get_nodes/get_enabled` | bare |

The polynomial-basis **factory** is the one deliberate exception: a bare `basis()` would read as an accessor, so `polynomial_basis::get_basis`/`get_basis_T` become `make_basis`/`make_basis_T`, while the per-element accessor `FiniteElementBasisT::get_basis(iel)` becomes `basis(iel)`.

Members renamed where the bare method name would otherwise collide: the `PolynomialBasisT` family (`nprim_`, `enabled_`, `noverlap_`, `id_`, `nnodes_`, `x0_`), `FiniteElementBasisT` (`poly_`, `bval_`, the `zero_*_` flags, `*_func_in_element_`), and both radial bases (`xq_`, `wq_`, `fem_`, the `*fq_cache_` tables). Constructor parameters that used to carry the trailing underscore lose it, since that spelling now means "member".

Not touched here: the app-level names (`get_Z`, `get_sym_idx`, `get_rad_*`, `get_mval/lval`, ...) — next slice; and NAORadialBasis access levels, per the audit decision.

## Verification

Pure rename. Full build (0 warnings from the rename), `ctest -L unit` 8/8, and the full ci tier: **49/49 with bit-identical references**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)