### PR TITLE
Second-order optimization in the atomic and diatomic codes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Higher-level library linking against `helfem`. Contains SCF infrastructure, DFT 
 | `diatomic_dgrid` | `src/diatomic/density_grid.cpp` | Density on 2D grid |
 | `aij` | `src/sadatom/aij.cpp` | Atom in jellium |
 
-## Second-order convergence in `aij` and `gensap`
+## Second-order convergence
 
 The atom-in-jellium problem optimizes the occupations as well as the
 orbitals, and that is what makes it converge badly at first order. When
@@ -205,6 +205,51 @@ somewhere different. On Fe with that guess the energy is right from
 and the convergence line is not printed; with the core guess
 (`--iguess=0`) the same run reaches 4.9e-10. The energy is not what is
 uncertain -- it repeats to all printed digits -- only the flag.
+
+### `atomic` and `diatomic`
+
+The same optimizer drives these two as well. What differs is the basis
+bookkeeping: they orthonormalize each symmetry block separately over its
+own subset of the basis functions, so `trscf::Optimizer` takes one
+`Sinvh` per block rather than one shared radial basis. Each driver splits
+its Fock build into a density-driven core plus the OpenOrbitalOptimizer
+wrapper, so the second-order phase shares the energy expression rather
+than restating it.
+
+**The XC response is LDA-shaped in both.** Only the density-density
+kernel block is used, which is exact for an LDA and an approximation
+beyond it. That costs iterations, not correctness -- every step is
+validated against the true energy by the trust-region ratio test -- and
+`--sotest` reports the deviation instead of failing. Measured: PBE on N
+converges to the same energy as first order at an RMS gradient of 4.9e-9.
+`DFTGridWorkerBase::set_response_potential` already takes the gradient
+and tau channels, so that is the seam when they arrive.
+
+**Occupations are integer in `atomic`**, so the free occupation
+coordinates vanish of their own accord and it reduces to a pure
+orbital-rotation Newton step. Nothing special-cases that. `diatomic` is
+where they can be fractional -- `--symmetry=3` splits pi+ from pi- and
+spreads the occupations over both -- and the same parametrization picks
+them up. Note the arithmetic: it takes TWO fractionally occupied blocks
+before there is any occupation freedom at all, since the sum-zero
+subspace of one free block has dimension zero. Spin-restricted O2 at
+`--symmetry=3` has exactly one (pi*, 2 electrons of a maximum 4) and
+reports `0 occupation transfers among 1 fractionally occupied blocks`.
+
+**Mirrored blocks are the trap.** A +m / -m block stands for two
+degenerate spatial orbitals and its maximum occupation counts both, so
+its density is shared equally between them. That halving must live in the
+scatter, which is the one point BOTH density builds go through -- the
+SCF's and the trust-region optimizer's own. Put it in the SCF's alone and
+the optimizer double-counts every mirrored block: Ne at `--symmetry=3`
+hands over 5.5 Eh wrong and never converges.
+
+That class of mistake is invisible to `--sotest`, which differentiates
+one energy expression against finite differences of *itself* and so
+agrees perfectly with a wrong one. It needs a case with occupied mirrored
+blocks, which is what `diatomic-Ne-dummy-lda-absm-secondorder` is for.
+When adding a second-order path to a new driver, check the handover
+energy against the first-order one before trusting any derivative check.
 
 Occupation coupling is where the exact preconditioner earns itself, and it
 takes two occupation coordinates to see it -- with one the block is 1x1

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -577,6 +577,41 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
+      helfem::Matrix DFTGridWorker::eval_density(const helfem::Matrix & dP0) const {
+        // The same contraction update_density performs, on a different
+        // density matrix and without touching any member state: the
+        // response needs the perturbation's density while the worker
+        // still holds the reference's.
+        helfem::Matrix dP(bf_ind.size(), bf_ind.size());
+        for(size_t i=0;i<bf_ind.size();i++)
+          for(size_t j=0;j<bf_ind.size();j++)
+            dP(i,j)=dP0(bf_ind[i],bf_ind[j]);
+
+        const helfem::Matrix dPvA(dP*bf_re), dPvB(dP*bf_im);
+        helfem::Matrix drho=helfem::Matrix::Zero(1,wtot.size());
+        for(Eigen::Index ip=0;ip<wtot.size();ip++)
+          drho(0,ip)=dPvA.col(ip).dot(bf_re.col(ip))+dPvB.col(ip).dot(bf_im.col(ip));
+        return drho;
+      }
+
+      helfem::Matrix DFTGridWorker::eval_density(const helfem::Matrix & dPa0, const helfem::Matrix & dPb0) const {
+        helfem::Matrix dPa(bf_ind.size(), bf_ind.size()), dPb(bf_ind.size(), bf_ind.size());
+        for(size_t i=0;i<bf_ind.size();i++)
+          for(size_t j=0;j<bf_ind.size();j++) {
+            dPa(i,j)=dPa0(bf_ind[i],bf_ind[j]);
+            dPb(i,j)=dPb0(bf_ind[i],bf_ind[j]);
+          }
+
+        const helfem::Matrix dPavA(dPa*bf_re), dPavB(dPa*bf_im);
+        const helfem::Matrix dPbvA(dPb*bf_re), dPbvB(dPb*bf_im);
+        helfem::Matrix drho=helfem::Matrix::Zero(2,wtot.size());
+        for(Eigen::Index ip=0;ip<wtot.size();ip++) {
+          drho(0,ip)=dPavA.col(ip).dot(bf_re.col(ip))+dPavB.col(ip).dot(bf_im.col(ip));
+          drho(1,ip)=dPbvA.col(ip).dot(bf_re.col(ip))+dPbvB.col(ip).dot(bf_im.col(ip));
+        }
+        return drho;
+      }
+
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P, helfem::Matrix & H, double & Exc, double & Nel, double & Ekin, double thr) {
         // Eigen throughout; the worker now consumes/produces Eigen matrices.
         H=helfem::Matrix::Zero(P.rows(),P.rows());
@@ -710,6 +745,103 @@ namespace helfem {
         Exc=exc;
         Ekin=ekin;
         Nel=nel;
+      }
+
+      void DFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P, const std::vector<helfem::Matrix> & dP, std::vector<helfem::Matrix> & dH, double thr) {
+        dH.assign(dP.size(), helfem::Matrix::Zero(P.rows(),P.rows()));
+        if(dP.empty())
+          return;
+        for(size_t ip=0;ip<dP.size();ip++)
+          if(dP[ip].rows()!=P.rows() || dP[ip].cols()!=P.cols())
+            throw std::logic_error("Perturbation has a different shape than the reference density.\n");
+
+        // One pass over the elements, exactly as eval_Fxc does, except
+        // that the potential handed to the assembly is the response
+        // potential of each perturbation in turn.
+        auto do_element = [&](DFTGridWorker & grid, size_t iel) {
+          grid.compute_bf(iel);
+          grid.update_density(P);
+          grid.init_fxc();
+          if(x_func>0)
+            grid.compute_fxc(x_func, x_pars, thr);
+          if(c_func>0)
+            grid.compute_fxc(c_func, c_pars, thr);
+          for(size_t ip=0; ip<dP.size(); ip++) {
+            // Empty gradient / tau arguments select the LDA-shaped
+            // response; see the header for why that is the right kernel
+            // for a model Hessian.
+            grid.set_response_potential(grid.eval_density(dP[ip]),
+                                         helfem::Matrix(), helfem::Matrix(),
+                                         helfem::Matrix());
+            grid.eval_Fxc(dH[ip]);
+          }
+        };
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        {
+          DFTGridWorker grid(basp,lang,mang);
+          grid.check_grad_tau_lapl(x_func,c_func);
+
+          // Same even/odd element split as eval_Fxc: neighbouring
+          // elements share boundary functions, so writing them from two
+          // threads at once would race.
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=0;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=1;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+        }
+      }
+
+      void DFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa, const helfem::Matrix & Pb, const std::vector<helfem::Matrix> & dPa, const std::vector<helfem::Matrix> & dPb, std::vector<helfem::Matrix> & dHa, std::vector<helfem::Matrix> & dHb, double thr) {
+        dHa.assign(dPa.size(), helfem::Matrix::Zero(Pa.rows(),Pa.rows()));
+        dHb.assign(dPa.size(), helfem::Matrix::Zero(Pa.rows(),Pa.rows()));
+        if(dPa.empty())
+          return;
+        if(dPb.size()!=dPa.size())
+          throw std::logic_error("Got a different number of alpha and beta perturbations.\n");
+
+        auto do_element = [&](DFTGridWorker & grid, size_t iel) {
+          grid.compute_bf(iel);
+          grid.update_density(Pa,Pb);
+          grid.init_fxc();
+          if(x_func>0)
+            grid.compute_fxc(x_func, x_pars, thr);
+          if(c_func>0)
+            grid.compute_fxc(c_func, c_pars, thr);
+          for(size_t ip=0; ip<dPa.size(); ip++) {
+            grid.set_response_potential(grid.eval_density(dPa[ip],dPb[ip]),
+                                         helfem::Matrix(), helfem::Matrix(),
+                                         helfem::Matrix());
+            grid.eval_Fxc(dHa[ip],dHb[ip],true);
+          }
+        };
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        {
+          DFTGridWorker grid(basp,lang,mang);
+          grid.check_grad_tau_lapl(x_func,c_func);
+
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=0;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+#ifdef _OPENMP
+#pragma omp for
+#endif
+          for(size_t iel=1;iel<basp->rad_Nel();iel+=2)
+            do_element(grid, iel);
+        }
       }
 
     }

--- a/src/atomic/dftgrid.cpp
+++ b/src/atomic/dftgrid.cpp
@@ -761,6 +761,10 @@ namespace helfem {
         auto do_element = [&](DFTGridWorker & grid, size_t iel) {
           grid.compute_bf(iel);
           grid.update_density(P);
+          // init_xc allocates the potential buffers that
+          // set_response_potential writes the response into, and resets
+          // the do_gga / do_mgga flags so the assembly is LDA-shaped.
+          grid.init_xc();
           grid.init_fxc();
           if(x_func>0)
             grid.compute_fxc(x_func, x_pars, thr);
@@ -811,6 +815,10 @@ namespace helfem {
         auto do_element = [&](DFTGridWorker & grid, size_t iel) {
           grid.compute_bf(iel);
           grid.update_density(Pa,Pb);
+          // init_xc allocates the potential buffers that
+          // set_response_potential writes the response into, and resets
+          // the do_gga / do_mgga flags so the assembly is LDA-shaped.
+          grid.init_xc();
           grid.init_fxc();
           if(x_func>0)
             grid.compute_fxc(x_func, x_pars, thr);

--- a/src/atomic/dftgrid.h
+++ b/src/atomic/dftgrid.h
@@ -116,6 +116,16 @@ namespace helfem {
         /// Update values of density, unrestricted calculation
         void update_density(const helfem::Matrix & Pa, const helfem::Matrix & Pb);
 
+        /// Density of a SECOND density matrix on the current element's
+        /// grid, without disturbing the reference the worker is holding.
+        /// This is the same bilinear form update_density uses, applied to
+        /// the perturbation, and it is all an LDA response kernel needs.
+        /// 1 x Npts restricted, 2 x Npts polarized.
+        helfem::Matrix eval_density(const helfem::Matrix & dP) const;
+        /// Same for a spin-polarized perturbation
+        helfem::Matrix eval_density(const helfem::Matrix & dPa,
+                                     const helfem::Matrix & dPb) const;
+
         // compute_Nel() is inherited from DFTGridWorkerBase.
         /// Compute integral over density laplacian
         double compute_laplsum() const;
@@ -163,6 +173,37 @@ namespace helfem {
         /// Compute Fock matrix, exchange-correlation energy and integrated
         /// electron density, unrestricted case. Eigen-typed public boundary.
         void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa, const helfem::Matrix & Pb, helfem::Matrix & Ha, helfem::Matrix & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr);
+
+        /// Linear response of the XC matrix to a BATCH of density
+        /// perturbations dP, at the reference density P.
+        ///
+        /// Batched because the expensive parts -- the basis values on the
+        /// grid, the reference density and the libxc kernel -- are shared
+        /// across the perturbations, so a d-dimensional Hessian subspace
+        /// costs far less than d separate response builds.
+        ///
+        /// LDA-shaped: only the density-density block of the kernel is
+        /// used, which is exact for an LDA and an approximation beyond
+        /// it. That is sound here because this builds the model Hessian
+        /// of a trust-region method, never the energy or the gradient --
+        /// an approximate kernel costs iterations, not correctness, since
+        /// the step is validated against the true energy by the ratio
+        /// test. The seam for the gradient and tau channels is
+        /// DFTGridWorkerBase::set_response_potential, which already takes
+        /// them; passing empty matrices selects the LDA-shaped path.
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars,
+                                int c_func, const helfem::Vector & c_pars,
+                                const helfem::Matrix & P,
+                                const std::vector<helfem::Matrix> & dP,
+                                std::vector<helfem::Matrix> & dH, double thr);
+        /// Spin-polarized counterpart
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars,
+                                int c_func, const helfem::Vector & c_pars,
+                                const helfem::Matrix & Pa, const helfem::Matrix & Pb,
+                                const std::vector<helfem::Matrix> & dPa,
+                                const std::vector<helfem::Matrix> & dPb,
+                                std::vector<helfem::Matrix> & dHa,
+                                std::vector<helfem::Matrix> & dHb, double thr);
 
       };
 

--- a/src/atomic/main.cpp
+++ b/src/atomic/main.cpp
@@ -36,6 +36,8 @@
 #include "../general/elements.h"
 #include "../general/scf_helpers.h"
 #include "../general/scf_driver_common.h"
+#include "../general/trustregion_scf.h"
+#include "../general/otr_solver.h"
 #include "../general/checkpoint.h"
 #include "../general/eigen_io.h"
 
@@ -127,6 +129,16 @@ int main(int argc, char **argv) {
   // separated subset of DIIS, ODA, CG and LBFGS. OOO switches between
   // whichever are enabled and collapses gracefully on a subset.
   parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "DIIS + ODA + CG");
+  parser.add<bool>("secondorder", 0, "follow the first-order SCF with second-order trust-region optimization of the orbitals and the occupations", false, false);
+  parser.add<int>("preiter", 0, "first-order iterations to run before switching to the second-order optimizer", false, 100);
+  parser.add<double>("soconvthr", 0, "RMS gradient the second-order optimizer converges to", false, 1e-8);
+  parser.add<int>("somacro", 0, "second-order macroiteration cap", false, 150);
+  parser.add<int>("somicro", 0, "second-order microiteration cap", false, 50);
+  parser.add<int>("somaxhess", 0, "ceiling on Hessian-vector products per macroiteration; 0 for the default", false, 0);
+  parser.add<double>("soredfac", 0, "second-order residual-reduction factor", false, 3e-1);
+  parser.add<std::string>("sosolver", 0, "second-order reduced-space solver: davidson or tcg", false, "davidson");
+  parser.add<bool>("soprecond", 0, "use the exact occupation-block preconditioner", false, true);
+  parser.add<double>("sotest", 0, "instead of optimizing, check the analytic gradient and Hessian against finite differences with this step size", false, 0.0);
 
   parser.parse_check(argc, argv);
 
@@ -366,15 +378,49 @@ int main(int argc, char **argv) {
         fock, b, dsym, k, Sinvh, F_full);
   };
 
-  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
-      [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+  // Atomic exchange kernel: kfrac * K + kshort * K_rs. Empty branches
+  // contribute zero, so RS hybrids and plain hybrids all flow through the
+  // same builder. The sign convention is baked into basis.exchange, which
+  // returns the signed contribution that gets ADDED to the Fock matrix.
+  //
+  // Hoisted out of the Fock build so the response shares it: exchange is
+  // linear in the density, so the response of K is the same contraction
+  // applied to the perturbation, and the two must not drift apart.
+  auto exchange_kernel = [&](const helfem::Matrix & Pin) {
+    helfem::Matrix K = helfem::Matrix::Zero(Nbf, Nbf);
+    if (kfrac  != 0.0) K += kfrac  * basis.exchange(Pin);
+    if (kshort != 0.0) K += kshort * basis.rs_exchange(Pin);
+    return K;
+  };
+
+  // Per-block FEM densities of an OpenOrbitalOptimizer solution: block k
+  // is the density restricted to that symmetry block's own basis-function
+  // subset dsym[k]. Restricted has one channel of nsym blocks; unrestricted
+  // has alpha then beta.
+  auto blocked_density = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
     const auto & orbitals    = dm.first;
     const auto & occupations = dm.second;
+    helfem::Cube P(nsym * nparttype);
+    for (size_t b = 0; b < nsym * nparttype; ++b) {
+      const size_t k = b % nsym;
+      const helfem::Matrix C_k = Sinvh[k] * orbitals[b];
+      P[b] = C_k * occupations[b].asDiagonal() * C_k.transpose();
+    }
+    return P;
+  };
 
-    // --- Density assembly. Restricted mode has a single closed-shell
-    //     channel with max_occ = 2, so P comes straight from the alpha
-    //     channel; no Pa/Pb split, no *0.5 double-scatter, no unused Pb.
-    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
+  // Energy and per-block AO Fock matrices from the per-block FEM
+  // densities. This is the whole energy expression, lifted out of the
+  // OpenOrbitalOptimizer builder below so that the second-order optimizer
+  // -- which works from densities rather than from orbitals and
+  // occupations -- shares it instead of restating it. F is returned in
+  // the FEM basis of each block; the OOO wrapper orthonormalizes, the
+  // trust-region one does not.
+  auto fock_fem = [&](const helfem::Cube & P_blocks, helfem::Cube & F_blocks,
+                      bool report) -> double {
+    if (P_blocks.size() != nsym * nparttype)
+      throw std::logic_error("Density has an unexpected number of blocks.\n");
+
     helfem::Matrix P = helfem::Matrix::Zero(Nbf, Nbf);
     // Spin-density buffers used for both the XC branch and the HF
     // exchange branch; for restricted the alpha density is 0.5 * P.
@@ -383,11 +429,14 @@ int main(int argc, char **argv) {
     double nelnum = 0.0, ekin_grid = 0.0;
     helfem::Matrix XCa, XCb;
 
-    // grid.eval_Fxc takes/returns Eigen at its public boundary; the driver
-    // density is now Eigen-native, so pass it straight through.
+    // Scatter each block back into the full basis through its index set.
+    auto scatter = [&](helfem::Matrix & dest, size_t b) {
+      const std::vector<Eigen::Index> & idx = dsym[b % nsym];
+      if (!idx.empty()) dest(idx, idx) += P_blocks[b];
+    };
+
     if (restricted) {
-      for (size_t k = 0; k < nsym; ++k)
-        accumulate_density(P, k, orbitals[k], occupations[k]);
+      for (size_t k = 0; k < nsym; ++k) scatter(P, k);
       if (have_xc) {
         grid.eval_Fxc(x_func, x_pars, c_func, c_pars, P, XCa,
                        Exc, nelnum, ekin_grid, dftthr);
@@ -396,10 +445,7 @@ int main(int argc, char **argv) {
     } else {
       Pa = helfem::Matrix::Zero(Nbf, Nbf);
       Pb = helfem::Matrix::Zero(Nbf, Nbf);
-      for (size_t k = 0; k < nsym; ++k) {
-        accumulate_density(Pa, k, orbitals[k],        occupations[k]);
-        accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
-      }
+      for (size_t k = 0; k < nsym; ++k) { scatter(Pa, k); scatter(Pb, nsym + k); }
       P = Pa + Pb;
       if (have_xc) {
         grid.eval_Fxc(x_func, x_pars, c_func, c_pars, Pa, Pb,
@@ -431,20 +477,14 @@ int main(int argc, char **argv) {
     // Atomic exchange kernel: kfrac * K + kshort * K_rs. Empty
     // branches contribute zero, so RS hybrids and plain hybrids all
     // flow through the same builder.
-    auto exchange_fn = [&](const helfem::Matrix & P) {
-      helfem::Matrix K = helfem::Matrix::Zero(Nbf, Nbf);
-      if (kfrac  != 0.0) K += kfrac  * basis.exchange(P);
-      if (kshort != 0.0) K += kshort * basis.rs_exchange(P);
-      return K;
-    };
     helfem::Matrix Ka, Kb;
     double Exx = 0.0;
     helfem::scf_driver::assemble_hf_exchange(
-        Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
+        Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_kernel);
 
     const double Etot = Ekin + Enuc + Eefield + Emfield + Econf
                        + Ecoul + Exc + Exx + Enucr;
-    if (verbosity >= 1) {
+    if (report && verbosity >= 1) {
       printf("kinetic %.10f nuclear %.10f Coulomb %.10f XC %.10f Exx %.10f",
               Ekin, Enuc, Ecoul, Exc, Exx);
       if (have_efield) printf(" Eefield %.10f", Eefield);
@@ -456,17 +496,135 @@ int main(int argc, char **argv) {
     }
     fflush(stdout);
 
-    // --- Fock assembly. Restricted: one AO Fock, orthonormalize per block.
-    //     Unrestricted: separate Fa/Fb AO Fock matrices for the two channels.
+    // --- Fock assembly. Restricted: one AO Fock. Unrestricted: separate
+    //     Fa/Fb AO Fock matrices for the two channels.
     // Pre-assembled 1-electron core matrix. Vel/Vmag/Vconf are zero when
     // their coupling is off so this is unchanged from H0 = T + Vnuc in
     // the no-field case.
     const helfem::Matrix H1 = T + Vnuc + Vel + Vmag + Vconf;
-    helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
-        fock, H1, J, XCa, XCb, Ka, Kb, S,
-        nsym, restricted, have_xc, have_exx, have_bfield, Bz,
-        orthonormalize_block);
+    helfem::Matrix Fa_ao = H1 + J;
+    if (have_xc)  Fa_ao += XCa;
+    if (have_exx) Fa_ao += Ka;
+    helfem::Matrix Fb_ao;
+    if (!restricted) {
+      Fb_ao = H1 + J;
+      if (have_xc)  Fb_ao += XCb;
+      if (have_exx) Fb_ao += Kb;
+      // Spin-Zeeman: alpha <- -Bz/2 * S, beta <- +Bz/2 * S.
+      if (have_bfield) {
+        Fa_ao -= 0.5 * Bz * S;
+        Fb_ao += 0.5 * Bz * S;
+      }
+    }
+
+    F_blocks.assign(nsym * nparttype, helfem::Matrix());
+    for (size_t b = 0; b < nsym * nparttype; ++b) {
+      const size_t k = b % nsym;
+      const std::vector<Eigen::Index> & idx = dsym[k];
+      const helfem::Matrix & F_ao = (b < nsym) ? Fa_ao : Fb_ao;
+      F_blocks[b] = idx.empty() ? helfem::Matrix()
+                                : helfem::Matrix(F_ao(idx, idx));
+    }
+    return Etot;
+  };
+
+  // The same build in the form OpenOrbitalOptimizer wants: a density
+  // matrix in, energy and orthonormal-basis Fock out.
+  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
+      [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    helfem::Cube F_blocks;
+    const double Etot = fock_fem(blocked_density(dm), F_blocks, true);
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
+    for (size_t b = 0; b < nsym * nparttype; ++b) {
+      const size_t k = b % nsym;
+      fock[b] = F_blocks[b].size()
+                    ? helfem::Matrix(Sinvh[k].transpose() * F_blocks[b] * Sinvh[k])
+                    : helfem::Matrix();
+    }
     return std::make_pair(Etot, fock);
+  };
+
+  // Linear response of those Fock matrices to a batch of density
+  // perturbations, at the reference density. The one-electron terms are
+  // density-independent and drop out; the Coulomb and exchange halves
+  // are linear, so their response is exact and costs one more build of
+  // each; the XC half goes through the LDA-shaped response kernel.
+  auto response_fem = [&](const helfem::Cube & P_blocks,
+                          const std::vector<helfem::Cube> & dP_blocks,
+                          std::vector<helfem::Cube> & dF_blocks) {
+    const size_t nt = dP_blocks.size();
+    dF_blocks.assign(nt, helfem::Cube());
+    if (!nt) return;
+
+    auto scatter = [&](helfem::Matrix & dest, const helfem::Cube & blocks, size_t b) {
+      const std::vector<Eigen::Index> & idx = dsym[b % nsym];
+      if (!idx.empty()) dest(idx, idx) += blocks[b];
+    };
+
+    // Reference densities, in the same layout fock_fem builds them.
+    helfem::Matrix P = helfem::Matrix::Zero(Nbf, Nbf), Pa, Pb;
+    if (restricted) {
+      for (size_t k = 0; k < nsym; ++k) scatter(P, P_blocks, k);
+      Pa = 0.5 * P;
+    } else {
+      Pa = helfem::Matrix::Zero(Nbf, Nbf);
+      Pb = helfem::Matrix::Zero(Nbf, Nbf);
+      for (size_t k = 0; k < nsym; ++k) { scatter(Pa, P_blocks, k); scatter(Pb, P_blocks, nsym + k); }
+      P = Pa + Pb;
+    }
+
+    // Perturbation densities, likewise.
+    std::vector<helfem::Matrix> dP(nt), dPa(nt), dPb(nt);
+    for (size_t it = 0; it < nt; ++it) {
+      dP[it] = helfem::Matrix::Zero(Nbf, Nbf);
+      if (restricted) {
+        for (size_t k = 0; k < nsym; ++k) scatter(dP[it], dP_blocks[it], k);
+        dPa[it] = 0.5 * dP[it];
+      } else {
+        dPa[it] = helfem::Matrix::Zero(Nbf, Nbf);
+        dPb[it] = helfem::Matrix::Zero(Nbf, Nbf);
+        for (size_t k = 0; k < nsym; ++k) {
+          scatter(dPa[it], dP_blocks[it], k);
+          scatter(dPb[it], dP_blocks[it], nsym + k);
+        }
+        dP[it] = dPa[it] + dPb[it];
+      }
+    }
+
+    std::vector<helfem::Matrix> dXCa, dXCb;
+    if (have_xc) {
+      if (restricted)
+        grid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, P, dP, dXCa, dftthr);
+      else
+        grid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, Pa, Pb,
+                                dPa, dPb, dXCa, dXCb, dftthr);
+    }
+
+    for (size_t it = 0; it < nt; ++it) {
+      const helfem::Matrix dJ = basis.coulomb(dP[it]);
+      // Exchange is linear in the density, so its response is the same
+      // contraction applied to the perturbation.
+      helfem::Matrix dKa, dKb;
+      if (have_exx) {
+        dKa = exchange_kernel(dPa[it]);
+        if (!restricted) dKb = exchange_kernel(dPb[it]);
+      }
+      helfem::Matrix dFa = dJ, dFb;
+      if (have_xc)  dFa += dXCa[it];
+      if (have_exx) dFa += dKa;
+      if (!restricted) {
+        dFb = dJ;
+        if (have_xc)  dFb += dXCb[it];
+        if (have_exx) dFb += dKb;
+      }
+      dF_blocks[it].assign(nsym * nparttype, helfem::Matrix());
+      for (size_t b = 0; b < nsym * nparttype; ++b) {
+        const std::vector<Eigen::Index> & idx = dsym[b % nsym];
+        const helfem::Matrix & dF = (b < nsym) ? dFa : dFb;
+        dF_blocks[it][b] = idx.empty() ? helfem::Matrix()
+                                       : helfem::Matrix(dF(idx, idx));
+      }
+    }
   };
 
   // Initial-guess Hamiltonian per block per particle type. Include the
@@ -664,9 +822,99 @@ int main(int argc, char **argv) {
     scfsolver.initialize_with_fock(CoreH);
   }
 
+  bool secondorder = parser.get<bool>("secondorder");
+  const double sotest = parser.get<double>("sotest");
+  if (sotest > 0.0) secondorder = true;
+  if (secondorder && !helfem::otr::available())
+    throw std::logic_error("This HelFEM was built without OpenTrustRegion, so "
+                           "--secondorder is unavailable. Configure with "
+                           "-DHELFEM_OPENTRUSTREGION=ON.\n");
+
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
+  // With a second-order phase to follow, the first-order one only has to
+  // get close enough for a quadratic model to mean something.
+  // This driver exposes no iteration cap of its own -- it uses
+  // OpenOrbitalOptimizer's default -- so --preiter simply becomes the cap.
+  if (secondorder)
+    scfsolver.set("maximum_iterations", parser.get<int>("preiter"));
   scfsolver.print_citation();
   scfsolver.run();
+
+  if (secondorder) {
+    std::vector<double> maxocc((size_t) maximum_occupation.size());
+    for (Eigen::Index i = 0; i < maximum_occupation.size(); ++i)
+      maxocc[(size_t) i] = maximum_occupation(i);
+
+    helfem::trscf::FockBuilder so_fock =
+        [&](const helfem::Cube & P, helfem::Cube & F) {
+      // No reporting: the trust-region solver prints its own iteration
+      // table, and a microiteration sweep makes many objective
+      // evaluations that are not iterations.
+      return fock_fem(P, F, false);
+    };
+    helfem::trscf::ResponseBuilder so_response =
+        [&](const helfem::Cube & P, const std::vector<helfem::Cube> & dP,
+            std::vector<helfem::Cube> & dF) { response_fem(P, dP, dF); };
+
+    // One orthonormalizer per BLOCK: unrestricted has alpha and beta
+    // copies of the same nsym symmetry blocks, and both channels
+    // orthonormalize over the same basis-function subsets.
+    std::vector<helfem::Matrix> Sinvh_blocks;
+    Sinvh_blocks.reserve(nsym * nparttype);
+    for (size_t t = 0; t < nparttype; ++t)
+      Sinvh_blocks.insert(Sinvh_blocks.end(), Sinvh.begin(), Sinvh.end());
+
+    helfem::trscf::Optimizer opt(Sinvh_blocks, maxocc,
+                                  std::vector<size_t>(nparttype, nsym),
+                                  so_fock, so_response);
+    auto orbitals    = scfsolver.get_orbitals();
+    auto occupations = scfsolver.get_orbital_occupations();
+    opt.set_reference(orbitals, occupations);
+
+    if (sotest > 0.0) {
+      // Derivative check only: the analytic gradient and Hessian are the
+      // whole content of the second-order method, and nothing downstream
+      // can tell a wrong Hessian from a hard problem. The response kernel
+      // here is LDA-shaped, so beyond an LDA the Hessian is deliberately
+      // approximate and is measured rather than tested.
+      bool xg=false, xt=false, xl=false, cg=false, ct=false, cl=false;
+      if (x_func > 0) ::is_gga_mgga(x_func, xg, xt, xl);
+      if (c_func > 0) ::is_gga_mgga(c_func, cg, ct, cl);
+      const bool exact_kernel = !(xg||xt||xl||cg||ct||cl);
+      if (!opt.verify(sotest, 1e-4, verbosity, exact_kernel))
+        throw std::runtime_error("The analytic derivatives disagree with "
+                                 "finite differences.\n");
+      return 0;
+    }
+
+    helfem::trscf::Options sopt;
+    sopt.otr.conv_tol = parser.get<double>("soconvthr");
+    sopt.otr.n_macro = parser.get<int>("somacro");
+    sopt.otr.n_micro = parser.get<int>("somicro");
+    sopt.max_hessian = parser.get<int>("somaxhess");
+    sopt.otr.global_red_factor = parser.get<double>("soredfac");
+    sopt.otr.local_red_factor = 0.1 * sopt.otr.global_red_factor;
+    sopt.otr.subsystem_solver = parser.get<std::string>("sosolver");
+    // OpenTrustRegion prints its iteration table at level 3.
+    sopt.otr.verbose = (verbosity >= 1) ? std::max(3, verbosity) : 0;
+    sopt.exact_precond = parser.get<bool>("soprecond");
+    sopt.verbosity = verbosity;
+
+    const helfem::trscf::Result res = opt.run(sopt);
+    scfsolver.initialize_with_orbitals(opt.orbitals(), opt.occupations());
+
+    if (res.converged)
+      printf("Converged to energy %.10f!\n", res.energy);
+    if (verbosity >= 1) {
+      printf("\nSecond-order optimization reached energy %.10f with RMS "
+             "gradient %.3e\n", res.energy, res.grad_rms);
+      printf("  %i reference updates, %i objective evaluations, %i "
+             "Hessian-vector products in %i response builds\n",
+             (int) res.n_update, (int) res.n_objective,
+             (int) res.n_hessian, (int) res.n_response);
+      fflush(stdout);
+    }
+  }
 
   // --save: reconstruct the AO densities from the converged per-block
   // orbitals + occupations and write them plus the basis to a

--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -558,6 +558,38 @@ namespace helfem {
         return tasks;
       }
 
+      helfem::Matrix DFTGridWorker::eval_density(const helfem::Matrix & dPexp) const {
+        // The same contraction update_density performs, on a different
+        // density matrix and without touching any member state.
+        helfem::Matrix dP(bf_ind.size(), bf_ind.size());
+        for(size_t i=0;i<bf_ind.size();i++)
+          for(size_t j=0;j<bf_ind.size();j++)
+            dP(i,j)=dPexp(bf_ind[i],bf_ind[j]);
+
+        const helfem::Matrix dPvA(dP*bf_re), dPvB(dP*bf_im);
+        helfem::Matrix drho=helfem::Matrix::Zero(1,wtot.size());
+        for(Eigen::Index ip=0;ip<wtot.size();ip++)
+          drho(0,ip)=dPvA.col(ip).dot(bf_re.col(ip))+dPvB.col(ip).dot(bf_im.col(ip));
+        return drho;
+      }
+
+      helfem::Matrix DFTGridWorker::eval_density(const helfem::Matrix & dPaexp, const helfem::Matrix & dPbexp) const {
+        helfem::Matrix dPa(bf_ind.size(), bf_ind.size()), dPb(bf_ind.size(), bf_ind.size());
+        for(size_t i=0;i<bf_ind.size();i++)
+          for(size_t j=0;j<bf_ind.size();j++) {
+            dPa(i,j)=dPaexp(bf_ind[i],bf_ind[j]);
+            dPb(i,j)=dPbexp(bf_ind[i],bf_ind[j]);
+          }
+        const helfem::Matrix dPavA(dPa*bf_re), dPavB(dPa*bf_im);
+        const helfem::Matrix dPbvA(dPb*bf_re), dPbvB(dPb*bf_im);
+        helfem::Matrix drho=helfem::Matrix::Zero(2,wtot.size());
+        for(Eigen::Index ip=0;ip<wtot.size();ip++) {
+          drho(0,ip)=dPavA.col(ip).dot(bf_re.col(ip))+dPavB.col(ip).dot(bf_im.col(ip));
+          drho(1,ip)=dPbvA.col(ip).dot(bf_re.col(ip))+dPbvB.col(ip).dot(bf_im.col(ip));
+        }
+        return drho;
+      }
+
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
         // Eigen flows straight through the worker and remove_boundaries.
         helfem::Matrix H = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
@@ -702,6 +734,95 @@ namespace helfem {
         // Clean up matrices
         Ha_e=basp->remove_boundaries(Ha);
         Hb_e=basp->remove_boundaries(Hb);
+      }
+
+      void DFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P_e, const std::vector<helfem::Matrix> & dP_e, std::vector<helfem::Matrix> & dH_e, double thr) {
+        dH_e.assign(dP_e.size(), helfem::Matrix());
+        if(dP_e.empty())
+          return;
+
+        std::vector<helfem::Matrix> dH(dP_e.size(), helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy()));
+        {
+          DFTGridWorker grid(basp,lang,mang);
+          grid.check_grad_tau_lapl(x_func,c_func);
+
+          // Loop-invariant: expand once, not once per grid point.
+          const helfem::Matrix P_exp(basp->expand_boundaries(P_e));
+          std::vector<helfem::Matrix> dP_exp(dP_e.size());
+          for(size_t ip=0;ip<dP_e.size();ip++)
+            dP_exp[ip]=basp->expand_boundaries(dP_e[ip]);
+
+          for(size_t iel=0;iel<basp->rad_Nel();iel++) {
+            for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
+              grid.compute_bf(iel,irad);
+              grid.update_density(P_exp);
+              // init_xc allocates the potential buffers the response is
+              // written into, and resets the do_gga / do_mgga flags so
+              // the assembly is LDA-shaped.
+              grid.init_xc();
+              grid.init_fxc();
+              if(x_func>0)
+                grid.compute_fxc(x_func, x_pars, thr);
+              if(c_func>0)
+                grid.compute_fxc(c_func, c_pars, thr);
+              for(size_t ip=0;ip<dP_exp.size();ip++) {
+                grid.set_response_potential(grid.eval_density(dP_exp[ip]),
+                                             helfem::Matrix(), helfem::Matrix(),
+                                             helfem::Matrix());
+                grid.eval_Fxc(dH[ip]);
+              }
+            }
+          }
+        }
+        for(size_t ip=0;ip<dH.size();ip++)
+          dH_e[ip]=basp->remove_boundaries(dH[ip]);
+      }
+
+      void DFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa_e, const helfem::Matrix & Pb_e, const std::vector<helfem::Matrix> & dPa_e, const std::vector<helfem::Matrix> & dPb_e, std::vector<helfem::Matrix> & dHa_e, std::vector<helfem::Matrix> & dHb_e, double thr) {
+        dHa_e.assign(dPa_e.size(), helfem::Matrix());
+        dHb_e.assign(dPa_e.size(), helfem::Matrix());
+        if(dPa_e.empty())
+          return;
+        if(dPb_e.size()!=dPa_e.size())
+          throw std::logic_error("Got a different number of alpha and beta perturbations.\n");
+
+        std::vector<helfem::Matrix> dHa(dPa_e.size(), helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy()));
+        std::vector<helfem::Matrix> dHb(dPa_e.size(), helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy()));
+        {
+          DFTGridWorker grid(basp,lang,mang);
+          grid.check_grad_tau_lapl(x_func,c_func);
+
+          const helfem::Matrix Pa_exp(basp->expand_boundaries(Pa_e));
+          const helfem::Matrix Pb_exp(basp->expand_boundaries(Pb_e));
+          std::vector<helfem::Matrix> dPa_exp(dPa_e.size()), dPb_exp(dPa_e.size());
+          for(size_t ip=0;ip<dPa_e.size();ip++) {
+            dPa_exp[ip]=basp->expand_boundaries(dPa_e[ip]);
+            dPb_exp[ip]=basp->expand_boundaries(dPb_e[ip]);
+          }
+
+          for(size_t iel=0;iel<basp->rad_Nel();iel++) {
+            for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
+              grid.compute_bf(iel,irad);
+              grid.update_density(Pa_exp,Pb_exp);
+              grid.init_xc();
+              grid.init_fxc();
+              if(x_func>0)
+                grid.compute_fxc(x_func, x_pars, thr);
+              if(c_func>0)
+                grid.compute_fxc(c_func, c_pars, thr);
+              for(size_t ip=0;ip<dPa_exp.size();ip++) {
+                grid.set_response_potential(grid.eval_density(dPa_exp[ip],dPb_exp[ip]),
+                                             helfem::Matrix(), helfem::Matrix(),
+                                             helfem::Matrix());
+                grid.eval_Fxc(dHa[ip],dHb[ip],true);
+              }
+            }
+          }
+        }
+        for(size_t ip=0;ip<dHa.size();ip++) {
+          dHa_e[ip]=basp->remove_boundaries(dHa[ip]);
+          dHb_e[ip]=basp->remove_boundaries(dHb[ip]);
+        }
       }
 
     }

--- a/src/diatomic/dftgrid.h
+++ b/src/diatomic/dftgrid.h
@@ -103,6 +103,16 @@ namespace helfem {
         /// Update values of density, unrestricted calculation
         void update_density(const helfem::Matrix & Paexp, const helfem::Matrix & Pbexp);
 
+        /// Density of a SECOND density matrix on the current grid point,
+        /// without disturbing the reference the worker is holding. The
+        /// same bilinear form update_density uses, applied to the
+        /// perturbation, which is all an LDA response kernel needs.
+        /// dP is expanded to the dummy basis, as update_density's is.
+        helfem::Matrix eval_density(const helfem::Matrix & dPexp) const;
+        /// Same for a spin-polarized perturbation
+        helfem::Matrix eval_density(const helfem::Matrix & dPaexp,
+                                     const helfem::Matrix & dPbexp) const;
+
         // compute_Nel() is inherited from DFTGridWorkerBase.
         /// Compute kinetic energy
         double compute_Ekin() const;
@@ -146,6 +156,31 @@ namespace helfem {
         /// Compute Fock matrix, exchange-correlation energy and integrated
         /// electron density, unrestricted case. Eigen-typed public boundary.
         void eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & Pa, const helfem::Matrix & Pb, helfem::Matrix & Ha, helfem::Matrix & Hb, double & Exc, double & Nel, double & Ekin, bool beta, double thr);
+
+        /// Linear response of the XC matrix to a BATCH of density
+        /// perturbations, at the reference density P. Batched because the
+        /// basis values, the reference density and the libxc kernel are
+        /// shared across the perturbations.
+        ///
+        /// LDA-shaped: only the density-density block of the kernel is
+        /// used. That is exact for an LDA and an approximation beyond it,
+        /// which is sound because this builds the model Hessian of a
+        /// trust-region method, never the energy or the gradient -- the
+        /// step is validated against the true energy by the ratio test,
+        /// so an approximate kernel costs iterations, not correctness.
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars,
+                                int c_func, const helfem::Vector & c_pars,
+                                const helfem::Matrix & P,
+                                const std::vector<helfem::Matrix> & dP,
+                                std::vector<helfem::Matrix> & dH, double thr);
+        /// Spin-polarized counterpart
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars,
+                                int c_func, const helfem::Vector & c_pars,
+                                const helfem::Matrix & Pa, const helfem::Matrix & Pb,
+                                const std::vector<helfem::Matrix> & dPa,
+                                const std::vector<helfem::Matrix> & dPb,
+                                std::vector<helfem::Matrix> & dHa,
+                                std::vector<helfem::Matrix> & dHb, double thr);
 
       };
 

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -343,6 +343,37 @@ namespace helfem {
         }
       }
 
+      helfem::Matrix PureMDFTGridWorker::eval_density(const helfem::Matrix & dP0) const {
+        const helfem::Matrix dP(basp->expand_boundaries(dP0));
+        const Eigen::Index nang = cth.size();
+        helfem::Matrix drho = helfem::Matrix::Zero(1, nang);
+        // Every m block walked in its own right: see the header for why
+        // the mirrored-partner sharing update_density does is not valid
+        // for an arbitrary perturbation.
+        for (size_t im = 0; im < mlist.size(); im++) {
+          if (bf_ind_m[im].empty()) continue;
+          const helfem::Matrix dPblk = gather_block(dP, bf_ind_m[im]);
+          const helfem::Matrix dPv = dPblk * bf_m[im];
+          drho.row(0) += (dPv.array() * bf_m[im].array()).colwise().sum().matrix();
+        }
+        return drho;
+      }
+
+      helfem::Matrix PureMDFTGridWorker::eval_density(const helfem::Matrix & dPa0, const helfem::Matrix & dPb0) const {
+        const helfem::Matrix dPa(basp->expand_boundaries(dPa0));
+        const helfem::Matrix dPb(basp->expand_boundaries(dPb0));
+        const Eigen::Index nang = cth.size();
+        helfem::Matrix drho = helfem::Matrix::Zero(2, nang);
+        for (size_t im = 0; im < mlist.size(); im++) {
+          if (bf_ind_m[im].empty()) continue;
+          const helfem::Matrix dPav = gather_block(dPa, bf_ind_m[im]) * bf_m[im];
+          const helfem::Matrix dPbv = gather_block(dPb, bf_ind_m[im]) * bf_m[im];
+          drho.row(0) += (dPav.array() * bf_m[im].array()).colwise().sum().matrix();
+          drho.row(1) += (dPbv.array() * bf_m[im].array()).colwise().sum().matrix();
+        }
+        return drho;
+      }
+
       void PureMDFTGridWorker::update_density(const helfem::Matrix & Pa0, const helfem::Matrix & Pb0) {
         if (!Pa0.size() || !Pb0.size())
           throw std::runtime_error("Error - density matrix is empty!\n");
@@ -835,6 +866,83 @@ namespace helfem {
         // assigns unconditionally; the two grids differed in contract, and
         // this one is the default path.
         Hb_e = basp->remove_boundaries(Hb);
+      }
+
+      void PureMDFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars,
+                                            const helfem::Matrix & P,
+                                            const std::vector<helfem::Matrix> & dP,
+                                            std::vector<helfem::Matrix> & dH_e, double thr) {
+        dH_e.assign(dP.size(), helfem::Matrix());
+        if (dP.empty())
+          return;
+        std::vector<helfem::Matrix> dH(dP.size(), helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy()));
+        {
+          PureMDFTGridWorker grid(basp, lang);
+          grid.check_grad_tau_lapl(x_func, c_func);
+
+          for (size_t iel = 0; iel < basp->rad_Nel(); iel++) {
+            for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++) {
+              grid.compute_bf(iel, irad);
+              grid.update_density(P);
+              // init_xc allocates the potential buffers the response is
+              // written into, and resets the do_gga / do_mgga flags so
+              // the assembly is LDA-shaped.
+              grid.init_xc();
+              grid.init_fxc();
+              if (x_func > 0) grid.compute_fxc(x_func, x_pars, thr);
+              if (c_func > 0) grid.compute_fxc(c_func, c_pars, thr);
+              for (size_t ip = 0; ip < dP.size(); ip++) {
+                grid.set_response_potential(grid.eval_density(dP[ip]),
+                                             helfem::Matrix(), helfem::Matrix(),
+                                             helfem::Matrix());
+                grid.eval_Fxc(dH[ip]);
+              }
+            }
+          }
+        }
+        for (size_t ip = 0; ip < dH.size(); ip++)
+          dH_e[ip] = basp->remove_boundaries(dH[ip]);
+      }
+
+      void PureMDFTGrid::eval_Fxc_response(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars,
+                                            const helfem::Matrix & Pa, const helfem::Matrix & Pb,
+                                            const std::vector<helfem::Matrix> & dPa,
+                                            const std::vector<helfem::Matrix> & dPb,
+                                            std::vector<helfem::Matrix> & dHa_e,
+                                            std::vector<helfem::Matrix> & dHb_e, double thr) {
+        dHa_e.assign(dPa.size(), helfem::Matrix());
+        dHb_e.assign(dPa.size(), helfem::Matrix());
+        if (dPa.empty())
+          return;
+        if (dPb.size() != dPa.size())
+          throw std::logic_error("Got a different number of alpha and beta perturbations.\n");
+        std::vector<helfem::Matrix> dHa(dPa.size(), helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy()));
+        std::vector<helfem::Matrix> dHb(dPa.size(), helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy()));
+        {
+          PureMDFTGridWorker grid(basp, lang);
+          grid.check_grad_tau_lapl(x_func, c_func);
+
+          for (size_t iel = 0; iel < basp->rad_Nel(); iel++) {
+            for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++) {
+              grid.compute_bf(iel, irad);
+              grid.update_density(Pa, Pb);
+              grid.init_xc();
+              grid.init_fxc();
+              if (x_func > 0) grid.compute_fxc(x_func, x_pars, thr);
+              if (c_func > 0) grid.compute_fxc(c_func, c_pars, thr);
+              for (size_t ip = 0; ip < dPa.size(); ip++) {
+                grid.set_response_potential(grid.eval_density(dPa[ip], dPb[ip]),
+                                             helfem::Matrix(), helfem::Matrix(),
+                                             helfem::Matrix());
+                grid.eval_Fxc(dHa[ip], dHb[ip], true);
+              }
+            }
+          }
+        }
+        for (size_t ip = 0; ip < dHa.size(); ip++) {
+          dHa_e[ip] = basp->remove_boundaries(dHa[ip]);
+          dHb_e[ip] = basp->remove_boundaries(dHb[ip]);
+        }
       }
 
     }

--- a/src/diatomic/dftgrid_purem.h
+++ b/src/diatomic/dftgrid_purem.h
@@ -131,6 +131,22 @@ namespace helfem {
         /// the analytic phi integration.
         /// Index of the block holding -m, or mlist.size() if none.
         size_t mirror_block(size_t im) const;
+        /// Density of a SECOND density matrix on the current angular
+        /// grid, without disturbing the reference the worker holds. The
+        /// same per-m gather update_density performs, applied to the
+        /// perturbation; all an LDA response kernel needs.
+        ///
+        /// Unlike update_density this never shares a block between
+        /// mirrored +m / -m partners. Sharing is valid only when
+        /// P(+m) == P(-m), which --symmetry=3 guarantees for the density
+        /// but which nothing guarantees for an arbitrary perturbation;
+        /// walking both blocks is correct either way and costs one extra
+        /// product per mirrored block.
+        helfem::Matrix eval_density(const helfem::Matrix & dP) const;
+        /// Same for a spin-polarized perturbation
+        helfem::Matrix eval_density(const helfem::Matrix & dPa,
+                                     const helfem::Matrix & dPb) const;
+
         /// Assemble the gradient coefficient of the assembly from
         /// vsigma and the stored density gradient. Call after
         /// compute_xc and before eval_Fxc.
@@ -164,6 +180,24 @@ namespace helfem {
                        const helfem::Matrix & Pa, const helfem::Matrix & Pb,
                        helfem::Matrix & Ha, helfem::Matrix & Hb,
                        double & Exc, double & Nel, double & Ekin, bool beta, double thr);
+
+        /// Linear response of the XC matrix to a BATCH of density
+        /// perturbations, at the reference density. LDA-shaped, as in the
+        /// general 3D grid: only the density-density kernel block is
+        /// used, which is what a trust-region model Hessian needs.
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars,
+                                int c_func, const helfem::Vector & c_pars,
+                                const helfem::Matrix & P,
+                                const std::vector<helfem::Matrix> & dP,
+                                std::vector<helfem::Matrix> & dH, double thr);
+        /// Spin-polarized counterpart
+        void eval_Fxc_response(int x_func, const helfem::Vector & x_pars,
+                                int c_func, const helfem::Vector & c_pars,
+                                const helfem::Matrix & Pa, const helfem::Matrix & Pb,
+                                const std::vector<helfem::Matrix> & dPa,
+                                const std::vector<helfem::Matrix> & dPb,
+                                std::vector<helfem::Matrix> & dHa,
+                                std::vector<helfem::Matrix> & dHb, double thr);
       };
 
     }

--- a/src/diatomic/main.cpp
+++ b/src/diatomic/main.cpp
@@ -36,6 +36,8 @@
 #include "../general/elements.h"
 #include "../general/scf_helpers.h"
 #include "../general/scf_driver_common.h"
+#include "../general/trustregion_scf.h"
+#include "../general/otr_solver.h"
 #include "../general/timer.h"
 #include "../general/checkpoint.h"
 #include "../general/eigen_io.h"
@@ -117,6 +119,16 @@ int main(int argc, char **argv) {
   // separated subset of DIIS, ODA, CG and LBFGS. OOO switches between
   // whichever are enabled and collapses gracefully on a subset.
   parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "DIIS + ODA + CG");
+  parser.add<bool>("secondorder", 0, "follow the first-order SCF with second-order trust-region optimization of the orbitals and the fractional occupations", false, false);
+  parser.add<int>("preiter", 0, "first-order iterations to run before switching to the second-order optimizer", false, 100);
+  parser.add<double>("soconvthr", 0, "RMS gradient the second-order optimizer converges to", false, 1e-8);
+  parser.add<int>("somacro", 0, "second-order macroiteration cap", false, 150);
+  parser.add<int>("somicro", 0, "second-order microiteration cap", false, 50);
+  parser.add<int>("somaxhess", 0, "ceiling on Hessian-vector products per macroiteration; 0 for the default", false, 0);
+  parser.add<double>("soredfac", 0, "second-order residual-reduction factor", false, 3e-1);
+  parser.add<std::string>("sosolver", 0, "second-order reduced-space solver: davidson or tcg", false, "davidson");
+  parser.add<bool>("soprecond", 0, "use the exact occupation-block preconditioner", false, true);
+  parser.add<double>("sotest", 0, "instead of optimizing, check the analytic gradient and Hessian against finite differences with this step size", false, 0.0);
 
   parser.parse_check(argc, argv);
 
@@ -368,29 +380,78 @@ int main(int argc, char **argv) {
   // outside it in the SCF solver. See helfem::scf_driver::FockTimer.
   helfem::scf_driver::FockTimer ftimer;
 
-  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
-      [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
-    ftimer.enter();
-    helfem::scf_driver::FockTimer::Components tcomps;
+  // Diatomic exchange kernel: pure Coulomb K (no RS split yet). Hoisted
+  // out of the Fock build so the response shares it -- exchange is linear
+  // in the density, so the response of K is the same contraction applied
+  // to the perturbation, and the two must not drift apart.
+  auto exchange_kernel = [&](const helfem::Matrix & Pin) {
+    return helfem::Matrix(kfrac * basis.exchange(Pin));
+  };
+
+  // Per-block FEM densities of an OpenOrbitalOptimizer solution: block k
+  // is the density restricted to that symmetry block's basis-function
+  // subset dsym[k]. A mirrored +m / -m block stands for two degenerate
+  // spatial orbitals, so its occupation is shared equally between them --
+  // the same convention accumulate_density_block uses.
+  auto blocked_density = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
     const auto & orbitals    = dm.first;
     const auto & occupations = dm.second;
+    helfem::Cube P(nsym * nparttype);
+    for (size_t b = 0; b < nsym * nparttype; ++b) {
+      const size_t k = b % nsym;
+      const helfem::Matrix C_k = Sinvh[k] * orbitals[b];
+      // Full occupation here: the halving a mirrored block needs belongs
+      // in scatter_block, which is the one point BOTH this path and the
+      // trust-region optimizer's own density build go through.
+      P[b] = C_k * occupations[b].asDiagonal() * C_k.transpose();
+    }
+    return P;
+  };
 
-    // Density assembly. Restricted mode has a single closed-shell channel
-    // with max_occ = 2, so P comes straight from the alpha channel; no
-    // Pa/Pb split, no *0.5 double-scatter.
-    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
+  // Scatter one block density back into the full basis, into both index
+  // sets when the block is mirrored.
+  auto scatter_block = [&](helfem::Matrix & dest, const helfem::Cube & blocks, size_t b) {
+    const size_t k = b % nsym;
+    const std::vector<Eigen::Index> & idx = dsym[k];
+    if (idx.empty()) return;
+    // A mirrored block stands for two degenerate spatial orbitals (+m and
+    // -m), and its maximum occupation counts both, so its density is
+    // shared equally between them -- the cylindrically averaged density,
+    // and the same convention accumulate_density_block uses.
+    //
+    // This MUST live here rather than in blocked_density: the
+    // trust-region optimizer builds its own densities from the same
+    // per-block occupations and never goes through blocked_density, so a
+    // halving applied there would leave the optimizer double-counting
+    // every mirrored block.
+    if (dmirror[k].empty()) {
+      dest(idx, idx) += blocks[b];
+    } else {
+      dest(idx, idx) += 0.5 * blocks[b];
+      dest(dmirror[k], dmirror[k]) += 0.5 * blocks[b];
+    }
+  };
+
+  // Energy and per-block AO Fock matrices from the per-block FEM
+  // densities. The whole energy expression, lifted out of the
+  // OpenOrbitalOptimizer builder below so the second-order optimizer --
+  // which works from densities rather than orbitals and occupations --
+  // shares it instead of restating it.
+  auto fock_fem = [&](const helfem::Cube & P_blocks, helfem::Cube & F_blocks,
+                      bool report) -> double {
+    if (P_blocks.size() != nsym * nparttype)
+      throw std::logic_error("Density has an unexpected number of blocks.\n");
+    helfem::scf_driver::FockTimer::Components tcomps;
+
     helfem::Matrix P = helfem::Matrix::Zero(Nbf, Nbf);
     helfem::Matrix Pa, Pb;
     double Exc = 0.0;
     double nelnum = 0.0, ekin_grid = 0.0;
     helfem::Matrix XCa, XCb;
 
-    // grid.eval_Fxc takes/returns Eigen at its public boundary; densities
-    // and XC potentials are Eigen throughout, so no bridging is needed.
     Timer tcomp;
     if (restricted) {
-      for (size_t k = 0; k < nsym; ++k)
-        accumulate_density(P, k, orbitals[k], occupations[k]);
+      for (size_t k = 0; k < nsym; ++k) scatter_block(P, P_blocks, k);
       tcomps.density += tcomp.get();
       if (have_xc) {
         tcomp.set();
@@ -407,8 +468,8 @@ int main(int argc, char **argv) {
       Pa = helfem::Matrix::Zero(Nbf, Nbf);
       Pb = helfem::Matrix::Zero(Nbf, Nbf);
       for (size_t k = 0; k < nsym; ++k) {
-        accumulate_density(Pa, k, orbitals[k],        occupations[k]);
-        accumulate_density(Pb, k, orbitals[nsym + k], occupations[nsym + k]);
+        scatter_block(Pa, P_blocks, k);
+        scatter_block(Pb, P_blocks, nsym + k);
       }
       P = Pa + Pb;
       tcomps.density += tcomp.get();
@@ -437,20 +498,16 @@ int main(int argc, char **argv) {
     const double Ecoul = 0.5 * (P * J).trace();
     tcomps.coulomb += tcomp.get();
 
-    // Diatomic exchange kernel: pure Coulomb K (no RS split yet).
-    auto exchange_fn = [&](const helfem::Matrix & P) {
-      return helfem::Matrix(kfrac * basis.exchange(P));
-    };
     helfem::Matrix Ka, Kb;
     double Exx = 0.0;
     tcomp.set();
     helfem::scf_driver::assemble_hf_exchange(
-        Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_fn);
+        Ka, Kb, Exx, Pa, Pb, restricted, have_exx, exchange_kernel);
     tcomps.exchange += tcomp.get();
 
     const double Etot = Ekin + Enuc + Eefield + Emfield
                        + Ecoul + Exc + Exx + Enucr;
-    if (verbosity >= 1) {
+    if (report && verbosity >= 1) {
       printf("kinetic %.10f nuclear %.10f Enucr %.10f Coulomb %.10f XC %.10f Exx %.10f",
               Ekin, Enuc, Enucr, Ecoul, Exc, Exx);
       if (have_efield) printf(" Eefield %.10f", Eefield);
@@ -462,21 +519,146 @@ int main(int argc, char **argv) {
     ftimer.add_build(tcomps);
     // Timings roughly double the per-iteration volume, so they sit one
     // rung above the energies rather than alongside them.
-    if (verbosity >= 5) ftimer.print_build(have_xc, have_exx);
+    if (report && verbosity >= 5) ftimer.print_build(have_xc, have_exx);
     fflush(stdout);
 
-    // Fock assembly. Restricted: one AO Fock matrix per block.
-    // Unrestricted: separate alpha/beta AO Fock matrices.
+    // Fock assembly. Restricted: one AO Fock matrix. Unrestricted:
+    // separate alpha/beta AO Fock matrices.
     // Pre-assembled 1-electron core. Vel/Vmag are zero matrices when
     // their coupling is off so this matches T + Vnuc + J exactly in the
     // no-field case.
     const helfem::Matrix H1 = T + Vnuc + Vel + Vmag;
-    helfem::scf_driver::assemble_fock_blocks<OOO_Real>(
-        fock, H1, J, XCa, XCb, Ka, Kb, S,
-        nsym, restricted, have_xc, have_exx, have_bfield, Bz,
-        orthonormalize_block);
+    helfem::Matrix Fa_ao = H1 + J;
+    if (have_xc)  Fa_ao += XCa;
+    if (have_exx) Fa_ao += Ka;
+    helfem::Matrix Fb_ao;
+    if (!restricted) {
+      Fb_ao = H1 + J;
+      if (have_xc)  Fb_ao += XCb;
+      if (have_exx) Fb_ao += Kb;
+      // Spin-Zeeman: alpha <- -Bz/2 * S, beta <- +Bz/2 * S.
+      if (have_bfield) {
+        Fa_ao -= 0.5 * Bz * S;
+        Fb_ao += 0.5 * Bz * S;
+      }
+    }
+
+    // Gather each block's own sub-block. A mirrored block's two index
+    // sets are related by symmetry and carry the same Fock sub-block, so
+    // taking one of them is right: the density scatter above put half the
+    // block's density into each, which makes dE/dP_block exactly this.
+    F_blocks.assign(nsym * nparttype, helfem::Matrix());
+    for (size_t b = 0; b < nsym * nparttype; ++b) {
+      const std::vector<Eigen::Index> & idx = dsym[b % nsym];
+      const helfem::Matrix & F_ao = (b < nsym) ? Fa_ao : Fb_ao;
+      F_blocks[b] = idx.empty() ? helfem::Matrix()
+                                : helfem::Matrix(F_ao(idx, idx));
+    }
+    return Etot;
+  };
+
+  // The same build in the form OpenOrbitalOptimizer wants.
+  OpenOrbitalOptimizer::FockBuilder<OOO_Real, OOO_Real> fock_builder =
+      [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm) {
+    ftimer.enter();
+    helfem::Cube F_blocks;
+    const double Etot = fock_fem(blocked_density(dm), F_blocks, true);
+    OpenOrbitalOptimizer::FockMatrix<OOO_Real> fock(nsym * nparttype);
+    for (size_t b = 0; b < nsym * nparttype; ++b) {
+      const size_t k = b % nsym;
+      fock[b] = F_blocks[b].size()
+                    ? helfem::Matrix(Sinvh[k].transpose() * F_blocks[b] * Sinvh[k])
+                    : helfem::Matrix();
+    }
     ftimer.leave();
     return std::make_pair(Etot, fock);
+  };
+
+  // Linear response of those Fock matrices to a batch of density
+  // perturbations. The one-electron terms are density-independent and
+  // drop out; Coulomb and exchange are linear so their response is the
+  // same contraction applied to the perturbation; the XC half goes
+  // through the grid's LDA-shaped response kernel.
+  auto response_fem = [&](const helfem::Cube & P_blocks,
+                          const std::vector<helfem::Cube> & dP_blocks,
+                          std::vector<helfem::Cube> & dF_blocks) {
+    const size_t nt = dP_blocks.size();
+    dF_blocks.assign(nt, helfem::Cube());
+    if (!nt) return;
+
+    helfem::Matrix P = helfem::Matrix::Zero(Nbf, Nbf), Pa, Pb;
+    if (restricted) {
+      for (size_t k = 0; k < nsym; ++k) scatter_block(P, P_blocks, k);
+      Pa = 0.5 * P;
+    } else {
+      Pa = helfem::Matrix::Zero(Nbf, Nbf);
+      Pb = helfem::Matrix::Zero(Nbf, Nbf);
+      for (size_t k = 0; k < nsym; ++k) {
+        scatter_block(Pa, P_blocks, k);
+        scatter_block(Pb, P_blocks, nsym + k);
+      }
+      P = Pa + Pb;
+    }
+
+    std::vector<helfem::Matrix> dP(nt), dPa(nt), dPb(nt);
+    for (size_t it = 0; it < nt; ++it) {
+      dP[it] = helfem::Matrix::Zero(Nbf, Nbf);
+      if (restricted) {
+        for (size_t k = 0; k < nsym; ++k) scatter_block(dP[it], dP_blocks[it], k);
+        dPa[it] = 0.5 * dP[it];
+      } else {
+        dPa[it] = helfem::Matrix::Zero(Nbf, Nbf);
+        dPb[it] = helfem::Matrix::Zero(Nbf, Nbf);
+        for (size_t k = 0; k < nsym; ++k) {
+          scatter_block(dPa[it], dP_blocks[it], k);
+          scatter_block(dPb[it], dP_blocks[it], nsym + k);
+        }
+        dP[it] = dPa[it] + dPb[it];
+      }
+    }
+
+    std::vector<helfem::Matrix> dXCa, dXCb;
+    if (have_xc) {
+      // The same grid the energy used: purem_xc picks the analytic-phi
+      // fast path, which is what --symmetry >= 1 runs by default.
+      if (restricted) {
+        if (purem_xc)
+          pmgrid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, P, dP, dXCa, dftthr);
+        else
+          grid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, P, dP, dXCa, dftthr);
+      } else {
+        if (purem_xc)
+          pmgrid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, Pa, Pb,
+                                    dPa, dPb, dXCa, dXCb, dftthr);
+        else
+          grid.eval_Fxc_response(x_func, x_pars, c_func, c_pars, Pa, Pb,
+                                  dPa, dPb, dXCa, dXCb, dftthr);
+      }
+    }
+
+    for (size_t it = 0; it < nt; ++it) {
+      const helfem::Matrix dJ = basis.coulomb(dP[it]);
+      helfem::Matrix dKa, dKb;
+      if (have_exx) {
+        dKa = exchange_kernel(dPa[it]);
+        if (!restricted) dKb = exchange_kernel(dPb[it]);
+      }
+      helfem::Matrix dFa = dJ, dFb;
+      if (have_xc)  dFa += dXCa[it];
+      if (have_exx) dFa += dKa;
+      if (!restricted) {
+        dFb = dJ;
+        if (have_xc)  dFb += dXCb[it];
+        if (have_exx) dFb += dKb;
+      }
+      dF_blocks[it].assign(nsym * nparttype, helfem::Matrix());
+      for (size_t b = 0; b < nsym * nparttype; ++b) {
+        const std::vector<Eigen::Index> & idx = dsym[b % nsym];
+        const helfem::Matrix & dF = (b < nsym) ? dFa : dFb;
+        dF_blocks[it][b] = idx.empty() ? helfem::Matrix()
+                                       : helfem::Matrix(dF(idx, idx));
+      }
+    }
   };
 
   // Initial-guess Hamiltonian per block per particle type. Fold in the
@@ -727,9 +909,90 @@ int main(int argc, char **argv) {
     scfsolver.initialize_with_fock(CoreH);
   }
 
+  bool secondorder = parser.get<bool>("secondorder");
+  const double sotest = parser.get<double>("sotest");
+  if (sotest > 0.0) secondorder = true;
+  if (secondorder && !helfem::otr::available())
+    throw std::logic_error("This HelFEM was built without OpenTrustRegion, so "
+                           "--secondorder is unavailable. Configure with "
+                           "-DHELFEM_OPENTRUSTREGION=ON.\n");
+
   scfsolver.set("methods", parser.get<std::string>("scfmethods"));
+  // This driver exposes no iteration cap of its own -- it uses
+  // OpenOrbitalOptimizer's default -- so --preiter simply becomes the cap.
+  if (secondorder)
+    scfsolver.set("maximum_iterations", parser.get<int>("preiter"));
   scfsolver.print_citation();
   scfsolver.run();
+
+  if (secondorder) {
+    std::vector<double> maxocc((size_t) maximum_occupation.size());
+    for (Eigen::Index i = 0; i < maximum_occupation.size(); ++i)
+      maxocc[(size_t) i] = maximum_occupation(i);
+
+    helfem::trscf::FockBuilder so_fock =
+        [&](const helfem::Cube & P, helfem::Cube & F) {
+      return fock_fem(P, F, false);
+    };
+    helfem::trscf::ResponseBuilder so_response =
+        [&](const helfem::Cube & P, const std::vector<helfem::Cube> & dP,
+            std::vector<helfem::Cube> & dF) { response_fem(P, dP, dF); };
+
+    // One orthonormalizer per BLOCK: unrestricted has alpha and beta
+    // copies of the same nsym symmetry blocks.
+    std::vector<helfem::Matrix> Sinvh_blocks;
+    Sinvh_blocks.reserve(nsym * nparttype);
+    for (size_t t = 0; t < nparttype; ++t)
+      Sinvh_blocks.insert(Sinvh_blocks.end(), Sinvh.begin(), Sinvh.end());
+
+    helfem::trscf::Optimizer opt(Sinvh_blocks, maxocc,
+                                  std::vector<size_t>(nparttype, nsym),
+                                  so_fock, so_response);
+    opt.set_reference(scfsolver.get_orbitals(),
+                      scfsolver.get_orbital_occupations());
+
+    if (sotest > 0.0) {
+      // Derivative check only. The response kernel here is LDA-shaped, so
+      // beyond an LDA the Hessian is deliberately approximate and is
+      // measured rather than tested.
+      bool xg=false, xt=false, xl=false, cg=false, ct=false, cl=false;
+      if (x_func > 0) ::is_gga_mgga(x_func, xg, xt, xl);
+      if (c_func > 0) ::is_gga_mgga(c_func, cg, ct, cl);
+      const bool exact_kernel = !(xg||xt||xl||cg||ct||cl);
+      if (!opt.verify(sotest, 1e-4, verbosity, exact_kernel))
+        throw std::runtime_error("The analytic derivatives disagree with "
+                                 "finite differences.\n");
+      return 0;
+    }
+
+    helfem::trscf::Options sopt;
+    sopt.otr.conv_tol = parser.get<double>("soconvthr");
+    sopt.otr.n_macro = parser.get<int>("somacro");
+    sopt.otr.n_micro = parser.get<int>("somicro");
+    sopt.max_hessian = parser.get<int>("somaxhess");
+    sopt.otr.global_red_factor = parser.get<double>("soredfac");
+    sopt.otr.local_red_factor = 0.1 * sopt.otr.global_red_factor;
+    sopt.otr.subsystem_solver = parser.get<std::string>("sosolver");
+    // OpenTrustRegion prints its iteration table at level 3.
+    sopt.otr.verbose = (verbosity >= 1) ? std::max(3, verbosity) : 0;
+    sopt.exact_precond = parser.get<bool>("soprecond");
+    sopt.verbosity = verbosity;
+
+    const helfem::trscf::Result res = opt.run(sopt);
+    scfsolver.initialize_with_orbitals(opt.orbitals(), opt.occupations());
+
+    if (res.converged)
+      printf("Converged to energy %.10f!\n", res.energy);
+    if (verbosity >= 1) {
+      printf("\nSecond-order optimization reached energy %.10f with RMS "
+             "gradient %.3e\n", res.energy, res.grad_rms);
+      printf("  %i reference updates, %i objective evaluations, %i "
+             "Hessian-vector products in %i response builds\n",
+             (int) res.n_update, (int) res.n_objective,
+             (int) res.n_hessian, (int) res.n_response);
+      fflush(stdout);
+    }
+  }
   if (verbosity >= 5) ftimer.print_summary(have_xc, have_exx);
 
   if (savefile.size()) {

--- a/src/general/trustregion_scf.cpp
+++ b/src/general/trustregion_scf.cpp
@@ -173,7 +173,20 @@ namespace helfem {
                          const std::vector<double> &maxocc,
                          const std::vector<size_t> &blocks_per_particle,
                          FockBuilder fock, ResponseBuilder response)
+        : Optimizer(std::vector<helfem::Matrix>(maxocc.size(), Sinvh), maxocc,
+                    blocks_per_particle, fock, response) {}
+
+    Optimizer::Optimizer(const std::vector<helfem::Matrix> &Sinvh,
+                         const std::vector<double> &maxocc,
+                         const std::vector<size_t> &blocks_per_particle,
+                         FockBuilder fock, ResponseBuilder response)
         : Sinvh_(Sinvh), maxocc_(maxocc), fock_(fock), response_(response) {
+      if (Sinvh_.size() != maxocc_.size()) {
+        std::ostringstream oss;
+        oss << "Got " << Sinvh_.size() << " orthonormalizers for "
+            << maxocc_.size() << " blocks.\n";
+        throw std::logic_error(oss.str());
+      }
       size_t b = 0;
       for (size_t p = 0; p < blocks_per_particle.size(); p++) {
         std::vector<size_t> blocks;
@@ -193,7 +206,7 @@ namespace helfem {
 
     void Optimizer::fill_occupations(size_t b, double q, helfem::Vector &f,
                                      Eigen::Index &k) const {
-      const Eigen::Index n = Nrad();
+      const Eigen::Index n = norb(b);
       const double w = maxocc_[b];
       f = helfem::Vector::Zero(n);
       for (Eigen::Index i = 0; i < n; i++)
@@ -227,11 +240,11 @@ namespace helfem {
       C_.resize(nblock());
 
       for (size_t b = 0; b < nblock(); b++) {
-        if (orbs[b].rows() != Nrad() || orbs[b].cols() != Nrad()) {
+        if (orbs[b].rows() != norb(b) || orbs[b].cols() != norb(b)) {
           std::ostringstream oss;
           oss << "Block " << b << " has " << orbs[b].rows() << "x"
-              << orbs[b].cols() << " orbitals, expected " << Nrad() << "x"
-              << Nrad() << ".\n";
+              << orbs[b].cols() << " orbitals, expected " << norb(b) << "x"
+              << norb(b) << ".\n";
           throw std::logic_error(oss.str());
         }
         // The occupations are read only as a block electron count: which
@@ -249,7 +262,7 @@ namespace helfem {
             throw std::logic_error(oss.str());
           }
         fill_occupations(b, q_[b], f_[b], active_[b]);
-        C_[b] = Sinvh_ * U_[b];
+        C_[b] = Sinvh_[b] * U_[b];
       }
     }
 
@@ -258,9 +271,9 @@ namespace helfem {
       pair_j_.assign(nblock(), std::vector<Eigen::Index>());
       koff_.assign(nblock(), 0);
 
-      const Eigen::Index n = Nrad();
       size_t off = 0;
       for (size_t b = 0; b < nblock(); b++) {
+        const Eigen::Index n = norb(b);
         koff_[b] = off;
         const Eigen::Index k = active_[b];
         // A rotation changes the density only if the two orbitals differ
@@ -540,7 +553,9 @@ namespace helfem {
 
     void Optimizer::decode(const double *x, std::vector<helfem::Matrix> &kappa,
                            std::vector<double> &dq) const {
-      kappa.assign(nblock(), helfem::Matrix::Zero(Nrad(), Nrad()));
+      kappa.resize(nblock());
+      for (size_t b = 0; b < nblock(); b++)
+        kappa[b] = helfem::Matrix::Zero(norb(b), norb(b));
       for (size_t b = 0; b < nblock(); b++)
         for (size_t p = 0; p < pair_i_[b].size(); p++) {
           const double v = x[koff_[b] + p];
@@ -578,7 +593,9 @@ namespace helfem {
     void Optimizer::densities(const std::vector<helfem::Matrix> &U,
                               const std::vector<double> &q,
                               helfem::Cube &P) const {
-      P.assign(nblock(), helfem::Matrix::Zero(Sinvh_.rows(), Sinvh_.rows()));
+      P.resize(nblock());
+      for (size_t b = 0; b < nblock(); b++)
+        P[b] = helfem::Matrix::Zero(nfem(b), nfem(b));
       for (size_t b = 0; b < nblock(); b++) {
         helfem::Vector f;
         Eigen::Index k;
@@ -586,7 +603,7 @@ namespace helfem {
         // Only orbitals up to the fractionally occupied one carry any
         // density, so the density build is O(Nfem^2 * nocc), not O(N^3).
         const Eigen::Index nocc = k + 1;
-        const helfem::Matrix Cocc = Sinvh_ * U[b].leftCols(nocc);
+        const helfem::Matrix Cocc = Sinvh_[b] * U[b].leftCols(nocc);
         P[b] = Cocc * f.head(nocc).asDiagonal() * Cocc.transpose();
       }
     }
@@ -634,7 +651,9 @@ namespace helfem {
 
       std::vector<helfem::Cube> probe(nb), resp;
       for (size_t c = 0; c < nb; c++) {
-        probe[c].assign(nb, helfem::Matrix::Zero(Sinvh_.rows(), Sinvh_.rows()));
+        probe[c].resize(nb);
+        for (size_t b = 0; b < nb; b++)
+          probe[c][b] = helfem::Matrix::Zero(nfem(b), nfem(b));
         const helfem::Vector ck = C_[c].col(active_[c]);
         probe[c][c] = ck * ck.transpose();
       }
@@ -816,7 +835,7 @@ namespace helfem {
       for (size_t b = 0; b < nblock(); b++) {
         reorthonormalize(U_[b]);
         fill_occupations(b, q_[b], f_[b], active_[b]);
-        C_[b] = Sinvh_ * U_[b];
+        C_[b] = Sinvh_[b] * U_[b];
       }
 
       helfem::Cube P, F;

--- a/src/general/trustregion_scf.h
+++ b/src/general/trustregion_scf.h
@@ -171,8 +171,13 @@ namespace helfem {
     };
 
     class Optimizer {
-      /// Half-inverse overlap, Nfem x Nrad
-      helfem::Matrix Sinvh_;
+      /// Half-inverse overlap of each block, Nfem_b x Norb_b.
+      ///
+      /// Per block, not shared: the spherically averaged atom gives every
+      /// l the same radial basis, but the atomic and diatomic codes
+      /// orthonormalize each symmetry block separately over its own
+      /// basis-function subset, so the blocks differ in both dimensions.
+      std::vector<helfem::Matrix> Sinvh_;
       /// Occupation of a filled orbital in each block
       std::vector<double> maxocc_;
       /// Particle type each block belongs to
@@ -242,8 +247,10 @@ namespace helfem {
       /// Counters
       mutable Result stats_;
 
-      /// Number of radial functions
-      Eigen::Index Nrad() const { return Sinvh_.cols(); }
+      /// Number of orbitals in a block
+      Eigen::Index norb(size_t b) const { return Sinvh_[b].cols(); }
+      /// Number of basis functions in a block
+      Eigen::Index nfem(size_t b) const { return Sinvh_[b].rows(); }
       /// Number of blocks
       size_t nblock() const { return maxocc_.size(); }
 
@@ -307,6 +314,13 @@ namespace helfem {
       /// blocks_per_particle gives the number of blocks belonging to each
       /// particle type, in order; maxocc the occupation of a filled
       /// orbital in each block.
+      Optimizer(const std::vector<helfem::Matrix> &Sinvh,
+                const std::vector<double> &maxocc,
+                const std::vector<size_t> &blocks_per_particle, FockBuilder fock,
+                ResponseBuilder response);
+
+      /// Convenience overload for the case every block shares one basis,
+      /// which is what the spherically averaged atom has.
       Optimizer(const helfem::Matrix &Sinvh, const std::vector<double> &maxocc,
                 const std::vector<size_t> &blocks_per_particle, FockBuilder fock,
                 ResponseBuilder response);

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -3783,6 +3783,53 @@
         "--preiter=30",
         "--soconvthr=1e-8"
       ]
+    },
+    {
+      "name": "atomic-Be-lda-r-secondorder",
+      "code": "atomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "closed-shell Be through the trust-region optimizer. Occupations are integer in the atomic code, so the free occupation coordinates vanish and this is a pure orbital-rotation Newton step -- which is exactly what makes it a clean test of the orbital half of the gradient and Hessian, with the occupation half switched off.",
+      "args": [
+        "--Z=Be",
+        "--M=1",
+        "--lmax=0",
+        "--mmax=0",
+        "--nelem=4",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1",
+        "--secondorder=1",
+        "--preiter=20",
+        "--soconvthr=1e-8"
+      ]
+    },
+    {
+      "name": "atomic-N-lda-u-secondorder",
+      "code": "atomic",
+      "tags": [
+        "unrestricted",
+        "lda",
+        "open-shell",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "the same statement for the spin-polarized path, where alpha and beta carry separate copies of every symmetry block and therefore separate orthonormalizers.",
+      "args": [
+        "--Z=N",
+        "--M=4",
+        "--lmax=1",
+        "--mmax=1",
+        "--nelem=4",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=0",
+        "--secondorder=1",
+        "--preiter=20",
+        "--soconvthr=1e-8"
+      ]
     }
   ],
   "_invariants_comment": [
@@ -4548,6 +4595,26 @@
       "cases": [
         "gensap-Cr-firstorder",
         "gensap-Cr-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "atomic-secondorder-equals-firstorder-Be",
+      "_why": "the second-order optimizer must find the SAME minimum as the ordinary SCF, not merely a fast one. Reference-free. This is the atomic code's version of the aij/gensap statement, and it is the check that the per-block orthonormalizers, the density scatter into the full basis and the LDA response kernel of the atomic grid all compose correctly.",
+      "cases": [
+        "atomic-Be-lda-r",
+        "atomic-Be-lda-r-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "atomic-secondorder-equals-firstorder-N",
+      "_why": "same statement for the spin-polarized path.",
+      "cases": [
+        "atomic-N-lda-u",
+        "atomic-N-lda-u-secondorder"
       ],
       "field": "total",
       "tolerance": 1e-08

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -3596,7 +3596,7 @@
         "consistency",
         "secondorder"
       ],
-      "_why": "spin-restricted Fe handed over to the second-order optimizer EARLY. There is no first-order Fe case because there should not be one: whether the first-order solver converges this system depends on the thread count -- 634 Fock builds and converged on four threads, 607 and not converged on one -- and it is the system the second-order machinery exists for in the first place. Paired with the preiter=30 run below, so that agreement tests the handover and the KKT release rather than one trajectory. DIIS is deliberately absent: this is the case with a genuine occupation coordinate (2 fractionally occupied blocks, 1 transfer), and DIIS extrapolates on the assumption that the occupations are fixed.",
+      "_why": "spin-restricted Fe handed over to the second-order optimizer EARLY. There is no first-order Fe case because there should not be one: whether the first-order solver converges this system depends on the thread count -- 634 Fock builds and converged on four threads, 607 and not converged on one -- and it is the system the second-order machinery exists for in the first place. Paired with the preiter=30 run below, so that agreement tests the handover and the KKT release rather than one trajectory. DIIS is deliberately absent: this is the case with a genuine occupation coordinate (2 fractionally occupied blocks, 1 transfer), and DIIS extrapolates on the assumption that the occupations are fixed. Before the KKT release existed, preiter=20 converged tightly to the pure-state solution 0.032 Eh above the ensemble one.",
       "args": [
         "--Z=Fe",
         "--M=0",
@@ -4504,7 +4504,7 @@
     },
     {
       "name": "aij-secondorder-handover-agrees-Fe",
-      "_why": "the second-order optimizer must land on the same minimum wherever the first-order phase hands over, not merely converge tightly from one lucky starting point. Reference-free. Fe is the discriminating case: an early handover can inherit an occupation pattern with a block frozen on the wrong side of the Fermi level, which is stationary for the restricted problem and so converges to a tiny gradient at a wrong energy. The handover points are chosen from measurement, not from the middle of a range: 22 and 30 both converge for aij AND gensap, while 20 and 28 converge for aij only and 25 fails for both.",
+      "_why": "the second-order optimizer must land on the same minimum wherever the first-order phase hands over, not merely converge tightly from one lucky starting point. Reference-free. Fe is the discriminating case: an early handover can inherit an occupation pattern with a block frozen on the wrong side of the Fermi level, -- a KKT violation, and by Janak's theorem a full block must lie below the Fermi level -- which is stationary for the restricted problem and so converges to a tiny gradient at a wrong energy. The handover points are chosen from measurement, not from the middle of a range: 22 and 30 both converge for aij AND gensap, while 20 and 28 converge for aij only and 25 fails for both.",
       "cases": [
         "aij-Fe-secondorder-early",
         "aij-Fe-secondorder"

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -3830,6 +3830,83 @@
         "--preiter=20",
         "--soconvthr=1e-8"
       ]
+    },
+    {
+      "name": "diatomic-H2-lda-r-secondorder",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "H2 through the trust-region optimizer on the pure-m XC path, which is what --symmetry >= 1 runs by default. Ties the diatomic response kernel, the per-block orthonormalizers and the mirrored +m / -m density scatter to the ordinary SCF.",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1",
+        "--purem=1",
+        "--secondorder=1",
+        "--preiter=20",
+        "--soconvthr=1e-8"
+      ]
+    },
+    {
+      "name": "diatomic-H2-lda-r-secondorder-purem-off",
+      "code": "diatomic",
+      "tags": [
+        "restricted",
+        "lda",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "the same run on the general three-dimensional grid instead. The two XC paths have separate response implementations, so both need tying down; that these agree with each other AND with the first-order energy is the statement.",
+      "args": [
+        "--Z1=1",
+        "--Z2=1",
+        "--Rbond=1.4",
+        "--nelem=3",
+        "--lmax=4",
+        "--nela=1",
+        "--nelb=1",
+        "--method=lda_x-lda_c_vwn",
+        "--restricted=1",
+        "--purem=0",
+        "--secondorder=1",
+        "--preiter=20",
+        "--soconvthr=1e-8"
+      ]
+    },
+    {
+      "name": "diatomic-Ne-dummy-lda-absm-secondorder",
+      "code": "diatomic",
+      "tags": [
+        "lda",
+        "consistency",
+        "secondorder",
+        "absm"
+      ],
+      "_why": "the only second-order case with MIRRORED +m / -m symmetry blocks, which --symmetry=3 creates and which nothing else here exercises. Ne has an occupied pi shell, so those blocks carry charge. A mirrored block stands for two degenerate spatial orbitals and its density must be shared equally between them; getting that convention wrong in only one of the two density builds -- the SCF's and the trust-region optimizer's -- is invisible to --sotest, which differentiates one energy expression against itself. Measured with the halving misplaced, this case hands over 5.5 Eh wrong (-122.7116 against -128.2335) and never converges; with it right it takes four Hessian-vector products.",
+      "args": [
+        "--Z1=10",
+        "--Z2=0",
+        "--Rbond=1.0",
+        "--nelem=3",
+        "--lmax=13,9",
+        "--nela=5",
+        "--nelb=5",
+        "--method=lda_x-lda_c_vwn",
+        "--symmetry=3",
+        "--secondorder=1",
+        "--preiter=20",
+        "--soconvthr=1e-8"
+      ]
     }
   ],
   "_invariants_comment": [
@@ -4615,6 +4692,27 @@
       "cases": [
         "atomic-N-lda-u",
         "atomic-N-lda-u-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-secondorder-equals-firstorder-H2",
+      "_why": "the second-order optimizer must find the SAME minimum as the ordinary SCF. Reference-free. Both XC paths are included, so the pure-m response and the general 3D response are tied to each other and to first order in one statement.",
+      "cases": [
+        "diatomic-H2-lda-r",
+        "diatomic-H2-lda-r-secondorder",
+        "diatomic-H2-lda-r-secondorder-purem-off"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "diatomic-secondorder-equals-firstorder-Ne-absm",
+      "_why": "the second-order optimizer must reproduce the ordinary SCF on a system with mirrored symmetry blocks. Reference-free, and it is the guard on the +m / -m density-sharing convention: the two density builds have to agree, and only a case with occupied mirrored blocks can tell.",
+      "cases": [
+        "diatomic-Ne-dummy-lda-absm",
+        "diatomic-Ne-dummy-lda-absm-secondorder"
       ],
       "field": "total",
       "tolerance": 1e-08


### PR DESCRIPTION
Extends the trust-region optimizer from the spherically averaged drivers to `atomic` and `diatomic`.

## What it takes

**Per-block orthonormalizers.** These two codes orthonormalize each symmetry block separately over its own subset of the basis functions, so blocks differ in both dimensions — unlike sadatom, where every `l` shares one radial basis. `trscf::Optimizer` now takes one `Sinvh` per block, with a convenience constructor for the shared-basis case so the sadatom callers are untouched.

**An LDA response kernel** for the atomic grid and for *both* diatomic grids — both, because `--symmetry >= 1` turns the pure-m fast path on by default and that is exactly the regime of interest. Empty gradient/tau arguments already select the density-density block in `set_response_potential`, so there is no new kernel code and that function is the ready-made seam for the generated GGA/mGGA channels.

**The same `fock_fem`/`response_fem` split** as gensap: a density-driven core plus the OpenOrbitalOptimizer wrapper, so the second-order phase shares the energy expression rather than restating it.

## Verification

`--sotest` at step 1e-4:

| driver | grid | method | `d1·H·d1` rel.err |
|---|---|---|---|
| atomic | — | LDA | 3.4e-09 |
| atomic | — | HF | 3.2e-09 |
| diatomic | general | LDA unrestricted | 3.7e-09 |
| diatomic | pure-m | LDA unrestricted | 3.4e-09 |
| diatomic | pure-m | HF unrestricted | 3.4e-09 |
| diatomic | pure-m | LDA restricted | 7.4e-09 |

all at the finite-difference noise floor. The optimizer reproduces the first-order energy to all ten printed digits on Be, Ne, N and O (atomic, restricted and unrestricted), and on H2, N2, Ne at `--symmetry=3` and spin-restricted O2 at `--symmetry=3` (diatomic). PBE on N converges to the same energy at an RMS gradient of 4.9e-9 despite the LDA-shaped Hessian — the intended behaviour: an approximate model Hessian costs iterations, not correctness, since every step is validated against the true energy by the ratio test.

Both refactors are behaviour-preserving, A/B'd against the pre-refactor binaries: 32 atomic cases (HF/LDA/GGA/hybrid × restricted/unrestricted) and 23 diatomic cases (H2, LiH, BH, N2, CH, Ne) reproduce their energies exactly.

Full suite: **185 passed, 0 failed** — no reference energy moved. Two timeouts (`atomic-N-mgga-r`, `diatomic-CH-piplus-lda`) are pre-existing; the mGGA one also fails to finish in 1800 s on unmodified master.

## The bug worth reading about

A mirrored +m / −m block stands for two degenerate spatial orbitals and its maximum occupation counts both, so its density must be shared equally between them. I first put that halving in `blocked_density` — which **only the SCF path calls**. The trust-region optimizer builds its own densities from the same per-block occupations and never goes through it, so the scatter added the full block to both index sets and double-counted every mirrored block. Ne at `--symmetry=3` then handed over at −122.7116 against a correct −128.2335 and never converged.

The halving now lives in `scatter_block`, the one point both density builds share.

Two things about how this hid:

- **`--sotest` cannot see it.** It differentiates one energy expression against finite differences of *itself*, so both sides used the same wrong scatter and agreed to 3e-9. It validates derivatives, not agreement between two density conventions.
- **No existing test had occupied mirrored blocks.** Every other case here runs at the default symmetry, which produces no ±m pairs at all.

Hence `diatomic-Ne-dummy-lda-absm-secondorder`, which I verified guards the bug by reverting the fix and re-running: 5.5 Eh wrong at handover and no convergence in 900 s, against four Hessian-vector products with the fix. The general lesson is in CLAUDE.md: when adding a second-order path to a new driver, check the handover energy against the first-order one before trusting any derivative check.

## Occupations

Integer in `atomic`, so the free occupation coordinates vanish of their own accord and it reduces to a pure orbital-rotation Newton step — nothing special-cases that. `diatomic` is where they can be fractional, and the same parametrization picks them up.

Worth knowing: it takes **two** fractionally occupied blocks before there is any occupation freedom at all, since the sum-zero subspace of one free block has dimension zero. Spin-restricted O2 at `--symmetry=3` has exactly one (π\*, 2 electrons of a maximum 4) and correctly reports `0 occupation transfers among 1 fractionally occupied blocks`. A transition-metal dimer with two partly-filled channels is what would actually exercise that machinery — the analogue of Curium in the atomic case.

## Tests

Five cases and four reference-free invariants tying the second-order path to the ordinary SCF: atomic restricted and unrestricted, both diatomic XC paths, and the mirrored-block convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
