### PR TITLE
Document what the ±|m| exchange mirror can actually save

### DIFF
--- a/src/diatomic/basis.cpp
+++ b/src/diatomic/basis.cpp
@@ -2066,6 +2066,23 @@ namespace helfem {
 
         // Mirror the m >= 0 half onto the negative-m output blocks.
         // Channel (l,m) pairs with (l,-m); K(-mj,-mk) = K(mj,mk).
+        //
+        // How much this can save is set by the block structure, not by
+        // this implementation. Whenever the density is block diagonal
+        // in m -- every symmetry >= 1 case -- so is K, so the build
+        // touches
+        //     n0^2 + 2 sum_{m>0} nm^2
+        // output blocks (nm = shells of that |m|), of which the mirror
+        // removes sum_{m>0} nm^2. The ratio approaches 2 only when the
+        // m = 0 channel is negligible, and in the usual angular bases
+        // m = 0 carries the MOST shells, so the ceiling is well below:
+        //     N2  lmax=13,9       358 -> 277 blocks   1.29x
+        //     Cu2 lmax=46,34,28  5979 -> 4094 blocks  1.46x
+        // Counting the work deterministically (output blocks, radial
+        // contractions and multiply flops) reproduces those ratios
+        // exactly, so the mirror already delivers everything the
+        // structure allows. Wall-clock comparisons suggest a shortfall
+        // only because a loaded machine adds +-20% between builds.
         if(absm_symmetric) {
           std::vector<size_t> mirror_ang(Nang, Nang);
           for(size_t a1=0;a1<Nang;a1++)


### PR DESCRIPTION
Closes out the tracker item asking whether the ±|m| equivalence really saves Fock-build time. **It does, fully — but the ceiling is not 2×**, and the commit that introduced it claimed otherwise.

## The structural limit

Whenever the density is block diagonal in m (every `symmetry >= 1` case), so is K. The build therefore touches

```
n0^2 + 2 * sum_{m>0} nm^2     output blocks   (nm = shells of that |m|)
```

of which the mirror removes `sum_{m>0} nm^2`. That ratio approaches 2 only if the m = 0 channel is negligible — but in the angular bases actually used, m = 0 carries the *most* shells:

| system | shells per \|m\| | blocks | ceiling |
|---|---|---|---|
| N2, lmax=13,9 | 14, 9 | 358 → 277 | **1.29×** |
| Cu2, lmax=46,34,28 (the motivating case) | 47, 34, 27 | 5979 → 4094 | **1.46×** |

## The implementation already reaches it

Counting work deterministically — output blocks, radial contractions, and multiply flops — on an H2 probe with the angular basis widened:

| angular basis | blocks (sym=1 → sym=3) | measured ratio | structural prediction |
|---|---|---|---|
| lmax=12,11 | 411 → 290 | 1.417 | 1.417 |
| lmax=12,11,10,9 | 671 → 420 | 1.598 | 1.598 |

Contractions and flops give identical ratios, i.e. the skipped blocks cost the same on average as the kept ones. Nothing is left on the table.

## Why it looked broken

Wall-clock speedups came out at 1.17×–1.31× and *drifted downward* as channels were added, which looks exactly like an implementation that fails to scale. It was machine load: the same build varies ±20% between iterations at load average 13.5. The counters are load independent, which is why they settle it rather than another timing run.

Comment-only change; no behaviour is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)