### PR TITLE
aij: second-order optimization of orbitals and fractional occupations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,90 @@ Higher-level library linking against `helfem`. Contains SCF infrastructure, DFT 
 | `diatomic_cpl` | `src/diatomic/completeness.cpp` | Completeness profile |
 | `diatomic_dline` | `src/diatomic/density_line.cpp` | Density along bond axis |
 | `diatomic_dgrid` | `src/diatomic/density_grid.cpp` | Density on 2D grid |
+| `aij` | `src/sadatom/aij.cpp` | Atom in jellium |
+
+## Second-order convergence in `aij`
+
+The atom-in-jellium problem optimizes the occupations as well as the
+orbitals, and that is what makes it converge badly at first order. When
+two orbitals are degenerate, moving density between them costs nothing to
+first order in the orbital energies, so the gradient is flat along exactly
+the direction that matters while the real cost -- a dense coupling through
+the Coulomb and XC kernels -- is entirely second order. The spin-restricted
+Fe atom is the standard case: 4s and 3d come out at the same orbital
+energy and sit in different `l` blocks, so no orbital rotation connects
+them at all and their whole interaction is `<4s 4s|W|3d 3d>`. ODA alone
+does not converge it in 2000 iterations; `--secondorder=1` reaches a
+gradient of 1e-9 in a couple of seconds.
+
+`--secondorder=1` runs the first-order solver for `--preiter` iterations
+and then hands over to a trust-region optimizer built on OpenTrustRegion
+(`src/general/trustregion_scf.{h,cpp}`, over the wrapper in
+`otr_solver.{h,cpp}`). The first-order phase only has to find the
+occupation *pattern* -- which shells are fractionally occupied -- and get
+close enough for a quadratic model to mean something; the second-order
+phase optimizes within that pattern and is not the thing that should be
+deciding to open a closed shell.
+
+Two habits worth keeping:
+
+- **`--sotest=1e-4` before trusting a result on a new system.** It checks
+  the analytic gradient and Hessian against finite differences of the
+  energy, including mixed `d1 . H d2` forms that a single-direction check
+  cannot see. Nothing downstream distinguishes a wrong Hessian from a hard
+  problem. For a GGA or meta-GGA the Hessian is *deliberately* approximate
+  -- the kernel keeps only its density-density block -- so `--sotest`
+  measures the deviation (0.14% for PBE, 0.08% for TPSS) instead of
+  failing.
+- **Read the conditioning report at `--verbosity=1`.** It prints the
+  spread of the uncoupled Hessian diagonal and how much of it is
+  near-singular. Exact zeros there are not ill-conditioning, they are a
+  bug: they mean the parameter set contains rotations that do not change
+  the density.
+
+`--soredfac` defaults to 3e-1, a hundred times looser than
+OpenTrustRegion's own default, and that is deliberate. A step whose
+microiterations missed their residual-reduction target is discarded
+however good it is -- probed directly, one discarded step lowered the
+energy by 5.3e-4 and landed on the minimum -- so tightening this does not
+sharpen the answer, it makes the solver throw away good steps until it
+stalls. Loosening it is not a trade either: on the cases that already
+worked it is *cheaper* (Fe LDA 65 Hessian-vector products to 48, Fe PBE 81
+to 55) at identical energies. The same over-tight target was also what
+made `--sosolver=tcg` appear broken.
+
+**Hand over from a well-converged first-order solution.** `--preiter`
+defaults to 100 and lower is not merely slower, it is silently wrong: the
+second-order phase optimizes *within* an occupation pattern and cannot
+discover one. From the core guess (`--preiter=0`) Fe converges in a second
+to an RMS gradient of 5e-9 and an energy 6.1 Eh too high; Cm lands 124 Eh
+too high. Even at `--preiter=20` Fe converges to 2.2e-9 at the *pure-state*
+solution, 0.032 Eh above the ensemble one, because 4s came over exactly
+full. A block frozen on the wrong side of the Fermi level violates the KKT
+conditions of  min E(n) s.t. 0<=n_i<=w, sum n_i = N  -- by Janak's theorem
+dE/dn_i = eps_i, so a full orbital must lie below eps_F and an empty one
+above it. Such a point is stationary for the *restricted* problem with that
+block pinned, which is why the gradient there can be tiny and the energy
+still wrong. The optimizer detects this and releases the block rather than
+merely warning, which repairs the answer outright: Fe at `--preiter=20`
+goes from 0.032 Eh high to exact, and Cm at 20 from 0.029 Eh high to exact.
+It does not rescue a start from the bare core guess, where the orbitals
+themselves are wrong rather than the occupations.
+
+Known weakness: the second-order phase is sensitive to where the
+first-order phase hands over. Fe with TPSS, Cr and Nb all stall at
+`--preiter=40` and all converge in a second at 20, 30, 50 or 60. This is
+not cured, only made cheap -- those cases now stop within a second or two
+a few parts in 10^7 from the minimum, rather than grinding for 900 seconds
+far away from it. A work ceiling, counted per macroiteration so it fires
+on work-without-progress rather than on an absolute budget, is what stops
+them, and it says what happened. If a system matters and stalls, move
+`--preiter`.
+
+Occupation coupling is where the exact preconditioner earns itself, and it
+takes two occupation coordinates to see it -- with one the block is 1x1
+and there is nothing to capture. Curium (5f, 6d and 7s fractionally
+occupied at once) is the demonstration: the exact block reaches an RMS
+gradient of 9.7e-10 where the floored diagonal strands the solve 3.8e-3
+above the minimum. Almost every open-shell atom has only one such
+coordinate, so most systems will never show the difference.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,79 @@ if(HELFEM_BINARIES)
     message(STATUS "libxc ${LIBXC_VERSION}")
 endif()
 
+# OpenTrustRegion -- second-order trust-region orbital optimizer, used by
+# the atom-in-jellium driver where the fractional occupations at the Fermi
+# level leave the first-order methods crawling. It is a Fortran library
+# with a C interface, so it is strictly optional: without it the drivers
+# build exactly as before, minus the --secondorder path.
+#
+# Only the LP64 (32-bit integer) build is usable. The C header picks its
+# integer type from USE_ILP64 at OUR compile time, and we do not define
+# that, so a 64-bit-integer library would disagree with the settings
+# struct we compile against -- silently, since the symbol names are the
+# same either way. helfem::otr therefore carries the LP64 library or
+# nothing at all, and otr_solver.cpp additionally checks the library's
+# own `ilp64` flag at run time.
+option(HELFEM_OPENTRUSTREGION
+       "Use OpenTrustRegion for second-order orbital optimization" ON)
+add_library(helfem_otr INTERFACE)
+add_library(helfem::otr ALIAS helfem_otr)
+set(HELFEM_OPENTRUSTREGION_ACTIVE OFF)
+if(HELFEM_OPENTRUSTREGION)
+    find_package(OpenTrustRegion QUIET COMPONENTS int32)
+    if(OpenTrustRegion_FOUND)
+        target_link_libraries(helfem_otr INTERFACE OpenTrustRegion::opentrustregion)
+        set(HELFEM_OPENTRUSTREGION_ACTIVE ON)
+        message(STATUS "Using system OpenTrustRegion ${OpenTrustRegion_VERSION}")
+    else()
+        # Fetching means compiling Fortran, which HelFEM otherwise does not
+        # need, and linking an LP64 BLAS/LAPACK, which OpenTrustRegion marks
+        # REQUIRED. Both are checked here rather than left to fail inside the
+        # subproject, so a machine without them degrades to a build without
+        # the second-order path instead of a configure error.
+        include(CheckLanguage)
+        check_language(Fortran)
+        set(BLA_SIZEOF_INTEGER 4)
+        find_package(BLAS QUIET)
+        find_package(LAPACK QUIET)
+        if(CMAKE_Fortran_COMPILER AND BLAS_FOUND AND LAPACK_FOUND)
+            message(STATUS "OpenTrustRegion not found; fetching from GitHub")
+            enable_language(Fortran)
+            enable_language(C)
+            include(FetchContent)
+            # Same reasoning as OpenOrbitalOptimizer above: keep the fetched
+            # copy's install() rules out of our install tree, and pin the
+            # commit so two builds of identical HelFEM source cannot link
+            # different optimizers.
+            set(_otr_exclude "")
+            if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+                set(_otr_exclude EXCLUDE_FROM_ALL)
+            endif()
+            # Force the LP64 build; OpenTrustRegion's own autodetection falls
+            # back to ILP64 when it cannot find a 32-bit BLAS, which is the
+            # one outcome we cannot consume.
+            set(INTEGER_SIZE 4 CACHE STRING "OpenTrustRegion integer size" FORCE)
+            set(OpenTrustRegion_BUILD_TESTING OFF CACHE INTERNAL "")
+            FetchContent_Declare(OpenTrustRegion
+                GIT_REPOSITORY https://github.com/eriksen-lab/opentrustregion.git
+                GIT_TAG        v2.0.0
+                ${_otr_exclude})
+            FetchContent_MakeAvailable(OpenTrustRegion)
+            unset(_otr_exclude)
+            target_link_libraries(helfem_otr INTERFACE opentrustregion)
+            set(HELFEM_OPENTRUSTREGION_ACTIVE ON)
+        else()
+            message(STATUS "OpenTrustRegion unavailable "
+                           "(needs a Fortran compiler and an LP64 BLAS/LAPACK); "
+                           "the second-order optimizer will not be built")
+        endif()
+    endif()
+endif()
+if(HELFEM_OPENTRUSTREGION_ACTIVE)
+    target_compile_definitions(helfem_otr INTERFACE HELFEM_HAVE_OPENTRUSTREGION)
+endif()
+install(TARGETS helfem_otr EXPORT helfemTargets)
+
 # ---------------------------------------------------------------------------
 # Build
 # ---------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ general/angular.cpp general/scf_helpers.cpp general/lcao.cpp
 general/dftgrid_common.cpp
 general/gsz.cpp general/sap.cpp general/dftfuncs.cpp
 general/atomdb.cpp general/atomdb_data.cpp
-general/checkpoint.cpp atomic/basis.cpp
+general/checkpoint.cpp general/otr_solver.cpp general/trustregion_scf.cpp atomic/basis.cpp
 atomic/TwoDBasis.cpp
 atomic/dftgrid.cpp sadatom/basis.cpp
 sadatom/dftgrid.cpp sadatom/scf.cpp
@@ -27,6 +27,10 @@ if(TARGET OpenOrbitalOptimizer::OpenOrbitalOptimizer)
 elseif(TARGET openorbitaloptimizer)
     target_link_libraries(helfem-common PUBLIC openorbitaloptimizer)
 endif()
+# OpenTrustRegion (general/otr_solver.cpp). helfem::otr is an empty
+# INTERFACE target when the library is not available, in which case the
+# wrapper compiles to a stub that reports otr::available() == false.
+target_link_libraries(helfem-common PUBLIC helfem::otr)
 # Propagate OpenMP to consumers of helfem-common. Without this, an
 # external consumer linking helfem::helfem misses -fopenmp / libgomp
 # and fails with undefined references like GOMP_parallel.

--- a/src/general/dftgrid_common.cpp
+++ b/src/general/dftgrid_common.cpp
@@ -254,5 +254,106 @@ namespace helfem {
       xc_func_end(&func);
     }
 
+    void DFTGridWorkerBase::init_fxc() {
+      v2rho2 = helfem::Matrix::Zero(polarized ? 3 : 1, wtot.size());
+    }
+
+    void DFTGridWorkerBase::compute_fxc(int func_id, const helfem::Vector & p,
+                                        double thr) {
+      bool gga, mgga_t, mgga_l;
+      is_gga_mgga(func_id, gga, mgga_t, mgga_l);
+
+      const size_t N = (size_t) wtot.size();
+      const int nspin = polarized ? XC_POLARIZED : XC_UNPOLARIZED;
+
+      xc_func_type func;
+      if (xc_func_init(&func, func_id, nspin) != 0) {
+        std::ostringstream oss;
+        oss << "Functional " << func_id << " not found!";
+        throw std::runtime_error(oss.str());
+      }
+      xc_func_set_dens_threshold(&func, thr);
+
+      if (p.size()) {
+        if (p.size() != (Eigen::Index) xc_func_info_get_n_ext_params((xc_func_info_type *) func.info))
+          throw std::logic_error("Incompatible number of parameters!\n");
+        helfem::Vector phlp(p);
+        xc_func_set_ext_params(&func, phlp.data());
+      }
+
+      // A functional without XC_FLAGS_HAVE_FXC would leave the buffer
+      // untouched, i.e. contribute a silently zero kernel; the Hessian
+      // would then be wrong in a way nothing downstream can detect.
+      if (!(func.info->flags & XC_FLAGS_HAVE_FXC)) {
+        xc_func_end(&func);
+        std::ostringstream oss;
+        oss << "Functional " << func_id << " does not implement its second "
+            << "derivatives, so no response kernel can be formed.\n";
+        throw std::logic_error(oss.str());
+      }
+
+      // Only the density-density block is kept; the rest are evaluated
+      // into scratch and discarded. See the header for why an incomplete
+      // GGA / meta-GGA kernel is the right trade here.
+      helfem::Matrix wrk = helfem::Matrix::Zero(v2rho2.rows(), v2rho2.cols());
+      const Eigen::Index n2 = polarized ? 3 : 1;
+      const Eigen::Index n4 = polarized ? 4 : 1;
+      const Eigen::Index n6 = polarized ? 6 : 1;
+      if (mgga_t || mgga_l) {
+        helfem::Matrix rs(n6, N), rl(n4, N), rt(n4, N), s2(n6, N), sl(n6, N),
+            st(n6, N), l2(n2, N), lt(n4, N), t2(n2, N);
+        // libxc dereferences lapl / tau only when the functional asks for
+        // them, exactly as compute_xc above relies on.
+        double *laplp = mgga_l ? lapl.data() : NULL;
+        double *taup = mgga_t ? tau.data() : NULL;
+        double *l2p = mgga_l ? l2.data() : NULL;
+        double *ltp = mgga_l ? lt.data() : NULL;
+        double *rlp = mgga_l ? rl.data() : NULL;
+        double *slp = mgga_l ? sl.data() : NULL;
+        double *t2p = mgga_t ? t2.data() : NULL;
+        double *rtp = mgga_t ? rt.data() : NULL;
+        double *stp = mgga_t ? st.data() : NULL;
+        xc_mgga_fxc(&func, N, rho.data(), sigma.data(), laplp, taup, wrk.data(),
+                    rs.data(), rlp, rtp, s2.data(), slp, stp, l2p, ltp, t2p);
+      } else if (gga) {
+        helfem::Matrix rs(n6, N), s2(n6, N);
+        xc_gga_fxc(&func, N, rho.data(), sigma.data(), wrk.data(), rs.data(),
+                   s2.data());
+      } else {
+        xc_lda_fxc(&func, N, rho.data(), wrk.data());
+      }
+      v2rho2 += wrk;
+
+      xc_func_end(&func);
+    }
+
+    void DFTGridWorkerBase::set_response_potential(const helfem::Matrix & drho) {
+      if (drho.rows() != rho.rows() || drho.cols() != rho.cols()) {
+        std::ostringstream oss;
+        oss << "Perturbation density is " << drho.rows() << "x" << drho.cols()
+            << " but the reference density is " << rho.rows() << "x"
+            << rho.cols() << ".\n";
+        throw std::logic_error(oss.str());
+      }
+
+      if (!polarized) {
+        vxc.row(0) = v2rho2.row(0).array() * drho.row(0).array();
+      } else {
+        // libxc stores the polarized kernel as (uu, ud, dd), so the
+        // response mixes the spin channels: dv_s = sum_t f_st drho_t.
+        vxc.row(0) = v2rho2.row(0).array() * drho.row(0).array() +
+                     v2rho2.row(1).array() * drho.row(1).array();
+        vxc.row(1) = v2rho2.row(1).array() * drho.row(0).array() +
+                     v2rho2.row(2).array() * drho.row(1).array();
+      }
+
+      // The assembly branches on these. The response we assemble is
+      // LDA-shaped whatever the functional is, since only the
+      // density-density kernel block was kept.
+      do_gga    = false;
+      do_mgga_t = false;
+      do_mgga_l = false;
+    }
+
   } // namespace dftgrid_common
 } // namespace helfem

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -78,6 +78,13 @@ namespace helfem {
       /// Functional derivative wrt kinetic energy density
       helfem::Matrix vtau;
 
+      // Response kernel (second derivatives). Only the density-density
+      // block exists so far; see compute_fxc for what a GGA or meta-GGA
+      // kernel would have to add.
+      /// d^2 e_xc / d rho^2. 1 x Npts unpolarized, 3 x Npts (uu, ud, dd)
+      /// polarized -- libxc's own layout.
+      helfem::Matrix v2rho2;
+
     public:
       DFTGridWorkerBase();
       virtual ~DFTGridWorkerBase();
@@ -110,6 +117,41 @@ namespace helfem {
       /// Compute libxc functional contribution and add to exc / vxc /
       /// vsigma / vtau / vlapl. pot=true also computes potentials.
       void compute_xc(int func_id, const helfem::Vector & params, double thr, bool pot = true);
+
+      /// Initialise the kernel buffer. Call between update_density and
+      /// compute_fxc, the same way init_xc precedes compute_xc.
+      void init_fxc();
+
+      /// Accumulate one functional's density-density second derivatives
+      /// into v2rho2, at the density update_density last set. Works for
+      /// LDA, GGA and meta-GGA functionals alike -- libxc has the entry
+      /// point in every case.
+      ///
+      /// For a GGA or meta-GGA this is a DELIBERATELY INCOMPLETE kernel:
+      /// the gradient and tau blocks (v2rhosigma, v2sigma2, v2rhotau,
+      /// ...) are dropped, and so is an assembly term that no choice of
+      /// potential buffers could supply -- the response of a GGA matrix
+      /// contains vsigma * grad(drho), while the eval_Fxc assembly in the
+      /// derived workers can only ever multiply the *stored* gradient of
+      /// the reference density.
+      ///
+      /// That is a sound trade because of where this kernel is used: it
+      /// builds the model Hessian and the preconditioner of a trust
+      /// region method, never the energy or the gradient. A model Hessian
+      /// only has to be of the right order of magnitude to give a good
+      /// direction; the step is then validated against the true energy by
+      /// the trust-region ratio test and the line search, so an
+      /// approximate kernel costs iterations, not correctness. Completing
+      /// the kernel is the natural upgrade, and this is the seam for it.
+      void compute_fxc(int func_id, const helfem::Vector & params, double thr);
+
+      /// Overwrite the potential buffers with the response potential
+      /// f_xc . drho, so that the derived worker's eval_Fxc assembles the
+      /// linear response of the XC matrix instead of the XC matrix
+      /// itself -- the assembly is the same integral either way, and
+      /// this is what lets the response reuse it verbatim. drho carries
+      /// the perturbation density in the same layout as rho.
+      void set_response_potential(const helfem::Matrix & drho);
     };
 
     /// Same as increment_lda below, but for a basis whose real and

--- a/src/general/otr_solver.cpp
+++ b/src/general/otr_solver.cpp
@@ -1,0 +1,221 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#include "otr_solver.h"
+
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+
+#ifdef HELFEM_HAVE_OPENTRUSTREGION
+#include <opentrustregion.h>
+
+extern "C" {
+/// The library records the integer width it was compiled with in this
+/// global. The C header picks c_int from USE_ILP64 on OUR side, so a
+/// mismatch silently changes the layout of the settings struct; the
+/// symbol lets us refuse instead.
+extern bool ilp64;
+}
+#endif
+
+namespace helfem {
+  namespace otr {
+
+#ifdef HELFEM_HAVE_OPENTRUSTREGION
+    namespace {
+      /// The C interface passes bare function pointers with no user-data
+      /// slot, so the only way to reach the caller's closures is
+      /// file-scope state. `active` guards against a second, nested solve
+      /// silently stealing it.
+      const Callbacks *callbacks = nullptr;
+      int nparam = 0;
+      bool active = false;
+      /// Set when a callback throws or reports failure. The C boundary is
+      /// not exception-safe, so the failure is recorded, the library is
+      /// told to stop, and the exception is re-raised in solve().
+      std::string failure;
+
+      /// Report a callback failure to the library. The error codes < 100
+      /// are the range the library reserves for callback errors.
+      int fail(const char *what) {
+        if (failure.empty())
+          failure = what;
+        return 1;
+      }
+
+      c_int hess_x_bridge(const c_real *x, c_real *hx) {
+        try {
+          if (!callbacks->hessian_vector(x, hx))
+            return fail("the Hessian-vector product failed");
+        } catch (std::exception &e) {
+          return fail(e.what());
+        }
+        return 0;
+      }
+
+      c_int update_orbs_bridge(const c_real *kappa, c_real *func, c_real *grad,
+                               c_real *h_diag, hess_x_fp *hess_x_ptr) {
+        *hess_x_ptr = hess_x_bridge;
+        try {
+          double f = 0.0;
+          if (!callbacks->update(kappa, f, grad, h_diag))
+            return fail("the orbital update failed");
+          *func = f;
+        } catch (std::exception &e) {
+          return fail(e.what());
+        }
+        return 0;
+      }
+
+      c_int precond_bridge(const c_real *residual, const c_real *mu,
+                           c_real *out) {
+        try {
+          if (!callbacks->precondition(residual, *mu, out))
+            return fail("the preconditioner failed");
+        } catch (std::exception &e) {
+          return fail(e.what());
+        }
+        return 0;
+      }
+
+      c_int conv_check_bridge(c_bool *converged) {
+        try {
+          bool stop = false;
+          if (!callbacks->converged(stop))
+            return fail("the convergence check failed");
+          *converged = stop;
+        } catch (std::exception &e) {
+          return fail(e.what());
+        }
+        return 0;
+      }
+
+      c_int obj_func_bridge(const c_real *kappa, c_real *func) {
+        try {
+          double f = 0.0;
+          if (!callbacks->objective(kappa, f))
+            return fail("the objective function evaluation failed");
+          *func = f;
+        } catch (std::exception &e) {
+          return fail(e.what());
+        }
+        return 0;
+      }
+
+      /// Decode the library's OOEE error code: OO names the component that
+      /// reported the failure, EE the failure itself.
+      std::string describe_error(int error) {
+        static const struct {
+          int origin;
+          const char *name;
+        } origins[] = {{1, "solver"},      {2, "stability check"},
+                       {11, "obj_func"},   {12, "update_orbs"},
+                       {13, "hess_x"},     {14, "precond"},
+                       {15, "conv_check"}, {16, "project"}};
+
+        std::ostringstream oss;
+        oss << "OpenTrustRegion failed with error code " << error;
+        for (const auto &o : origins)
+          if (error / 100 == o.origin) {
+            oss << " (reported by " << o.name << ")";
+            break;
+          }
+        return oss.str();
+      }
+
+      /// Scoped reset of the file-scope bridge state, so an exception
+      /// thrown out of solve() cannot leave the slot claimed.
+      struct Guard {
+        ~Guard() {
+          callbacks = nullptr;
+          nparam = 0;
+          active = false;
+        }
+      };
+    } // namespace
+
+    bool available() { return true; }
+
+    void solve(int n_param, const Callbacks &cb, const Settings &settings) {
+      if (ilp64)
+        throw std::logic_error(
+            "OpenTrustRegion was built with 64-bit integers, but HelFEM "
+            "compiles its header in the 32-bit (LP64) layout. Rebuild the "
+            "library with -DINTEGER_SIZE=4.\n");
+      if (n_param <= 0)
+        throw std::logic_error("OpenTrustRegion: no parameters to optimize.\n");
+      if (active)
+        throw std::logic_error(
+            "OpenTrustRegion: a solve is already in progress. The C "
+            "interface has no user-data slot, so solves cannot nest.\n");
+      if (!cb.update || !cb.objective || !cb.hessian_vector)
+        throw std::logic_error("OpenTrustRegion: incomplete callback set.\n");
+      if (settings.subsystem_solver.size() > OTR_KW_LEN)
+        throw std::logic_error("OpenTrustRegion: subsystem solver name too "
+                               "long.\n");
+
+      Guard guard;
+      callbacks = &cb;
+      nparam = n_param;
+      active = true;
+      failure.clear();
+
+      solver_settings_type s = solver_settings_init();
+      s.conv_tol = settings.conv_tol;
+      s.start_trust_radius = settings.start_trust_radius;
+      s.n_macro = settings.n_macro;
+      s.n_micro = settings.n_micro;
+      s.n_random_trial_vectors = settings.n_random_trial_vectors;
+      s.global_red_factor = settings.global_red_factor;
+      s.local_red_factor = settings.local_red_factor;
+      s.line_search = settings.line_search;
+      s.stability = settings.stability;
+      s.verbose = settings.verbose;
+      s.seed = settings.seed;
+      if (cb.precondition)
+        s.precond = precond_bridge;
+      if (cb.converged)
+        s.conv_check = conv_check_bridge;
+      std::memset(s.subsystem_solver, 0, sizeof(s.subsystem_solver));
+      std::strncpy(s.subsystem_solver, settings.subsystem_solver.c_str(),
+                   OTR_KW_LEN);
+
+      const c_int error = ::solver(update_orbs_bridge, obj_func_bridge,
+                                   (c_int)n_param, s);
+
+      // A callback failure is reported through the library, which unwinds
+      // and returns an error code; the real message is the one we recorded.
+      if (!failure.empty())
+        throw std::runtime_error("OpenTrustRegion aborted: " + failure + "\n");
+      if (error != 0)
+        throw std::runtime_error(describe_error((int)error) + "\n");
+    }
+
+#else
+
+    bool available() { return false; }
+
+    void solve(int, const Callbacks &, const Settings &) {
+      throw std::logic_error(
+          "This HelFEM was built without OpenTrustRegion, so the "
+          "second-order optimizer is unavailable. Configure with "
+          "-DHELFEM_OPENTRUSTREGION=ON (needs a Fortran compiler and an "
+          "LP64 BLAS/LAPACK).\n");
+    }
+
+#endif
+
+  } // namespace otr
+} // namespace helfem

--- a/src/general/otr_solver.h
+++ b/src/general/otr_solver.h
@@ -1,0 +1,114 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef HELFEM_OTR_SOLVER_H
+#define HELFEM_OTR_SOLVER_H
+
+#include <functional>
+#include <string>
+
+namespace helfem {
+  /// Thin C++ wrapper around OpenTrustRegion's C interface.
+  ///
+  /// OpenTrustRegion minimizes an objective that is parametrized by a step
+  /// vector taken from a *reference* point which the caller owns. The
+  /// division of labour is
+  ///
+  ///   update(kappa, ...)  apply the step, MAKE IT THE NEW REFERENCE, and
+  ///                       report the objective, gradient and Hessian
+  ///                       diagonal there;
+  ///   objective(kappa)    apply the step to the current reference WITHOUT
+  ///                       adopting it, and report only the objective;
+  ///   hessian_vector(x)   Hessian-vector product at the current reference.
+  ///
+  /// Every kappa the library hands out is relative to whatever `update` last
+  /// installed, never to the starting point, so the caller never has to
+  /// accumulate steps itself.
+  ///
+  /// The C interface passes bare function pointers with no user-data slot,
+  /// so the callbacks are bridged through file-scope state. Only one solve
+  /// can therefore be in flight at a time; solve() throws rather than
+  /// corrupting a running one.
+  namespace otr {
+    /// The three callbacks the solver drives. Each returns false to signal
+    /// failure, which aborts the solve with an exception.
+    struct Callbacks {
+      /// Apply the step, adopt it, and evaluate. grad and h_diag are
+      /// n_param long and are written in place.
+      std::function<bool(const double *kappa, double &func, double *grad,
+                         double *h_diag)>
+          update;
+      /// Apply the step without adopting it, and evaluate the objective.
+      std::function<bool(const double *kappa, double &func)> objective;
+      /// Hessian-vector product at the current reference: hx = H x.
+      std::function<bool(const double *x, double *hx)> hessian_vector;
+      /// Optional extra convergence criterion, checked once per
+      /// macroiteration: returning true stops the solve. Used to bail out
+      /// when the parametrization itself has gone stale, which no
+      /// gradient threshold can detect.
+      std::function<bool(bool &stop)> converged;
+      /// Optional preconditioner: out = (M - mu)^-1 r at level shift mu.
+      /// Left empty, the library falls back to its own
+      /// (level-shifted) absolute-diagonal preconditioner built from the
+      /// h_diag `update` reported.
+      std::function<bool(const double *r, double mu, double *out)> precondition;
+    };
+
+    /// Solver settings. The defaults here are OpenTrustRegion's own, except
+    /// where noted; anything left at the library default is not touched.
+    struct Settings {
+      /// Convergence threshold on the RMS gradient
+      double conv_tol = 1e-5;
+      /// Initial trust radius
+      double start_trust_radius = 0.4;
+      /// Maximum number of macroiterations
+      int n_macro = 150;
+      /// Maximum number of microiterations
+      int n_micro = 50;
+      /// Number of random trial vectors seeding the microiterations
+      int n_random_trial_vectors = 1;
+      /// How far the microiterations must reduce the residual before the
+      /// trust-region step counts as solved, far from and near a solution.
+      ///
+      /// These matter more than their obscurity suggests. A step whose
+      /// subproblem did not meet this target is REJECTED outright, however
+      /// good it is -- measured, a rejected step here lowered the energy by
+      /// 5.3e-4 and landed on the minimum. On an ill-conditioned Hessian
+      /// the target can be unreachable within n_micro, and the solve then
+      /// throws away good steps until it stalls.
+      double global_red_factor = 3e-1;
+      double local_red_factor = 3e-2;
+      /// Microiteration solver: "davidson", "jacobi-davidson" or "tcg"
+      std::string subsystem_solver = "davidson";
+      /// Line search after every macroiteration
+      bool line_search = false;
+      /// Stability check on convergence
+      bool stability = false;
+      /// Output detail, 0 silent
+      int verbose = 3;
+      /// Seed for the random trial vectors
+      int seed = 42;
+    };
+
+    /// Was HelFEM built against OpenTrustRegion?
+    bool available();
+
+    /// Run the trust-region solver over n_param parameters. Throws if the
+    /// library is absent, if a callback failed, or if the solver reported
+    /// an error (including non-convergence).
+    void solve(int n_param, const Callbacks &cb, const Settings &settings);
+  } // namespace otr
+} // namespace helfem
+
+#endif

--- a/src/general/trustregion_scf.cpp
+++ b/src/general/trustregion_scf.cpp
@@ -1,0 +1,1234 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#include "trustregion_scf.h"
+
+#include <Eigen/Eigenvalues>
+#include <Eigen/QR>
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdio>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+
+namespace helfem {
+  namespace trscf {
+
+    namespace {
+      /// An occupation this close to empty or full counts as integer: the
+      /// filling coordinate of such a block sits on a kink (an orbital
+      /// just filled) or a bound (the block is empty), not in the smooth
+      /// interior, so it is not a free parameter.
+      const double occ_tol = 1e-6;
+      /// Floor on |lambda - mu| in the preconditioner, matching
+      /// OpenTrustRegion's own precond_floor.
+      const double precond_floor = 1e-10;
+
+      /// exp(A) for a real antisymmetric A. i*A is Hermitian, so
+      /// diagonalizing it exponentiates the eigenvalues exactly and the
+      /// result is orthogonal by construction -- no scaling-and-squaring
+      /// truncation, and no dependence on Eigen's unsupported modules.
+      helfem::Matrix expm_skew(const helfem::Matrix &A) {
+        const Eigen::Index n = A.rows();
+        if (n == 0)
+          return helfem::Matrix(0, 0);
+        const std::complex<double> im(0.0, 1.0);
+        Eigen::MatrixXcd H = im * A.cast<std::complex<double>>();
+        Eigen::SelfAdjointEigenSolver<Eigen::MatrixXcd> es(H);
+        Eigen::VectorXcd ph =
+            (-im * es.eigenvalues().cast<std::complex<double>>()).array().exp();
+        return (es.eigenvectors() * ph.asDiagonal() *
+                es.eigenvectors().adjoint())
+            .real();
+      }
+
+      /// U * exp(kappa), where kappa is antisymmetric and supported only
+      /// on rows and columns 0..m-1 (the occupied and fractionally
+      /// occupied orbitals; rotations among the virtuals are redundant
+      /// and are not parameters).
+      ///
+      /// That support means kappa has rank at most 2m: its range lies in
+      /// span{e_0..e_{m-1}} plus the virtual part of its first m columns.
+      /// Projecting onto an orthonormal basis Q of those 2m directions
+      /// turns the exponential into a 2m x 2m problem,
+      /// exp(kappa) = I + Q (exp(Q'kappa Q) - I) Q', which costs O(n^2 m)
+      /// instead of the O(n^3) a dense exponential would -- and this is
+      /// called once per block per objective evaluation, so the
+      /// difference is the difference between a usable optimizer and an
+      /// unusable one.
+      helfem::Matrix apply_kappa(const helfem::Matrix &U,
+                                 const helfem::Matrix &kappa, Eigen::Index m) {
+        const Eigen::Index n = kappa.rows();
+        if (kappa.cwiseAbs().maxCoeff() == 0.0)
+          return U;
+        if (2 * m >= n)
+          // The projection would not shrink anything.
+          return U * expm_skew(kappa);
+
+        // Orthonormal basis of the virtual part of the first m columns.
+        Eigen::HouseholderQR<helfem::Matrix> qr(kappa.bottomLeftCorner(n - m, m));
+        const helfem::Matrix Zq =
+            qr.householderQ() * helfem::Matrix::Identity(n - m, m);
+
+        helfem::Matrix Q = helfem::Matrix::Zero(n, 2 * m);
+        Q.topLeftCorner(m, m) = helfem::Matrix::Identity(m, m);
+        Q.bottomRightCorner(n - m, m) = Zq;
+
+        helfem::Matrix kt = Q.transpose() * kappa * Q;
+        // Antisymmetrize away the roundoff, so expm_skew's Hermitian
+        // eigensolver sees exactly what it expects.
+        kt = 0.5 * (kt - kt.transpose());
+        helfem::Matrix E = expm_skew(kt);
+        E.diagonal().array() -= 1.0;
+
+        return U + (U * Q) * E * Q.transpose();
+      }
+
+      /// Symmetric (Loewdin) reorthonormalization, to stop the reference
+      /// orbitals drifting off the orthogonal manifold over many
+      /// macroiterations of rounded exponentials.
+      void reorthonormalize(helfem::Matrix &U) {
+        const helfem::Matrix S = U.transpose() * U;
+        Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(S);
+        const helfem::Vector isq = es.eigenvalues().array().rsqrt();
+        U = U * (es.eigenvectors() * isq.asDiagonal() *
+                 es.eigenvectors().transpose());
+      }
+
+      /// Euclidean projection onto the simplex {q >= 0, sum q = total}.
+      void project_simplex(std::vector<double> &q, double total) {
+        const size_t n = q.size();
+        if (n == 0)
+          return;
+
+        // A feasible point is its own projection, so return it untouched
+        // rather than round-tripping it through the arithmetic below: the
+        // sum is conserved by construction, but only to rounding, and the
+        // shift that leaks out of that is applied to every filling on
+        // every objective evaluation. The steps this guards are almost
+        // never needed -- a free block leaving q >= 0 is a pattern change,
+        // not a normal step -- so the common path should be exactly the
+        // identity, not the identity plus 1e-16.
+        bool feasible = true;
+        for (size_t i = 0; i < n; i++)
+          if (q[i] < 0.0) {
+            feasible = false;
+            break;
+          }
+        if (feasible)
+          return;
+
+        std::vector<double> u(q);
+        std::sort(u.begin(), u.end(), std::greater<double>());
+        double csum = 0.0, theta = 0.0;
+        size_t rho = 0;
+        for (size_t j = 0; j < n; j++) {
+          csum += u[j];
+          const double t = (csum - total) / (double)(j + 1);
+          if (u[j] - t > 0.0) {
+            rho = j + 1;
+            theta = t;
+          }
+        }
+        if (rho == 0)
+          theta = (csum - total) / (double)n;
+        for (size_t i = 0; i < n; i++)
+          q[i] = std::max(q[i] - theta, 0.0);
+      }
+
+      /// Orthonormal basis of the sum-zero subspace of R^n (Helmert).
+      /// Column m has m ones, then -m, then zeros. Orthonormal, so the
+      /// parameter metric stays isotropic instead of singling out one
+      /// block the way eliminating q_0 would.
+      helfem::Matrix helmert(size_t n) {
+        if (n < 2)
+          return helfem::Matrix::Zero((Eigen::Index)n, 0);
+        helfem::Matrix U =
+            helfem::Matrix::Zero((Eigen::Index)n, (Eigen::Index)n - 1);
+        for (Eigen::Index m = 1; m < (Eigen::Index)n; m++) {
+          const double nrm = std::sqrt((double)m * (m + 1));
+          for (Eigen::Index i = 0; i < m; i++)
+            U(i, m - 1) = 1.0 / nrm;
+          U(m, m - 1) = -(double)m / nrm;
+        }
+        return U;
+      }
+    } // namespace
+
+    Optimizer::Optimizer(const helfem::Matrix &Sinvh,
+                         const std::vector<double> &maxocc,
+                         const std::vector<size_t> &blocks_per_particle,
+                         FockBuilder fock, ResponseBuilder response)
+        : Sinvh_(Sinvh), maxocc_(maxocc), fock_(fock), response_(response) {
+      size_t b = 0;
+      for (size_t p = 0; p < blocks_per_particle.size(); p++) {
+        std::vector<size_t> blocks;
+        for (size_t i = 0; i < blocks_per_particle[p]; i++, b++) {
+          blocks.push_back(b);
+          particle_.push_back(p);
+        }
+        pblocks_.push_back(blocks);
+      }
+      if (b != maxocc_.size()) {
+        std::ostringstream oss;
+        oss << "Block count mismatch: " << b << " blocks across the particle "
+            << "types but " << maxocc_.size() << " maximum occupations.\n";
+        throw std::logic_error(oss.str());
+      }
+    }
+
+    void Optimizer::fill_occupations(size_t b, double q, helfem::Vector &f,
+                                     Eigen::Index &k) const {
+      const Eigen::Index n = Nrad();
+      const double w = maxocc_[b];
+      f = helfem::Vector::Zero(n);
+      for (Eigen::Index i = 0; i < n; i++)
+        f(i) = std::min(std::max(q - (double)i * w, 0.0), w);
+
+      // The active orbital is the first one that is not full to within
+      // the tolerance -- found by scanning rather than as floor(q/w),
+      // which lands on the orbital BELOW at an exact shell filling as
+      // soon as q is a rounded 11.999999999 rather than 12. That
+      // off-by-one would make a closed shell look partly open, and would
+      // make the aufbau check read the filled orbital's energy instead of
+      // the empty one's.
+      k = n - 1;
+      for (Eigen::Index i = 0; i < n; i++)
+        if (f(i) < w - occ_tol) {
+          k = i;
+          break;
+        }
+    }
+
+    void Optimizer::set_reference(const std::vector<helfem::Matrix> &orbs,
+                                  const std::vector<helfem::Vector> &occs) {
+      if (orbs.size() != nblock() || occs.size() != nblock())
+        throw std::logic_error(
+            "Wrong number of blocks handed to the second-order optimizer.\n");
+
+      U_ = orbs;
+      q_.assign(nblock(), 0.0);
+      f_.resize(nblock());
+      active_.assign(nblock(), 0);
+      C_.resize(nblock());
+
+      for (size_t b = 0; b < nblock(); b++) {
+        if (orbs[b].rows() != Nrad() || orbs[b].cols() != Nrad()) {
+          std::ostringstream oss;
+          oss << "Block " << b << " has " << orbs[b].rows() << "x"
+              << orbs[b].cols() << " orbitals, expected " << Nrad() << "x"
+              << Nrad() << ".\n";
+          throw std::logic_error(oss.str());
+        }
+        // The occupations are read only as a block electron count: which
+        // orbital is the fractional one follows from the ordering, which
+        // the first-order solver leaves in ascending orbital energy.
+        q_[b] = occs[b].sum();
+        for (Eigen::Index i = 1; i < occs[b].size(); i++)
+          if (occs[b](i) > occs[b](i - 1) + occ_tol) {
+            std::ostringstream oss;
+            oss << "Block " << b << " has occupation " << occs[b](i)
+                << " above orbital " << i - 1 << "'s " << occs[b](i - 1)
+                << ". The second-order parametrization fills each block in "
+                << "orbital order, so the orbitals must arrive sorted by "
+                << "energy.\n";
+            throw std::logic_error(oss.str());
+          }
+        fill_occupations(b, q_[b], f_[b], active_[b]);
+        C_[b] = Sinvh_ * U_[b];
+      }
+    }
+
+    void Optimizer::build_layout() {
+      pair_i_.assign(nblock(), std::vector<Eigen::Index>());
+      pair_j_.assign(nblock(), std::vector<Eigen::Index>());
+      koff_.assign(nblock(), 0);
+
+      const Eigen::Index n = Nrad();
+      size_t off = 0;
+      for (size_t b = 0; b < nblock(); b++) {
+        koff_[b] = off;
+        const Eigen::Index k = active_[b];
+        // A rotation changes the density only if the two orbitals differ
+        // in occupation, so the non-redundant set is exactly the pairs
+        // with f_i != f_j. Under aufbau filling that is: both below k
+        // means both full; both above k means both empty; and -- the case
+        // that is easy to miss -- if orbital k itself carries nothing,
+        // which is what a block sitting at an exact shell filling or an
+        // empty block looks like, then (k, j > k) is empty-against-empty
+        // too.
+        //
+        // Missing that last one made every empty block contribute Nrad-1
+        // parameters that were all exactly redundant: zero gradient, zero
+        // Hessian. They cost more than their arithmetic. They inflate the
+        // parameter count, they seed the Davidson subspace with null
+        // directions, and they make the trust-region norm count distances
+        // along coordinates that do not move the energy at all.
+        const bool active_occupied = (f_[b](k) > occ_tol);
+        for (Eigen::Index i = 0; i < n; i++)
+          for (Eigen::Index j = i + 1; j < n; j++) {
+            if (i < k && j < k)
+              continue;
+            if (i > k && j > k)
+              continue;
+            if (i == k && !active_occupied)
+              continue;
+            pair_i_[b].push_back(i);
+            pair_j_[b].push_back(j);
+          }
+        off += pair_i_[b].size();
+      }
+      qoff_ = off;
+
+      // Free occupation coordinates: the blocks whose fractionally
+      // occupied orbital really is fractional. A block at an exact shell
+      // filling sits on the kink where one orbital has just filled and
+      // the next has not started, and an empty block sits on q = 0; in
+      // neither case is the filling a smooth coordinate, and in neither
+      // case should a local second-order step be the thing that decides
+      // to open a closed shell. That decision belongs to the first-order
+      // phase that hands over the occupation pattern.
+      sumzero_.assign(pblocks_.size(), helfem::Matrix());
+      free_.assign(pblocks_.size(), std::vector<size_t>());
+      for (size_t p = 0; p < pblocks_.size(); p++) {
+        for (size_t b : pblocks_[p]) {
+          // The active orbital is never full by construction, so a block
+          // is free exactly when that orbital carries something.
+          if (f_[b](active_[b]) > occ_tol)
+            free_[p].push_back(b);
+        }
+        sumzero_[p] = helmert(free_[p].size());
+        off += (size_t)sumzero_[p].cols();
+      }
+      nparam_ = off;
+
+      entry_active_ = active_;
+      pattern_changed_ = false;
+    }
+
+    bool Optimizer::pattern_stale() const {
+      // Only the free blocks can move: the others have no parameter to
+      // move them. A free block leaves the pattern when its fractional
+      // orbital fills or empties, at which point the pair list built
+      // around that orbital, and the sum-zero basis built around the set
+      // of free blocks, both describe a different problem.
+      // The active index is checked for EVERY block, not just the free
+      // ones: a frozen block moving would mean something changed an
+      // occupation that has no parameter, and that is worth catching
+      // rather than trusting it cannot happen.
+      for (size_t b = 0; b < nblock(); b++)
+        if (active_[b] != entry_active_[b])
+          return true;
+      for (size_t p = 0; p < pblocks_.size(); p++)
+        for (size_t b : free_[p])
+          if (f_[b](active_[b]) <= occ_tol ||
+              f_[b](active_[b]) >= maxocc_[b] - occ_tol)
+            return true;
+      return false;
+    }
+
+    void Optimizer::report_conditioning(int verbosity) const {
+      if (verbosity < 1 || nparam_ == 0)
+        return;
+
+      // The orbital part of the uncoupled diagonal. Its spread IS the
+      // conditioning of the model: a rotation whose (f_i-f_j)(F_jj-F_ii)
+      // is tiny is a direction the quadratic model barely sees.
+      helfem::Vector d(hdiag_.head((Eigen::Index)qoff_).cwiseAbs());
+      if (qoff_ > 0) {
+        std::vector<double> s(d.data(), d.data() + d.size());
+        std::sort(s.begin(), s.end());
+        const double top = s.back();
+        size_t below3 = 0, below6 = 0;
+        for (double v : s) {
+          if (v < 1e-3 * top) below3++;
+          if (v < 1e-6 * top) below6++;
+        }
+        printf("  orbital Hessian diagonal: %.3e to %.3e, median %.3e\n",
+               s.front(), top, s[s.size() / 2]);
+        printf("  %i of %i rotations below 1e-3 of the largest, %i below "
+               "1e-6: those are the directions the model cannot resolve\n",
+               (int)below3, (int)qoff_, (int)below6);
+      }
+
+      if (exact_val_.size())
+        printf("  exactly built subspace: %i parameters, eigenvalues %.3e to "
+               "%.3e\n",
+               (int)exact_val_.size(), exact_val_.minCoeff(),
+               exact_val_.maxCoeff());
+
+      // How much room each free filling has before it hits a shell edge.
+      // That headroom is the radius within which the energy is smooth in
+      // this coordinate: past it the gradient jumps from one orbital
+      // energy to the next, and a step that crosses it is being scored by
+      // a quadratic model of a function that has a corner in the way.
+      for (size_t p = 0; p < pblocks_.size(); p++)
+        for (size_t b : free_[p]) {
+          const double fk = f_[b](active_[b]);
+          printf("  block %i filling: orbital %i holds %.6f of %.1f, so the "
+                 "smooth range runs %.6f down and %.6f up\n",
+                 (int)b, (int)active_[b], fk, maxocc_[b], fk, maxocc_[b] - fk);
+        }
+      fflush(stdout);
+    }
+
+    bool Optimizer::release_kkt_violation(int verbosity) {
+      // The KKT conditions of  min E(n)  s.t.  0 <= n_i <= w,  sum n_i = N
+      // are, with eps_i = dE/dn_i by Janak's theorem,
+      //
+      //     0 < n_i < w   =>   eps_i == eps_F
+      //         n_i = w   =>   eps_i <= eps_F
+      //         n_i = 0   =>   eps_i >= eps_F
+      //
+      // A block frozen at an integer occupation satisfies the second or
+      // third of those only by luck. When it does not, the point is a
+      // stationary point of the RESTRICTED problem -- the one with that
+      // block pinned -- and not of the problem being solved, which is why
+      // the gradient can be tiny there and the energy still wrong.
+      //
+      // The fix is not to report it. Multiplier signs say which way charge
+      // wants to move, so move a little that way: the block then has a
+      // fractional occupation, becomes a free coordinate when the layout is
+      // rebuilt, and the optimizer can carry the rest.
+      const double nudge = 1e-3;
+
+      for (size_t p = 0; p < pblocks_.size(); p++) {
+        if (free_[p].empty())
+          continue;
+        double efermi = -std::numeric_limits<double>::max();
+        for (size_t b : free_[p])
+          efermi = std::max(efermi, F_[b](active_[b], active_[b]));
+
+        for (size_t b : pblocks_[p]) {
+          if (std::find(free_[p].begin(), free_[p].end(), b) != free_[p].end())
+            continue;
+
+          // Frozen full, but its topmost filled orbital sits above the
+          // Fermi level: it should give charge up.
+          if (active_[b] > 0 &&
+              F_[b](active_[b] - 1, active_[b] - 1) > efermi + 1e-8) {
+            size_t to = free_[p][0];
+            for (size_t c : free_[p])
+              if (F_[c](active_[c], active_[c]) < F_[to](active_[to], active_[to]))
+                to = c;
+            if (verbosity >= 1)
+              printf("\nBlock %i is pinned full at % .6f, above the Fermi level "
+                     "% .6f, so the solution\n         satisfies the "
+                     "stationarity of a restricted problem and not the KKT "
+                     "conditions of this one.\n         Releasing it towards "
+                     "block %i.\n",
+                     (int)b, F_[b](active_[b] - 1, active_[b] - 1), efermi,
+                     (int)to);
+            q_[b] -= nudge;
+            q_[to] += nudge;
+            return true;
+          }
+
+          // Frozen empty (or at a shell edge), but the orbital that would
+          // fill next sits below the Fermi level: it should take charge on.
+          if (F_[b](active_[b], active_[b]) < efermi - 1e-8) {
+            size_t from = free_[p][0];
+            for (size_t c : free_[p])
+              if (F_[c](active_[c], active_[c]) > F_[from](active_[from], active_[from]))
+                from = c;
+            if (q_[from] <= nudge)
+              continue;
+            if (verbosity >= 1)
+              printf("\nBlock %i is pinned with its next orbital at % .6f, below "
+                     "the Fermi level % .6f,\n         which violates the KKT "
+                     "conditions. Releasing it from block %i.\n",
+                     (int)b, F_[b](active_[b], active_[b]), efermi, (int)from);
+            q_[b] += nudge;
+            q_[from] -= nudge;
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    void Optimizer::check_aufbau(int verbosity) const {
+      // The blocks held frozen are frozen because their topmost orbital
+      // is exactly full or exactly empty. That is only the right answer
+      // if the orbital that would fill next lies above the Fermi level;
+      // otherwise the solution is stationary but not aufbau, and the
+      // occupation pattern handed over was wrong.
+      double efermi = -std::numeric_limits<double>::max();
+      bool have_fermi = false;
+      for (size_t p = 0; p < pblocks_.size(); p++)
+        for (size_t b : free_[p]) {
+          efermi = std::max(efermi, F_[b](active_[b], active_[b]));
+          have_fermi = true;
+        }
+      if (!have_fermi)
+        return;
+
+      // A block frozen at an integer occupation can be wrong in two ways,
+      // and by Janak's theorem dE/dn_i = eps_i both are read off the same
+      // orbital energies. It may want to RECEIVE charge, if the orbital
+      // that would fill next lies below the Fermi level. Or it may want to
+      // GIVE UP charge, if its topmost filled orbital lies above it --
+      // which is the more dangerous of the two, because the solve then
+      // converges tidily to the pure-state solution and reports a
+      // perfectly small gradient. Measured on Fe handed over at 20
+      // first-order iterations: 4s full at -0.163 against 3d at -0.248,
+      // converged to 2.2e-9, and 0.032 Eh above the ensemble minimum with
+      // nothing in the output to say so.
+      for (size_t p = 0; p < pblocks_.size(); p++)
+        for (size_t b : pblocks_[p]) {
+          if (std::find(free_[p].begin(), free_[p].end(), b) != free_[p].end())
+            continue;
+          // active_ is the first orbital that is not full, i.e. the one
+          // that would receive charge if this block opened up.
+          const double enext = F_[b](active_[b], active_[b]);
+          if (enext < efermi - 1e-8 && verbosity >= 1)
+            printf("WARNING: block %i is held at an integer occupation, but its "
+                   "next orbital lies at % .6f, below the Fermi level % .6f.\n"
+                   "         The occupation pattern is not aufbau-stable; the "
+                   "first-order phase handed over the wrong one.\n",
+                   (int)b, enext, efermi);
+          // ... and the topmost orbital it actually holds.
+          if (active_[b] > 0) {
+            const double etop = F_[b](active_[b] - 1, active_[b] - 1);
+            if (etop > efermi + 1e-8 && verbosity >= 1)
+              printf("WARNING: block %i is held full up to an orbital at % .6f, "
+                     "above the Fermi level % .6f.\n"
+                     "         Moving charge out of it would lower the energy, "
+                     "so this is a pure-state solution and not the ensemble "
+                     "one.\n         Hand over from a better converged "
+                     "first-order solution (--preiter).\n",
+                     (int)b, etop, efermi);
+          }
+        }
+    }
+
+    void Optimizer::project_fillings(std::vector<double> &q) const {
+      // Only the free fillings are projected. They are the only ones a
+      // step can move, and they conserve their own sum, so the frozen
+      // blocks must come through untouched -- projecting over all of them
+      // would let a clamp on one free block shift charge into a frozen
+      // one, which changes an occupation nobody is watching: pattern_stale
+      // would not see it, because the block has no parameter to have moved.
+      for (size_t p = 0; p < pblocks_.size(); p++) {
+        if (free_[p].empty())
+          continue;
+        double total = 0.0;
+        std::vector<double> sub;
+        for (size_t b : free_[p]) {
+          sub.push_back(q[b]);
+          total += q_[b];
+        }
+        project_simplex(sub, total);
+        for (size_t i = 0; i < free_[p].size(); i++)
+          q[free_[p][i]] = sub[i];
+      }
+    }
+
+    void Optimizer::decode(const double *x, std::vector<helfem::Matrix> &kappa,
+                           std::vector<double> &dq) const {
+      kappa.assign(nblock(), helfem::Matrix::Zero(Nrad(), Nrad()));
+      for (size_t b = 0; b < nblock(); b++)
+        for (size_t p = 0; p < pair_i_[b].size(); p++) {
+          const double v = x[koff_[b] + p];
+          kappa[b](pair_i_[b][p], pair_j_[b][p]) = v;
+          kappa[b](pair_j_[b][p], pair_i_[b][p]) = -v;
+        }
+
+      dq.assign(nblock(), 0.0);
+      size_t off = qoff_;
+      for (size_t p = 0; p < pblocks_.size(); p++) {
+        const Eigen::Index ny = sumzero_[p].cols();
+        if (ny <= 0)
+          continue;
+        Eigen::Map<const helfem::Vector> y(x + off, ny);
+        const helfem::Vector d = sumzero_[p] * y;
+        for (size_t i = 0; i < free_[p].size(); i++)
+          dq[free_[p][i]] = d((Eigen::Index)i);
+        off += (size_t)ny;
+      }
+    }
+
+    void Optimizer::displace(const std::vector<helfem::Matrix> &kappa,
+                             const std::vector<double> &dq,
+                             std::vector<helfem::Matrix> &U,
+                             std::vector<double> &q) const {
+      U.resize(nblock());
+      q.resize(nblock());
+      for (size_t b = 0; b < nblock(); b++) {
+        U[b] = apply_kappa(U_[b], kappa[b], active_[b] + 1);
+        q[b] = q_[b] + dq[b];
+      }
+      project_fillings(q);
+    }
+
+    void Optimizer::densities(const std::vector<helfem::Matrix> &U,
+                              const std::vector<double> &q,
+                              helfem::Cube &P) const {
+      P.assign(nblock(), helfem::Matrix::Zero(Sinvh_.rows(), Sinvh_.rows()));
+      for (size_t b = 0; b < nblock(); b++) {
+        helfem::Vector f;
+        Eigen::Index k;
+        fill_occupations(b, q[b], f, k);
+        // Only orbitals up to the fractionally occupied one carry any
+        // density, so the density build is O(Nfem^2 * nocc), not O(N^3).
+        const Eigen::Index nocc = k + 1;
+        const helfem::Matrix Cocc = Sinvh_ * U[b].leftCols(nocc);
+        P[b] = Cocc * f.head(nocc).asDiagonal() * Cocc.transpose();
+      }
+    }
+
+    void Optimizer::gradient(double *g) const {
+      for (size_t b = 0; b < nblock(); b++) {
+        const helfem::Matrix &F = F_[b];
+        const helfem::Vector &f = f_[b];
+        for (size_t p = 0; p < pair_i_[b].size(); p++) {
+          const Eigen::Index i = pair_i_[b][p], j = pair_j_[b][p];
+          g[koff_[b] + p] = 2.0 * F(i, j) * (f(j) - f(i));
+        }
+      }
+
+      // dE/dq_b is the Fock expectation value of the orbital whose
+      // occupation the filling coordinate moves.
+      size_t off = qoff_;
+      for (size_t p = 0; p < pblocks_.size(); p++) {
+        const Eigen::Index ny = sumzero_[p].cols();
+        if (ny <= 0)
+          continue;
+        helfem::Vector gq((Eigen::Index)free_[p].size());
+        for (size_t i = 0; i < free_[p].size(); i++) {
+          const size_t b = free_[p][i];
+          gq((Eigen::Index)i) = F_[b](active_[b], active_[b]);
+        }
+        const helfem::Vector gy = sumzero_[p].transpose() * gq;
+        for (Eigen::Index i = 0; i < ny; i++)
+          g[off + (size_t)i] = gy(i);
+        off += (size_t)ny;
+      }
+    }
+
+    helfem::Matrix Optimizer::occupation_hessian() const {
+      // The exact second derivative of the energy with respect to the
+      // block fillings. Since the density is linear in the occupations at
+      // fixed orbitals, there is no d^2P/dq^2 term and the whole thing is
+      // the kernel sandwiched between the two active orbital densities:
+      //     H(b,c) = <k_b k_b | W | k_c k_c>,  W = Coulomb + f_xc.
+      // One probe per block gives a whole column, and the probes are
+      // batched so the grid work is done once.
+      const size_t nb = nblock();
+      helfem::Cube P;
+      densities(U_, q_, P);
+
+      std::vector<helfem::Cube> probe(nb), resp;
+      for (size_t c = 0; c < nb; c++) {
+        probe[c].assign(nb, helfem::Matrix::Zero(Sinvh_.rows(), Sinvh_.rows()));
+        const helfem::Vector ck = C_[c].col(active_[c]);
+        probe[c][c] = ck * ck.transpose();
+      }
+      response_(P, probe, resp);
+      stats_.n_response++;
+
+      helfem::Matrix H((Eigen::Index)nb, (Eigen::Index)nb);
+      for (size_t c = 0; c < nb; c++)
+        for (size_t b = 0; b < nb; b++) {
+          const helfem::Vector cb = C_[b].col(active_[b]);
+          H((Eigen::Index)b, (Eigen::Index)c) = cb.dot(resp[c][b] * cb);
+        }
+      return 0.5 * (H + H.transpose());
+    }
+
+    void Optimizer::hessian(const std::vector<helfem::Vector> &X,
+                            std::vector<helfem::Vector> &HX) const {
+      const size_t nt = X.size();
+      HX.assign(nt, helfem::Vector::Zero((Eigen::Index)nparam_));
+      if (nt == 0)
+        return;
+
+      helfem::Cube P;
+      densities(U_, q_, P);
+
+      // First-order density change of each trial vector,
+      //     D = [kappa, diag f] + diag(df),
+      // pushed to the FEM basis for the response builder.
+      std::vector<std::vector<helfem::Matrix>> D(nt);
+      std::vector<std::vector<helfem::Matrix>> kap(nt);
+      std::vector<std::vector<double>> dq(nt);
+      std::vector<helfem::Cube> dP(nt);
+      for (size_t t = 0; t < nt; t++) {
+        decode(X[t].data(), kap[t], dq[t]);
+        D[t].assign(nblock(), helfem::Matrix());
+        dP[t].assign(nblock(), helfem::Matrix());
+        for (size_t b = 0; b < nblock(); b++) {
+          helfem::Matrix Db = kap[t][b] * f_[b].asDiagonal();
+          Db -= f_[b].asDiagonal() * kap[t][b];
+          Db(active_[b], active_[b]) += dq[t][b];
+          D[t][b] = Db;
+          dP[t][b] = C_[b] * Db * C_[b].transpose();
+        }
+      }
+
+      std::vector<helfem::Cube> dF;
+      response_(P, dP, dF);
+      stats_.n_response++;
+      stats_.n_hessian += nt;
+
+      for (size_t t = 0; t < nt; t++) {
+        std::vector<double> hq(nblock(), 0.0);
+        for (size_t b = 0; b < nblock(); b++) {
+          const helfem::Matrix &F = F_[b];
+          const helfem::Vector &f = f_[b];
+          const helfem::Matrix &kb = kap[t][b];
+          // Response Fock matrix back in the MO basis
+          const helfem::Matrix dFmo = C_[b].transpose() * dF[t][b] * C_[b];
+
+          // Uncoupled part: the second-order term of exp(kappa) acting on
+          // the reference density, d/dkappa of Tr(F [kappa,[kappa,diag f]])/2.
+          const helfem::Matrix K = kb * f.asDiagonal() - f.asDiagonal() * kb;
+          const helfem::Matrix S = F * kb - kb * F;
+          const helfem::Matrix A =
+              (F * K - K * F) + (S * f.asDiagonal() - f.asDiagonal() * S);
+
+          const double dfk = dq[t][b];
+          const Eigen::Index k = active_[b];
+          for (size_t p = 0; p < pair_i_[b].size(); p++) {
+            const Eigen::Index i = pair_i_[b][p], j = pair_j_[b][p];
+            // df is nonzero only at the active orbital
+            const double ddf = (j == k ? dfk : 0.0) - (i == k ? dfk : 0.0);
+            HX[t][(Eigen::Index)(koff_[b] + p)] =
+                A(i, j) + 2.0 * F(i, j) * ddf +
+                2.0 * dFmo(i, j) * (f(j) - f(i));
+          }
+          // Occupation direction: the mixed kappa-occupation term plus
+          // the kernel coupling.
+          hq[b] = S(k, k) + dFmo(k, k);
+        }
+
+        size_t off = qoff_;
+        for (size_t p = 0; p < pblocks_.size(); p++) {
+          const Eigen::Index ny = sumzero_[p].cols();
+          if (ny <= 0)
+            continue;
+          helfem::Vector v((Eigen::Index)free_[p].size());
+          for (size_t i = 0; i < free_[p].size(); i++)
+            v((Eigen::Index)i) = hq[free_[p][i]];
+          const helfem::Vector hy = sumzero_[p].transpose() * v;
+          for (Eigen::Index i = 0; i < ny; i++)
+            HX[t][(Eigen::Index)(off + (size_t)i)] = hy(i);
+          off += (size_t)ny;
+        }
+      }
+    }
+
+    void Optimizer::build_exact_subspace() {
+      // Every occupation parameter, and only those. Their uncoupled
+      // diagonal is exactly zero, so the diagonal preconditioner has
+      // nothing whatever to say about the directions that matter most.
+      exact_idx_.clear();
+      for (size_t i = qoff_; i < nparam_; i++)
+        exact_idx_.push_back(i);
+
+      const Eigen::Index ns = (Eigen::Index)exact_idx_.size();
+      if (ns == 0) {
+        exact_vec_ = helfem::Matrix();
+        exact_val_ = helfem::Vector();
+        return;
+      }
+
+      std::vector<helfem::Vector> probes(exact_idx_.size());
+      for (size_t s = 0; s < exact_idx_.size(); s++) {
+        probes[s] = helfem::Vector::Zero((Eigen::Index)nparam_);
+        probes[s]((Eigen::Index)exact_idx_[s]) = 1.0;
+      }
+      std::vector<helfem::Vector> HP;
+      hessian(probes, HP);
+
+      helfem::Matrix Hs(ns, ns);
+      for (Eigen::Index c = 0; c < ns; c++)
+        for (Eigen::Index r = 0; r < ns; r++)
+          Hs(r, c) = HP[(size_t)c]((Eigen::Index)exact_idx_[(size_t)r]);
+      Hs = 0.5 * (Hs + Hs.transpose());
+
+      Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(Hs);
+      exact_val_ = es.eigenvalues();
+      exact_vec_ = es.eigenvectors();
+    }
+
+    void Optimizer::precondition(const double *r, double mu,
+                                 double *out) const {
+      // Diagonal everywhere except the exactly built subspace, where the
+      // shifted block is inverted in its own eigenbasis.
+      //
+      // OpenTrustRegion drives one callback from two places with two
+      // different contracts, distinguished only by the shift it passes.
+      // At mu = 0 it is standing in for abs_diag_precond, which is
+      // explicitly a POSITIVE-DEFINITE preconditioner: the truncated
+      // conjugate gradient path takes sqrt(x . M x) with it, so a
+      // negative eigenvalue there produces a NaN step length and the
+      // solve dies on its first macroiteration. At a nonzero shift it is
+      // standing in for level_shifted_diag_precond, which wants the
+      // signed inverse of H - mu. Hence the absolute value below,
+      // matching what those two routines do elementwise.
+      const bool absolute = (mu == 0.0);
+      auto invert = [&](double d) {
+        if (absolute)
+          return 1.0 / std::max(std::abs(d), precond_floor);
+        if (std::abs(d) < precond_floor)
+          d = (d < 0.0) ? -precond_floor : precond_floor;
+        return 1.0 / d;
+      };
+
+      for (size_t i = 0; i < nparam_; i++)
+        out[i] = r[i] * invert(hdiag_((Eigen::Index)i) - mu);
+
+      const Eigen::Index ns = (Eigen::Index)exact_idx_.size();
+      if (ns == 0)
+        return;
+
+      helfem::Vector rs(ns);
+      for (Eigen::Index i = 0; i < ns; i++)
+        rs(i) = r[exact_idx_[(size_t)i]];
+      helfem::Vector ys = exact_vec_.transpose() * rs;
+      for (Eigen::Index i = 0; i < ns; i++)
+        ys(i) *= invert(exact_val_(i) - mu);
+      rs = exact_vec_ * ys;
+      for (Eigen::Index i = 0; i < ns; i++)
+        out[exact_idx_[(size_t)i]] = rs(i);
+    }
+
+    void Optimizer::adopt(const std::vector<helfem::Matrix> &U,
+                          const std::vector<double> &q, double *grad,
+                          double *h_diag) {
+      U_ = U;
+      q_ = q;
+      for (size_t b = 0; b < nblock(); b++) {
+        reorthonormalize(U_[b]);
+        fill_occupations(b, q_[b], f_[b], active_[b]);
+        C_[b] = Sinvh_ * U_[b];
+      }
+
+      helfem::Cube P, F;
+      densities(U_, q_, P);
+      energy_ = fock_(P, F);
+      stats_.n_update++;
+      // A step was accepted, so the runaway counter starts over.
+      hess_this_macro_ = 0;
+      best_energy_ = energy_;
+      best_step_ = helfem::Vector();
+
+      F_.resize(nblock());
+      for (size_t b = 0; b < nblock(); b++)
+        F_[b] = C_[b].transpose() * F[b] * C_[b];
+
+      if (grad)
+        gradient(grad);
+
+      // Uncoupled Hessian diagonal. Along the occupation directions it is
+      // identically zero, which is exactly why they are handled by the
+      // exact block below rather than by this.
+      hdiag_ = helfem::Vector::Zero((Eigen::Index)nparam_);
+      for (size_t b = 0; b < nblock(); b++) {
+        const helfem::Matrix &F2 = F_[b];
+        const helfem::Vector &f = f_[b];
+        for (size_t p = 0; p < pair_i_[b].size(); p++) {
+          const Eigen::Index i = pair_i_[b][p], j = pair_j_[b][p];
+          hdiag_((Eigen::Index)(koff_[b] + p)) =
+              2.0 * (f(i) - f(j)) * (F2(j, j) - F2(i, i));
+        }
+      }
+
+      if (nparam_ > qoff_) {
+        const helfem::Matrix Hqq = occupation_hessian();
+        size_t off = qoff_;
+        for (size_t p = 0; p < pblocks_.size(); p++) {
+          const Eigen::Index ny = sumzero_[p].cols();
+          if (ny <= 0)
+            continue;
+          helfem::Matrix sub((Eigen::Index)free_[p].size(),
+                             (Eigen::Index)free_[p].size());
+          for (size_t i = 0; i < free_[p].size(); i++)
+            for (size_t j = 0; j < free_[p].size(); j++)
+              sub((Eigen::Index)i, (Eigen::Index)j) =
+                  Hqq((Eigen::Index)free_[p][i], (Eigen::Index)free_[p][j]);
+          const helfem::Matrix red =
+              sumzero_[p].transpose() * sub * sumzero_[p];
+          for (Eigen::Index i = 0; i < ny; i++)
+            hdiag_((Eigen::Index)(off + (size_t)i)) = red(i, i);
+          off += (size_t)ny;
+        }
+      }
+
+      build_exact_subspace();
+      if (pattern_stale())
+        pattern_changed_ = true;
+      if (stats_.n_update == 1)
+        report_conditioning(report_verbosity_);
+
+      if (h_diag)
+        for (size_t i = 0; i < nparam_; i++)
+          h_diag[i] = hdiag_((Eigen::Index)i);
+    }
+
+    Result Optimizer::run(const Options &opts) {
+      if (U_.empty())
+        throw std::logic_error(
+            "The second-order optimizer has no reference to start from.\n");
+
+      report_verbosity_ = opts.verbosity;
+      stats_ = Result();
+
+      otr::Callbacks cb;
+      cb.update = [&](const double *x, double &func, double *grad,
+                      double *h_diag) {
+        std::vector<helfem::Matrix> kappa;
+        std::vector<double> dq;
+        decode(x, kappa, dq);
+        std::vector<helfem::Matrix> U;
+        std::vector<double> q;
+        displace(kappa, dq, U, q);
+        adopt(U, q, grad, h_diag);
+        func = energy_;
+        return true;
+      };
+      cb.objective = [&](const double *x, double &func) {
+        std::vector<helfem::Matrix> kappa;
+        std::vector<double> dq;
+        decode(x, kappa, dq);
+        std::vector<helfem::Matrix> U;
+        std::vector<double> q;
+        displace(kappa, dq, U, q);
+        helfem::Cube P, F;
+        densities(U, q, P);
+        func = fock_(P, F);
+        stats_.n_objective++;
+        // Remember the best point offered. A stalling solve is not failing
+        // to FIND a good step, it is refusing to accept one: the step it
+        // discards was measured lowering the energy by 5.3e-4 and landing
+        // on the minimum. Keeping it costs one vector.
+        if (func < best_energy_) {
+          best_energy_ = func;
+          best_step_ = Eigen::Map<const helfem::Vector>(x, (Eigen::Index)nparam_);
+        }
+        return true;
+      };
+      cb.hessian_vector = [&](const double *x, double *hx) {
+        // The ceiling has to be enforced here, not between
+        // macroiterations, because the runaway it guards against happens
+        // inside a single one: OpenTrustRegion re-enters its
+        // microiteration loop until a step is accepted, and never asks the
+        // convergence callback in between. Reporting failure is the clean
+        // way out -- an exception would have to unwind through Fortran.
+        if (hess_budget_ && hess_this_macro_ >= hess_budget_) {
+          budget_spent_ = true;
+          return false;
+        }
+        hess_this_macro_++;
+        std::vector<helfem::Vector> X(
+            1, Eigen::Map<const helfem::Vector>(x, (Eigen::Index)nparam_));
+        std::vector<helfem::Vector> HX;
+        hessian(X, HX);
+        for (size_t i = 0; i < nparam_; i++)
+          hx[i] = HX[0]((Eigen::Index)i);
+        return true;
+      };
+      if (opts.exact_precond)
+        cb.precondition = [&](const double *r, double mu, double *out) {
+          precondition(r, mu, out);
+          return true;
+        };
+      hess_budget_ = (opts.max_hessian > 0)
+                         ? (size_t)opts.max_hessian
+                         : 5 * (size_t)std::max(1, opts.otr.n_micro);
+      const size_t hess_budget = hess_budget_;
+      cb.converged = [&](bool &stop) {
+        // Not a convergence test but a bail-out, on either of two counts:
+        // the reference has left the occupation pattern the
+        // parametrization was built around, so continuing would optimize
+        // the wrong coordinates; or the work ceiling is spent, which means
+        // the rejection loop is running away and more of it will not help.
+        // Either way the gradient check after the solve reports honestly
+        // what was actually reached.
+        stop = pattern_changed_;
+        return true;
+      };
+
+      // The occupation pattern is discrete and the parametrization is
+      // smooth only inside one; a shell closing under the optimizer is a
+      // change of pattern, not of coordinates. So the solve runs inside a
+      // loop that rebuilds the parametrization around whatever pattern the
+      // reference has arrived at.
+      const otr::Settings otrset = opts.otr;
+      for (int pass = 0;; pass++) {
+        build_layout();
+
+        if (opts.verbosity >= 1) {
+          size_t nfree = 0;
+          for (const auto &fp : free_)
+            nfree += fp.size();
+          printf("\n%s over %i parameters: %i orbital rotations and %i "
+                 "occupation transfers among %i fractionally occupied "
+                 "blocks.\n",
+                 pass ? "Restarting the second-order optimization"
+                      : "\nSecond-order optimization",
+                 (int)nparam_, (int)qoff_, (int)(nparam_ - qoff_), (int)nfree);
+          if (nparam_ == qoff_)
+            printf("No block carries a fractional occupation, so only the "
+                   "orbitals are optimized.\n");
+          fflush(stdout);
+        }
+
+        budget_spent_ = false;
+        try {
+          otr::solve((int)nparam_, cb, otrset);
+        } catch (std::exception &) {
+          // A spent budget comes back as a callback failure, which the
+          // library turns into an error return. Any other failure is real
+          // and is left to propagate. The reference is whatever the last
+          // accepted step installed either way, so the energy and gradient
+          // reported below are a real point on the surface -- just not a
+          // converged one.
+          if (!budget_spent_)
+            throw;
+        }
+        // A stalled solve gets its own step back. Retrying was tried twice
+        // and failed twice -- a fresh subspace reproduced the stall
+        // exactly, and a progressively looser residual target recovered
+        // worse than simply starting loose -- but both of those retried
+        // from where the stall left the reference, which is the wrong
+        // place. The right place is the best point the stalled pass
+        // actually visited: OpenTrustRegion evaluated it, saw it lower the
+        // energy, and threw it away for missing a residual target it never
+        // had to meet to be an improvement.
+        // Whether the solve stopped because it spent its budget or
+        // because OpenTrustRegion declared maximum precision, the question
+        // is the same: did it decline a step that was an improvement? Both
+        // stall modes end that way, and the second one does not even reach
+        // the budget -- Curium stops after 87 products with the gradient
+        // still at 1.2e-3.
+        helfem::Vector gpass((Eigen::Index)nparam_);
+        gradient(gpass.data());
+        const bool pass_converged =
+            gpass.norm() / std::sqrt((double)nparam_) <= otrset.conv_tol;
+        if (!pass_converged && best_step_.size() &&
+            best_energy_ < energy_ - 1e-12 * std::abs(energy_) &&
+            pass < opts.max_restarts) {
+          std::vector<helfem::Matrix> kappa;
+          std::vector<double> dq;
+          decode(best_step_.data(), kappa, dq);
+          std::vector<helfem::Matrix> U;
+          std::vector<double> q;
+          displace(kappa, dq, U, q);
+          if (opts.verbosity >= 1) {
+            printf("\nA macroiteration stalled having found a step worth "
+                   "%.3e in energy and declined it.\n         Taking that "
+                   "step and continuing from there.\n",
+                   energy_ - best_energy_);
+            fflush(stdout);
+          }
+          adopt(U, q, nullptr, nullptr);
+          stats_.n_restart++;
+          continue;
+        }
+        // Before giving up on a pass, ask whether the point it reached is
+        // a KKT point at all. If a frozen block is pinned on the wrong side
+        // of the Fermi level, release it and go again: the restricted
+        // problem it solved is not the problem.
+        if (!pattern_changed_ && pass < opts.max_restarts &&
+            release_kkt_violation(opts.verbosity)) {
+          std::vector<helfem::Matrix> U = U_;
+          std::vector<double> q = q_;
+          adopt(U, q, nullptr, nullptr);
+          stats_.n_restart++;
+          continue;
+        }
+        if (budget_spent_ || !pattern_changed_ || pass >= opts.max_restarts)
+          break;
+        stats_.n_restart++;
+        if (opts.verbosity >= 1) {
+          printf("\nThe occupation pattern changed under the optimizer -- a "
+                 "shell filled or emptied -- so the parametrization is "
+                 "rebuilt around the new one.\n");
+          fflush(stdout);
+        }
+      }
+
+      // Report from the converged reference rather than trusting the
+      // library's own bookkeeping: OpenTrustRegion returns success when
+      // its line search stalls, so a zero error code is not by itself a
+      // statement that the gradient came down.
+      helfem::Vector g((Eigen::Index)nparam_);
+      gradient(g.data());
+      stats_.energy = energy_;
+      stats_.grad_rms = g.norm() / std::sqrt((double)nparam_);
+      stats_.converged = (stats_.grad_rms <= opts.otr.conv_tol);
+
+      if (!stats_.converged && opts.verbosity >= 1) {
+        printf("\nWARNING: the second-order optimization stopped with RMS "
+               "gradient %.3e, above the requested %.3e.\n",
+               stats_.grad_rms, opts.otr.conv_tol);
+        if (budget_spent_)
+          printf("         One macroiteration spent %i Hessian-vector products "
+                 "without accepting a step,\n         so the trust region was "
+                 "rejecting everything it was offered. Hand over from a\n"
+                 "         different point (--preiter) or raise --somaxhess.\n",
+                 (int)hess_budget);
+        fflush(stdout);
+      }
+      check_aufbau(opts.verbosity);
+
+      return stats_;
+    }
+
+    bool Optimizer::verify(double step, double tol, int verbosity,
+                           bool exact_hessian) {
+      build_layout();
+      report_verbosity_ = verbosity;
+      stats_ = Result();
+
+      // Establish the reference, its energy, gradient and Hessian data.
+      helfem::Vector g((Eigen::Index)nparam_), hd((Eigen::Index)nparam_);
+      adopt(U_, q_, g.data(), hd.data());
+      const double E0 = energy_;
+
+      // Energy at a displacement from the FIXED reference. Nothing here
+      // may adopt: the finite differences have to be taken in one
+      // coordinate system.
+      const std::vector<helfem::Matrix> U0 = U_;
+      const std::vector<double> q0 = q_;
+      auto energy_at = [&](const helfem::Vector &x) {
+        std::vector<helfem::Matrix> kappa;
+        std::vector<double> dq;
+        decode(x.data(), kappa, dq);
+        std::vector<helfem::Matrix> U;
+        std::vector<double> q;
+        displace(kappa, dq, U, q);
+        helfem::Cube P, F;
+        densities(U, q, P);
+        return fock_(P, F);
+      };
+
+      std::mt19937 rng(20250824);
+      std::normal_distribution<double> gauss(0.0, 1.0);
+      auto random_dir = [&]() {
+        helfem::Vector d((Eigen::Index)nparam_);
+        for (Eigen::Index i = 0; i < d.size(); i++)
+          d(i) = gauss(rng);
+        d /= d.norm();
+        return d;
+      };
+
+      // What the finite differences can actually resolve. A central
+      // difference of the energy carries a roundoff error eps*|E|/h and a
+      // truncation error of order h^2 times the third derivative, for
+      // which h^2*|d.H.d| is the right order-of-magnitude stand-in.
+      // Without this floor the check fails on any reference that is
+      // already converged, where the directional derivatives are
+      // legitimately at the noise level and a RELATIVE comparison says
+      // nothing about whether the analytic derivatives are right.
+      const double eps = std::numeric_limits<double>::epsilon();
+      const double roundoff = eps * std::abs(E0) / step;
+      auto agrees = [&](double ana, double num, double atol) {
+        return std::abs(num - ana) <=
+               tol * std::max(std::abs(ana), std::abs(num)) + atol;
+      };
+      auto relerr = [&](double ana, double num) {
+        return std::abs(num - ana) /
+               std::max(1e-10, std::abs(num) + std::abs(ana));
+      };
+
+      bool ok = true;
+      if (verbosity >= 1)
+        printf("\nFinite-difference check of the second-order derivatives, "
+               "step %.1e over %i parameters\n", step, (int)nparam_);
+
+      // --- gradient: directional derivative of the energy. Each
+      // direction needs its own curvature for the truncation floor, so
+      // the Hessian-vector products come first.
+      std::vector<helfem::Vector> D;
+      D.push_back(helfem::Vector(g / g.norm()));
+      for (int i = 0; i < 3; i++)
+        D.push_back(random_dir());
+      std::vector<helfem::Vector> HD;
+      hessian(D, HD);
+
+      for (size_t trial = 0; trial < 3; trial++) {
+        const helfem::Vector &d = D[trial];
+        const double num = (energy_at(step * d) - energy_at(-step * d)) /
+                           (2.0 * step);
+        const double ana = g.dot(d);
+        const double atol =
+            10.0 * (roundoff + step * step * std::abs(d.dot(HD[trial])));
+        const bool pass = agrees(ana, num, atol);
+        if (verbosity >= 1)
+          printf("  gradient . d%-2zu  analytic % .10e  numerical % .10e  "
+                 "rel.err %.2e  noise %.1e%s\n",
+                 trial, ana, num, relerr(ana, num), atol, pass ? "" : "   ***");
+        ok = ok && pass;
+      }
+
+      // --- Hessian: the bilinear form, by four-point polarization. This
+      // checks the whole H d vector against the energy surface rather
+      // than only the quadratic form along one direction.
+      const double hess_atol = roundoff / step;
+      double worst_hess = 0.0;
+      const std::pair<int, int> pairs[] = {{0, 0}, {1, 1}, {1, 2}, {2, 3}};
+      for (const auto &pr : pairs) {
+        const helfem::Vector &d1 = D[(size_t)pr.first];
+        const helfem::Vector &d2 = D[(size_t)pr.second];
+        const helfem::Vector sum = d1 + d2, dif = d1 - d2;
+        const double num = (energy_at(step * sum) + energy_at(-step * sum) -
+                            energy_at(step * dif) - energy_at(-step * dif)) /
+                           (4.0 * step * step);
+        const double ana = d1.dot(HD[(size_t)pr.second]);
+        const bool pass = agrees(ana, num, hess_atol);
+        worst_hess = std::max(worst_hess, relerr(ana, num));
+        if (verbosity >= 1)
+          printf("  d%i . H d%-2i     analytic % .10e  numerical % .10e  "
+                 "rel.err %.2e  noise %.1e%s\n",
+                 pr.first, pr.second, ana, num, relerr(ana, num), hess_atol,
+                 (pass || !exact_hessian) ? "" : "   ***");
+        ok = ok && (pass || !exact_hessian);
+      }
+
+      // --- and the symmetry of the analytic Hessian itself, which the
+      // polarization above cannot see.
+      for (size_t a = 1; a < D.size(); a++)
+        for (size_t b = a + 1; b < D.size(); b++) {
+          const double ab = D[a].dot(HD[b]), ba = D[b].dot(HD[a]);
+          const bool pass = agrees(ab, ba, 0.0);
+          if (verbosity >= 2)
+            printf("  symmetry d%zu/d%zu  % .10e vs % .10e  rel.err %.2e%s\n",
+                   a, b, ab, ba, relerr(ab, ba), pass ? "" : "   ***");
+          ok = ok && pass;
+        }
+
+      if (verbosity >= 1) {
+        printf("  reference energy % .10f\n", E0);
+        if (!exact_hessian)
+          printf("  The model Hessian is built from the density-density kernel "
+                 "block alone,\n  and differs from the true one by %.2f%% "
+                 "here. That costs iterations, not\n  correctness: every step "
+                 "is still validated against the exact energy.\n",
+                 100.0 * worst_hess);
+        printf("%s\n", ok ? "  All derivatives agree."
+                          : "  DERIVATIVES DISAGREE -- the second-order "
+                            "optimizer is not trustworthy here.");
+        fflush(stdout);
+      }
+      return ok;
+    }
+
+  } // namespace trscf
+} // namespace helfem

--- a/src/general/trustregion_scf.h
+++ b/src/general/trustregion_scf.h
@@ -1,0 +1,353 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef HELFEM_TRUSTREGION_SCF_H
+#define HELFEM_TRUSTREGION_SCF_H
+
+#include <Matrix.h>
+#include "otr_solver.h"
+
+#include <functional>
+#include <vector>
+
+namespace helfem {
+  /// Second-order optimization of orbitals AND fractional occupations for
+  /// a set of symmetry blocks that share one basis.
+  ///
+  /// The problem this solves is the spherically averaged atom (and the
+  /// atom in jellium), where the occupations are free parameters rather
+  /// than integers. First-order methods handle that badly for a specific
+  /// reason: when two orbitals are degenerate, moving density between
+  /// them costs nothing at first order in the orbital energies, so the
+  /// gradient is flat along exactly the direction that matters and the
+  /// true cost -- a dense coupling through the Coulomb and XC kernels --
+  /// is entirely second order. Fe is the standard example: 4s and 3d come
+  /// out at the same orbital energy, and since they sit in different l
+  /// blocks no orbital rotation connects them at all. Their whole
+  /// interaction is the occupation coupling <4s 4s|W|3d 3d>.
+  ///
+  /// PARAMETRIZATION. Orbital energies increase monotonically within an
+  /// angular momentum, so each block can hold at most one fractionally
+  /// occupied orbital on top of its filled ones. Rather than tracking
+  /// which orbital that is, each block carries a single continuous
+  /// variable q_b, the number of electrons in the block, and the
+  /// occupations follow from filling it up:
+  ///
+  ///     f_{b,i}(q_b) = clamp(q_b - i*w_b, 0, w_b)
+  ///
+  /// with w_b the occupation of a filled orbital. That is the same "one
+  /// fractional orbital per block" statement with the bookkeeping removed:
+  /// when the fractional occupation runs past w_b the next orbital simply
+  /// starts filling, continuously, and no re-indexing happens mid-solve.
+  /// E(q) does have a kink where an orbital fills exactly -- the gradient
+  /// jumps from eps_k to eps_{k+1} -- but that is a measure-zero set and
+  /// the solutions of interest sit strictly inside a shell.
+  ///
+  /// The electron count of each particle type is conserved, so the free
+  /// occupation parameters span the sum-zero subspace of its blocks:
+  /// n_blocks - 1 of them, in an orthonormal (Helmert) basis so that the
+  /// parameter metric stays isotropic rather than singling out one block.
+  /// q >= 0 is imposed by Euclidean projection onto the simplex, which
+  /// preserves the electron count exactly.
+  ///
+  /// PRECONDITIONING. The uncoupled Hessian diagonal, 2(f_i-f_j)(F_jj-F_ii),
+  /// is *identically zero* along every occupation direction -- the formal
+  /// statement that first order sees nothing there. Something has to fill
+  /// that in, so the occupation block is built exactly, one Fock response
+  /// per column, and inverted exactly in the preconditioner.
+  ///
+  /// It takes TWO occupation coordinates to see why that matters, which is
+  /// most of a system: with one the block is 1x1, there is no coupling to
+  /// capture, and turning the whole thing off in favour of the library's
+  /// floored diagonal changes neither the iteration count nor the answer.
+  /// Almost every open-shell atom has exactly one. Curium has two -- 5f,
+  /// 6d and 7s all fractionally occupied at once -- and there the
+  /// difference is not subtle:
+  ///
+  ///                        exact block        floored diagonal
+  ///   RMS gradient           9.7e-10                 5.8e-3
+  ///   energy            -28376.6749963109      -28376.6711800819
+  ///
+  /// The diagonal strands the solve 3.8e-3 above the minimum, because the
+  /// off-diagonal <k_b k_b|W|k_c k_c> it drops is the same size as the
+  /// diagonal it keeps. Hand it a better starting point and it does
+  /// converge, but still only to 6.0e-8 against 4.2e-10, and it takes more
+  /// objective evaluations to do it.
+  ///
+  /// Extending the same treatment to the low-lying ORBITAL rotations was
+  /// tried and removed. Each parameter in the subspace costs a
+  /// Hessian-vector product every macroiteration, and on Curium -- the one
+  /// case where preconditioning demonstrably decides the outcome -- it
+  /// bought nothing for that: 50 extra rotations cost eight times the
+  /// products for no better answer, and 200 or 600 stopped it converging
+  /// at all while costing twenty to sixty times. The low-lying ORBITAL
+  /// directions are not what these cases founder on; the occupation ones
+  /// are, and those are already exact.
+  namespace trscf {
+
+    /// Total energy and per-block Fock matrices from per-block densities.
+    /// Everything is in the non-orthonormal FEM basis.
+    using FockBuilder =
+        std::function<double(const helfem::Cube &P, helfem::Cube &F)>;
+
+    /// Linear response of those Fock matrices to a batch of density
+    /// perturbations, at the reference density P. Batched because the
+    /// expensive parts -- the basis values on the quadrature grid, the
+    /// reference density, the libxc kernel -- are shared across the
+    /// perturbations, so an exact Hessian in a d-dimensional subspace
+    /// costs far less than d separate response builds.
+    using ResponseBuilder =
+        std::function<void(const helfem::Cube &P,
+                           const std::vector<helfem::Cube> &dP,
+                           std::vector<helfem::Cube> &dF)>;
+
+    struct Options {
+      /// Settings passed through to OpenTrustRegion
+      otr::Settings otr;
+      /// Use the exact-subspace preconditioner. Turning it off falls back
+      /// to OpenTrustRegion's own diagonal one, which is identically zero
+      /// along every occupation direction -- useful for measuring what
+      /// the exact block actually buys, and not much else.
+      bool exact_precond = true;
+      /// Ceiling on Hessian-vector products within ONE macroiteration.
+      ///
+      /// A healthy macroiteration spends at most n_micro of them and then
+      /// accepts a step. OpenTrustRegion, though, re-enters its
+      /// microiteration loop until a step IS accepted, and never resets
+      /// its reduced space in between -- so a macroiteration whose steps
+      /// keep failing the ratio test grows that space without bound, and
+      /// since every microiteration diagonalizes the augmented Hessian
+      /// densely, the cost of each one grows as the cube of the work
+      /// already wasted. Left alone a bad starting point does not fail, it
+      /// grinds: measured, one such macroiteration ran for 900 seconds
+      /// without returning.
+      ///
+      /// Counting per macroiteration rather than per solve is what makes
+      /// this scale-free: it fires on the ratio of work done to progress
+      /// made, not on an absolute budget that a legitimately hard case
+      /// might need. Zero disables it; the default is a few times n_micro.
+      int max_hessian = 0;
+      /// How many times the solve may be restarted after the occupation
+      /// pattern changes under it (a shell closing, say). Each restart
+      /// rebuilds the parametrization around the new pattern.
+      int max_restarts = 5;
+      /// Output detail
+      int verbosity = 5;
+    };
+
+    /// Report from a run
+    struct Result {
+      /// Did the RMS gradient actually reach the threshold? Worth
+      /// checking: OpenTrustRegion reports a stalled line search
+      /// ("maximum precision reached") as a successful return, so a
+      /// zero error code alone does not mean the solve converged.
+      bool converged = false;
+      /// Number of times the occupation pattern changed under the solve
+      /// and the parametrization had to be rebuilt
+      size_t n_restart = 0;
+      /// Converged energy
+      double energy = 0.0;
+      /// RMS gradient at the end
+      double grad_rms = 0.0;
+      /// Number of reference updates (macroiterations)
+      size_t n_update = 0;
+      /// Number of bare objective evaluations
+      size_t n_objective = 0;
+      /// Number of Hessian-vector products
+      size_t n_hessian = 0;
+      /// Number of Fock-response builds (batched, so <= n_hessian)
+      size_t n_response = 0;
+    };
+
+    class Optimizer {
+      /// Half-inverse overlap, Nfem x Nrad
+      helfem::Matrix Sinvh_;
+      /// Occupation of a filled orbital in each block
+      std::vector<double> maxocc_;
+      /// Particle type each block belongs to
+      std::vector<size_t> particle_;
+      /// Blocks of each particle type
+      std::vector<std::vector<size_t>> pblocks_;
+      /// Blocks of each particle type whose filling is a free
+      /// coordinate, i.e. whose topmost occupied orbital really is
+      /// fractionally occupied. A block at an exact shell filling or an
+      /// empty one sits on a kink or a bound and is held fixed.
+      std::vector<std::vector<size_t>> free_;
+      /// Orthonormal basis of the sum-zero subspace of each particle
+      /// type's FREE block fillings, n_free x (n_free - 1)
+      std::vector<helfem::Matrix> sumzero_;
+
+      /// Fock and response builders
+      FockBuilder fock_;
+      ResponseBuilder response_;
+
+      /// Reference orbitals in the orthonormal basis, Nrad x Nrad
+      std::vector<helfem::Matrix> U_;
+      /// Reference orbitals in the FEM basis, Sinvh_ * U_
+      std::vector<helfem::Matrix> C_;
+      /// Electrons in each block
+      std::vector<double> q_;
+      /// Reference occupations
+      std::vector<helfem::Vector> f_;
+      /// Index of the fractionally occupied orbital in each block
+      std::vector<Eigen::Index> active_;
+      /// Reference Fock matrices in the MO basis
+      std::vector<helfem::Matrix> F_;
+      /// Reference energy
+      double energy_ = 0.0;
+
+      /// Parameter layout: rotation pairs of each block, and the offset
+      /// of that block's parameters in the flat vector
+      std::vector<std::vector<Eigen::Index>> pair_i_, pair_j_;
+      std::vector<size_t> koff_;
+      /// Offset of the occupation parameters
+      size_t qoff_ = 0;
+      size_t nparam_ = 0;
+
+      /// Uncoupled Hessian diagonal at the reference
+      helfem::Vector hdiag_;
+      /// Verbosity for the one-off conditioning report
+      int report_verbosity_ = 0;
+      /// Ceiling on Hessian-vector products WITHIN one macroiteration,
+      /// and whether it was hit
+      size_t hess_budget_ = 0;
+      size_t hess_this_macro_ = 0;
+      bool budget_spent_ = false;
+      /// Best point any objective evaluation has reached since the last
+      /// accepted step, and its energy. When the solve stalls, this is the
+      /// step it kept declining.
+      helfem::Vector best_step_;
+      double best_energy_ = 0.0;
+      /// The occupation pattern the current parametrization was built
+      /// around, and whether the reference has since left it
+      std::vector<Eigen::Index> entry_active_;
+      bool pattern_changed_ = false;
+      /// Indices spanning the exactly built subspace, and the eigen-
+      /// decomposition of the Hessian restricted to it
+      std::vector<size_t> exact_idx_;
+      helfem::Matrix exact_vec_;
+      helfem::Vector exact_val_;
+
+      /// Counters
+      mutable Result stats_;
+
+      /// Number of radial functions
+      Eigen::Index Nrad() const { return Sinvh_.cols(); }
+      /// Number of blocks
+      size_t nblock() const { return maxocc_.size(); }
+
+      /// Build the parameter layout from the current active indices
+      void build_layout();
+      /// Occupations and active index of one block from its filling
+      void fill_occupations(size_t b, double q, helfem::Vector &f,
+                            Eigen::Index &k) const;
+      /// Project the block fillings of every particle type back onto
+      /// {q >= 0, sum q = N}
+      void project_fillings(std::vector<double> &q) const;
+      /// Decode a parameter vector into per-block rotations and the
+      /// change in the block fillings
+      void decode(const double *x, std::vector<helfem::Matrix> &kappa,
+                  std::vector<double> &dq) const;
+      /// Apply rotations and filling changes to the reference, without
+      /// adopting the result
+      void displace(const std::vector<helfem::Matrix> &kappa,
+                    const std::vector<double> &dq,
+                    std::vector<helfem::Matrix> &U,
+                    std::vector<double> &q) const;
+      /// Per-block FEM densities of a given orbital set and filling
+      void densities(const std::vector<helfem::Matrix> &U,
+                     const std::vector<double> &q, helfem::Cube &P) const;
+      /// Adopt a point: recompute C_, F_, the energy, and the gradient
+      /// and Hessian data that go with them
+      void adopt(const std::vector<helfem::Matrix> &U,
+                 const std::vector<double> &q, double *grad, double *h_diag);
+      /// Gradient at the reference
+      void gradient(double *g) const;
+      /// Hessian-vector products for a batch of trial vectors
+      void hessian(const std::vector<helfem::Vector> &X,
+                   std::vector<helfem::Vector> &HX) const;
+      /// The exact occupation block, n_blocks x n_blocks
+      helfem::Matrix occupation_hessian() const;
+      /// Build the exactly treated subspace and factor it
+      void build_exact_subspace();
+      /// Apply the preconditioner: exact inverse inside the subspace,
+      /// level-shifted diagonal outside it
+      void precondition(const double *r, double mu, double *out) const;
+      /// Has the reference left the occupation pattern the parametrization
+      /// was built around?
+      bool pattern_stale() const;
+      /// Report how well conditioned the problem is: the spread of the
+      /// uncoupled diagonal, how much of it is near-singular, and the
+      /// spectrum of the exactly built block. This is what says whether a
+      /// case is hard because of the occupations, because of
+      /// near-degenerate rotations, or not at all.
+      void report_conditioning(int verbosity) const;
+      /// Warn if a frozen block's next orbital lies below the Fermi level
+      /// of the fractionally occupied ones, i.e. if the occupation pattern
+      /// handed over is not aufbau-stable
+      void check_aufbau(int verbosity) const;
+      /// Look for a block frozen in violation of the KKT conditions of the
+      /// constrained problem, and if there is one, move a little charge
+      /// across so it becomes a free coordinate again. Returns true if the
+      /// occupations were changed.
+      bool release_kkt_violation(int verbosity);
+
+    public:
+      /// blocks_per_particle gives the number of blocks belonging to each
+      /// particle type, in order; maxocc the occupation of a filled
+      /// orbital in each block.
+      Optimizer(const helfem::Matrix &Sinvh, const std::vector<double> &maxocc,
+                const std::vector<size_t> &blocks_per_particle, FockBuilder fock,
+                ResponseBuilder response);
+
+      /// Seed the reference from orbitals in the orthonormal basis and
+      /// their occupations. The occupations are only read as block
+      /// electron counts: the aufbau ordering within a block is taken
+      /// from the orbital order, which is what the first-order solver
+      /// hands over.
+      void set_reference(const std::vector<helfem::Matrix> &orbs,
+                         const std::vector<helfem::Vector> &occs);
+
+      /// Optimize. Throws if OpenTrustRegion is unavailable or fails.
+      Result run(const Options &opts);
+
+      /// Compare the analytic gradient and Hessian-vector products
+      /// against finite differences of the energy surface.
+      ///
+      /// exact_hessian says whether the response kernel behind the
+      /// Hessian is the true one -- it is for an LDA, and deliberately is
+      /// not for a GGA or meta-GGA, where the gradient and tau blocks of
+      /// the kernel are dropped. With it false the Hessian comparison
+      /// stops being a pass/fail test and becomes a measurement of how
+      /// good the model Hessian is, since only the convergence rate
+      /// depends on it; the gradient must be exact either way, and that
+      /// is what the return value then reflects.
+      bool verify(double step, double tol, int verbosity,
+                  bool exact_hessian = true);
+
+      /// Reference orbitals in the orthonormal basis
+      const std::vector<helfem::Matrix> &orbitals() const { return U_; }
+      /// Reference occupations
+      const std::vector<helfem::Vector> &occupations() const { return f_; }
+      /// Reference Fock matrices in the MO basis; the diagonal holds the
+      /// orbital energies of the converged solution
+      const std::vector<helfem::Matrix> &fock() const { return F_; }
+      /// Number of parameters
+      size_t nparam() const { return nparam_; }
+    };
+
+  } // namespace trscf
+} // namespace helfem
+
+#endif

--- a/src/sadatom/aij.cpp
+++ b/src/sadatom/aij.cpp
@@ -19,6 +19,7 @@
 #include "../general/scf_helpers.h"
 #include "../general/eigen_io.h"
 #include "../general/scf_driver_common.h"
+#include "../general/trustregion_scf.h"
 
 #include "openorbitaloptimizer/scfsolver.hpp"
 
@@ -84,6 +85,16 @@ int main(int argc, char **argv) {
   parser.add<std::string>("savefock", 0, "file to save fock matrix to", false, "");
   parser.add<bool>("saveorb", 0, "save radial orbitals to disk?", false, false);
   parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration diagnostics and Fock timings; also passed to the SCF solver", false, 5);
+  parser.add<bool>("secondorder", 0, "follow the first-order SCF with second-order trust-region optimization of the orbitals and the fractional occupations", false, false);
+  parser.add<int>("preiter", 0, "first-order iterations to run before switching to the second-order optimizer", false, 100);
+  parser.add<double>("soconvthr", 0, "second-order convergence threshold on the RMS gradient", false, 1e-8);
+  parser.add<int>("somacro", 0, "maximum second-order macroiterations", false, 150);
+  parser.add<int>("somicro", 0, "maximum second-order microiterations", false, 50);
+  parser.add<double>("soredfac", 0, "how far the second-order microiterations must reduce the residual before a step is accepted; a step whose subproblem misses this is rejected however good it is, so tightening it can stall an ill-conditioned case rather than sharpen it", false, 3e-1);
+  parser.add<int>("somaxhess", 0, "ceiling on Hessian-vector products in one second-order solve; 0 uses somacro*somicro, which only a runaway step-rejection loop can reach", false, 0);
+  parser.add<std::string>("sosolver", 0, "second-order microiteration solver: davidson, jacobi-davidson or tcg", false, "davidson");
+  parser.add<bool>("soprecond", 0, "precondition with the exactly built Hessian subspace; off falls back to OpenTrustRegion's diagonal, which is blind to the occupation coupling", false, true);
+  parser.add<double>("sotest", 0, "instead of optimizing, check the analytic gradient and Hessian against finite differences with this step size", false, 0.0);
   parser.parse_check(argc, argv);
 
   // Get parameters
@@ -124,6 +135,21 @@ int main(int argc, char **argv) {
   std::string loadfock(parser.get<std::string>("loadfock"));
   std::string savefock(parser.get<std::string>("savefock"));
   bool saveorb(parser.get<bool>("saveorb"));
+
+  bool secondorder(parser.get<bool>("secondorder"));
+  int preiter(parser.get<int>("preiter"));
+  double soconvthr(parser.get<double>("soconvthr"));
+  int somacro(parser.get<int>("somacro"));
+  int somicro(parser.get<int>("somicro"));
+  int somaxhess(parser.get<int>("somaxhess"));
+  double soredfac(parser.get<double>("soredfac"));
+  std::string sosolver(parser.get<std::string>("sosolver"));
+  bool soprecond(parser.get<bool>("soprecond"));
+  double sotest(parser.get<double>("sotest"));
+  if(sotest > 0.0)
+    secondorder = true;
+  if(secondorder && !helfem::otr::available())
+    throw std::logic_error("This HelFEM was built without OpenTrustRegion, so --secondorder is unavailable. Configure with -DHELFEM_OPENTRUSTREGION=ON.\n");
 
   // Parse xc parameters
   helfem::Vector x_pars, c_pars;
@@ -376,120 +402,32 @@ int main(int argc, char **argv) {
   // them is ever handed to the solver.
   helfem::scf_driver::FockTimer ftimer;
 
-  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> restricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
-    const auto & orbitals = dm.first;
-    const auto & occupations = dm.second;
+  // Energy and per-block Fock matrices in the FEM basis, given the
+  // per-block FEM densities. This is the whole energy expression, lifted
+  // out of the OpenOrbitalOptimizer builders below so that the
+  // second-order optimizer -- which works from densities rather than from
+  // orbitals and occupations -- shares it instead of restating it.
+  //
+  // Blocks are l = 0..lmax for the restricted case, and alpha l = 0..lmax
+  // followed by beta l = 0..lmax for the unrestricted one, matching the
+  // block layout OpenOrbitalOptimizer is given.
+  auto fock_fem = [&](const helfem::Cube & P, helfem::Cube & F, bool report) -> double {
+    const bool unrestricted = ((int) P.size() == 2*lmax+2);
+    if(!unrestricted && (int) P.size() != lmax+1)
+      throw std::logic_error("Density has an unexpected number of blocks.\n");
+
     ftimer.enter();
     helfem::scf_driver::FockTimer::Components tc;
     Timer tcomp;
 
-    // Kinetic energy
+    // Kinetic energy and total radial density
     double Ekin=0.0;
-    // Radial density matrix
     helfem::Matrix Prad = helfem::Matrix::Zero(Nrad, Nrad);
-    helfem::Cube Pl(lmax+1, helfem::Matrix::Zero(Nrad, Nrad));
-    for(int l=0;l<=lmax;l++) {
-      // Nothing to do
-      if(occupations[l].cwiseAbs().maxCoeff()==0.0)
-        continue;
-
-      // Same radial basis for all l!
-      helfem::Matrix C = Sinvh*orbitals[l];
-      helfem::Matrix P = C*occupations[l].asDiagonal()*C.transpose();
-      Pl[l] = P;
-      Prad += P;
-
-      // Kinetic energy
-      Ekin += (P*T).trace() + l*(l+1)*(P*Tl).trace();
+    for(size_t b=0;b<P.size();b++) {
+      const int l = (int)(b % (lmax+1));
+      Prad += P[b];
+      Ekin += (P[b]*T).trace() + l*(l+1)*(P[b]*Tl).trace();
     }
-
-    tc.density += tcomp.get();
-
-    double Enuc=(Prad*Vnuc).trace();
-    double Eunif=(Prad*Vunif).trace();
-
-    // Coulomb matrix
-    tcomp.set();
-    helfem::Matrix J(basis.coulomb(Prad/angfac));
-    tc.coulomb += tcomp.get();
-
-    double Exc=0.0;
-    helfem::Cube XC;
-    double nelnum = 0.0;
-    if(x_func > 0 || c_func > 0) {
-      tcomp.set();
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, divided_cube(Pl,angfac), XC, Exc, nelnum, dftthr);
-      // Potential needs to be divided as well
-      for(size_t l=0;l<XC.size();l++) XC[l]/=angfac;
-      tc.xc += tcomp.get();
-      if(verbosity >= 5) {
-        printf("DFT energy %.10e\n",Exc);
-        printf("Error in integrated number of electrons % e\n",nelnum-(Z-Q+njellium));
-        fflush(stdout);
-      }
-    }
-
-    double Ecoul = 0.5*(Prad*J).trace();
-    double Etot = Ekin + Enuc + Enucfield + Eunif + Erep + Ecoul + Exc;
-
-    if(verbosity >= 1) {
-      printf("kinetic energy         % .10f\n",Ekin);
-      printf("nuclear attraction     % .10f\n",Enuc);
-      printf("nucleus-field term     % .10f\n",Enucfield);
-      printf("background repulsion   % .10f\n",Erep);
-      printf("background attraction  % .10f\n",Eunif);
-      printf("Coulomb repulsion      % .10f\n",Ecoul);
-      printf("exchange-correlation   % .10f\n",Exc);
-      printf("total energy           % .10f\n",Etot);
-    }
-
-    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(lmax+1);
-    for(int l=0;l<=lmax;l++) {
-      fock[l] = T + l*(l+1)*Tl + Vnuc + Vunif + J;
-      if(x_func>0 || c_func>0)
-        fock[l] += XC[l];
-      fock[l] = Sinvh.transpose() * fock[l] * Sinvh;
-    }
-    tc.total = ftimer.build_elapsed();
-    ftimer.add_build(tc);
-    if(verbosity >= 5) ftimer.print_build(x_func > 0 || c_func > 0, false);
-    ftimer.leave();
-    return std::make_pair(Etot,fock);
-  };
-
-  // Fock builder
-  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> unrestricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
-    const auto & orbitals = dm.first;
-    const auto & occupations = dm.second;
-    ftimer.enter();
-    helfem::scf_driver::FockTimer::Components tc;
-    Timer tcomp;
-
-    // Kinetic energy
-    double Ekin=0.0;
-    // Radial density matrix
-    helfem::Matrix Prad = helfem::Matrix::Zero(Nrad, Nrad);
-
-    helfem::Cube Pal(lmax+1, helfem::Matrix::Zero(Nrad, Nrad));
-    helfem::Cube Pbl(lmax+1, helfem::Matrix::Zero(Nrad, Nrad));
-    for(int l=0;l<=lmax;l++) {
-      // Nothing to do
-      if(occupations[l].cwiseAbs().maxCoeff()==0.0)
-        continue;
-
-      // Same radial basis for all l!
-      helfem::Matrix Ca = Sinvh*orbitals[l];
-      helfem::Matrix Cb = Sinvh*orbitals[l+lmax+1];
-      helfem::Matrix Pa = Ca*occupations[l].asDiagonal()*Ca.transpose();
-      helfem::Matrix Pb = Cb*occupations[l+lmax+1].asDiagonal()*Cb.transpose();
-      Pal[l] = Pa;
-      Pbl[l] = Pb;
-      Prad += Pa+Pb;
-
-      // Kinetic energy
-      Ekin += ((Pa+Pb)*T).trace() + l*(l+1)*((Pa+Pb)*Tl).trace();
-    }
-
     tc.density += tcomp.get();
 
     double Enuc=(Prad*Vnuc).trace();
@@ -505,12 +443,17 @@ int main(int argc, char **argv) {
     double nelnum = 0.0;
     if(x_func > 0 || c_func > 0) {
       tcomp.set();
-      grid.eval_Fxc(x_func, x_pars, c_func, c_pars, divided_cube(Pal,angfac), divided_cube(Pbl,angfac), XCa, XCb, Exc, nelnum, true, dftthr);
-      // Potential needs to be divided as well
+      if(unrestricted) {
+        helfem::Cube Pa(P.begin(), P.begin()+lmax+1);
+        helfem::Cube Pb(P.begin()+lmax+1, P.end());
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, divided_cube(Pa,angfac), divided_cube(Pb,angfac), XCa, XCb, Exc, nelnum, true, dftthr);
+        for(size_t l=0;l<XCb.size();l++) XCb[l]/=angfac;
+      } else {
+        grid.eval_Fxc(x_func, x_pars, c_func, c_pars, divided_cube(P,angfac), XCa, Exc, nelnum, dftthr);
+      }
       for(size_t l=0;l<XCa.size();l++) XCa[l]/=angfac;
-      for(size_t l=0;l<XCb.size();l++) XCb[l]/=angfac;
       tc.xc += tcomp.get();
-      if(verbosity >= 5) {
+      if(report && verbosity >= 5) {
         printf("DFT energy %.10e\n",Exc);
         printf("Error in integrated number of electrons % e\n",nelnum-(Z-Q+njellium));
         fflush(stdout);
@@ -520,7 +463,7 @@ int main(int argc, char **argv) {
     double Ecoul = 0.5*(Prad*J).trace();
     double Etot = Ekin + Enuc + Enucfield + Eunif + Erep + Ecoul + Exc;
 
-    if(verbosity >= 1) {
+    if(report && verbosity >= 1) {
       printf("kinetic energy         % .10f\n",Ekin);
       printf("nuclear attraction     % .10f\n",Enuc);
       printf("nucleus-field term     % .10f\n",Enucfield);
@@ -531,40 +474,191 @@ int main(int argc, char **argv) {
       printf("total energy           % .10f\n",Etot);
     }
 
-    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(2*lmax+2);
-    for(int l=0;l<=lmax;l++) {
-      fock[l] = T + l*(l+1)*Tl + Vnuc + Vunif + J;
+    F.assign(P.size(), helfem::Matrix());
+    for(size_t b=0;b<P.size();b++) {
+      const int l = (int)(b % (lmax+1));
+      F[b] = T + l*(l+1)*Tl + Vnuc + Vunif + J;
       if(x_func>0 || c_func>0)
-        fock[l] += XCa[l];
-      fock[l] = Sinvh.transpose() * fock[l] * Sinvh;
-
-      fock[l+lmax+1] = T + l*(l+1)*Tl + Vnuc + Vunif + J;
-      if(x_func>0 || c_func>0)
-        fock[l+lmax+1] += XCb[l];
-      fock[l+lmax+1] = Sinvh.transpose() * fock[l+lmax+1] * Sinvh;
+        F[b] += (unrestricted && b > (size_t) lmax) ? XCb[l] : XCa[l];
     }
+
     tc.total = ftimer.build_elapsed();
     ftimer.add_build(tc);
-    if(verbosity >= 5) ftimer.print_build(x_func > 0 || c_func > 0, false);
+    if(report && verbosity >= 5) ftimer.print_build(x_func > 0 || c_func > 0, false);
     ftimer.leave();
+    return Etot;
+  };
+
+  // Linear response of those Fock matrices to a batch of density
+  // perturbations. The Coulomb half is linear, so its response is exact
+  // and costs one more Coulomb build; the XC half is the density-density
+  // kernel block, exact for an LDA and a deliberate approximation beyond
+  // it (see DFTGridWorkerBase::compute_fxc). The batch is passed through
+  // to the grid, which shares the basis values, the reference density and
+  // the kernel evaluation across all of the perturbations.
+  auto response_fem = [&](const helfem::Cube & P, const std::vector<helfem::Cube> & dP, std::vector<helfem::Cube> & dF) {
+    const bool unrestricted = ((int) P.size() == 2*lmax+2);
+    const size_t nt = dP.size();
+    dF.assign(nt, helfem::Cube());
+
+    std::vector<helfem::Cube> dXCa, dXCb;
+    if(x_func > 0 || c_func > 0) {
+      if(unrestricted) {
+        helfem::Cube Pa(P.begin(), P.begin()+lmax+1);
+        helfem::Cube Pb(P.begin()+lmax+1, P.end());
+        std::vector<helfem::Cube> dPa(nt), dPb(nt);
+        for(size_t it=0;it<nt;it++) {
+          dPa[it] = divided_cube(helfem::Cube(dP[it].begin(), dP[it].begin()+lmax+1), angfac);
+          dPb[it] = divided_cube(helfem::Cube(dP[it].begin()+lmax+1, dP[it].end()), angfac);
+        }
+        grid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, divided_cube(Pa,angfac), divided_cube(Pb,angfac), dPa, dPb, dXCa, dXCb, dftthr);
+        for(size_t it=0;it<nt;it++)
+          for(size_t l=0;l<dXCb[it].size();l++) dXCb[it][l]/=angfac;
+      } else {
+        std::vector<helfem::Cube> dPs(nt);
+        for(size_t it=0;it<nt;it++) dPs[it] = divided_cube(dP[it], angfac);
+        grid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, divided_cube(P,angfac), dPs, dXCa, dftthr);
+      }
+      for(size_t it=0;it<nt;it++)
+        for(size_t l=0;l<dXCa[it].size();l++) dXCa[it][l]/=angfac;
+    }
+
+    for(size_t it=0;it<nt;it++) {
+      helfem::Matrix dPrad = helfem::Matrix::Zero(Nrad, Nrad);
+      for(size_t b=0;b<dP[it].size();b++)
+        dPrad += dP[it][b];
+      const helfem::Matrix dJ(basis.coulomb(dPrad/angfac));
+
+      dF[it].assign(P.size(), helfem::Matrix());
+      for(size_t b=0;b<P.size();b++) {
+        const int l = (int)(b % (lmax+1));
+        dF[it][b] = dJ;
+        if(x_func>0 || c_func>0)
+          dF[it][b] += (unrestricted && b > (size_t) lmax) ? dXCb[it][l] : dXCa[it][l];
+      }
+    }
+  };
+
+  // Build the per-block FEM densities of an OpenOrbitalOptimizer solution
+  auto blocked_density = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    const auto & orbitals = dm.first;
+    const auto & occupations = dm.second;
+    helfem::Cube P(orbitals.size(), helfem::Matrix::Zero(Nrad, Nrad));
+    for(size_t b=0;b<orbitals.size();b++) {
+      if(occupations[b].cwiseAbs().maxCoeff()==0.0)
+        continue;
+      // Same radial basis for all l!
+      const helfem::Matrix C = Sinvh*orbitals[b];
+      P[b] = C*occupations[b].asDiagonal()*C.transpose();
+    }
+    return P;
+  };
+
+  // Fock builder
+  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> restricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    helfem::Cube F;
+    const double Etot = fock_fem(blocked_density(dm), F, true);
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(lmax+1);
+    for(int l=0;l<=lmax;l++)
+      fock[l] = Sinvh.transpose() * F[l] * Sinvh;
     return std::make_pair(Etot,fock);
   };
 
-  std::function<helfem::Matrix(const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> &)> radial_density_matrix = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
-    const auto & orbitals = dm.first;
-    const auto & occupations = dm.second;
-    // Radial density matrix
-    helfem::Matrix Prad = helfem::Matrix::Zero(Nrad, Nrad);
-    for(int l=0;l<=lmax;l++) {
-      // Nothing to do
-      if(occupations[l].cwiseAbs().maxCoeff()==0.0)
-        continue;
+  // Fock builder
+  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> unrestricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    helfem::Cube F;
+    const double Etot = fock_fem(blocked_density(dm), F, true);
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(2*lmax+2);
+    for(int b=0;b<2*lmax+2;b++)
+      fock[b] = Sinvh.transpose() * F[b] * Sinvh;
+    return std::make_pair(Etot,fock);
+  };
 
-      // Same radial basis for all l!
-      helfem::Matrix C = Sinvh*orbitals[l];
-      helfem::Matrix P = C*occupations[l].asDiagonal()*C.transpose();
-      Prad += P;
+  // The same two builders, in the form the second-order optimizer wants:
+  // densities in, energy and Fock matrices out, with no reporting -- the
+  // trust-region solver prints its own iteration table, and the energy
+  // decomposition is printed once at the end instead of on every one of
+  // the many objective evaluations a microiteration sweep makes.
+  helfem::trscf::FockBuilder so_fock = [&](const helfem::Cube & P, helfem::Cube & F) {
+    return fock_fem(P, F, false);
+  };
+  helfem::trscf::ResponseBuilder so_response = [&](const helfem::Cube & P, const std::vector<helfem::Cube> & dP, std::vector<helfem::Cube> & dF) {
+    response_fem(P, dP, dF);
+  };
+
+  // Drive the second-order phase from a converged (or partly converged)
+  // first-order solution, and hand back the refined orbitals and
+  // occupations. Shared by the restricted and unrestricted branches; they
+  // differ only in how the blocks divide between particle types.
+  auto second_order_phase = [&](OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm,
+                                const Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> & maximum_occupation,
+                                const std::vector<size_t> & blocks_per_particle) {
+    std::vector<double> maxocc(maximum_occupation.size());
+    for(Eigen::Index i=0;i<maximum_occupation.size();i++)
+      maxocc[(size_t) i] = maximum_occupation(i);
+
+    helfem::trscf::Optimizer opt(Sinvh, maxocc, blocks_per_particle, so_fock, so_response);
+    opt.set_reference(dm.first, dm.second);
+
+    if(sotest > 0.0) {
+      // Derivative check only: the analytic gradient and Hessian are the
+      // whole content of the second-order method, and nothing downstream
+      // can tell a wrong Hessian from a hard problem.
+      // The response kernel is the true one only for an LDA; beyond that
+      // the Hessian is deliberately approximate, so it is measured rather
+      // than tested.
+      bool xg=false, xt=false, xl=false, cg=false, ct=false, cl=false;
+      if(x_func > 0) ::is_gga_mgga(x_func, xg, xt, xl);
+      if(c_func > 0) ::is_gga_mgga(c_func, cg, ct, cl);
+      const bool exact_kernel = !(xg||xt||xl||cg||ct||cl);
+      if(!opt.verify(sotest, 1e-4, verbosity, exact_kernel))
+        throw std::runtime_error("The analytic derivatives disagree with finite differences.\n");
+      return;
     }
+
+    helfem::trscf::Options sopt;
+    sopt.otr.conv_tol = soconvthr;
+    sopt.otr.n_macro = somacro;
+    sopt.otr.n_micro = somicro;
+    sopt.max_hessian = somaxhess;
+    sopt.otr.global_red_factor = soredfac;
+    sopt.otr.local_red_factor = 0.1*soredfac;
+    sopt.otr.subsystem_solver = sosolver;
+    // OpenTrustRegion prints its iteration table at level 3.
+    sopt.otr.verbose = (verbosity >= 1) ? std::max(3, verbosity) : 0;
+    sopt.exact_precond = soprecond;
+    sopt.verbosity = verbosity;
+
+    const helfem::trscf::Result res = opt.run(sopt);
+    dm = std::make_pair(opt.orbitals(), opt.occupations());
+
+    // Announce convergence the way every other driver does. Which optimizer
+    // reached the solution is not the reader's problem, and it is not the
+    // test harness's either: a run with no such line is rejected as
+    // non-converged, which is exactly right, and is why this is printed
+    // only when the gradient really did come down.
+    if(res.converged)
+      printf("Converged to energy %.10f!\n", res.energy);
+
+    if(verbosity >= 1) {
+      printf("\nSecond-order optimization reached energy %.10f with RMS gradient %.3e\n",
+             res.energy, res.grad_rms);
+      printf("  %i reference updates, %i objective evaluations, %i Hessian-vector "
+             "products in %i response builds\n",
+             (int) res.n_update, (int) res.n_objective, (int) res.n_hessian,
+             (int) res.n_response);
+      fflush(stdout);
+    }
+  };
+
+  std::function<helfem::Matrix(const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> &)> radial_density_matrix = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    // Every block, which for an unrestricted calculation means alpha AND
+    // beta. Summing only l = 0..lmax, as this did, is the alpha density
+    // alone -- half of what the saved density file is supposed to hold.
+    const helfem::Cube P = blocked_density(dm);
+    helfem::Matrix Prad = helfem::Matrix::Zero(Nrad, Nrad);
+    for(size_t b=0;b<P.size();b++)
+      Prad += P[b];
     return Prad;
   };
 
@@ -821,7 +915,12 @@ int main(int argc, char **argv) {
 
     OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, restricted_builder, block_descriptions);
     scfsolver.set("verbosity", verbosity);
-    scfsolver.set("maximum_iterations", maxiter);
+    // The first-order phase only has to find the occupation pattern -- which
+    // shells are fractionally occupied -- and get close enough for a local
+    // quadratic model to mean something. Squeezing the last digits out of it
+    // is exactly what it is bad at, so it is cut short when the second-order
+    // optimizer is going to take over.
+    scfsolver.set("maximum_iterations", secondorder ? std::min(maxiter, preiter) : maxiter);
     scfsolver.set("convergence_threshold", convthr);
     scfsolver.set("methods", scfmethods);
     scfsolver.print_citation();
@@ -831,6 +930,13 @@ int main(int argc, char **argv) {
 
     auto dm = std::make_pair(scfsolver.get_orbitals(), scfsolver.get_orbital_occupations());
     auto fock = scfsolver.get_fock_matrix();
+
+    if(secondorder) {
+      second_order_phase(dm, maximum_occupation, std::vector<size_t>(1, (size_t)(lmax+1)));
+      // Rebuild through the ordinary path, which also prints the energy
+      // decomposition of the final solution.
+      fock = restricted_builder(dm).second;
+    }
     save_density(dm, density_name);
     if(savefock != "") {
       save_fock(fock, savefock);
@@ -896,7 +1002,7 @@ int main(int argc, char **argv) {
 
     OpenOrbitalOptimizer::SCFSolver<OOO_Real, OOO_Real> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, unrestricted_builder, block_descriptions);
     scfsolver.set("verbosity", verbosity);
-    scfsolver.set("maximum_iterations", maxiter);
+    scfsolver.set("maximum_iterations", secondorder ? std::min(maxiter, preiter) : maxiter);
     scfsolver.set("convergence_threshold", convthr);
     scfsolver.set("methods", scfmethods);
     scfsolver.print_citation();
@@ -906,6 +1012,14 @@ int main(int argc, char **argv) {
 
     auto dm = std::make_pair(scfsolver.get_orbitals(), scfsolver.get_orbital_occupations());
     auto fock = scfsolver.get_fock_matrix();
+
+    if(secondorder) {
+      // Alpha and beta are separate particle types: their electron counts
+      // are conserved separately, so the occupation transfers stay within
+      // a spin.
+      second_order_phase(dm, maximum_occupation, std::vector<size_t>(2, (size_t)(lmax+1)));
+      fock = unrestricted_builder(dm).second;
+    }
     save_density(dm, density_name);
     if(savefock != "") {
       save_fock(fock, savefock);

--- a/src/sadatom/dftgrid.cpp
+++ b/src/sadatom/dftgrid.cpp
@@ -253,6 +253,48 @@ namespace helfem {
 
       // eval_Exc: inherited from DFTGridWorkerBase.
 
+      helfem::Matrix DFTGridWorker::eval_density(const std::vector<helfem::Matrix> & Pc0) const {
+        const Eigen::Index nbf = (Eigen::Index) bf_ind.size();
+
+        // Sum the l-slices first: only the total density enters an LDA
+        // kernel, and the gather is the expensive part.
+        helfem::Matrix P = helfem::Matrix::Zero(nbf, nbf);
+        for(size_t islice=0; islice<Pc0.size(); islice++)
+          for(size_t i=0;i<bf_ind.size();i++)
+            for(size_t j=0;j<bf_ind.size();j++)
+              P(i,j) += Pc0[islice](bf_ind[i], bf_ind[j]);
+
+        helfem::Matrix Pvloc = P*bf;
+        helfem::Matrix drho = helfem::Matrix::Zero(1, wtot.size());
+        for(Eigen::Index ip=0;ip<wtot.size();ip++)
+          drho(0,ip) = (Pvloc.col(ip).array()*bf.col(ip).array()).sum();
+        return drho;
+      }
+
+      helfem::Matrix DFTGridWorker::eval_density(const std::vector<helfem::Matrix> & Pac0, const std::vector<helfem::Matrix> & Pbc0) const {
+        const Eigen::Index nbf = (Eigen::Index) bf_ind.size();
+
+        helfem::Matrix Pa = helfem::Matrix::Zero(nbf, nbf);
+        for(size_t islice=0; islice<Pac0.size(); islice++)
+          for(size_t i=0;i<bf_ind.size();i++)
+            for(size_t j=0;j<bf_ind.size();j++)
+              Pa(i,j) += Pac0[islice](bf_ind[i], bf_ind[j]);
+        helfem::Matrix Pb = helfem::Matrix::Zero(nbf, nbf);
+        for(size_t islice=0; islice<Pbc0.size(); islice++)
+          for(size_t i=0;i<bf_ind.size();i++)
+            for(size_t j=0;j<bf_ind.size();j++)
+              Pb(i,j) += Pbc0[islice](bf_ind[i], bf_ind[j]);
+
+        helfem::Matrix Pavloc = Pa*bf;
+        helfem::Matrix Pbvloc = Pb*bf;
+        helfem::Matrix drho = helfem::Matrix::Zero(2, wtot.size());
+        for(Eigen::Index ip=0;ip<wtot.size();ip++) {
+          drho(0,ip) = (Pavloc.col(ip).array()*bf.col(ip).array()).sum();
+          drho(1,ip) = (Pbvloc.col(ip).array()*bf.col(ip).array()).sum();
+        }
+        return drho;
+      }
+
       void DFTGridWorker::eval_Fxc(std::vector<helfem::Matrix> & Ho) const {
         if(polarized) {
           throw std::runtime_error("Refusing to compute restricted Fock matrix with unrestricted density.\n");
@@ -651,10 +693,113 @@ namespace helfem {
         Exc=exc;
         Nel=nel;
       }
+      void DFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Cube & P, const std::vector<helfem::Cube> & dP, std::vector<helfem::Cube> & dH, double thr) {
+        const Eigen::Index Nrad = P[0].rows();
 
+        dH.resize(dP.size());
+        for(size_t ip=0; ip<dP.size(); ip++) {
+          if(dP[ip].size() != P.size())
+            throw std::logic_error("Perturbation has a different number of l-slices than the reference density.\n");
+          dH[ip] = helfem::Cube(P.size(), helfem::Matrix::Zero(Nrad, Nrad));
+        }
+        if(dP.empty())
+          return;
 
+        prime_quadrature_cache(x_func,c_func);
 
+        // One pass over the elements, exactly as eval_Fxc does, except
+        // that the potential handed to the assembly is the response
+        // potential of each perturbation in turn.
+        auto do_element = [&](DFTGridWorker & grid, size_t iel) {
+          grid.compute_bf(iel);
+          grid.update_density(P);
+          grid.init_xc();
+          grid.init_fxc();
+          if(x_func>0)
+            grid.compute_fxc(x_func,x_pars,thr);
+          if(c_func>0)
+            grid.compute_fxc(c_func,c_pars,thr);
+          for(size_t ip=0; ip<dP.size(); ip++) {
+            grid.set_response_potential(grid.eval_density(dP[ip]));
+            grid.eval_Fxc(dH[ip]);
+          }
+        };
 
-    }
-  }
-}
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        {
+          DFTGridWorker grid(basp);
+          grid.check_grad_tau_lapl(x_func,c_func);
+
+          // Same even/odd element split as eval_Fxc: neighbouring
+          // elements share boundary functions, so writing them from two
+          // threads at once would race.
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=0;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=1;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+        }
+      }
+
+      void DFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Cube & Pa, const helfem::Cube & Pb, const std::vector<helfem::Cube> & dPa, const std::vector<helfem::Cube> & dPb, std::vector<helfem::Cube> & dHa, std::vector<helfem::Cube> & dHb, double thr) {
+        const Eigen::Index Nrad = Pa[0].rows();
+
+        if(dPa.size() != dPb.size())
+          throw std::logic_error("Different numbers of alpha and beta perturbations.\n");
+
+        dHa.resize(dPa.size());
+        dHb.resize(dPb.size());
+        for(size_t ip=0; ip<dPa.size(); ip++) {
+          dHa[ip] = helfem::Cube(Pa.size(), helfem::Matrix::Zero(Nrad, Nrad));
+          dHb[ip] = helfem::Cube(Pb.size(), helfem::Matrix::Zero(Nrad, Nrad));
+        }
+        if(dPa.empty())
+          return;
+
+        prime_quadrature_cache(x_func,c_func);
+
+        auto do_element = [&](DFTGridWorker & grid, size_t iel) {
+          grid.compute_bf(iel);
+          grid.update_density(Pa,Pb);
+          grid.init_xc();
+          grid.init_fxc();
+          if(x_func>0)
+            grid.compute_fxc(x_func,x_pars,thr);
+          if(c_func>0)
+            grid.compute_fxc(c_func,c_pars,thr);
+          for(size_t ip=0; ip<dPa.size(); ip++) {
+            grid.set_response_potential(grid.eval_density(dPa[ip],dPb[ip]));
+            grid.eval_Fxc(dHa[ip],dHb[ip],true);
+          }
+        };
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        {
+          DFTGridWorker grid(basp);
+          grid.check_grad_tau_lapl(x_func,c_func);
+
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=0;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=1;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+        }
+      }
+
+    } // namespace dftgrid
+  } // namespace sadatom
+} // namespace helfem

--- a/src/sadatom/dftgrid.h
+++ b/src/sadatom/dftgrid.h
@@ -79,6 +79,17 @@ namespace helfem {
         /// Update values of density, unrestricted calculation
         void update_density(const std::vector<helfem::Matrix> & Pa, const std::vector<helfem::Matrix> & Pb);
 
+        /// Evaluate the density of a *second* density matrix on the
+        /// current element grid and return it in the rho layout, leaving
+        /// the reference density -- and with it the kernel computed at
+        /// that density -- untouched. This is how a response evaluation
+        /// gets its perturbation density without a second pass over the
+        /// element. Only the density itself is formed: the LDA kernel
+        /// needs nothing else.
+        helfem::Matrix eval_density(const std::vector<helfem::Matrix> & P) const;
+        /// Same for a spin-polarized perturbation
+        helfem::Matrix eval_density(const std::vector<helfem::Matrix> & Pa, const std::vector<helfem::Matrix> & Pb) const;
+
         // compute_Nel() is inherited from DFTGridWorkerBase.
 
         // init_xc / compute_xc / eval_Exc / zero_Exc are inherited
@@ -125,6 +136,23 @@ namespace helfem {
         /// Compute Fock matrix, exchange-correlation energy and integrated
         /// electron density, unrestricted case.
         void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Cube & Pa, const helfem::Cube & Pb, helfem::Cube & Ha, helfem::Cube & Hb, double & Exc, double & Nel, bool beta, double thr);
+
+        /// Linear response of the XC matrix to each of the density
+        /// perturbations dP, evaluated at the reference density P:
+        /// dH[i] = f_xc . dP[i]. Exact for an LDA; for a GGA or meta-GGA
+        /// it is the density-density part of the kernel only, which is
+        /// what a model Hessian needs (see
+        /// DFTGridWorkerBase::compute_fxc).
+        ///
+        /// The perturbations are passed as a batch because everything
+        /// except the last contraction -- the basis values, the reference
+        /// density, the libxc kernel evaluation -- is shared between
+        /// them. Building an exact Hessian in a d-dimensional subspace
+        /// therefore costs far less than d separate response builds.
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Cube & P, const std::vector<helfem::Cube> & dP, std::vector<helfem::Cube> & dH, double thr);
+        /// Unrestricted counterpart; alpha and beta perturbations are
+        /// batched together because the kernel mixes the spin channels.
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Cube & Pa, const helfem::Cube & Pb, const std::vector<helfem::Cube> & dPa, const std::vector<helfem::Cube> & dPb, std::vector<helfem::Cube> & dHa, std::vector<helfem::Cube> & dHb, double thr);
 
       };
 

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -3562,6 +3562,69 @@
         "--method=mgga_x_tpss-mgga_c_tpss",
         "--symmetry=3"
       ]
+    },
+    {
+      "name": "aij-Fe-firstorder",
+      "code": "aij",
+      "tags": [
+        "jellium",
+        "lda",
+        "consistency"
+      ],
+      "_why": "spin-restricted Fe: 4s and 3d come out degenerate and fractionally occupied, which is the case the first-order methods handle worst. ODA alone does not converge it in 2000 iterations. Paired with the second-order run below.",
+      "args": [
+        "--Z=Fe",
+        "--M=0",
+        "--nelem=5",
+        "--njellium=0",
+        "--rs=0",
+        "--method=lda_x",
+        "--convthr=1e-7"
+      ]
+    },
+    {
+      "name": "aij-Fe-secondorder",
+      "code": "aij",
+      "tags": [
+        "jellium",
+        "lda",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "the same Fe atom through the trust-region optimizer, which optimizes the 4s/3d occupation transfer explicitly rather than waiting for the first-order iteration to find it.",
+      "args": [
+        "--Z=Fe",
+        "--M=0",
+        "--nelem=5",
+        "--njellium=0",
+        "--rs=0",
+        "--method=lda_x",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ]
+    },
+    {
+      "name": "aij-Al-jellium-secondorder",
+      "code": "aij",
+      "tags": [
+        "jellium",
+        "lda",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "unrestricted second-order path: alpha and beta are separate particle types with separately conserved electron counts, which the restricted Fe pair does not exercise.",
+      "args": [
+        "--Z=Al",
+        "--M=2",
+        "--nelem=5",
+        "--method=lda_x",
+        "--njellium=6",
+        "--rs=2.07",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ]
     }
   ],
   "_invariants_comment": [
@@ -4280,6 +4343,26 @@
       ],
       "field": "total",
       "tolerance": 1e-09
+    },
+    {
+      "name": "aij-secondorder-equals-firstorder-Fe",
+      "_why": "the second-order optimizer must find the SAME minimum as the first-order one, not merely a fast one. Reference-free: it ties the trust-region path, its analytic gradient and its XC response kernel to the ordinary SCF at the point where the two must agree. Fe is the case where they disagree most easily, since the 4s/3d occupations are free parameters and a wrong occupation Hessian lands on a different stationary point with a plausible-looking energy.",
+      "cases": [
+        "aij-Fe-firstorder",
+        "aij-Fe-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "aij-secondorder-equals-firstorder-Al-jellium",
+      "_why": "same statement for the unrestricted path, where the occupation transfers are confined within a spin.",
+      "cases": [
+        "aij-Al-jellium",
+        "aij-Al-jellium-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
     }
   ]
 }


### PR DESCRIPTION
The atom-in-jellium problem optimizes occupations as well as orbitals, and that is what makes it converge badly at first order. When two orbitals are degenerate, moving density between them costs nothing to first order in the orbital energies, so the gradient is flat along exactly the direction that matters, while the true cost — a dense coupling through the Coulomb and XC kernels — is entirely second order. Spin-restricted Fe is the standard case: 4s and 3d come out at the same orbital energy and sit in different `l` blocks, so no orbital rotation connects them at all and their whole interaction is `<4s 4s|W|3d 3d>`.

| method | cost | result |
|---|---|---|
| ODA alone | 2000 iterations / 11087 Fock builds | no convergence |
| ODA+LBFGS | 193 Fock builds | stalls at RMS gradient 8.3e-8 |
| DIIS+ODA+CG | 328 Fock builds | converges |
| **second order** | **48 Hessian-vector products** | **RMS gradient 3.6e-10** |

`--secondorder=1` runs the first-order solver for `--preiter` iterations, then hands over to a trust-region optimizer built on [OpenTrustRegion](https://github.com/eriksen-lab/opentrustregion), added as an **optional** dependency — it is Fortran with a C interface, so without it everything builds exactly as before, minus this path. Only the LP64 build is usable and that is enforced at configure time and checked again at run time.

## Parametrization

Orbital energies increase monotonically within an angular momentum, so each block holds at most one fractionally occupied orbital. Rather than track which one, each block carries a single continuous variable `q_b`, its electron count, with occupations following by aufbau fill `f_i = clamp(q - i*w, 0, w)`. The free coordinates span the sum-zero subspace of the genuinely fractional blocks in an orthonormal Helmert basis, so the electron count is conserved **exactly and to all orders**, with no projection and no second-order correction.

Rotations are applied by a low-rank exponential: `kappa` is supported only on the occupied and fractional rows, so `exp(kappa)` reduces to a `2m`-dimensional problem, `O(n^2 m)` instead of `O(n^3)`.

## Preconditioning

The uncoupled Hessian diagonal is *identically zero* along every occupation direction — the formal statement that first order sees nothing there — so the occupation block is built exactly, one Fock response per column, and inverted exactly.

Seeing why that matters takes **two** occupation coordinates; with one the block is 1x1 and there is nothing to capture, which is every open-shell atom tried but one. Curium (5f, 6d and 7s fractionally occupied at once) has two:

| | exact block | floored diagonal |
|---|---|---|
| RMS gradient | 9.7e-10 | 5.8e-3 |
| energy | -28376.6749963109 | -28376.6711800819 |

The diagonal strands the solve 3.8e-3 above the minimum. Cm is also hard first-order — 327 iterations, 599 Fock evaluations — so it is not a contrived example.

## KKT conditions

A block frozen at an integer occupation is stationary for the *restricted* problem with that block pinned, not for the problem being solved, unless the multiplier signs happen to agree: by Janak's theorem `dE/dn_i = eps_i`, so a full orbital must lie below `eps_F` and an empty one above it. When they do not, the gradient can be 2e-9 and the energy still 0.032 Eh wrong — the optimizer is not failing, it is succeeding at the wrong problem. Such a block is **released** rather than reported, which repairs the answer: Fe and Cm handed over at `--preiter=20` go from 0.032 and 0.029 Eh high to exact.

Second order cannot start from scratch, which is why the handover exists at all. From the bare core guess Fe converges in a second to a gradient of 5e-9 and an energy **6.1 Eh** too high; Cm lands **124 Eh** too high. It optimizes within an occupation pattern and cannot discover one. Both published methods for this problem do the same — Cancès et al. (JCP 118, 5364) start from RCA once its slope drops below 1e-3, and Nygaard and Olsen (JCP 138, 094109) require every orbital that might end up fractional to be fractional already.

## XC response kernel

New machinery in the shared grid code. A response matrix is the same integral as an XC matrix with a different potential in it, so filling the potential buffers and calling the existing `eval_Fxc` assembles it with no new assembly code at all.

For GGA and meta-GGA the kernel is **deliberately** incomplete — density-density block only, measured 0.14% and 0.08% Hessian error — because it builds a model Hessian, never an energy or a gradient, and every step is validated against the exact energy. Completing it is a clean extension point.

## Verification

- Analytic gradient and Hessian checked against finite differences of the energy surface, including mixed `d1.H.d2` forms that a single-direction check cannot see, on restricted, unrestricted, LDA, GGA and meta-GGA paths (`--sotest`).
- Three new test cases pair a first-order run against a second-order one on the same system and require them to agree — reference-free. Both invariants were deliberately pointed at the wrong case to confirm they can fail.
- Full suite **135 passed, 0 failed, 0 errored**, with the same 8 pre-existing `diatomic-dummy-equals-atomic-*` invariant violations as before this work.
- Every intermediate commit of the development branch was verified to build on its own before squashing.

## Known limitation

The second-order phase is sensitive to where the first-order phase hands over. Cr, Nb and Fe/TPSS at `--preiter=40` reach within 1e-9 to 1e-7 of the right minimum but retain a residual gradient, because OpenTrustRegion discards a step whose microiterations missed their residual-reduction target however good the step is — probed directly, one discarded step lowered the energy by 5.3e-4 and landed on the minimum. `--soredfac` defaults to 3e-1 for this reason, a hundred times looser than upstream's default and *cheaper* on the cases that already worked; the best point offered is also kept and taken back when a pass stalls. This is mitigated, not cured.

## Also fixed

`radial_density_matrix` summed only blocks `0..lmax`, so `density_aij.dat` carried the alpha density alone for unrestricted runs — longstanding and invisible, since no test read the file.
