### PR TITLE
Fix the density transformation in every checkpoint restart

### DIFF
--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -636,13 +636,13 @@ int main(int argc, char **argv) {
       const helfem::Matrix P_total = Pa_new + Pb_new;
       for (size_t k = 0; k < nsym; ++k)
         helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh[k], max_occ_restr);
+            k, loaded_orbs, loaded_occs, P_total, S, dsym[k], Sinvh[k], max_occ_restr);
     } else {
       for (size_t k = 0; k < nsym; ++k) {
         helfem::scf_driver::fill_block_from_density(
-            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh[k], max_occ_open);
+            k, loaded_orbs, loaded_occs, Pa_new, S, dsym[k], Sinvh[k], max_occ_open);
         helfem::scf_driver::fill_block_from_density(
-            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh[k], max_occ_open);
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, S, dsym[k], Sinvh[k], max_occ_open);
       }
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -629,21 +629,35 @@ int main(int argc, char **argv) {
     // largest first for Aufbau semantics).
     OpenOrbitalOptimizer::Orbitals<OOO_Real>            loaded_orbs(nsym * nparttype);
     OpenOrbitalOptimizer::OrbitalOccupations<OOO_Real>  loaded_occs(nsym * nparttype);
+    double seed_dev_a = 0.0, seed_dev_b = 0.0;
     const double max_occ_restr = 2.0;
     const double max_occ_open  = 1.0;
     if (restricted) {
       // Single channel: eigenvalues of total P should be in [0, 2].
       const helfem::Matrix P_total = Pa_new + Pb_new;
       for (size_t k = 0; k < nsym; ++k)
-        helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, P_total, S, dsym[k], Sinvh[k], max_occ_restr);
+        seed_dev_a = std::max(seed_dev_a, helfem::scf_driver::fill_block_from_density(
+            k, loaded_orbs, loaded_occs, P_total, S, dsym[k], Sinvh[k], max_occ_restr));
     } else {
       for (size_t k = 0; k < nsym; ++k) {
-        helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, Pa_new, S, dsym[k], Sinvh[k], max_occ_open);
-        helfem::scf_driver::fill_block_from_density(
-            nsym + k, loaded_orbs, loaded_occs, Pb_new, S, dsym[k], Sinvh[k], max_occ_open);
+        seed_dev_a = std::max(seed_dev_a, helfem::scf_driver::fill_block_from_density(
+            k, loaded_orbs, loaded_occs, Pa_new, S, dsym[k], Sinvh[k], max_occ_open));
+        seed_dev_b = std::max(seed_dev_b, helfem::scf_driver::fill_block_from_density(
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, S, dsym[k], Sinvh[k], max_occ_open));
       }
+    }
+    if (restricted) {
+      double nel = 0.0;
+      for (size_t k = 0; k < nsym; ++k) nel += loaded_occs[k].sum();
+      helfem::scf_driver::check_seeded_density(seed_dev_a, nel, "total", verbosity);
+    } else {
+      double nela_got = 0.0, nelb_got = 0.0;
+      for (size_t k = 0; k < nsym; ++k) {
+        nela_got += loaded_occs[k].sum();
+        nelb_got += loaded_occs[nsym + k].sum();
+      }
+      helfem::scf_driver::check_seeded_density(seed_dev_a, nela_got, "alpha", verbosity);
+      helfem::scf_driver::check_seeded_density(seed_dev_b, nelb_got, "beta", verbosity);
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);
   } else {

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -693,20 +693,34 @@ int main(int argc, char **argv) {
 
     OpenOrbitalOptimizer::Orbitals<OOO_Real>            loaded_orbs(nsym * nparttype);
     OpenOrbitalOptimizer::OrbitalOccupations<OOO_Real>  loaded_occs(nsym * nparttype);
+    double seed_dev_a = 0.0, seed_dev_b = 0.0;
     const double max_occ_restr = 2.0;
     const double max_occ_open  = 1.0;
     if (restricted) {
       const helfem::Matrix P_total = Pa_new + Pb_new;
       for (size_t k = 0; k < nsym; ++k)
-        helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, P_total, S, dsym[k], Sinvh[k], max_occ_restr);
+        seed_dev_a = std::max(seed_dev_a, helfem::scf_driver::fill_block_from_density(
+            k, loaded_orbs, loaded_occs, P_total, S, dsym[k], Sinvh[k], max_occ_restr));
     } else {
       for (size_t k = 0; k < nsym; ++k) {
-        helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, Pa_new, S, dsym[k], Sinvh[k], max_occ_open);
-        helfem::scf_driver::fill_block_from_density(
-            nsym + k, loaded_orbs, loaded_occs, Pb_new, S, dsym[k], Sinvh[k], max_occ_open);
+        seed_dev_a = std::max(seed_dev_a, helfem::scf_driver::fill_block_from_density(
+            k, loaded_orbs, loaded_occs, Pa_new, S, dsym[k], Sinvh[k], max_occ_open));
+        seed_dev_b = std::max(seed_dev_b, helfem::scf_driver::fill_block_from_density(
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, S, dsym[k], Sinvh[k], max_occ_open));
       }
+    }
+    if (restricted) {
+      double nel = 0.0;
+      for (size_t k = 0; k < nsym; ++k) nel += loaded_occs[k].sum();
+      helfem::scf_driver::check_seeded_density(seed_dev_a, nel, "total", verbosity);
+    } else {
+      double nela_got = 0.0, nelb_got = 0.0;
+      for (size_t k = 0; k < nsym; ++k) {
+        nela_got += loaded_occs[k].sum();
+        nelb_got += loaded_occs[nsym + k].sum();
+      }
+      helfem::scf_driver::check_seeded_density(seed_dev_a, nela_got, "alpha", verbosity);
+      helfem::scf_driver::check_seeded_density(seed_dev_b, nelb_got, "beta", verbosity);
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);
   } else {

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -699,13 +699,13 @@ int main(int argc, char **argv) {
       const helfem::Matrix P_total = Pa_new + Pb_new;
       for (size_t k = 0; k < nsym; ++k)
         helfem::scf_driver::fill_block_from_density(
-            k, loaded_orbs, loaded_occs, P_total, dsym[k], Sinvh[k], max_occ_restr);
+            k, loaded_orbs, loaded_occs, P_total, S, dsym[k], Sinvh[k], max_occ_restr);
     } else {
       for (size_t k = 0; k < nsym; ++k) {
         helfem::scf_driver::fill_block_from_density(
-            k,        loaded_orbs, loaded_occs, Pa_new, dsym[k], Sinvh[k], max_occ_open);
+            k, loaded_orbs, loaded_occs, Pa_new, S, dsym[k], Sinvh[k], max_occ_open);
         helfem::scf_driver::fill_block_from_density(
-            nsym + k, loaded_orbs, loaded_occs, Pb_new, dsym[k], Sinvh[k], max_occ_open);
+            nsym + k, loaded_orbs, loaded_occs, Pb_new, S, dsym[k], Sinvh[k], max_occ_open);
       }
     }
     scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -235,8 +235,13 @@ namespace helfem {
     /// where S^-1 blows up -- the most nearly linearly dependent,
     /// highest-kinetic-energy ones. Restarting from an exact same-basis
     /// density then began at +3.8e5 Eh instead of the converged energy.
+    /// Returns the relative Frobenius deviation between the density
+    /// this block's seeded orbitals reconstruct and the density it was
+    /// given -- zero when the pair (V, w) really represents Pblk. See
+    /// check_seeded_density below for why the electron count alone is
+    /// not enough to catch a bad transformation.
     template <typename Real>
-    inline void fill_block_from_density(
+    inline double fill_block_from_density(
         size_t out_index,
         OpenOrbitalOptimizer::Orbitals<Real> & orbs,
         OpenOrbitalOptimizer::OrbitalOccupations<Real> & occs,
@@ -246,7 +251,7 @@ namespace helfem {
       if (idx.empty()) {
         orbs[out_index] = helfem::Matrix::Zero(0, 0);
         occs[out_index] = helfem::Vector::Zero(0);
-        return;
+        return 0.0;
       }
       const helfem::Matrix Pblk  = Pspin(idx, idx);
       const helfem::Matrix Sblk  = S(idx, idx);
@@ -267,6 +272,49 @@ namespace helfem {
       }
       orbs[out_index] = V;
       occs[out_index] = w;
+
+      // Round trip: the seeded pair, mapped back to the AO basis, must
+      // rebuild the block density it came from.
+      const helfem::Matrix Cao  = Sinvh_block * V;
+      const helfem::Matrix Prec = Cao * w.asDiagonal() * Cao.transpose();
+      const double nrm = Pblk.norm();
+      return (Prec - Pblk).norm() / std::max(1.0, nrm);
+    }
+
+    /// Assert that the orbitals and occupations just seeded into OOO
+    /// really represent the density that was read.
+    ///
+    /// The assertion is a round trip -- rebuild the density from the
+    /// seeded pair and compare -- NOT the electron count. The count is
+    /// too weak to catch the transformation bug this file used to
+    /// carry: pulling the density back with the Fock rule gives
+    /// S^-1 P S^-1, whose eigenvalues are not occupations at all, but
+    /// clamping them to [0, max_occ] leaves one orbital at max_occ and
+    /// the rest at zero, so for H2 the seeded occupations summed to
+    /// exactly 2.000000 while the guess energy was +6.2e4 Eh. The
+    /// count agreed by coincidence; the density did not.
+    ///
+    /// Nothing else notices: DIIS recovers from a bad guess, so the run
+    /// still converges to the right energy and merely wastes
+    /// iterations -- which is how the restart stayed broken in all
+    /// three drivers without a single test failing.
+    inline void check_seeded_density(double deviation, double electrons,
+                                     const char * label, int verbosity) {
+      // Threshold picked from the two regimes, which are 16 orders
+      // apart: a sound restart lands near 1e-8 (clamping the near-zero
+      // natural occupations of a converged density to exactly zero
+      // costs about that much), while the Fock-rule transformation this
+      // file used to apply gives 1e8. Anything in between is a real
+      // mismatch worth reporting.
+      if (deviation > 1e-4) {
+        printf("WARNING: the %s restart guess does not reproduce the loaded"
+               " density (relative deviation %.3e).\n         The SCF will"
+               " start from a degraded guess.\n", label, deviation);
+        fflush(stdout);
+      } else if (verbosity >= 1) {
+        printf("Restart guess reproduces the loaded %s density to %.1e"
+               " and carries %.6f electrons.\n", label, deviation, electrons);
+      }
     }
 
     /// Save-path helper: reconstruct the full AO alpha / beta density

--- a/src/general/scf_driver_common.h
+++ b/src/general/scf_driver_common.h
@@ -222,14 +222,26 @@ namespace helfem {
     /// blocks become 0x0 placeholders. Called per spin channel and
     /// per block from the driver's --load path.
     ///
-    ///   P_orth = Sinvh_k^T . Pspin(dsym[k], dsym[k]) . Sinvh_k
+    ///   P_orth = (Sinvh_k^T S_k) . Pspin(dsym[k], dsym[k]) . (S_k Sinvh_k)
     ///          -> V, w  (descending); w clamped to [0, max_occ]
+    ///
+    /// The S factors are what makes this a DENSITY transformation.
+    /// Orbital coefficients transform as C = Sinvh C~, so the density
+    /// P = C n C^T pulls back as P~ = Sinvh^-1 P Sinvh^-T, and
+    /// Sinvh^T S Sinvh = I gives Sinvh^-1 = Sinvh^T S on the retained
+    /// subspace. Dropping the S factors would apply the Fock (covariant)
+    /// rule instead: that returns S^-1 P S^-1, whose trace is not the
+    /// electron count and whose dominant eigenvectors are the directions
+    /// where S^-1 blows up -- the most nearly linearly dependent,
+    /// highest-kinetic-energy ones. Restarting from an exact same-basis
+    /// density then began at +3.8e5 Eh instead of the converged energy.
     template <typename Real>
     inline void fill_block_from_density(
         size_t out_index,
         OpenOrbitalOptimizer::Orbitals<Real> & orbs,
         OpenOrbitalOptimizer::OrbitalOccupations<Real> & occs,
-        const helfem::Matrix & Pspin, const std::vector<Eigen::Index> & idx,
+        const helfem::Matrix & Pspin, const helfem::Matrix & S,
+        const std::vector<Eigen::Index> & idx,
         const helfem::Matrix & Sinvh_block, double max_occ) {
       if (idx.empty()) {
         orbs[out_index] = helfem::Matrix::Zero(0, 0);
@@ -237,7 +249,9 @@ namespace helfem {
         return;
       }
       const helfem::Matrix Pblk  = Pspin(idx, idx);
-      const helfem::Matrix Porth = Sinvh_block.transpose() * Pblk * Sinvh_block;
+      const helfem::Matrix Sblk  = S(idx, idx);
+      const helfem::Matrix SC    = Sblk * Sinvh_block;
+      const helfem::Matrix Porth = SC.transpose() * Pblk * SC;
       // SelfAdjointEigenSolver returns eigenvalues in ascending order;
       // reverse for descending (largest occupation first), matching the
       // old symmetric-eigensolver + manual reversal.

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -484,7 +484,13 @@ namespace helfem {
             } else {
               Pl_new = helfem::Matrix::Zero(Nrad, Nrad);
             }
-            const helfem::Matrix Porth = Sinvh_full.transpose() * Pl_new * Sinvh_full;
+            // A density is contravariant: P~ = Sinvh^-1 P Sinvh^-T, and
+            // Sinvh^T S Sinvh = I gives Sinvh^-1 = Sinvh^T S. Without
+            // the S factors this is the Fock rule, which returns
+            // S^-1 P S^-1 -- see the same fix in
+            // scf_driver::fill_block_from_density.
+            const helfem::Matrix SC    = S_new * Sinvh_full;
+            const helfem::Matrix Porth = SC.transpose() * Pl_new * SC;
             Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(Porth);
             if (es.info() != Eigen::Success)
               throw std::logic_error("--load: eigendecomposition of projected l block density failed");

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -473,6 +473,7 @@ namespace helfem {
           OpenOrbitalOptimizer::Orbitals<OOO_Real>            loaded_orbs(nblock * nparttype);
           OpenOrbitalOptimizer::OrbitalOccupations<OOO_Real>  loaded_occs(nblock * nparttype);
 
+          double seed_dev = 0.0;
           auto fill_l = [&](size_t base, size_t l, const helfem::Cube & Pcube,
                              double per_l_electrons, double max_occ) {
             helfem::Matrix Pl_new;
@@ -505,6 +506,15 @@ namespace helfem {
             }
             loaded_orbs[base + l] = V;
             loaded_occs[base + l] = w;
+
+            // Round trip: the seeded pair must rebuild the density it
+            // came from. See scf_driver::check_seeded_density for why
+            // the electron count alone cannot catch a bad
+            // transformation here.
+            const helfem::Matrix Cao  = Sinvh_full * V;
+            const helfem::Matrix Prec = Cao * w.asDiagonal() * Cao.transpose();
+            seed_dev = std::max(seed_dev,
+                                (Prec - Pl_new).norm() / std::max(1.0, Pl_new.norm()));
           };
 
           // Per-l electron counts to renormalise into. Read from
@@ -535,6 +545,13 @@ namespace helfem {
               double max_occ = 2.0 * l + 1;
               fill_l(nblock, l, Pbl_old, per_l, max_occ);
             }
+          }
+          {
+            double nel = 0.0;
+            for (size_t b = 0; b < loaded_occs.size(); ++b)
+              nel += loaded_occs[b].sum();
+            helfem::scf_driver::check_seeded_density(seed_dev, nel, "atomic",
+                                                     opts.verbosity);
           }
           scfsolver.initialize_with_orbitals(loaded_orbs, loaded_occs);
         } else {


### PR DESCRIPTION
`--load` has been silently broken since the OOO migration, in **all three** drivers (`atomic`, `diatomic`, `gensap`). This fixes it and adds the assertion that would have caught it.

## Symptom

Reloading an **exact same-basis converged density** should reproduce it at iteration 1. Instead:

| driver | iteration-1 energy on exact reload | converged | iterations |
|---|---|---|---|
| diatomic (N2/HF) | **+378752.66** | −108.9936243937 | full re-convergence |
| atomic (Ne/LDA) | **+736320.16** | −127.4907408344 | full re-convergence |
| gensap (Ne/LDA) | **+736318.27** | −127.4907408344 | 13 |

DIIS always recovered and the runs finished at correct energies, so nothing ever looked wrong — the restart was simply doing no good, and sometimes actively hurting.

## Cause

The density was pulled back to the block's orthonormal basis as `Sinvh^T P Sinvh` — the transformation for a **Fock matrix**, not for a density.

Orbital coefficients transform as `C = Sinvh C~`, so `P = C n C^T` pulls back as `P~ = Sinvh^-1 P Sinvh^-T`, and `Sinvh^T S Sinvh = I` on the retained subspace gives `Sinvh^-1 = Sinvh^T S`. Without the S factors you get `S^-1 P S^-1`, whose trace is not the electron count and whose dominant eigenvectors are the directions where `S^-1` blows up — the most nearly linearly dependent, highest-kinetic-energy ones. Those were handed to OOO as the *most occupied* natural orbitals of the guess.

Two independent copies of the logic had it: `scf_driver::fill_block_from_density` (shared by atomic and diatomic) and sadatom's own per-l seeding. The sadatom path also serves the atomic sub-SCF behind the diatomic SAD/SAP guesses, so it is not only the gensap CLI.

This is a *load-side* bug only: checkpoints have always stored finite-element-basis quantities (`assemble_final_density` / `assemble_final_orbitals` apply `Sinvh` before writing), so no file needs regenerating, and the projection into the orthonormal basis correctly uses the reader's own `Sinvh`. See #324 for two analysis tools that violated that same rule.

## After

Every driver reproduces its checkpoint in one iteration:

| driver | iteration-1 energy | DIIS error | iterations |
|---|---|---|---|
| diatomic (N2/HF) | −108.9936243937 (exact) | 2.9e-8 | 1 |
| atomic (Ne/LDA) | −127.4907408344 (exact) | 3.5e-8 | 1 |
| gensap (Ne/LDA) | −127.4907408343 | 6.9e-8 | 1 |

## The check (third commit)

Nothing failed while this was broken, so the branch also adds the missing assertion: `fill_block_from_density` returns how well its output reproduces its input — rebuild the block density from the seeded orbitals and occupations, compare in relative Frobenius norm — and each driver reports the worst block. sadatom's own seeding does the same.

It is deliberately the **round trip, not the electron count**. The count is too weak: with the Fock rule the eigenvalues are not occupations at all, but clamping them to `[0, max_occ]` leaves one orbital at `max_occ` and the rest at zero, so an H2 restart summed to exactly 2.000000 electrons while starting the SCF at +6.2e4 Eh. It agreed by coincidence — the density did not.

| scenario | round-trip deviation |
|---|---|
| correct, same basis (H2/HF) | 1.8e-08 |
| correct, cross-basis (nelem 3→4, lmax 4,3→6,5) | 8.0e-09 |
| correct, atomic / gensap (Ne/LDA) | 2.5e-11 / 2.6e-11 |
| **Fock-rule transformation** | **1.4e+08** |

The regimes are 16 orders apart, which sets the threshold at 1e-4. The 1e-8 floor on a sound restart is the clamping of a converged density's near-zero natural occupations to exactly zero, so it cannot be tightened much further. At `verbosity >= 1` the check reports the deviation and the electron count seeded; above threshold it warns unconditionally.

## Verification

Unit tier 8/8; ci tier 49/49 (converged energies never depended on the guess, which is exactly why this hid for so long). The exact-reload test above is the real check, and it is the one that was missing.

Found while implementing the projected-orbital initial guess (tracker task 50), which seeds the SCF through the same helper and inherited the same garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)