### PR TITLE
Keep checkpoints basis independent: derive Sinvh, never store it

### DIFF
--- a/src/diatomic/1e.cpp
+++ b/src/diatomic/1e.cpp
@@ -142,7 +142,10 @@ int main(int argc, char **argv) {
   bool diag=true;
   bool symm=false;
   helfem::Matrix Sinvh(basis.Sinvh(!diag,symm));
-  chkpt.write("Sinvh",Sinvh);
+  // Deliberately NOT written to the checkpoint: it is a property of
+  // the basis and the linear-dependence threshold, so a reader on
+  // another machine may legitimately form a different one. Readers
+  // rebuild it from the stored basis instead.
   printf("Half-inverse formed in %.6f\n",timer.get());
   {
     helfem::Matrix Smo(Sinvh.transpose()*S*Sinvh);

--- a/src/diatomic/density_grid.cpp
+++ b/src/diatomic/density_grid.cpp
@@ -82,9 +82,17 @@ int main(int argc, char **argv) {
   loadchk.read("nela",nela);
   loadchk.read("nelb",nelb);
 
-  // Inverse overlap
-  helfem::Matrix Sinvh;
-  loadchk.read("Sinvh", Sinvh);
+  // Inverse overlap, rebuilt from the loaded basis rather than read
+  // from the checkpoint. Sinvh is a property of the basis and of the
+  // linear-dependence threshold applied to it, not of the wave
+  // function: storing it makes the file depend on the machine that
+  // wrote it (a different BLAS or eigensolver can truncate or order
+  // the null space differently), and the SCF drivers do not write it
+  // at all, so reading it made this tool usable only with
+  // diatomic_1e checkpoints. Everything in a checkpoint is in the
+  // finite element basis; anything orthonormal-basis dependent is
+  // derived here, at load time, from the basis in hand.
+  const helfem::Matrix Sinvh(basis.Sinvh(/*chol=*/false, /*sym=*/0));
   helfem::Matrix Sinv(Sinvh*Sinvh.transpose());
 
   // mu array


### PR DESCRIPTION
`Sinvh` is a property of the basis and of the linear-dependence threshold applied to it — not of the wave function. Two machines can legitimately form different ones from the same basis (a different eigensolver or BLAS can order or truncate the null space differently), so a checkpoint that carries it is not portable, and a reader that trusts it is reading *someone else's* orthonormal basis.

## The SCF drivers already follow this rule

`assemble_final_density` and `assemble_final_orbitals` multiply by `Sinvh` before writing, and sadatom converts back with `C_ao = Sinvh * C`. Every quantity in an SCF checkpoint — `Pa`, `Pb`, `Ca`, `Cb`, occupations, basis parameters — is in the finite element basis, and no driver writes `Sinvh`.

## Two places broke it

- **`diatomic_1e`** wrote `Sinvh` into its checkpoint. It no longer does (the local copy still serves the orthonormality report).
- **`diatomic_dgrid`** *read* `Sinvh` from the checkpoint, so it only ever worked with `diatomic_1e` files. Against an SCF checkpoint it threw `The entry Sinvh does not exist` — the same dead-on-arrival failure `diatomic_cpl` had before #320. It now rebuilds `Sinvh` from the loaded basis, which is all it needs: the only use is `Sinv = Sinvh Sinvh^T` to form `S^-1 T C`, a purely basis-derived quantity.

## Verification

`diatomic_dgrid` now runs end to end on an H2/HF SCF checkpoint whose contents are `Ca Cb Pa Pb Rhalf Z1 Z2 bval lval mval n_quad nela nelb occa occb poly_id poly_nnodes` — no `Sinvh` anywhere — and reports orbital non-orthonormality of **3.0e-13** against the basis it rebuilt, so the stored AO orbitals and the locally formed orthonormal basis agree.

Complements #322, which fixes the *transformation* used when projecting a stored AO density into the current orthonormal basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)