### PR TITLE
Revive diatomic_cpl: save orbitals in checkpoints, rebuild Sinvh

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -669,6 +669,17 @@ int main(int argc, char **argv) {
     // Densities written straight through the checkpoint's helfem::Matrix overloads.
     savechk.write("Pa", Pa_final);
     savechk.write("Pb", Pb_final);
+    // The AO-basis orbitals, occupied columns first (same layout as the
+    // diatomic checkpoint; used by the analysis tools).
+    helfem::Matrix Ca_final, Cb_final;
+    helfem::Vector occa_final, occb_final;
+    helfem::scf_driver::assemble_final_orbitals<OOO_Real>(
+        Nbf, restricted, dsym, Sinvh, final_orbs, final_occs,
+        Ca_final, occa_final, Cb_final, occb_final);
+    savechk.write("Ca", Ca_final);
+    savechk.write("Cb", Cb_final);
+    savechk.write("occa", occa_final);
+    savechk.write("occb", occb_final);
     savechk.write("nela", nela);
     savechk.write("nelb", nelb);
     if (verbosity >= 1)

--- a/src/diatomic/completeness.cpp
+++ b/src/diatomic/completeness.cpp
@@ -59,9 +59,11 @@ int main(int argc, char **argv) {
   // Basis set
   diatomic::basis::TwoDBasis basis;
   loadchk.read(basis);
-  // Sinvh
-  helfem::Matrix Sinvh;
-  loadchk.read("Sinvh",Sinvh);
+  // Whole-basis orthonormalization, rebuilt from the loaded basis: the
+  // OOO-era checkpoints don't carry Sinvh (the drivers work per
+  // symmetry block), and recomputing it here also keeps this tool
+  // independent of how the checkpoint was produced.
+  helfem::Matrix Sinvh = basis.Sinvh(/*chol=*/false, /*sym=*/0);
   helfem::Matrix Sinv(Sinvh*Sinvh.transpose());
   // Orbitals
   helfem::Matrix Ca, Cb;

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -729,6 +729,17 @@ int main(int argc, char **argv) {
     // Densities written straight through the checkpoint's helfem::Matrix overloads.
     savechk.write("Pa", Pa_final);
     savechk.write("Pb", Pb_final);
+    // The AO-basis orbitals, occupied columns first: what diatomic_cpl
+    // projects the probe AOs against.
+    helfem::Matrix Ca_final, Cb_final;
+    helfem::Vector occa_final, occb_final;
+    helfem::scf_driver::assemble_final_orbitals<OOO_Real>(
+        Nbf, restricted, dsym, Sinvh, final_orbs, final_occs,
+        Ca_final, occa_final, Cb_final, occb_final);
+    savechk.write("Ca", Ca_final);
+    savechk.write("Cb", Cb_final);
+    savechk.write("occa", occa_final);
+    savechk.write("occb", occb_final);
     savechk.write("nela", nela);
     savechk.write("nelb", nelb);
     // Extra parameters needed by density_line / density_grid / completeness.

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -290,6 +290,64 @@ namespace helfem {
       return {Pa_final, Pb_final};
     }
 
+    /// Assemble global AO-basis orbital matrices from the converged
+    /// per-block orthonormal-basis orbitals, for --save. Columns are
+    /// sorted by occupation (descending), so leftCols(nocc) spans the
+    /// occupied space -- the layout the analysis tools (diatomic_cpl,
+    /// ...) expect of the checkpoint's Ca/Cb. The occupation vectors
+    /// come back in the same order, as per-spin occupations (the
+    /// restricted channel's total is split evenly).
+    template <typename Real>
+    inline void assemble_final_orbitals(
+        size_t Nbf, bool restricted,
+        const std::vector<std::vector<Eigen::Index>> & dsym,
+        const std::vector<helfem::Matrix> & Sinvh,
+        const OpenOrbitalOptimizer::Orbitals<Real> & final_orbs,
+        const OpenOrbitalOptimizer::OrbitalOccupations<Real> & final_occs,
+        helfem::Matrix & Ca, helfem::Vector & occa,
+        helfem::Matrix & Cb, helfem::Vector & occb) {
+      const size_t nsym = dsym.size();
+      const Eigen::Index N = static_cast<Eigen::Index>(Nbf);
+
+      auto build = [&](size_t block_offset, helfem::Matrix & C, helfem::Vector & occ,
+                       double occ_scale) {
+        // (occupation, block, column-in-block), sorted descending by
+        // occupation; ties keep block-then-column order (stable_sort).
+        std::vector<std::tuple<double, size_t, Eigen::Index>> order;
+        for (size_t k = 0; k < nsym; ++k) {
+          if (dsym[k].empty()) continue;
+          const helfem::Vector & o = final_occs[block_offset + k];
+          for (Eigen::Index c = 0; c < o.size(); ++c)
+            order.emplace_back(o(c), k, c);
+        }
+        std::stable_sort(order.begin(), order.end(),
+                         [](const auto & a, const auto & b) {
+                           return std::get<0>(a) > std::get<0>(b);
+                         });
+
+        C = helfem::Matrix::Zero(N, static_cast<Eigen::Index>(order.size()));
+        occ = helfem::Vector::Zero(static_cast<Eigen::Index>(order.size()));
+        for (size_t i = 0; i < order.size(); ++i) {
+          const size_t k = std::get<1>(order[i]);
+          const Eigen::Index c = std::get<2>(order[i]);
+          const helfem::Vector col_ao = Sinvh[k] * final_orbs[block_offset + k].col(c);
+          const std::vector<Eigen::Index> & idx = dsym[k];
+          for (size_t r = 0; r < idx.size(); ++r)
+            C(idx[r], static_cast<Eigen::Index>(i)) = col_ao(static_cast<Eigen::Index>(r));
+          occ(static_cast<Eigen::Index>(i)) = occ_scale * std::get<0>(order[i]);
+        }
+      };
+
+      if (restricted) {
+        build(0, Ca, occa, 0.5);
+        Cb = Ca;
+        occb = occa;
+      } else {
+        build(0, Ca, occa, 1.0);
+        build(nsym, Cb, occb, 1.0);
+      }
+    }
+
     /// CLI-input normalisation shared by both drivers:
     /// * scf::parse_nela_nelb fills in nela/nelb from --Q and --M
     ///   when both are zero on entry;


### PR DESCRIPTION
Stage 1 of the diatomic half of the profile-quadrature fix (follows #318; tracker task 65).

## The tool was dead

`diatomic_cpl` throws `Sinvh does not exist in the checkpoint file!` on every checkpoint produced since the OOO migration — the drivers save only densities, the tool needs occupied orbitals + `Sinvh`.

## Changes

- **Both drivers** now also save the AO-basis orbitals `Ca`/`Cb` and per-spin occupations `occa`/`occb` at `--save`, assembled from the per-block orthonormal OOO orbitals (`C_AO = Sinvh[k]·C_ortho`), columns occupation-sorted so `leftCols(nocc)` spans the occupied space. New shared helper `assemble_final_orbitals` mirrors `assemble_final_density`.
- **diatomic_cpl** rebuilds the whole-basis `Sinvh` from the loaded basis instead of reading it — works with any checkpoint, old or new.

## Verification

N2/HF (suite grid): saved orbitals reproduce the saved density to 6e-12; the tool runs end to end; minimal-basis projections physical (0.98 for m=0,1). Unit 8/8, ci spot checks bit-identical (the save path only adds datasets).

## What this deliberately does not fix

The profiles are still computed with the fixed solution-grid quadrature, and the tight-exponent tails are quantitatively wrong — now measurable since the tool runs: STO completeness log-log slope −2.4 vs the analytic −3 already at ζ~1e4–1e6, full collapse to denormals past 1e8; GTO −0.9…−1.3 vs −1.5 across 1e4–1e10. The onset (~1e4) is four orders below the atomic case, matching the coarser 2D rule. Stage 2 ports the gensap fix to prolate geometry: function-specific FE expansions on exponent-scaled μ-grids contracted through a cross-basis μ-direction overlap (the prolate overlap separates into two 1D μ-integrals × angular factors, so only the 1D pair-intersection machinery needs porting from `FEMRadialBasisT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)