### PR TITLE
gensap: second-order optimization, and stop rebuilding libxc functionals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Higher-level library linking against `helfem`. Contains SCF infrastructure, DFT 
 | `diatomic_dgrid` | `src/diatomic/density_grid.cpp` | Density on 2D grid |
 | `aij` | `src/sadatom/aij.cpp` | Atom in jellium |
 
-## Second-order convergence in `aij`
+## Second-order convergence in `aij` and `gensap`
 
 The atom-in-jellium problem optimizes the occupations as well as the
 orbitals, and that is what makes it converge badly at first order. When
@@ -172,6 +172,39 @@ far away from it. A work ceiling, counted per macroiteration so it fires
 on work-without-progress rather than on an absolute budget, is what stops
 them, and it says what happened. If a system matters and stalls, move
 `--preiter`.
+
+`gensap` carries the same optimizer over the same parametrization, since
+the spherically averaged atom is the same problem with the jellium
+switched off. The options are spelled the same (`--secondorder`,
+`--preiter`, `--sotest`, ...), and the two drivers can be compared
+directly: `aij` with `--njellium=0 --rs=0` IS the bare atom, and on Fe
+both reach `-1258.9186876173` through separate energy expressions, Fock
+builders and SCF drivers.
+
+That case is worth knowing about, because in `gensap` first order does
+not merely converge slowly -- it stops at `-1258.8157`, **0.103 Eh above
+the minimum**, without printing a convergence line. The second-order
+phase repairs it outright.
+
+Two things are specific to `gensap`:
+
+- **Exact exchange goes through the Hessian too.** `gensap` supports HF
+  and hybrids, which `aij` does not. Exchange is linear in the density,
+  so its response is exact; `--sotest` confirms it (`d1.H.d1` agrees with
+  finite differences to 1.9e-10 at HF), and on Fe the first- and
+  second-order answers agree to 2e-10 Eh.
+- **Frozen occupations and `--secondorder` are refused together.** The
+  occupations are among the variables the optimizer optimizes, so
+  `--fixed-per-l` style pinning has no meaning there, and the driver
+  throws rather than silently ignoring one of the two.
+
+The handover sensitivity is more visible here than in `aij`, because
+`gensap` defaults to the SAP initial guess (`--iguess=2`) and lands
+somewhere different. On Fe with that guess the energy is right from
+`--preiter` 30 upwards, but the RMS gradient stalls between 1e-8 and 4e-7
+and the convergence line is not printed; with the core guess
+(`--iguess=0`) the same run reaches 4.9e-10. The energy is not what is
+uncertain -- it repeats to all printed digits -- only the flag.
 
 Occupation coupling is where the exact preconditioner earns itself, and it
 takes two occupation coordinates to see it -- with one the block is 1x1

--- a/src/general/dftgrid_common.cpp
+++ b/src/general/dftgrid_common.cpp
@@ -96,9 +96,56 @@ namespace helfem {
       return nel;
     }
 
+    const DFTGridWorkerBase::Functional &
+    DFTGridWorkerBase::functional(int func_id, const helfem::Vector & p,
+                                  double thr) {
+      const int nspin = polarized ? XC_POLARIZED : XC_UNPOLARIZED;
+      for (const Functional & f : funcs)
+        if (f.id == func_id && f.nspin == nspin && f.thr == thr &&
+            f.params.size() == p.size() &&
+            (p.size() == 0 || (f.params - p).cwiseAbs().maxCoeff() == 0.0))
+          return f;
+
+      Functional f;
+      f.id = func_id;
+      f.nspin = nspin;
+      f.thr = thr;
+      f.params = p;
+      is_gga_mgga(func_id, f.gga, f.mgga_t, f.mgga_l);
+      f.have_exc = has_exc(func_id);
+
+      // Initialize first, wrap second: the deleter calls xc_func_end, and
+      // running that on a functional xc_func_init refused would be worse
+      // than the failure it reports.
+      xc_func_type * raw = new xc_func_type;
+      if (xc_func_init(raw, func_id, nspin) != 0) {
+        delete raw;
+        std::ostringstream oss;
+        oss << "Functional " << func_id << " not found!";
+        throw std::runtime_error(oss.str());
+      }
+      f.func = std::shared_ptr<xc_func_type>(raw, [](xc_func_type * q) {
+        xc_func_end(q);
+        delete q;
+      });
+
+      xc_func_set_dens_threshold(raw, thr);
+      if (p.size()) {
+        if (p.size() != (Eigen::Index) xc_func_info_get_n_ext_params((xc_func_info_type *) raw->info))
+          throw std::logic_error("Incompatible number of parameters!\n");
+        helfem::Vector phlp(p);
+        xc_func_set_ext_params(raw, phlp.data());
+      }
+
+      funcs.push_back(f);
+      return funcs.back();
+    }
+
     void DFTGridWorkerBase::compute_xc(int func_id, const helfem::Vector & p, double thr, bool pot) {
-      bool gga, mgga_t, mgga_l;
-      is_gga_mgga(func_id, gga, mgga_t, mgga_l);
+      const Functional & fc = functional(func_id, p, thr);
+      xc_func_type & func = *fc.func;
+      const bool gga = fc.gga, mgga_t = fc.mgga_t, mgga_l = fc.mgga_l;
+      const bool have_exc = fc.have_exc;
 
       do_gga    = do_gga    || gga || mgga_t || mgga_l;
       do_mgga_t = do_mgga_t || mgga_t;
@@ -109,7 +156,7 @@ namespace helfem {
       helfem::Vector exc_wrk;
       helfem::Matrix vxc_wrk, vsigma_wrk, vlapl_wrk, vtau_wrk;
 
-      if (has_exc(func_id))
+      if (have_exc)
         exc_wrk = helfem::Vector::Zero(exc.size());
       if (pot) {
         vxc_wrk = helfem::Matrix::Zero(vxc.rows(), vxc.cols());
@@ -121,24 +168,7 @@ namespace helfem {
           vlapl_wrk = helfem::Matrix::Zero(vlapl.rows(), vlapl.cols());
       }
 
-      const int nspin = polarized ? XC_POLARIZED : XC_UNPOLARIZED;
-
-      xc_func_type func;
-      if (xc_func_init(&func, func_id, nspin) != 0) {
-        std::ostringstream oss;
-        oss << "Functional " << func_id << " not found!";
-        throw std::runtime_error(oss.str());
-      }
-      xc_func_set_dens_threshold(&func, thr);
-
-      if (p.size()) {
-        if (p.size() != (Eigen::Index) xc_func_info_get_n_ext_params((xc_func_info_type *) func.info))
-          throw std::logic_error("Incompatible number of parameters!\n");
-        helfem::Vector phlp(p);
-        xc_func_set_ext_params(&func, phlp.data());
-      }
-
-      if (has_exc(func_id)) {
+      if (have_exc) {
         if (pot) {
           if (mgga_t || mgga_l) {
             double * laplp  = mgga_l ? lapl.data()      : NULL;
@@ -193,7 +223,7 @@ namespace helfem {
       // so atomic and diatomic get the same warning). Prints only;
       // never modifies state.
       for (size_t i = 0; i < N; ++i) {
-        const double e = has_exc(func_id) ? exc_wrk(i) : 0.0;
+        const double e = have_exc ? exc_wrk(i) : 0.0;
         double rhoa = 0.0, rhob = 0.0;
         double sigmaaa = 0.0, sigmaab = 0.0, sigmabb = 0.0;
         double lapla = 0.0, laplb = 0.0, taua = 0.0, taub = 0.0;
@@ -243,7 +273,7 @@ namespace helfem {
         }
       }
 
-      if (has_exc(func_id))
+      if (have_exc)
         exc += exc_wrk;
       if (pot) {
         if (mgga_l)                     vlapl  += vlapl_wrk;
@@ -251,8 +281,6 @@ namespace helfem {
         if (mgga_t || mgga_l || gga)    vsigma += vsigma_wrk;
         vxc += vxc_wrk;
       }
-
-      xc_func_end(&func);
     }
 
     void DFTGridWorkerBase::init_fxc() {
@@ -274,32 +302,16 @@ namespace helfem {
 
     void DFTGridWorkerBase::compute_fxc(int func_id, const helfem::Vector & p,
                                         double thr) {
-      bool gga, mgga_t, mgga_l;
-      is_gga_mgga(func_id, gga, mgga_t, mgga_l);
+      const Functional & fc = functional(func_id, p, thr);
+      xc_func_type & func = *fc.func;
+      const bool gga = fc.gga, mgga_t = fc.mgga_t, mgga_l = fc.mgga_l;
 
       const size_t N = (size_t) wtot.size();
-      const int nspin = polarized ? XC_POLARIZED : XC_UNPOLARIZED;
-
-      xc_func_type func;
-      if (xc_func_init(&func, func_id, nspin) != 0) {
-        std::ostringstream oss;
-        oss << "Functional " << func_id << " not found!";
-        throw std::runtime_error(oss.str());
-      }
-      xc_func_set_dens_threshold(&func, thr);
-
-      if (p.size()) {
-        if (p.size() != (Eigen::Index) xc_func_info_get_n_ext_params((xc_func_info_type *) func.info))
-          throw std::logic_error("Incompatible number of parameters!\n");
-        helfem::Vector phlp(p);
-        xc_func_set_ext_params(&func, phlp.data());
-      }
 
       // A functional without XC_FLAGS_HAVE_FXC would leave the buffer
       // untouched, i.e. contribute a silently zero kernel; the Hessian
       // would then be wrong in a way nothing downstream can detect.
       if (!(func.info->flags & XC_FLAGS_HAVE_FXC)) {
-        xc_func_end(&func);
         std::ostringstream oss;
         oss << "Functional " << func_id << " does not implement its second "
             << "derivatives, so no response kernel can be formed.\n";
@@ -349,8 +361,6 @@ namespace helfem {
         v2tau2   += t2;
         if (do_grad) v2sigmatau += st;
       }
-
-      xc_func_end(&func);
     }
 
     void DFTGridWorkerBase::build_vgrad(const helfem::Matrix & grho) {

--- a/src/general/dftgrid_common.h
+++ b/src/general/dftgrid_common.h
@@ -23,9 +23,15 @@
 // compute_Nel, etc.) stay in the derived classes.
 
 #include <Matrix.h>
+#include <deque>
+#include <memory>
 #include <vector>
 #include <sstream>
 #include <stdexcept>
+
+/// libxc's functional handle. Forward declared -- exactly as libxc's own
+/// header does -- so that <xc.h> stays out of every consumer of this one.
+struct xc_func_type;
 
 namespace helfem {
   namespace dftgrid_common {
@@ -96,6 +102,38 @@ namespace helfem {
       helfem::Matrix v2rhosigma, v2sigma2;
       /// meta-GGA (kinetic energy density) blocks
       helfem::Matrix v2rhotau, v2sigmatau, v2tau2;
+
+      /// One initialized libxc functional, together with the answers to
+      /// the constant questions HelFEM asks about it.
+      ///
+      /// None of this changes over a run, but all of it used to be
+      /// rebuilt constantly: compute_xc and compute_fxc did their own
+      /// xc_func_init / xc_func_end on every element, is_gga_mgga did
+      /// another pair on every call, and has_exc -- which does one too --
+      /// sat inside the NaN guard's loop over QUADRATURE POINTS, so a
+      /// libxc functional was constructed and destroyed once per grid
+      /// point per element per functional to answer a question whose
+      /// answer never changed.
+      struct Functional {
+        int id = 0;
+        int nspin = 0;
+        double thr = 0.0;
+        helfem::Vector params;
+        bool gga = false, mgga_t = false, mgga_l = false, have_exc = false;
+        /// The deleter carries the xc_func_end call, so it is bound in
+        /// the .cpp and <xc.h> is not needed here.
+        std::shared_ptr<xc_func_type> func;
+      };
+      /// A deque rather than a vector: functional() hands out references
+      /// into this, and a deque never invalidates them when it grows.
+      std::deque<Functional> funcs;
+
+      /// The initialized functional and its properties for this id, spin
+      /// channel, density threshold and parameter set, built on first use
+      /// and kept for the lifetime of the worker. Workers are per-thread,
+      /// so this needs no locking.
+      const Functional & functional(int func_id, const helfem::Vector & params,
+                                    double thr);
 
     public:
       DFTGridWorkerBase();

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -29,6 +29,7 @@
 #include "../general/lcao.h"
 #include "../atomic/basis.h"
 #include "scf.h"
+#include "../general/otr_solver.h"
 #include "../general/eigen_io.h"
 // std::abs / std::round / std::lround for the --occs integrality check.
 #include <cmath>
@@ -273,6 +274,16 @@ int main(int argc, char **argv) {
   parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration Fock timings; also passed to the SCF solver", false, 5);
   parser.add<int>("maxiter", 0, "maximum number of SCF iterations", false, 128);
   parser.add<double>("convthr", 0, "SCF convergence threshold", false, 1e-7);
+  parser.add<bool>("secondorder", 0, "follow the first-order SCF with second-order trust-region optimization of the orbitals and the fractional occupations", false, false);
+  parser.add<int>("preiter", 0, "first-order iterations to run before switching to the second-order optimizer", false, 100);
+  parser.add<double>("soconvthr", 0, "RMS gradient the second-order optimizer converges to", false, 1e-8);
+  parser.add<int>("somacro", 0, "second-order macroiteration cap", false, 150);
+  parser.add<int>("somicro", 0, "second-order microiteration cap", false, 50);
+  parser.add<int>("somaxhess", 0, "ceiling on Hessian-vector products per macroiteration; 0 for the default", false, 0);
+  parser.add<double>("soredfac", 0, "second-order residual-reduction factor", false, 3e-1);
+  parser.add<std::string>("sosolver", 0, "second-order reduced-space solver: davidson or tcg", false, "davidson");
+  parser.add<bool>("soprecond", 0, "use the exact occupation-block preconditioner", false, true);
+  parser.add<double>("sotest", 0, "instead of optimizing, check the analytic gradient and Hessian against finite differences with this step size", false, 0.0);
 
   // SAP / effective-potential generation (parity with bespoke gensap).
   // With a functional active, gensap tabulates the radial effective
@@ -391,6 +402,23 @@ int main(int argc, char **argv) {
   opts.scf_methods  = parser.get<std::string>("scfmethods");
   opts.maxiter      = parser.get<int>("maxiter");
   opts.convthr      = parser.get<double>("convthr");
+  opts.secondorder  = parser.get<bool>("secondorder");
+  opts.preiter      = parser.get<int>("preiter");
+  opts.soconvthr    = parser.get<double>("soconvthr");
+  opts.somacro      = parser.get<int>("somacro");
+  opts.somicro      = parser.get<int>("somicro");
+  opts.somaxhess    = parser.get<int>("somaxhess");
+  opts.soredfac     = parser.get<double>("soredfac");
+  opts.sosolver     = parser.get<std::string>("sosolver");
+  opts.soprecond    = parser.get<bool>("soprecond");
+  opts.sotest       = parser.get<double>("sotest");
+  // A derivative check is a second-order run that stops after checking.
+  if (opts.sotest > 0.0)
+    opts.secondorder = true;
+  if (opts.secondorder && !helfem::otr::available())
+    throw std::logic_error("This HelFEM was built without OpenTrustRegion, so "
+                           "--secondorder is unavailable. Configure with "
+                           "-DHELFEM_OPENTRUSTREGION=ON.\n");
   opts.iguess       = parser.get<int>("iguess");
   opts.load_file    = parser.get<std::string>("load");
   opts.save_file    = parser.get<std::string>("save");

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -19,6 +19,7 @@
 #include "../general/scf_helpers.h"
 #include "../general/checkpoint.h"
 #include "../general/scf_driver_common.h"
+#include "../general/trustregion_scf.h"
 
 #include "openorbitaloptimizer/scfsolver.hpp"
 
@@ -122,47 +123,61 @@ namespace helfem {
           return out;
         };
 
-        auto accumulate_density = [&](helfem::Matrix & Prad, helfem::Cube & Pl_cube,
-                                       size_t l, const helfem::Matrix & orb,
-                                       const helfem::Vector & occ, double & Ekin_out) {
-          if (occ.cwiseAbs().maxCoeff() == 0.0) return;
-          const helfem::Matrix C = Sinvh * orb;
-          const helfem::Matrix P_l = C * occ.asDiagonal() * C.transpose();
-          Prad += P_l;
-          Pl_cube[l] = P_l;
-          Ekin_out += (P_l * T).trace();
-          if (l > 0)
-            Ekin_out += l * (l + 1) * (P_l * Tl).trace();
-        };
-
-        // Shared implementation of the Fock build. `log_line`, when
-        // non-null, collects the energy breakdown instead of it going
-        // straight to stdout: a batched build evaluates its entries
-        // concurrently, and interleaved printf from several threads
-        // would be unreadable and out of order. Everything else here is
-        // either a local or a const capture, so the body is safe to run
-        // from several threads at once.
-        auto build_fock = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm,
-                              std::string * log_line,
-                              helfem::scf_driver::FockTimer::Components * tc) {
+        // Per-block FEM densities of an OpenOrbitalOptimizer solution.
+        // Blocks are l = 0..lmax for the restricted case, and alpha
+        // l = 0..lmax followed by beta l = 0..lmax for the unrestricted
+        // one, matching the block layout OOO is given.
+        auto blocked_density = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
           const auto & orbitals    = dm.first;
           const auto & occupations = dm.second;
+          helfem::Cube P(orbitals.size(), helfem::Matrix::Zero(Nrad, Nrad));
+          for (size_t b = 0; b < orbitals.size(); ++b) {
+            if (occupations[b].cwiseAbs().maxCoeff() == 0.0) continue;
+            // Same radial basis for every l
+            const helfem::Matrix C = Sinvh * orbitals[b];
+            P[b] = C * occupations[b].asDiagonal() * C.transpose();
+          }
+          return P;
+        };
+
+        // Energy and per-block Fock matrices in the FEM basis, given the
+        // per-block FEM densities. This is the whole energy expression,
+        // lifted out of the OpenOrbitalOptimizer builders below so that
+        // the second-order optimizer -- which works from densities
+        // rather than from orbitals and occupations -- shares it instead
+        // of restating it.
+        //
+        // `log_line`, when non-null, collects the energy breakdown
+        // instead of it going straight to stdout: a batched build
+        // evaluates its entries concurrently, and interleaved printf
+        // from several threads would be unreadable and out of order.
+        // Everything else here is either a local or a const capture, so
+        // the body is safe to run from several threads at once.
+        auto fock_fem = [&](const helfem::Cube & P, helfem::Cube & Fout,
+                            std::string * log_line,
+                            helfem::scf_driver::FockTimer::Components * tc) -> double {
+          if (P.size() != nblock * nparttype)
+            throw std::logic_error("Density has an unexpected number of blocks.\n");
           // Component timings go into the caller's own Components, never
           // into shared state: a batched build runs these concurrently.
           Timer tbuild, tcomp;
 
-          OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nblock * nparttype);
           helfem::Matrix Prad = helfem::Matrix::Zero(Nrad, Nrad);
           double Ekin = 0.0;
           double Exc = 0.0;
           double nelnum = 0.0;
           helfem::Cube XCa, XCb;
-          helfem::Cube Pal(nblock, helfem::Matrix::Zero(Nrad, Nrad));
+          helfem::Cube Pal(P.begin(), P.begin() + nblock);
           helfem::Cube Pbl;
 
+          for (size_t b = 0; b < P.size(); ++b) {
+            const size_t l = b % nblock;
+            Prad += P[b];
+            Ekin += (P[b] * T).trace();
+            if (l > 0) Ekin += l * (l + 1) * (P[b] * Tl).trace();
+          }
+
           if (restricted) {
-            for (size_t l = 0; l < nblock; ++l)
-              accumulate_density(Prad, Pal, l, orbitals[l], occupations[l], Ekin);
             if (tc) tc->density += tcomp.get();
             if (have_xc) {
               tcomp.set();
@@ -172,14 +187,7 @@ namespace helfem {
               if (tc) tc->xc += tcomp.get();
             }
           } else {
-            Pbl.assign(nblock, helfem::Matrix::Zero(Nrad, Nrad));
-            helfem::Matrix Prad_a = helfem::Matrix::Zero(Nrad, Nrad);
-            helfem::Matrix Prad_b = helfem::Matrix::Zero(Nrad, Nrad);
-            for (size_t l = 0; l < nblock; ++l) {
-              accumulate_density(Prad_a, Pal, l, orbitals[l], occupations[l], Ekin);
-              accumulate_density(Prad_b, Pbl, l, orbitals[nblock + l], occupations[nblock + l], Ekin);
-            }
-            Prad = Prad_a + Prad_b;
+            Pbl.assign(P.begin() + nblock, P.end());
             if (tc) tc->density += tcomp.get();
             if (have_xc) {
               tcomp.set();
@@ -265,21 +273,119 @@ namespace helfem {
               Fl += XC_cube[l];
             if (add_k)
               Fl += K_cube[l];
-            return Sinvh.transpose() * Fl * Sinvh;
+            return Fl;
           };
 
+          Fout.assign(nblock * nparttype, helfem::Matrix());
           if (restricted) {
             for (size_t l = 0; l < nblock; ++l)
-              fock[l] = build_fock_block(l, XCa, have_xc, Ka, have_exx);
+              Fout[l] = build_fock_block(l, XCa, have_xc, Ka, have_exx);
           } else {
             for (size_t l = 0; l < nblock; ++l) {
-              fock[l]          = build_fock_block(l, XCa, have_xc, Ka, have_exx);
-              fock[nblock + l] = build_fock_block(l, XCb, have_xc && opts.nelb > 0,
+              Fout[l]          = build_fock_block(l, XCa, have_xc, Ka, have_exx);
+              Fout[nblock + l] = build_fock_block(l, XCb, have_xc && opts.nelb > 0,
                                                    Kb, have_exx && opts.nelb > 0);
             }
           }
           if (tc) tc->total = tbuild.get();
+          return Etot;
+        };
+
+        // The same build in the form OpenOrbitalOptimizer wants: a
+        // density matrix in, energy and orthonormal-basis Fock out.
+        auto build_fock = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm,
+                              std::string * log_line,
+                              helfem::scf_driver::FockTimer::Components * tc) {
+          helfem::Cube F;
+          const double Etot = fock_fem(blocked_density(dm), F, log_line, tc);
+          OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nblock * nparttype);
+          for (size_t b = 0; b < F.size(); ++b)
+            fock[b] = Sinvh.transpose() * F[b] * Sinvh;
           return std::make_pair(Etot, fock);
+        };
+
+        // Linear response of those Fock matrices to a batch of density
+        // perturbations. The one-electron terms (T, Vnuc, Vconf, the
+        // centrifugal l(l+1)Tl) are independent of the density and drop
+        // out; the Coulomb and exchange halves are linear, so their
+        // response is exact and costs one more build of each; the XC
+        // half goes through the response kernel, which is exact for LDA
+        // and GGA and keeps only the density, gradient and tau channels
+        // beyond that.
+        auto response_fem = [&](const helfem::Cube & P,
+                                const std::vector<helfem::Cube> & dP,
+                                std::vector<helfem::Cube> & dF) {
+          const size_t nt = dP.size();
+          dF.assign(nt, helfem::Cube());
+
+          std::vector<helfem::Cube> dXCa, dXCb;
+          if (have_xc) {
+            if (restricted) {
+              std::vector<helfem::Cube> dPs(nt);
+              for (size_t it = 0; it < nt; ++it)
+                dPs[it] = divided_cube(dP[it], angfac);
+              grid.eval_Fxc_response(opts.x_func, opts.x_pars, opts.c_func, opts.c_pars,
+                                      divided_cube(helfem::Cube(P.begin(), P.begin() + nblock), angfac),
+                                      dPs, dXCa, opts.dftthr);
+            } else {
+              std::vector<helfem::Cube> dPa(nt), dPb(nt);
+              for (size_t it = 0; it < nt; ++it) {
+                dPa[it] = divided_cube(helfem::Cube(dP[it].begin(), dP[it].begin() + nblock), angfac);
+                dPb[it] = divided_cube(helfem::Cube(dP[it].begin() + nblock, dP[it].end()), angfac);
+              }
+              grid.eval_Fxc_response(opts.x_func, opts.x_pars, opts.c_func, opts.c_pars,
+                                      divided_cube(helfem::Cube(P.begin(), P.begin() + nblock), angfac),
+                                      divided_cube(helfem::Cube(P.begin() + nblock, P.end()), angfac),
+                                      dPa, dPb, dXCa, dXCb, opts.dftthr);
+              for (size_t it = 0; it < nt; ++it)
+                for (size_t l = 0; l < dXCb[it].size(); ++l) dXCb[it][l] /= angfac;
+            }
+            for (size_t it = 0; it < nt; ++it)
+              for (size_t l = 0; l < dXCa[it].size(); ++l) dXCa[it][l] /= angfac;
+          }
+
+          for (size_t it = 0; it < nt; ++it) {
+            helfem::Matrix dPrad = helfem::Matrix::Zero(Nrad, Nrad);
+            for (size_t b = 0; b < dP[it].size(); ++b)
+              dPrad += dP[it][b];
+            const helfem::Matrix dJ = basis.coulomb(dPrad / angfac);
+
+            // Exchange is linear in the density, so its response is the
+            // same contraction applied to the perturbation.
+            helfem::Cube dKa, dKb;
+            if (have_exx) {
+              auto exchange_response = [&](const helfem::Cube & dPs, bool spin_averaged) {
+                helfem::Cube ang(dPs.size());
+                for (size_t l = 0; l < dPs.size(); ++l)
+                  ang[l] = dPs[l] / (spin_averaged ? 2.0 * (2 * l + 1) : (2 * l + 1));
+                helfem::Cube dK(dPs.size(), helfem::Matrix::Zero(Nrad, Nrad));
+                if (kfrac != 0.0) {
+                  const helfem::Cube Kx = basis.exchange(ang);
+                  for (size_t l = 0; l < dPs.size(); ++l) dK[l] += kfrac * Kx[l];
+                }
+                if (kshort != 0.0) {
+                  const helfem::Cube Kx = basis.rs_exchange(ang);
+                  for (size_t l = 0; l < dPs.size(); ++l) dK[l] += kshort * Kx[l];
+                }
+                return dK;
+              };
+              dKa = exchange_response(helfem::Cube(dP[it].begin(), dP[it].begin() + nblock),
+                                       restricted);
+              if (!restricted)
+                dKb = exchange_response(helfem::Cube(dP[it].begin() + nblock, dP[it].end()), false);
+            }
+
+            dF[it].assign(nblock * nparttype, helfem::Matrix::Zero(Nrad, Nrad));
+            for (size_t b = 0; b < dF[it].size(); ++b) {
+              const size_t l = b % nblock;
+              const bool beta_block = (b >= nblock);
+              dF[it][b] = dJ;
+              if (have_xc && !(beta_block && opts.nelb <= 0))
+                dF[it][b] += beta_block ? dXCb[it][l] : dXCa[it][l];
+              if (have_exx && !(beta_block && opts.nelb <= 0))
+                dF[it][b] += beta_block ? dKb[l] : dKa[l];
+            }
+          }
         };
 
         // Per-component wall clock for the Fock build, plus the time
@@ -384,7 +490,13 @@ namespace helfem {
             number_of_particles, fock_builder, block_descriptions);
         scfsolver.set_batched_fock_builder(batched_fock_builder);
         scfsolver.set("verbosity", opts.verbosity);
-        scfsolver.set("maximum_iterations", opts.maxiter);
+        // With a second-order phase to follow, the first-order one only
+        // has to find the occupation PATTERN -- which shells are
+        // fractionally occupied -- and get close enough for a quadratic
+        // model to mean something.
+        scfsolver.set("maximum_iterations",
+                      opts.secondorder ? std::min(opts.maxiter, opts.preiter)
+                                       : opts.maxiter);
         scfsolver.set("convergence_threshold", opts.convthr);
 
         // Frozen per-l occupation: hand OOO a per-block particle count
@@ -393,6 +505,12 @@ namespace helfem {
         // occupation directly rather than reading occs.dat.
         const bool freeze_a = static_cast<int>(opts.fixed_per_l_a.size()) == lmax + 1;
         const bool freeze_b = (!restricted) && static_cast<int>(opts.fixed_per_l_b.size()) == lmax + 1;
+        if ((freeze_a || freeze_b) && opts.secondorder)
+          throw std::logic_error("Frozen per-l occupations cannot be combined "
+                                 "with the second-order optimizer: the "
+                                 "occupations are among the variables it "
+                                 "optimizes, so pinning them has no meaning "
+                                 "there.\n");
         if (freeze_a || freeze_b) {
           Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1> fixed =
               Eigen::Matrix<OOO_Real, Eigen::Dynamic, 1>::Zero(nblock * nparttype);
@@ -566,8 +684,78 @@ namespace helfem {
         // (in the Sinvh-orthonormal basis) back to AO coefficients
         // (Nbf, Nbf) per l, matching the arma::cube layout the
         // bespoke sadatom SCFSolver used to hand back.
-        const auto orbitals    = scfsolver.get_orbitals();
-        const auto occupations = scfsolver.get_orbital_occupations();
+        auto orbitals    = scfsolver.get_orbitals();
+        auto occupations = scfsolver.get_orbital_occupations();
+
+        if (opts.secondorder) {
+          std::vector<double> maxocc((size_t) maximum_occupation.size());
+          for (Eigen::Index i = 0; i < maximum_occupation.size(); ++i)
+            maxocc[(size_t) i] = maximum_occupation(i);
+
+          helfem::trscf::FockBuilder so_fock =
+              [&](const helfem::Cube & P, helfem::Cube & F) {
+            // No reporting: the trust-region solver prints its own
+            // iteration table, and a microiteration sweep makes many
+            // objective evaluations that are not iterations.
+            return fock_fem(P, F, nullptr, nullptr);
+          };
+          helfem::trscf::ResponseBuilder so_response =
+              [&](const helfem::Cube & P, const std::vector<helfem::Cube> & dP,
+                  std::vector<helfem::Cube> & dF) { response_fem(P, dP, dF); };
+
+          helfem::trscf::Optimizer opt(Sinvh, maxocc,
+                                        std::vector<size_t>(nparttype, nblock),
+                                        so_fock, so_response);
+          opt.set_reference(orbitals, occupations);
+
+          if (opts.sotest > 0.0) {
+            // Derivative check only: the analytic gradient and Hessian
+            // are the whole content of the second-order method, and
+            // nothing downstream can tell a wrong Hessian from a hard
+            // problem. The response kernel is exact for LDA and GGA and
+            // for the tau channel of a meta-GGA; a Laplacian-dependent
+            // functional has no response channel at all, so there the
+            // Hessian is measured rather than tested.
+            bool xg=false, xt=false, xl=false, cg=false, ct=false, cl=false;
+            if (opts.x_func > 0) is_gga_mgga(opts.x_func, xg, xt, xl);
+            if (opts.c_func > 0) is_gga_mgga(opts.c_func, cg, ct, cl);
+            if (!opt.verify(opts.sotest, 1e-4, opts.verbosity, !(xl || cl)))
+              throw std::runtime_error("The analytic derivatives disagree with "
+                                       "finite differences.\n");
+          } else {
+            helfem::trscf::Options sopt;
+            sopt.otr.conv_tol = opts.soconvthr;
+            sopt.otr.n_macro = opts.somacro;
+            sopt.otr.n_micro = opts.somicro;
+            sopt.max_hessian = opts.somaxhess;
+            sopt.otr.global_red_factor = opts.soredfac;
+            sopt.otr.local_red_factor = 0.1 * opts.soredfac;
+            sopt.otr.subsystem_solver = opts.sosolver;
+            // OpenTrustRegion prints its iteration table at level 3.
+            sopt.otr.verbose = (opts.verbosity >= 1) ? std::max(3, opts.verbosity) : 0;
+            sopt.exact_precond = opts.soprecond;
+            sopt.verbosity = opts.verbosity;
+
+            const helfem::trscf::Result res = opt.run(sopt);
+            orbitals    = opt.orbitals();
+            occupations = opt.occupations();
+
+            // Announce convergence the way every other driver does; a
+            // run with no such line is rejected as non-converged, which
+            // is why this is printed only when the gradient came down.
+            if (res.converged)
+              printf("Converged to energy %.10f!\n", res.energy);
+            if (opts.verbosity >= 1) {
+              printf("\nSecond-order optimization reached energy %.10f with RMS "
+                     "gradient %.3e\n", res.energy, res.grad_rms);
+              printf("  %i reference updates, %i objective evaluations, %i "
+                     "Hessian-vector products in %i response builds\n",
+                     (int) res.n_update, (int) res.n_objective,
+                     (int) res.n_hessian, (int) res.n_response);
+              fflush(stdout);
+            }
+          }
+        }
 
         AtomicSCFResult result;
         result.basis = basis;

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -84,6 +84,41 @@ namespace helfem {
         /// above it -- their energy is stable to 1e-11 while the error
         /// sits frozen just above the target -- and need it relaxed.
         double convthr = 1e-7;
+        /// Follow the first-order SCF with second-order trust-region
+        /// optimization of the orbitals AND the fractional occupations.
+        ///
+        /// The spherically averaged atom optimizes its occupations as
+        /// well as its orbitals, and that is what makes the open-shell
+        /// transition metals converge badly: two degenerate orbitals in
+        /// different l blocks are connected by no orbital rotation at
+        /// all, so moving density between them costs nothing at first
+        /// order while its real cost -- the Coulomb and XC coupling
+        /// <k_b k_b|W|k_c k_c> -- is entirely second order. See
+        /// helfem::trscf for the parametrization.
+        bool secondorder = false;
+        /// First-order iterations to run before handing over. The
+        /// second-order phase optimizes WITHIN an occupation pattern and
+        /// cannot discover one, so this is not merely a speed knob:
+        /// handing over too early converges tightly to the wrong answer.
+        int preiter = 100;
+        /// RMS gradient the second-order phase converges to
+        double soconvthr = 1e-8;
+        /// Trust-region macro- and microiteration caps
+        int somacro = 150;
+        int somicro = 50;
+        /// Ceiling on Hessian-vector products per macroiteration; 0 uses
+        /// the optimizer's own default
+        int somaxhess = 0;
+        /// OpenTrustRegion's residual-reduction factor. Its own default
+        /// (1e-3) discards good steps; see helfem::trscf.
+        double soredfac = 3e-1;
+        /// Reduced-space solver: "davidson" or "tcg"
+        std::string sosolver = "davidson";
+        /// Use the exact occupation-block preconditioner
+        bool soprecond = true;
+        /// Instead of optimizing, check the analytic gradient and
+        /// Hessian against finite differences with this step size
+        double sotest = 0.0;
         /// Load orbital guess from checkpoint. Empty = start from core-H
         /// guess as before. When non-empty, the old basis + per-l AO
         /// densities are read from the checkpoint, projected into the

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -3625,6 +3625,65 @@
         "--preiter=30",
         "--soconvthr=1e-8"
       ]
+    },
+    {
+      "name": "gensap-Fe-secondorder",
+      "code": "gensap",
+      "tags": [
+        "lda",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "spin-restricted Fe through the trust-region optimizer. This is the case that motivates the feature in gensap: the first-order solver does not converge here at all, and stops 0.103 Eh above the minimum, because 4s and 3d come out degenerate in different l blocks and no orbital rotation connects them. Matched to aij's bare-atom settings (lmax 4, core guess) so the two drivers can be compared directly.",
+      "args": [
+        "--Z=Fe",
+        "--M=0",
+        "--lmax=4",
+        "--nelem=5",
+        "--iguess=0",
+        "--method=lda_x",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ]
+    },
+    {
+      "name": "gensap-Fe-hf-firstorder",
+      "code": "gensap",
+      "tags": [
+        "hf",
+        "unrestricted",
+        "consistency"
+      ],
+      "_why": "spin-polarized Fe at Hartree-Fock, where the Fock matrix carries exact exchange. Paired with the second-order run below: exchange is the one term of the response the DFT cases never exercise.",
+      "args": [
+        "--Z=Fe",
+        "--M=5",
+        "--lmax=2",
+        "--nelem=5",
+        "--method=HF"
+      ]
+    },
+    {
+      "name": "gensap-Fe-hf-secondorder",
+      "code": "gensap",
+      "tags": [
+        "hf",
+        "unrestricted",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "the same Hartree-Fock atom through the trust-region optimizer, so that the analytic exchange response is tied to the ordinary SCF.",
+      "args": [
+        "--Z=Fe",
+        "--M=5",
+        "--lmax=2",
+        "--nelem=5",
+        "--method=HF",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ]
     }
   ],
   "_invariants_comment": [
@@ -4360,6 +4419,26 @@
       "cases": [
         "aij-Al-jellium",
         "aij-Al-jellium-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-secondorder-equals-aij-bare-atom-Fe",
+      "_why": "aij with no jellium IS the bare atom, so gensap's second-order path and aij's must land on the same number. Reference-free, and it crosses two independent drivers: the energy expressions, the Fock builders and the SCF drivers are separate code, and only the trust-region optimizer beneath them is shared. Fe is the case that discriminates, since the 4s/3d occupations are free parameters and a wrong occupation Hessian lands on a different stationary point with a plausible-looking energy -- which is exactly what the first-order solver does here, 0.103 Eh high.",
+      "cases": [
+        "aij-Fe-secondorder",
+        "gensap-Fe-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-secondorder-equals-firstorder-Fe-hf",
+      "_why": "the second-order optimizer must find the same minimum as the ordinary SCF when the Fock matrix carries exact exchange. Exchange is linear in the density, so its response is exact -- but it is a separate term from the Coulomb and XC ones, and nothing else in the suite exercises it through the Hessian.",
+      "cases": [
+        "gensap-Fe-hf-firstorder",
+        "gensap-Fe-hf-secondorder"
       ],
       "field": "total",
       "tolerance": 1e-08


### PR DESCRIPTION
Two changes to the spherically averaged atom.

## Second-order optimization in `gensap`

`gensap` solves the same problem as `aij` with the jellium switched off — the occupations are free parameters — so the same second-order machinery applies. The optimizer is reused verbatim; what this adds is the seam.

On the spin-restricted Fe atom, first order does not merely converge slowly:

```
first order      -1258.8157        (no convergence line, 0.103 Eh high)
second order     -1258.9186876173  (RMS gradient 4.9e-10)
aij, same atom   -1258.9186876173
```

`aij` with `--njellium=0 --rs=0` **is** the bare atom, and the two agree bit-for-bit through separate energy expressions, Fock builders and SCF drivers.

**What changed structurally.** `build_fock` is split into a density-driven core (`fock_fem`) plus the OpenOrbitalOptimizer wrapper, so the second-order phase — which works from densities rather than from orbitals and occupations — shares the energy expression instead of restating it. `response_fem` supplies the linear response of the Coulomb, exchange and XC halves.

**Exact exchange goes through the Hessian**, which `aij` never exercises since it has no EXX. Exchange is linear in the density, so its response is exact. `--sotest` on Fe:

| rung | `d1 . H . d1` rel.err |
|---|---|
| LDA | 2.5e-09 |
| PBE | 5.1e-10 |
| TPSS | 1.9e-05 |
| **HF** | **1.9e-10** |

and the first- and second-order HF answers agree to 2e-10 Eh.

**Frozen occupations and `--secondorder` are refused together** rather than one silently ignoring the other: the occupations are among the variables being optimized, so pinning them has no meaning there.

## libxc functional lifetime

`has_exc()` does its own `xc_func_init`/`xc_func_end` (`dftfuncs.cpp:342`), and it was being called inside the NaN guard's loop over **quadrature points** (`dftgrid_common.cpp:196`) — so a libxc functional was constructed and destroyed once per grid point per element per functional, to answer a question whose answer never changes. `compute_xc` and `compute_fxc` each did another pair per element, and `is_gga_mgga` another per call.

The worker now builds each functional once and keeps it, together with the answers to those constant questions. Workers are per-thread, so no locking is involved.

Measured on a meta-GGA atomic run, libxc bookkeeping drops from **1.75% of the profile to 0.00%**.

I owe a correction here: I first put this at ~30%, from a profile of a *short* run where `do_lookup_x` and `xc_func_init_flags` together were 50%. Almost all of that was process startup — dynamic linking of a large C++ binary — not steady-state cost. In a longer run the honest number is the 1.75% above, and the end-to-end wall-clock difference (gensap Kr/TPSS, 1.86 s → 1.78 s over seven repetitions) is within the run-to-run spread. The per-grid-point construction was worth removing on its own terms, not for the wall clock.

## Tests

Three cases and two reference-free invariants:

- `gensap-secondorder-equals-aij-bare-atom-Fe` — crosses the two drivers at the point where they must coincide.
- `gensap-secondorder-equals-firstorder-Fe-hf` — ties the exchange response to the ordinary SCF.

Full suite: **0 failed** — no reference energy moved by either change. One timeout (`atomic-N-mgga-r`), which also fails to finish in 1800 s on unmodified master. The 14 invariant violations are the pre-existing convergence-limited `diatomic-dummy-equals-atomic-*` family, all HF/LDA/hybrid.

## Known caveat

The handover sensitivity documented for `aij` is more visible here, because `gensap` defaults to the SAP initial guess (`--iguess=2`) and lands somewhere different. On Fe with that guess the **energy** is right from `--preiter=30` upwards and repeats to all printed digits, but the RMS gradient stalls between 1e-8 and 4e-7 and the convergence line is not printed; with the core guess the same run reaches 4.9e-10. Only the flag is uncertain, not the answer. I did not touch the shared `trscf` convergence semantics to paper over this, since that would change `aij` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
