### PR TITLE
diatomic: panel-graded AO projections covering both integrand factors

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -534,7 +534,7 @@ namespace helfem {
         bool zero_func_right=true;
         bool zero_deriv_right=true;
         polynomial_basis::FiniteElementBasis fem_(poly, bval, zero_func_left, zero_deriv_left, zero_func_right, zero_deriv_right);
-        radial=RadialBasis(fem_, n_quad);
+        radial_=RadialBasis(fem_, n_quad);
         // Angular basis.
         lval_=lval;
         mval_=mval;
@@ -670,35 +670,35 @@ namespace helfem {
       }
 
       int TwoDBasis::nquad() const {
-        return radial.nquad();
+        return radial_.nquad();
       }
 
       helfem::Vector TwoDBasis::bval() const {
-        return radial.bval();
+        return radial_.bval();
       }
 
       double TwoDBasis::mumax() const {
-        helfem::Vector bval(radial.bval());
+        helfem::Vector bval(radial_.bval());
         return bval(bval.size()-1);
       }
 
       int TwoDBasis::poly_id() const {
-        return radial.poly_id();
+        return radial_.poly_id();
       }
 
       int TwoDBasis::poly_nnodes() const {
-        return radial.poly_nnodes();
+        return radial_.poly_nnodes();
       }
 
       size_t TwoDBasis::Ndummy() const {
-        return lval_.size()*radial.Nbf();
+        return lval_.size()*radial_.Nbf();
       }
 
       size_t TwoDBasis::Nbf() const {
         // Count total number of basis functions
         size_t nbf=0;
         for(size_t i=0;i<mval_.size();i++) {
-          nbf+=radial.Nbf();
+          nbf+=radial_.Nbf();
           if(mval_(i)!=0)
             // Remove first function
             nbf--;
@@ -708,7 +708,7 @@ namespace helfem {
       }
 
       size_t TwoDBasis::Nrad() const {
-        return radial.Nbf();
+        return radial_.Nbf();
       }
 
       size_t TwoDBasis::Nang() const {
@@ -722,14 +722,14 @@ namespace helfem {
         size_t ioff=0;
         for(size_t i=0;i<(size_t) mval_.size();i++) {
           if(mval_(i)==0) {
-            for(size_t j=0;j<radial.Nbf();j++)
-              idx[ioff+j]=(Eigen::Index) (i*radial.Nbf()+j);
-            ioff+=radial.Nbf();
+            for(size_t j=0;j<radial_.Nbf();j++)
+              idx[ioff+j]=(Eigen::Index) (i*radial_.Nbf()+j);
+            ioff+=radial_.Nbf();
           } else {
 	    // Just drop the first function
-            for(size_t j=0;j<radial.Nbf()-1;j++)
-              idx[ioff+j]=(Eigen::Index) (i*radial.Nbf()+1+j);
-            ioff+=radial.Nbf()-1;
+            for(size_t j=0;j<radial_.Nbf()-1;j++)
+              idx[ioff+j]=(Eigen::Index) (i*radial_.Nbf()+1+j);
+            ioff+=radial_.Nbf()-1;
           }
         }
 
@@ -739,7 +739,7 @@ namespace helfem {
       helfem::Matrix TwoDBasis::in_element_kernel(size_t iel, int L, int M) const {
         // Use the same auto-converged order as compute_tei so this diagnostic
         // reflects the kernel that was actually factorized.
-        const quadrature::TwoElectronElement el(radial.twoe_element(iel, converged_twoe_order(iel)));
+        const quadrature::TwoElectronElement el(radial_.twoe_element(iel, converged_twoe_order(iel)));
         quadrature::MLegendreCache leg(std::abs(M), L);
         const helfem::Matrix T00(quadrature::twoe_integral(el, 0, 0, L, M, leg));
         const helfem::Matrix T02(quadrature::twoe_integral(el, 0, 2, L, M, leg));
@@ -756,8 +756,8 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::in_element_kernel_exchange(size_t iel, int L, int M) const {
-        const quadrature::TwoElectronElement el(radial.twoe_element(iel, converged_twoe_order(iel)));
-        const size_t Ni(radial.Nprim(iel));
+        const quadrature::TwoElectronElement el(radial_.twoe_element(iel, converged_twoe_order(iel)));
+        const size_t Ni(radial_.Nprim(iel));
 
         quadrature::MLegendreCache leg(std::abs(M), L);
         const helfem::Matrix T00(quadrature::twoe_integral(el, 0, 0, L, M, leg));
@@ -780,15 +780,15 @@ namespace helfem {
       }
 
       std::pair<double,double> TwoDBasis::check_cd(size_t iel, int L, int M) const {
-        const size_t Ni(radial.Nprim(iel));
+        const size_t Ni(radial_.Nprim(iel));
         const size_t ilm(lmind(L,M));
-        const size_t Nel(radial.Nel());
+        const size_t Nel(radial_.Nel());
 
         // Exact kernel and the exact exchange-ordered tensors. Build at the
         // same auto-converged order compute_tei used, so the reference W here
         // matches the one that produced cd_B / cd_sigma (otherwise kerr would
         // pick up the order mismatch rather than the factorization error).
-        const quadrature::TwoElectronElement el(radial.twoe_element(iel, converged_twoe_order(iel)));
+        const quadrature::TwoElectronElement el(radial_.twoe_element(iel, converged_twoe_order(iel)));
         quadrature::MLegendreCache leg(std::abs(M), L);
         const helfem::Matrix T00(quadrature::twoe_integral(el,0,0,L,M,leg));
         const helfem::Matrix T02(quadrature::twoe_integral(el,0,2,L,M,leg));
@@ -854,13 +854,13 @@ namespace helfem {
 
       std::vector<Eigen::Index> TwoDBasis::m_indices(int m) const {
         return helfem::collect_shell_indices(mval_.size(),
-            [&](size_t i) { return (mval_(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
+            [&](size_t i) { return (mval_(i) == 0) ? radial_.Nbf() : radial_.Nbf() - 1; },
             [&](size_t i) { return mval_(i) == m; });
       }
 
       std::vector<Eigen::Index> TwoDBasis::m_indices(int m, bool odd) const {
         return helfem::collect_shell_indices(mval_.size(),
-            [&](size_t i) { return (mval_(i) == 0) ? radial.Nbf() : radial.Nbf() - 1; },
+            [&](size_t i) { return (mval_(i) == 0) ? radial_.Nbf() : radial_.Nbf() - 1; },
             [&](size_t i) { return mval_(i) == m && (lval_(i) % 2 == odd); });
       }
 
@@ -1020,19 +1020,19 @@ namespace helfem {
       }
 
       void TwoDBasis::set_sub(helfem::Matrix & M, size_t iang, size_t jang, const helfem::Matrix & Mrad) const {
-        const size_t N(radial.Nbf());
+        const size_t N(radial_.Nbf());
         M.block(iang*N,jang*N,N,N)=Mrad;
       }
 
       void TwoDBasis::add_sub(helfem::Matrix & M, size_t iang, size_t jang, const helfem::Matrix & Mrad) const {
-        const size_t N(radial.Nbf());
+        const size_t N(radial_.Nbf());
         M.block(iang*N,jang*N,N,N)+=Mrad;
       }
 
       helfem::Matrix TwoDBasis::overlap() const {
         // Build radial matrix elements
-        helfem::Matrix I10(radial.radial_integral(1,0));
-        helfem::Matrix I12(radial.radial_integral(1,2));
+        helfem::Matrix I10(radial_.radial_integral(1,0));
+        helfem::Matrix I12(radial_.radial_integral(1,2));
 
         // Full overlap matrix
         helfem::Matrix S(helfem::Matrix::Zero(Ndummy(),Ndummy()));
@@ -1067,11 +1067,11 @@ namespace helfem {
       helfem::Matrix TwoDBasis::overlap(const TwoDBasis & rh) const {
         // Cross-basis overlap. Same coupling structure as overlap() but
         // with rh's radial basis on the right.
-        helfem::Matrix I10(radial.overlap(rh.radial, 0));
-        helfem::Matrix I12(radial.overlap(rh.radial, 2));
+        helfem::Matrix I10(radial_.overlap(rh.radial_, 0));
+        helfem::Matrix I12(radial_.overlap(rh.radial_, 2));
 
-        const size_t Ni(radial.Nbf());
-        const size_t Nj(rh.radial.Nbf());
+        const size_t Ni(radial_.Nbf());
+        const size_t Nj(rh.radial_.Nbf());
         helfem::Matrix S(helfem::Matrix::Zero(Ndummy(), rh.Ndummy()));
         for(size_t iang=0;iang<lval_.size();iang++) {
           int li(lval_(iang));
@@ -1102,9 +1102,9 @@ namespace helfem {
 
       helfem::Matrix TwoDBasis::kinetic() const {
         // Build radial kinetic energy matrix
-        helfem::Matrix Trad(radial.kinetic());
-        helfem::Matrix Ip1(radial.radial_integral(1,0));
-        helfem::Matrix Im1(radial.radial_integral(-1,0));
+        helfem::Matrix Trad(radial_.kinetic());
+        helfem::Matrix Ip1(radial_.radial_integral(1,0));
+        helfem::Matrix Im1(radial_.radial_integral(-1,0));
 
         // Full kinetic energy matrix
         helfem::Matrix T(helfem::Matrix::Zero(Ndummy(),Ndummy()));
@@ -1129,8 +1129,8 @@ namespace helfem {
 
       helfem::Matrix TwoDBasis::nuclear() const {
         // Build radial matrices
-        helfem::Matrix I10(radial.radial_integral(1,0));
-        helfem::Matrix I11(radial.radial_integral(1,1));
+        helfem::Matrix I10(radial_.radial_integral(1,0));
+        helfem::Matrix I11(radial_.radial_integral(1,1));
 
         // Full nuclear attraction matrix
         helfem::Matrix V(helfem::Matrix::Zero(Ndummy(),Ndummy()));
@@ -1170,8 +1170,8 @@ namespace helfem {
         helfem::Matrix V(helfem::Matrix::Zero(Ndummy(),Ndummy()));
 
         // Build radial matrix elements
-        helfem::Matrix I11(radial.radial_integral(1,1));
-        helfem::Matrix I13(radial.radial_integral(1,3));
+        helfem::Matrix I11(radial_.radial_integral(1,1));
+        helfem::Matrix I13(radial_.radial_integral(1,3));
 
         // Fill elements
         for(size_t iang=0;iang<lval_.size();iang++) {
@@ -1208,9 +1208,9 @@ namespace helfem {
         helfem::Matrix V(helfem::Matrix::Zero(Ndummy(),Ndummy()));
 
         // Build radial matrix elements
-        helfem::Matrix I10(radial.radial_integral(1,0));
-        helfem::Matrix I12(radial.radial_integral(1,2));
-        helfem::Matrix I14(radial.radial_integral(1,4));
+        helfem::Matrix I10(radial_.radial_integral(1,0));
+        helfem::Matrix I12(radial_.radial_integral(1,2));
+        helfem::Matrix I14(radial_.radial_integral(1,4));
 
         // Fill elements
         for(size_t iang=0;iang<lval_.size();iang++) {
@@ -1251,10 +1251,10 @@ namespace helfem {
         helfem::Matrix V(helfem::Matrix::Zero(Ndummy(),Ndummy()));
 
         // Build radial matrix elements
-        helfem::Matrix I10(radial.radial_integral(1,0)*std::pow(Rhalf_,3));
-        helfem::Matrix I12(radial.radial_integral(1,2)*std::pow(Rhalf_,3));
-        helfem::Matrix I30(radial.radial_integral(3,0)*std::pow(Rhalf_,5));
-        helfem::Matrix I32(radial.radial_integral(3,2)*std::pow(Rhalf_,5));
+        helfem::Matrix I10(radial_.radial_integral(1,0)*std::pow(Rhalf_,3));
+        helfem::Matrix I12(radial_.radial_integral(1,2)*std::pow(Rhalf_,3));
+        helfem::Matrix I30(radial_.radial_integral(3,0)*std::pow(Rhalf_,5));
+        helfem::Matrix I32(radial_.radial_integral(3,2)*std::pow(Rhalf_,5));
 
         // Fill elements
         for(size_t iang=0;iang<lval_.size();iang++) {
@@ -1334,7 +1334,7 @@ namespace helfem {
       int TwoDBasis::converged_twoe_order(size_t iel) const {
         // Seed the refinement from the requested --nquad so the common case
         // converges in 1-2 steps; the loop, not the seed, sets the accuracy.
-        int nstart = radial.nquad();
+        int nstart = radial_.nquad();
         if(nstart < 5) nstart = 5;
         if(nstart > twoe_nmax) nstart = twoe_nmax;
 
@@ -1360,7 +1360,7 @@ namespace helfem {
         int nconv = nstart;
         converge_block(
             [&](int n) {
-              const quadrature::TwoElectronElement el(radial.twoe_element(iel, n));
+              const quadrature::TwoElectronElement el(radial_.twoe_element(iel, n));
               quadrature::MLegendreCache leg(std::abs(M), L);
         const helfem::Matrix T00(quadrature::twoe_integral(el, 0, 0, L, M, leg));
               const helfem::Matrix T02(quadrature::twoe_integral(el, 0, 2, L, M, leg));
@@ -1381,7 +1381,7 @@ namespace helfem {
 
       void TwoDBasis::compute_tei(bool exchange) {
         // Number of distinct L values is
-        size_t Nel(radial.Nel());
+        size_t Nel(radial_.Nel());
 
         // Compute disjoint integrals
         disjoint_P0.resize(Nel*lm_map.size());
@@ -1421,10 +1421,10 @@ namespace helfem {
           quadrature::MLegendreCache leg(Mabs, Lhi);
           for(size_t ilm=lo;ilm<hi;ilm++) {
             const int L(lm_map[ilm].first);
-            disjoint_P0[ilm*Nel+iel]=radial.Plm_integral(0,iel,L,Mabs,leg);
-            disjoint_P2[ilm*Nel+iel]=radial.Plm_integral(2,iel,L,Mabs,leg);
-            disjoint_Q0[ilm*Nel+iel]=radial.Qlm_integral(0,iel,L,Mabs,leg);
-            disjoint_Q2[ilm*Nel+iel]=radial.Qlm_integral(2,iel,L,Mabs,leg);
+            disjoint_P0[ilm*Nel+iel]=radial_.Plm_integral(0,iel,L,Mabs,leg);
+            disjoint_P2[ilm*Nel+iel]=radial_.Plm_integral(2,iel,L,Mabs,leg);
+            disjoint_Q0[ilm*Nel+iel]=radial_.Qlm_integral(0,iel,L,Mabs,leg);
+            disjoint_Q2[ilm*Nel+iel]=radial_.Qlm_integral(2,iel,L,Mabs,leg);
           }
         }
 
@@ -1457,7 +1457,7 @@ namespace helfem {
           // reuse it across all (L, |M|). The order is set by double's eps, not
           // by --nquad.
           const int nconv = converged_twoe_order(iel);
-          const quadrature::TwoElectronElement eldata(radial.twoe_element(iel, nconv));
+          const quadrature::TwoElectronElement eldata(radial_.twoe_element(iel, nconv));
 
           // lm_map is |M|-major, so the entries form contiguous runs of one
           // |M|. Re-point the Legendre cache at each run as it starts: every
@@ -1476,9 +1476,9 @@ namespace helfem {
               leg.reset(M, Lhi);
             }
 
-            const helfem::Matrix T00(radial.twoe_integral(0,0,eldata,L,M,leg));
-            const helfem::Matrix T02(radial.twoe_integral(0,2,eldata,L,M,leg));
-            const helfem::Matrix T22(radial.twoe_integral(2,2,eldata,L,M,leg));
+            const helfem::Matrix T00(radial_.twoe_integral(0,0,eldata,L,M,leg));
+            const helfem::Matrix T02(radial_.twoe_integral(0,2,eldata,L,M,leg));
+            const helfem::Matrix T22(radial_.twoe_integral(2,2,eldata,L,M,leg));
 
             const Eigen::Index n = T00.rows();
             helfem::Matrix W(2*n, 2*n);
@@ -1632,9 +1632,9 @@ namespace helfem {
         const helfem::Matrix P(expand_boundaries(P_in));
 
         // Number of radial elements
-        size_t Nel(radial.Nel());
+        size_t Nel(radial_.Nel());
         // Number of radial functions
-        size_t Nrad(radial.Nbf());
+        size_t Nrad(radial_.Nbf());
 
         // Radial helper matrices
         std::vector<helfem::Matrix> Paux0(LM_map.size());
@@ -1697,7 +1697,7 @@ namespace helfem {
           // Loop over input elements
           for(size_t jel=0;jel<Nel;jel++) {
             size_t jfirst, jlast;
-            radial.idx(jel,jfirst,jlast);
+            radial_.idx(jel,jfirst,jlast);
             size_t Nj(jlast-jfirst+1);
 
             // Get density submatrices
@@ -1715,7 +1715,7 @@ namespace helfem {
             double ifac2(-jbig0 + jbig2);
             for(size_t iel=0;iel<jel;iel++) {
               size_t ifirst, ilast;
-              radial.idx(iel,ifirst,ilast);
+              radial_.idx(iel,ifirst,ilast);
               size_t Ni(ilast-ifirst+1);
 
               const helfem::Matrix & iint0=disjoint_P0[ilm*Nel+iel];
@@ -1729,7 +1729,7 @@ namespace helfem {
             ifac2=-jsmall0 + jsmall2;
             for(size_t iel=jel+1;iel<Nel;iel++) {
               size_t ifirst, ilast;
-              radial.idx(iel,ifirst,ilast);
+              radial_.idx(iel,ifirst,ilast);
               size_t Ni(ilast-ifirst+1);
 
               const helfem::Matrix & iint0=disjoint_Q0[ilm*Nel+iel];
@@ -1823,9 +1823,9 @@ namespace helfem {
         const helfem::Matrix P(expand_boundaries(P_in));
 
         // Number of radial elements
-        size_t Nel(radial.Nel());
+        size_t Nel(radial_.Nel());
         // Number of radial basis functions
-        size_t Nrad(radial.Nbf());
+        size_t Nrad(radial_.Nbf());
 
         // Pre-compute the (L, |M|) angular prefactor table once per call so
         // the inner loop reduces to a vector lookup + sign branch.
@@ -1967,12 +1967,12 @@ namespace helfem {
               // Loop over elements: output
               for(size_t iel=0;iel<Nel;iel++) {
                 size_t ifirst, ilast;
-                radial.idx(iel,ifirst,ilast);
+                radial_.idx(iel,ifirst,ilast);
 
                 // Input
                 for(size_t jel=0;jel<Nel;jel++) {
                   size_t jfirst, jlast;
-                  radial.idx(jel,jfirst,jlast);
+                  radial_.idx(jel,jfirst,jlast);
 
                   // Number of functions in the two elements
                   size_t Ni(ilast-ifirst+1);
@@ -2124,7 +2124,7 @@ namespace helfem {
           sph(i)=::spherical_harmonics(lval_(i),mval_(i),cth,phi);
 
         // Evaluate radial functions (single quadrature point, 1 x Nc row)
-        const helfem::Matrix rad(radial.bf(iel).row(irad));
+        const helfem::Matrix rad(radial_.bf(iel).row(irad));
         const Eigen::Index Nc = rad.cols();
 
         // Form supermatrix. sph(i) is complex, rad is real -> cast rad.
@@ -2136,7 +2136,7 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m) const {
-        return eval_bf(iel, irad, cth, m, radial.bf(iel));
+        return eval_bf(iel, irad, cth, m, radial_.bf(iel));
       }
 
       helfem::Matrix TwoDBasis::eval_bf(size_t iel, size_t irad, double cth, int m, const helfem::Matrix & rad_all) const {
@@ -2165,7 +2165,7 @@ namespace helfem {
 
       Eigen::VectorXcd TwoDBasis::eval_bf(double mu, double cth, double phi) const {
 	// Find out which element mu belongs to
-	const helfem::Vector bval(radial.bval());
+	const helfem::Vector bval(radial_.bval());
 	Eigen::Index iel;
 	for(iel=0;iel<bval.size()-1;iel++)
 	  if(bval(iel)<=mu && mu<=bval(iel+1))
@@ -2185,17 +2185,17 @@ namespace helfem {
         for(size_t i=0;i<(size_t) lval_.size();i++)
           sph(i)=::spherical_harmonics(lval_(i),mval_(i),cth,phi);
         // Evaluate radial functions (1 x Nc row)
-        const helfem::Matrix rad(radial.bf(iel,x));
+        const helfem::Matrix rad(radial_.bf(iel,x));
 
 	// Get indices of radial functions
 	size_t ifirst, ilast;
-        radial.idx(iel,ifirst,ilast);
+        radial_.idx(iel,ifirst,ilast);
 
         // Form supermatrix. arma used trans() on a real matrix = plain
         // transpose; sph(i) is complex so cast the transposed radial row.
 	Eigen::VectorXcd bf(Eigen::VectorXcd::Zero(Ndummy()));
 	for(size_t i=0;i<(size_t) lval_.size();i++) {
-	  bf.segment(i*radial.Nbf()+ifirst,ilast-ifirst+1)=sph(i)*rad.transpose().cast<std::complex<double>>();
+	  bf.segment(i*radial_.Nbf()+ifirst,ilast-ifirst+1)=sph(i)*rad.transpose().cast<std::complex<double>>();
 	}
 
 	return bf(pure_idx);
@@ -2208,8 +2208,8 @@ namespace helfem {
           sph(i)=::spherical_harmonics(lval_(i),mval_(i),cth,phi);
 
         // Evaluate radial functions (single quadrature point, 1 x Nc rows)
-        const helfem::Matrix frad(radial.bf(iel).row(irad));
-        const helfem::Matrix drad(radial.df(iel).row(irad));
+        const helfem::Matrix frad(radial_.bf(iel).row(irad));
+        const helfem::Matrix drad(radial_.df(iel).row(irad));
         const Eigen::Index Nc = frad.cols();
 
         // Form supermatrices
@@ -2271,8 +2271,8 @@ namespace helfem {
         }
 
         // Radial functions and their derivatives at the single radial point
-        const helfem::Matrix frad(radial.bf(iel).row(irad));
-        const helfem::Matrix drad(radial.df(iel).row(irad));
+        const helfem::Matrix frad(radial_.bf(iel).row(irad));
+        const helfem::Matrix drad(radial_.df(iel).row(irad));
         const Eigen::Index Nc = frad.cols();
 
         dr = helfem::Matrix::Zero(frad.rows(),flist.size()*Nc);
@@ -2292,7 +2292,7 @@ namespace helfem {
             flist.push_back(i);
 
         // Geometry at this (mu, nu) point
-        const double mu(radial.r(iel)(irad));
+        const double mu(radial_.r(iel)(irad));
         const double shmu(std::sinh(mu)), chmu(std::cosh(mu));
         // sin^2(nu), written to avoid cancellation near |cth| = 1
         const double sth2(std::max((1.0-cth)*(1.0+cth), 0.0));
@@ -2304,9 +2304,9 @@ namespace helfem {
         const double m2_sh2((shmu>0.0) ? (m*m)/(shmu*shmu) : 0.0);
 
         // Radial functions and their first two mu derivatives (1 x Nc rows)
-        const helfem::Matrix frad(radial.bf(iel).row(irad));
-        const helfem::Matrix drad(radial.df(iel).row(irad));
-        const helfem::Matrix d2rad(radial.d2f(iel).row(irad));
+        const helfem::Matrix frad(radial_.bf(iel).row(irad));
+        const helfem::Matrix drad(radial_.df(iel).row(irad));
+        const helfem::Matrix d2rad(radial_.d2f(iel).row(irad));
         const Eigen::Index Nc = frad.cols();
 
         // R'' + coth(mu) R' is common to every l in the block
@@ -2356,12 +2356,12 @@ namespace helfem {
       std::vector<Eigen::Index> TwoDBasis::bf_list_dummy(size_t iel) const {
         // Radial functions in element
         size_t ifirst, ilast;
-        radial.idx(iel,ifirst,ilast);
+        radial_.idx(iel,ifirst,ilast);
         // Number of radial functions in element
         size_t Nr(ilast-ifirst+1);
 
         // Total number of radial functions
-        size_t Nrad(radial.Nbf());
+        size_t Nrad(radial_.Nbf());
 
         // List of functions in the element
         std::vector<Eigen::Index> idx(Nr*lval_.size());
@@ -2379,12 +2379,12 @@ namespace helfem {
       std::vector<Eigen::Index> TwoDBasis::bf_list_dummy(size_t iel, int m) const {
         // Radial functions in element
         size_t ifirst, ilast;
-        radial.idx(iel,ifirst,ilast);
+        radial_.idx(iel,ifirst,ilast);
         // Number of radial functions in element
         size_t Nr(ilast-ifirst+1);
 
         // Total number of radial functions
-        size_t Nrad(radial.Nbf());
+        size_t Nrad(radial_.Nbf());
 
         // List of functions in the element
         std::vector<Eigen::Index> idx;
@@ -2397,27 +2397,27 @@ namespace helfem {
       }
 
       size_t TwoDBasis::rad_Nel() const {
-        return radial.Nel();
+        return radial_.Nel();
       }
 
       helfem::Matrix TwoDBasis::rad_bf(size_t iel) const {
-        return radial.bf(iel);
+        return radial_.bf(iel);
       }
 
       helfem::Matrix TwoDBasis::rad_df(size_t iel) const {
-        return radial.df(iel);
+        return radial_.df(iel);
       }
 
       helfem::Matrix TwoDBasis::rad_d2f(size_t iel) const {
-        return radial.d2f(iel);
+        return radial_.d2f(iel);
       }
 
       helfem::Vector TwoDBasis::wrad(size_t iel) const {
-        return radial.wrad(iel);
+        return radial_.wrad(iel);
       }
 
       helfem::Vector TwoDBasis::r(size_t iel) const {
-        return radial.r(iel);
+        return radial_.r(iel);
       }
 
     }

--- a/src/diatomic/basis.h
+++ b/src/diatomic/basis.h
@@ -131,7 +131,7 @@ namespace helfem {
         double Rhalf_;
 
         /// Radial basis set
-        RadialBasis radial;
+        RadialBasis radial_;
         /// Angular basis set: function l values
         Eigen::VectorXi lval_;
         /// Angular basis set: function m values
@@ -236,6 +236,10 @@ namespace helfem {
         Eigen::VectorXi mval() const;
 
         /// Get number of quadrature points
+        /// The underlying radial basis (read-only), following
+        /// atomic::TwoDBasisT::radial(); the graded AO projection
+        /// evaluates radial functions at arbitrary points through this.
+        const RadialBasis & radial() const { return radial_; }
         int nquad() const;
         /// Get boundary values
         helfem::Vector bval() const;

--- a/src/diatomic/completeness.cpp
+++ b/src/diatomic/completeness.cpp
@@ -181,10 +181,16 @@ int main(int argc, char **argv) {
       fflush(stdout);
     }
 
-    for(int l=std::abs(m);l<=completeness;l++) {
+    {
       static const std::string indices[]={"lh", "mid", "rh"};
       static const helfem::diatomic::twodquad::probe_t probes[]={helfem::diatomic::twodquad::PROBE_LEFT, helfem::diatomic::twodquad::PROBE_MIDDLE, helfem::diatomic::twodquad::PROBE_RIGHT};
       for(int icen=0;icen<3;icen++) {
+        // One panelisation sweep per probe covers the whole l range and
+        // every exponent; the per-l processing below just reuses the
+        // returned projection blocks.
+        const std::vector<helfem::Matrix> Plcao_all =
+          qgrid.graded_projections(std::abs(m), completeness, m, expn, probes[icen], iprobe==1);
+        for(int l=std::abs(m);l<=completeness;l++) {
         // Importance profile (no minimal basis): expn, alpha, beta
         helfem::Matrix I0 = helfem::Matrix::Zero(3, expn.size());
         // Importance profile: expn, alpha, beta
@@ -200,23 +206,10 @@ int main(int argc, char **argv) {
         } else
           throw std::logic_error("Unknown probe\n");
 
-        // Loop over batches of exponents
-        Eigen::Index exponent_batch_size = 200;
-        for(Eigen::Index exponent_batch = 0; exponent_batch <= expn.size()/exponent_batch_size; exponent_batch++) {
-          Eigen::Index istart = exponent_batch_size*exponent_batch;
-          Eigen::Index iend = std::min(exponent_batch_size*(exponent_batch+1), expn.size()) - 1;
-          if(istart>iend)
-            break;
-          helfem::Vector expbatch(expn.segment(istart, iend-istart+1));
-
-          // LCAO projection <\alpha|FEM>
-          helfem::Matrix Plcao;
-          if(iprobe==0) {
-            Plcao=qgrid.gto_projection(l, m, expbatch, probes[icen]);
-          } else if(iprobe==1) {
-            Plcao=qgrid.sto_projection(l, m, expbatch, probes[icen]);
-          } else
-            throw std::logic_error("Unknown probe\n");
+        {
+          const helfem::Vector & expbatch = expn;
+          const Eigen::Index istart = 0;
+          const helfem::Matrix & Plcao = Plcao_all[l - std::abs(m)];
 
           // Completeness profile
           helfem::Vector Ysub = (Plcao*Sinv*Plcao.transpose()).diagonal();
@@ -325,6 +318,7 @@ int main(int argc, char **argv) {
           Slcao.print("rh sto overlap");
           printf("\n");
         */
+        }
       }
     }
   }

--- a/src/diatomic/twodquadrature.cpp
+++ b/src/diatomic/twodquadrature.cpp
@@ -17,10 +17,13 @@
 #include "../general/atomdb.h"
 #include "chebyshev.h"
 #include "../general/lcao.h"
+#include "../general/spherical_harmonics.h"
 #include "../general/model_potential.h"
 #include "../sadatom/scf.h"
 #include "utils.h"
 #include <algorithm>
+#include <map>
+#include <limits>
 #include <cmath>
 
 // PBE ground states determined with 10 radial elements
@@ -441,20 +444,307 @@ namespace helfem {
         return S;
       }
 
-      helfem::Matrix TwoDGrid::gto_projection(int l, int m, const helfem::Vector & expn, probe_t p) {
-        helfem::Matrix S = helfem::Matrix::Zero(expn.size(),basp->Ndummy());
-        TwoDGridWorker grid(basp,lang);
+      // Panel-graded AO projection: one quadrature whose panels are
+      // smooth for BOTH factors of the integrand at every exponent.
+      //
+      // The basis side is covered exactly by construction: panels never
+      // cross a mu-element boundary, so the basis functions restricted
+      // to any panel are polynomials. The AO side is covered by grading:
+      // within each element, panels are bisected until the AO's radial
+      // argument r_p spans no more than a couple of its decay lengths
+      // and its angular argument cos(theta_p) is narrow, so the AO is a
+      // low-degree function on every panel it can reach. Panels the AO
+      // cannot reach are dropped, and the recursion around the probe
+      // point itself stops once a panel's whole extent is deep inside
+      // the AO peak (its contribution is O((r_hi/scale)^(l+3)) of the
+      // total). Tensor Gauss on the accepted panels is then spectrally
+      // accurate for every exponent -- tight, moderate or diffuse --
+      // with no rule switch anywhere.
+      //
+      // The panel bounds are exact, not sampled: r_p and cos(theta_p)
+      // are monotone in mu and in eta for all three probes (e.g. left
+      // probe: dr_p/deta = a > 0, dcth_p/deta = sinh^2(mu)/(cosh(mu) +
+      // eta)^2 >= 0), so corner evaluations bound them. The one special
+      // case is a corner that touches the probe itself (r_p = 0), where
+      // the angle is undefined and is treated as spanning [-1, 1].
+      //
+      // Conventions match the (mu, nu) grid path: the same
+      // spherical_harmonics-at-phi=0 basis values, the same
+      // sph_legendre AO angular factor, the same analytic 2 pi from the
+      // phi integral. One deliberate difference: the midbond probe's
+      // angular argument is the true polar angle about the midpoint,
+      // cos(theta_c) = z / r_c, where the old grid path used the
+      // prolate eta. The two agree for l = 0 (both constant); for l > 0
+      // the old choice made the "midbond AO" a hybrid object rather
+      // than a spherical harmonic about the midpoint.
+      std::vector<helfem::Matrix> TwoDGrid::graded_projections(int lmin, int lmax_ao, int m,
+                                                                const helfem::Vector & expn,
+                                                                probe_t p, bool sto_probe) const {
+        const int nl = lmax_ao - lmin + 1;
+        const double a = basp->Rhalf();
+        const size_t Nrad = basp->Nrad();
+        const std::vector<Eigen::Index> pure = basp->pure_indices();
+        const Eigen::VectorXi shell_m = basp->mval();
 
-        for(size_t iel=0;iel<basp->rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
-            grid.compute_bf(iel,irad,m);
-            grid.gto(l, expn, p);
-            grid.multiply_Plm(l, m, p);
-            grid.eval_proj(S);
+        // The phi integral is analytic: it kills every m' != m block
+        // and yields the same 2 pi the grid path folds into its
+        // weights. Collect the surviving functions.
+        std::vector<Eigen::Index> mfun;
+        for(size_t i = 0; i < pure.size(); i++)
+          if(shell_m(pure[i] / Nrad) == m)
+            mfun.push_back((Eigen::Index) i);
+
+        std::vector<helfem::Matrix> SL(nl, helfem::Matrix::Zero(expn.size(), pure.size()));
+        if(mfun.empty())
+          return SL;
+
+        // Lean per-element evaluation tables: each surviving function is
+        // (angular shell) x (global radial function); within an element
+        // only the radial functions [ifirst, ilast] are non-zero, so per
+        // element we keep (output column, shell, local radial index).
+        const Eigen::VectorXi shell_l = basp->lval();
+        const helfem::diatomic::basis::RadialBasis & rad = basp->radial();
+        std::vector<int> live_shells;
+        for(Eigen::Index i = 0; i < shell_m.size(); i++)
+          if(shell_m(i) == m)
+            live_shells.push_back((int) i);
+        struct Entry { Eigen::Index col; int shell; Eigen::Index jloc; };
+        std::vector<std::vector<Entry>> eltab(rad.Nel());
+        for(size_t iel = 0; iel < rad.Nel(); iel++) {
+          size_t ifirst, ilast;
+          rad.idx(iel, ifirst, ilast);
+          for(Eigen::Index k = 0; k < (Eigen::Index) mfun.size(); k++) {
+            const Eigen::Index dummy = pure[mfun[k]];
+            const size_t g = dummy % Nrad;
+            if(g >= ifirst && g <= ilast)
+              eltab[iel].push_back({mfun[k], (int) (dummy / Nrad), (Eigen::Index) (g - ifirst)});
           }
         }
 
-        return S(Eigen::all,basp->pure_indices());
+        // AO geometry at a point, in cancellation-free form: near an
+        // on-focus probe both cosh(mu) - 1 and 1 +- eta vanish, so the
+        // textbook expressions lose all their digits exactly where the
+        // grading operates.
+        const auto geom = [a, p](double mu, double eta, double & rp, double & cthp) {
+          const double sh2 = std::sinh(0.5 * mu);
+          const double chm1 = 2.0 * sh2 * sh2;   // cosh(mu) - 1
+          const double ch = 1.0 + chm1;
+          if(p == PROBE_LEFT) {
+            const double q = 1.0 + eta;
+            rp = a * (chm1 + q);
+            cthp = (rp > 0.0) ? (ch * q - chm1) / (chm1 + q) : 1.0;
+          } else if(p == PROBE_RIGHT) {
+            const double q = 1.0 - eta;
+            rp = a * (chm1 + q);
+            cthp = (rp > 0.0) ? (ch * q - chm1) / (chm1 + q) : 1.0;
+          } else {
+            const double sh = std::sinh(mu);
+            rp = a * std::hypot(sh, eta);
+            cthp = (rp > 0.0) ? a * ch * eta / rp : 1.0;
+          }
+          cthp = std::clamp(cthp, -1.0, 1.0);
+        };
+
+        const auto eval_Plm = [m](int L, double u) {
+          return std::sph_legendre(static_cast<unsigned>(L),
+                                   static_cast<unsigned>(std::abs(m)),
+                                   std::acos(std::clamp(u, -1.0, 1.0)));
+        };
+
+        // Panel rules. Full orders cover the element-wide basis
+        // polynomials (degree ~ nnodes for the radial factor, ~ Lmax
+        // for the angular one); deeply graded panels see only a tiny
+        // slice of those polynomials, which is effectively low degree,
+        // so they get lean orders.
+        const int Lmax = basp->lval().maxCoeff();
+        helfem::Vector xf_mu, wf_mu, xf_eta, wf_eta, xl_mu, wl_mu, xl_eta, wl_eta;
+        lobatto::lobatto_compute(16, xf_mu, wf_mu);
+        lobatto::lobatto_compute((Lmax + lmax_ao) / 2 + 12, xf_eta, wf_eta);
+        lobatto::lobatto_compute(10, xl_mu, wl_mu);
+        lobatto::lobatto_compute(12, xl_eta, wl_eta);
+
+        const helfem::Vector bval(basp->bval());
+
+        // Octave batching: exponents within a factor two share one
+        // panelisation, graded for the tightest member and reaching as
+        // far as the most diffuse one. The basis evaluation -- the
+        // dominant cost -- is then paid once per point for the whole
+        // bucket instead of once per exponent.
+        std::map<int, std::vector<Eigen::Index>> buckets;
+        for(Eigen::Index ix = 0; ix < expn.size(); ix++)
+          buckets[(int) std::floor(std::log2(expn(ix)))].push_back(ix);
+        std::vector<std::vector<Eigen::Index>> bucket_list;
+        for(auto & b : buckets)
+          bucket_list.push_back(b.second);
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+        for(size_t ib = 0; ib < bucket_list.size(); ib++) {
+          const std::vector<Eigen::Index> & bucket = bucket_list[ib];
+          double scale = std::numeric_limits<double>::infinity(), rmax_ao = 0.0;
+          for(Eigen::Index ix : bucket) {
+            const double s = sto_probe ? 1.0 / expn(ix) : 1.0 / std::sqrt(expn(ix));
+            scale = std::min(scale, s);
+            rmax_ao = std::max(rmax_ao, (sto_probe ? 32.0 : std::sqrt(32.0)) * s);
+          }
+
+          std::vector<double> wao(nl * bucket.size());
+          double m1el = 0.0, m2el = 0.0;
+
+          const std::function<void(size_t,double,double,double,double,double,int)> panel =
+              [&](size_t iel, double m1, double m2, double e1, double e2, double elwidth, int depth) {
+            // Exact panel bounds from the corners (monotonicity; see
+            // above). A probe-touching corner leaves the angle free.
+            double r11, r12, r21, r22, c11, c12, c21, c22;
+            geom(m1, e1, r11, c11); geom(m1, e2, r12, c12);
+            geom(m2, e1, r21, c21); geom(m2, e2, r22, c22);
+            double rlo = std::min(std::min(r11, r12), std::min(r21, r22));
+            double rhi = std::max(std::max(r11, r12), std::max(r21, r22));
+            if(p == PROBE_MIDDLE && e1 < 0.0 && e2 > 0.0) {
+              double rm, cm;
+              geom(m1, 0.0, rm, cm);
+              rlo = std::min(rlo, rm);
+            }
+            double clo = std::min(std::min(c11, c12), std::min(c21, c22));
+            double chi = std::max(std::max(c11, c12), std::max(c21, c22));
+            if(rlo <= 0.0) { clo = -1.0; chi = 1.0; }
+
+            if(rlo > rmax_ao)
+              return;                        // the AO cannot reach this panel
+
+            const bool tiny = rhi < 1e-3 * scale;   // deep inside the AO peak
+            const bool rok = (rhi - rlo) <= 2.0 * scale;
+            // Far from the probe (proper annulus panels), cos(theta_p)
+            // is a tame analytic function of eta no matter how wide its
+            // range, and the full-order eta rule integrates it; only
+            // near the probe does the mapping distort violently.
+            const bool cok = (chi - clo) <= 0.6 || rlo >= 2.0 * (rhi - rlo);
+            if(!tiny && !(rok && cok) && depth < 48) {
+              // Bisect the direction that contributes more of the
+              // offending spread. r_p is monotone in mu, so corner
+              // differences measure the mu direction exactly; along eta
+              // the midpoint probe has an interior minimum at eta = 0
+              // (all four corners of a symmetric panel see the SAME
+              // r_p), so the eta span must include it or the chooser
+              // goes blind and bisects mu forever.
+              const double dr_mu  = std::max(std::abs(r21 - r11), std::abs(r22 - r12));
+              double dr_eta = std::max(std::abs(r12 - r11), std::abs(r22 - r21));
+              if(p == PROBE_MIDDLE && e1 < 0.0 && e2 > 0.0) {
+                double rmid1, rmid2, cdum;
+                geom(m1, 0.0, rmid1, cdum);
+                geom(m2, 0.0, rmid2, cdum);
+                dr_eta = std::max({dr_eta, r11 - rmid1, r12 - rmid1, r21 - rmid2, r22 - rmid2});
+              }
+              const double dc_mu  = std::max(std::abs(c21 - c11), std::abs(c22 - c12));
+              const double dc_eta = std::max(std::abs(c12 - c11), std::abs(c22 - c21));
+              const bool r_worse = ((rhi - rlo) / (2.0 * scale)) >= ((chi - clo) / 0.6);
+              bool split_mu = r_worse ? (dr_mu > dr_eta) : (dc_mu > dc_eta);
+              // degenerate metrics (e.g. a probe-corner panel): fall
+              // back to bisecting the longer side in relative units
+              if((r_worse && dr_mu <= 0.0 && dr_eta <= 0.0) ||
+                 (!r_worse && dc_mu <= 0.0 && dc_eta <= 0.0))
+                split_mu = ((m2 - m1) / elwidth) >= (0.5 * (e2 - e1));
+              if(split_mu) {
+                const double mm = 0.5 * (m1 + m2);
+                panel(iel, m1, mm, e1, e2, elwidth, depth + 1);
+                panel(iel, mm, m2, e1, e2, elwidth, depth + 1);
+              } else {
+                const double em = 0.5 * (e1 + e2);
+                panel(iel, m1, m2, e1, em, elwidth, depth + 1);
+                panel(iel, m1, m2, em, e2, elwidth, depth + 1);
+              }
+              return;
+            }
+
+            // Integrate. Lean rule once the panel is a small slice of
+            // the element in both directions.
+            const bool lean = (m2 - m1) < 0.0625 * elwidth && (e2 - e1) < 0.125;
+            const helfem::Vector & xmu = lean ? xl_mu : xf_mu, & wmu = lean ? wl_mu : wf_mu;
+            const helfem::Vector & xet = lean ? xl_eta : xf_eta, & wet = lean ? wl_eta : wf_eta;
+            const double mmid = 0.5 * (m2 + m1), mhw = 0.5 * (m2 - m1);
+            const double emid = 0.5 * (e2 + e1), ehw = 0.5 * (e2 - e1);
+            // Only the bucket members whose AO reaches this panel do
+            // any work here; the tight members die on the outer annuli.
+            std::vector<size_t> livek;
+            for(size_t k = 0; k < bucket.size(); k++) {
+              const double ex = expn(bucket[k]);
+              const bool reaches = sto_probe ? (ex * rlo <= 32.0)
+                                             : (ex * rlo * rlo <= 32.0);
+              if(reaches)
+                livek.push_back(k);
+            }
+            if(livek.empty())
+              return;
+
+            // Per-panel factor tables: the radial basis values depend
+            // only on mu and the shell harmonics only on eta, so they
+            // are evaluated once per node line, not once per point.
+            // (The Lobatto endpoints can land an ulp outside the
+            // element under round-off; clamp so the lookups succeed.)
+            helfem::Vector xloc(xmu.size());
+            for(Eigen::Index iq = 0; iq < xmu.size(); iq++) {
+              const double mu = std::clamp(mmid + mhw * xmu(iq), m1, m2);
+              xloc(iq) = std::clamp(2.0 * (mu - m1el) / (m2el - m1el) - 1.0, -1.0, 1.0);
+            }
+            const helfem::Matrix rmat = rad.bf(iel, xloc);   // (nmu x nlocal)
+            helfem::Matrix sph_tab(xet.size(), shell_l.size());
+            for(Eigen::Index jq = 0; jq < xet.size(); jq++) {
+              const double eta = std::clamp(emid + ehw * xet(jq), -1.0, 1.0);
+              for(int s : live_shells)
+                sph_tab(jq, s) = std::real(::spherical_harmonics(shell_l(s), m, eta, 0.0));
+            }
+
+            for(Eigen::Index iq = 0; iq < xmu.size(); iq++) {
+              const double mu = std::clamp(mmid + mhw * xmu(iq), m1, m2);
+              const double shmu = std::sinh(mu);
+              for(Eigen::Index jq = 0; jq < xet.size(); jq++) {
+                const double eta = std::clamp(emid + ehw * xet(jq), -1.0, 1.0);
+                double rp, cthp;
+                geom(mu, eta, rp, cthp);
+                if(rp <= 0.0)
+                  continue;
+                // dV = 2 pi a^3 sinh(mu) (sinh^2(mu) + 1 - eta^2) dmu deta
+                const double jac = a * a * a * shmu * (shmu * shmu + 1.0 - eta * eta);
+                const double wgeo = 2.0 * M_PI * mhw * wmu(iq) * ehw * wet(jq) * jac;
+                bool live = false;
+                for(int il = 0; il < nl; il++) {
+                  const double wPl = wgeo * eval_Plm(lmin + il, cthp);
+                  for(size_t kk = 0; kk < livek.size(); kk++) {
+                    const double ex = expn(bucket[livek[kk]]);
+                    const double Rao = sto_probe ? lcao::radial_STO(rp, lmin + il, ex)
+                                                 : lcao::radial_GTO(rp, lmin + il, ex);
+                    wao[il * livek.size() + kk] = wPl * Rao;
+                    live = live || (Rao != 0.0);
+                  }
+                }
+                if(!live)
+                  continue;
+                for(const Entry & en : eltab[iel]) {
+                  const double b = sph_tab(jq, en.shell) * rmat(iq, en.jloc);
+                  for(int il = 0; il < nl; il++) {
+                    helfem::Matrix & Sl = SL[il];
+                    const double * w = &wao[il * livek.size()];
+                    for(size_t kk = 0; kk < livek.size(); kk++)
+                      Sl(bucket[livek[kk]], en.col) += w[kk] * b;
+                  }
+                }
+              }
+            }
+          };
+
+          for(size_t iel = 0; iel + 1 < (size_t) bval.size(); iel++) {
+            m1el = bval(iel);
+            m2el = bval(iel + 1);
+            panel(iel, m1el, m2el, -1.0, 1.0, m2el - m1el, 0);
+          }
+        }
+
+        return SL;
+      }
+
+      helfem::Matrix TwoDGrid::gto_projection(int l, int m, const helfem::Vector & expn, probe_t p) {
+        return graded_projections(l, l, m, expn, p, /*sto_probe=*/false)[0];
       }
 
       helfem::Matrix TwoDGrid::gto_overlap(int l, int m, const helfem::Vector & expn, probe_t p) {
@@ -474,19 +764,7 @@ namespace helfem {
       }
 
       helfem::Matrix TwoDGrid::sto_projection(int l, int m, const helfem::Vector & expn, probe_t p) {
-        helfem::Matrix S = helfem::Matrix::Zero(expn.size(),basp->Ndummy());
-        TwoDGridWorker grid(basp,lang);
-
-        for(size_t iel=0;iel<basp->rad_Nel();iel++) {
-          for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
-            grid.compute_bf(iel,irad,m);
-            grid.sto(l, expn, p);
-            grid.multiply_Plm(l, m, p);
-            grid.eval_proj(S);
-          }
-        }
-
-        return S(Eigen::all,basp->pure_indices());
+        return graded_projections(l, l, m, expn, p, /*sto_probe=*/true)[0];
       }
 
       helfem::Matrix TwoDGrid::sto_overlap(int l, int m, const helfem::Vector & expn, probe_t p) {

--- a/src/diatomic/twodquadrature.h
+++ b/src/diatomic/twodquadrature.h
@@ -135,6 +135,26 @@ namespace helfem {
         helfem::Matrix gto_overlap(int l, int m, const helfem::Vector & expn, probe_t p);
         /// Compute STO projection
         helfem::Matrix sto_projection(int l, int m, const helfem::Vector & expn, probe_t p);
+
+        /// AO projection <bf|AO> on a panel-graded quadrature that
+        /// covers BOTH factors exactly: panels never cross a mu-element
+        /// boundary (the basis is polynomial on every panel) and are
+        /// bisected until the AO's radial and angular arguments are
+        /// narrow on each panel it can reach (the AO is low-degree
+        /// there). Spectrally accurate at every exponent, no rule
+        /// switch. Layout matches the grid path: (nexp x Nbf).
+        /// One panelisation sweep per probe serves every l and every
+        /// exponent: the panels, radial rows and shell harmonics are
+        /// l-independent, so computing the whole l-range at once is
+        /// what makes the tool's scan affordable. Returns one
+        /// (nexp x Nbf) matrix per l in [lmin, lmax_ao].
+        ///
+        /// Values below Y ~ 1e-14 in the derived profiles are noise
+        /// limited (that is eps^2 of the plateau) for ANY double
+        /// precision rule; this diagnostic makes no claims there.
+        std::vector<helfem::Matrix> graded_projections(int lmin, int lmax_ao, int m,
+                                                       const helfem::Vector & expn,
+                                                       probe_t p, bool sto_probe) const;
         /// Compute STO overlap
         helfem::Matrix sto_overlap(int l, int m, const helfem::Vector & expn, probe_t p);
 


### PR DESCRIPTION
Stage 2 of the diatomic profile fix (follows #320; tracker task 65), reworked per review: **one quadrature whose panels cover both factors of the integrand exactly**, replacing the earlier two-rule switch.

## The rule

Panels never cross a μ-element boundary — the basis functions restricted to any panel are polynomials — and within each element, panels are recursively bisected until the AO's radial argument spans ≤ 2 of its decay lengths and its angular argument is narrow, so the AO is low-degree on every panel it can reach. Tensor Gauss on the accepted panels is then spectrally accurate at *every* exponent: tight, moderate or diffuse, with no switch anywhere.

Panel bounds are exact, not sampled: r_p and cos θ_p are monotone per coordinate for all three probes, so corner evaluations bound them. The one subtlety — and the source of a runaway-bisection bug during development — is that the midbond probe's r_p has an interior minimum on the η = 0 line: all four corners of a symmetric panel see the *same* r_p, so the split-direction metric must include that line or it bisects the wrong direction indefinitely. Prolate coordinates are computed cancellation-free near the probe (ξ−1 vanishes to second order in r/a) and directly farther out (the stable denominators hit exact zeros on the axis).

## Performance structure

One panelisation sweep per probe serves **every l and every exponent**: octave-batched exponents, per-panel live-exponent lists (tight AOs are dead on the outer annuli), and per-node-line factor tables (radial values depend only on μ, shell harmonics only on η). `diatomic_cpl` requests the whole l range in one call per probe; the diatomic `TwoDBasis` exposes `radial()` (following the atomic accessor) for the per-element evaluations. Full 501-exponent, l ≤ 1, 3-probe N2 scan: ~24 CPU-min STO / ~11 CPU-min GTO.

## Accuracy (N2/HF suite grid)

- Plateau exact to 4e-9 or better (max Y−1 ∈ [−4.4e-9, +2e-14]).
- Agrees with the grid rule wherever that rule is valid: 3.8e-6 at ζ=3; 6e-4 at ζ=10, where the grid is already degrading (measured factor ~3 per basis function at midbond ζ=100).
- Projection-vector norms follow the analytic ζ^(−1.5) law to 11 digits over 1e5–1e8; STO completeness tails at ζ^(−3) (midbond −3.000 exact), GTO midbond at α^(−1.5).
- **Noise floor**: profile values below Y ~ 1e-14 (= ε² of the plateau) are noise-limited for any double-precision rule; the diagnostic makes no claims there (documented in the header).

## Convention note

The midbond probe's angular argument is now the true polar angle about the midpoint; the old grid path used the prolate η, which for l > 0 made the "midbond AO" a hybrid object rather than a spherical harmonic about the midpoint. Identical for l = 0.

Unit 8/8; ci spot checks bit-identical (`atomic_projection` and all SCF paths untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)