### PR TITLE
Make the AO to FEM projection reusable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(helfem-common
 general/gaunt.cpp
 general/spherical_harmonics.cpp
 general/timer.cpp general/elements.cpp
-general/angular.cpp general/scf_helpers.cpp general/lcao.cpp
+general/angular.cpp general/scf_helpers.cpp general/lcao.cpp general/lcao_projection.cpp
 general/dftgrid_common.cpp
 general/gsz.cpp general/sap.cpp general/dftfuncs.cpp
 general/atomdb.cpp general/atomdb_data.cpp
@@ -187,6 +187,9 @@ endif()
 
 add_executable(atomic_itest atomic/inttest.cpp)
 target_link_libraries(atomic_itest helfem-common legendre)
+
+add_executable(lcao_projection_test general/lcao_projection_test.cpp)
+target_link_libraries(lcao_projection_test helfem-common legendre)
 
 # Diatomic driver -- OpenOrbitalOptimizer-based (bespoke SCF retired).
 add_executable(diatomic diatomic/main.cpp)

--- a/src/general/lcao_projection.cpp
+++ b/src/general/lcao_projection.cpp
@@ -1,0 +1,130 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#include "lcao_projection.h"
+
+#include <PolynomialBasis.h>
+#include <cmath>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+
+namespace helfem {
+  namespace lcao {
+
+    double gto_rmax(double alpha) { return std::sqrt(50.0 / alpha); }
+
+    double sto_rmax(double zeta) { return 60.0 / zeta; }
+
+    AOBasis make_ao_basis(double rmax, int primbas, int nnodes, int nelem) {
+      if (primbas != 4) {
+        std::ostringstream oss;
+        oss << "make_ao_basis got primbas " << primbas << ", but only 4 (LIP) "
+            << "is supported: the AO expansion coefficients are the function "
+            << "values at the interpolation nodes, which is a valid "
+            << "expansion only for a basis that is cardinal at those nodes. "
+            << "A Hermite basis would additionally need the derivative of "
+            << "the AO, and a Legendre basis is modal.\n";
+        throw std::logic_error(oss.str());
+      }
+      if (rmax <= 0.0)
+        throw std::logic_error("make_ao_basis needs a positive box radius.\n");
+
+      const std::shared_ptr<const polynomial_basis::PolynomialBasis> poly(
+          polynomial_basis::make_basis(primbas, nnodes));
+      const helfem::Vector bval = helfem::Vector::LinSpaced(nelem + 1, 0.0, rmax);
+      // Dirichlet at both ends: u(0) = 0, and rmax is chosen so the AO has
+      // decayed to negligible size there.
+      polynomial_basis::FiniteElementBasis fem(poly, bval, true, false, true,
+                                               false);
+
+      AOBasis ao;
+      ao.rad = helfem::atomic::basis::FEMRadialBasis(fem, 2 * nnodes);
+      const helfem::Vector x0 = poly->nodes();
+      ao.rnode = helfem::Vector::Zero(ao.rad.Nbf());
+      for (size_t iel = 0; iel < ao.rad.Nel(); iel++) {
+        size_t ifirst, ilast;
+        ao.rad.idx(iel, ifirst, ilast);
+        const helfem::IVec en = ao.rad.fem().basis(iel)->enabled();
+        for (Eigen::Index j = 0; j < en.size(); j++)
+          ao.rnode(ifirst + j) = ao.rad.r(x0(en(j)), iel);
+      }
+      ao.Sao = ao.rad.overlap();
+      return ao;
+    }
+
+    helfem::Vector ao_coefficients(const AOBasis &ao, int l, double ex,
+                                   const RadialAO &eval_ao) {
+      helfem::Vector c(ao.rnode.size());
+      for (Eigen::Index i = 0; i < c.size(); i++)
+        c(i) = ao.rnode(i) * eval_ao(ao.rnode(i), l, ex);
+      const double nrm2 = c.dot(ao.Sao * c);
+      if (!(nrm2 > 0.0)) {
+        std::ostringstream oss;
+        oss << "Trial AO with l=" << l << " and exponent " << ex
+            << " has vanishing norm on its own basis; the box radius is "
+            << "probably wrong for this exponent.\n";
+        throw std::logic_error(oss.str());
+      }
+      c /= std::sqrt(nrm2);
+      return c;
+    }
+
+    helfem::Vector project_ao(const AOBasis &ao, const helfem::Matrix &Sx,
+                              int l, double ex, const RadialAO &eval_ao) {
+      return Sx * ao_coefficients(ao, l, ex, eval_ao);
+    }
+
+    double completeness(const helfem::Matrix &Sinvh, const helfem::Vector &b) {
+      return (Sinvh.transpose() * b).norm();
+    }
+
+    double importance(const helfem::Matrix &Cocc, const helfem::Vector &b) {
+      return (Cocc.transpose() * b).norm();
+    }
+
+    void ao_profiles(const helfem::atomic::basis::FEMRadialBasis &solrad,
+                     const helfem::Matrix &Sinvh, const helfem::Cube &C,
+                     const Eigen::VectorXi &occs, int lmax,
+                     const helfem::Vector &expn, const RadialAO &eval_ao,
+                     const std::function<double(double ex)> &ao_rmax,
+                     helfem::Matrix &completeness_out,
+                     helfem::Matrix &importance_out) {
+      completeness_out = helfem::Matrix::Zero(expn.size(), lmax + 2);
+      importance_out = helfem::Matrix::Zero(expn.size(), lmax + 2);
+      completeness_out.col(0) = expn;
+      importance_out.col(0) = expn;
+
+      for (Eigen::Index ix = 0; ix < expn.size(); ix++) {
+        const double ex = expn(ix);
+        // One AO basis and one cross overlap per exponent, shared by every
+        // l channel and both profiles: neither depends on l.
+        const AOBasis ao = make_ao_basis(ao_rmax(ex));
+        // <u_i | v_j> between the solution basis and the AO basis, via the
+        // auto-converging element-pair-intersection quadrature.
+        const helfem::Matrix Sx = solrad.overlap(ao.rad);
+        for (int l = 0; l <= lmax; l++) {
+          const helfem::Vector b = project_ao(ao, Sx, l, ex, eval_ao);
+          completeness_out(ix, l + 1) = completeness(Sinvh, b);
+          if (l < occs.size() && occs(l) > 0) {
+            const int nocc =
+                (int)std::ceil(occs(l) / (2.0 * (2.0 * l + 1.0)));
+            importance_out(ix, l + 1) = importance(C[l].leftCols(nocc), b);
+          }
+        }
+      }
+    }
+
+  } // namespace lcao
+} // namespace helfem

--- a/src/general/lcao_projection.h
+++ b/src/general/lcao_projection.h
@@ -1,0 +1,129 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef LCAO_PROJECTION_H
+#define LCAO_PROJECTION_H
+
+// Projection of analytic radial AOs (GTO / STO) onto a converged finite
+// element solution. lcao.h owns the evaluators; this owns the projection
+// half, and is kept separate so lcao.h stays free of the radial-basis
+// headers that only the projection needs.
+
+#include "lcao.h"
+#include <RadialBasis.h>
+#include <functional>
+
+namespace helfem {
+  namespace lcao {
+
+    /// Radial part R(r) of a trial AO of angular momentum l and exponent
+    /// ex. helfem::lcao::radial_GTO and radial_STO have this shape.
+    using RadialAO = std::function<double(double r, int l, double ex)>;
+
+    /// Box radius beyond which a GTO of this exponent is negligible:
+    /// alpha*rmax^2 = 50 puts the Gaussian factor below 1e-21, which the
+    /// r^(l+1) prefactor cannot bring back to significance for any sane l.
+    double gto_rmax(double alpha);
+    /// Same for an STO: zeta*rmax = 60.
+    double sto_rmax(double zeta);
+
+    /// Function-specific FE expansion of a trial radial AO.
+    ///
+    /// The AO is expanded as u(r) = r*R(r) on its OWN exponent-scaled
+    /// radial grid: LIP coefficients are nodal values, so the expansion
+    /// needs no quadrature, and on the AO's own scale the interpolation
+    /// is spectrally accurate. Every integral against a solution basis
+    /// then goes through the auto-converging cross-basis overlap, which
+    /// quadratures each element-pair intersection separately, so neither
+    /// basis's rule has to resolve the other's scale.
+    ///
+    /// Evaluating the AO at the SOLUTION basis's quadrature nodes instead
+    /// misintegrates both ends of an exponent sweep: a tight AO
+    /// (alpha ~ 1e10, support ~1e-5 au) lives entirely between the first
+    /// element's quadrature nodes, and a diffuse one extends past the last
+    /// element boundary, which also breaks its normalization.
+    struct AOBasis {
+      /// Exponent-scaled radial basis for the trial AO
+      helfem::atomic::basis::FEMRadialBasis rad;
+      /// Radius of each basis function's interpolation node
+      helfem::Vector rnode;
+      /// Overlap in this basis, used to normalize the expansion
+      helfem::Matrix Sao;
+    };
+
+    /// Build an AO basis spanning [0, rmax].
+    ///
+    /// primbas MUST be 4 (LIP). The coefficient construction in
+    /// ao_coefficients() reads the AO at the interpolation nodes and uses
+    /// those values directly as expansion coefficients, which is valid
+    /// only because LIP is cardinal at its nodes. A HIP basis carries
+    /// function values AND derivatives as its degrees of freedom, and a
+    /// Legendre basis is modal, so neither admits that construction
+    /// without also supplying the derivative. The restriction is enforced
+    /// rather than assumed: anything else throws.
+    AOBasis make_ao_basis(double rmax, int primbas = 4, int nnodes = 15,
+                          int nelem = 10);
+
+    /// Nodal expansion coefficients of u_AO = r*R_AO(r), normalized so
+    /// that c' Sao c = 1. The normalization is numerical rather than
+    /// analytic so that interpolation and box-truncation error cannot
+    /// push a completeness profile past 1.
+    helfem::Vector ao_coefficients(const AOBasis &ao, int l, double ex,
+                                   const RadialAO &eval_ao);
+
+    /// Cross-overlap b_i = <u_i | u_AO> between the solution basis
+    /// functions and one normalized trial AO.
+    ///
+    /// This is the primitive: everything below is a thin consumer of it.
+    /// Sx is the cross-basis overlap solrad.overlap(ao.rad), which depends
+    /// only on the two grids -- not on l, not on the evaluator -- so a
+    /// caller sweeping l or driving an optimizer builds it once alongside
+    /// the AO basis and passes it in.
+    helfem::Vector project_ao(const AOBasis &ao, const helfem::Matrix &Sx,
+                              int l, double ex, const RadialAO &eval_ao);
+
+    /// How completely the solution basis reproduces the AO: the norm of
+    /// its projection onto the orthonormalized FE space. 1 = fully
+    /// represented.
+    double completeness(const helfem::Matrix &Sinvh, const helfem::Vector &b);
+
+    /// How important the exponent is for the converged density: the norm
+    /// of the AO's projection onto the occupied orbitals. Cocc holds the
+    /// occupied columns for the relevant angular momentum.
+    double importance(const helfem::Matrix &Cocc, const helfem::Vector &b);
+
+    /// Completeness profile Y(alpha, l) and importance profile I(alpha, l)
+    /// over an exponent grid: a loop over project_ao.
+    ///
+    /// Column 0 is the exponent; columns 1..lmax+1 are the per-l profiles.
+    /// Both profiles come from the same cross-basis overlap, which depends
+    /// only on the grids, so they are computed together: one AO basis and
+    /// one cross overlap per exponent, shared by every l channel and both
+    /// profiles.
+    ///
+    /// C[l] holds the solution orbitals of angular momentum l and occs(l)
+    /// its electron count; the occupied column count follows as
+    /// ceil(occs(l) / (2*(2l+1))).
+    void ao_profiles(const helfem::atomic::basis::FEMRadialBasis &solrad,
+                     const helfem::Matrix &Sinvh, const helfem::Cube &C,
+                     const Eigen::VectorXi &occs, int lmax,
+                     const helfem::Vector &expn, const RadialAO &eval_ao,
+                     const std::function<double(double ex)> &ao_rmax,
+                     helfem::Matrix &completeness_out,
+                     helfem::Matrix &importance_out);
+
+  } // namespace lcao
+} // namespace helfem
+
+#endif

--- a/src/general/lcao_projection_test.cpp
+++ b/src/general/lcao_projection_test.cpp
@@ -1,0 +1,108 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+
+// Unit tests for the AO -> FEM projection primitive.
+//
+// The sweep (ao_profiles) is covered end to end by gensap --completeness.
+// What is NOT covered there is the way an optimizer drives this: build an
+// AO basis and its cross-overlap once, then project repeatedly. These
+// tests pin that path, since it is the one libatomscf consumes.
+
+#include "lcao_projection.h"
+#include <Eigen/Eigenvalues>
+#include <cmath>
+#include <cstdio>
+#include <stdexcept>
+
+using namespace helfem;
+
+static int failures = 0;
+
+static void check(bool ok, const char *what) {
+  printf("  %-58s %s\n", what, ok ? "ok" : "FAILED");
+  if (!ok)
+    failures++;
+}
+
+int main() {
+  printf("AO -> FEM projection tests\n");
+
+  // Any FEM radial basis serves as the "solution" basis here: the
+  // projection machinery only ever sees its grid.
+  const lcao::AOBasis sol = lcao::make_ao_basis(40.0, 4, 15, 12);
+  const Matrix Ssol = sol.rad.overlap();
+  Eigen::SelfAdjointEigenSolver<Matrix> es(Ssol);
+  const Vector sval = es.eigenvalues();
+  const Matrix svec = es.eigenvectors();
+  Matrix Sinvh(svec.rows(), svec.cols());
+  for (Eigen::Index i = 0; i < sval.size(); i++)
+    Sinvh.col(i) = svec.col(i) / std::sqrt(sval(i));
+
+  auto eval_gto = [](double r, int l, double ex) {
+    return lcao::radial_GTO(r, l, ex);
+  };
+
+  const double alpha = 1.3;
+  const int l = 1;
+
+  // Build once, project many times: the pattern an exponent optimizer uses.
+  const lcao::AOBasis ao = lcao::make_ao_basis(lcao::gto_rmax(alpha));
+  const Matrix Sx = sol.rad.overlap(ao.rad);
+  const Vector b = lcao::project_ao(ao, Sx, l, alpha, eval_gto);
+
+  // Rebuilding the AO basis and the cross overlap must change nothing:
+  // that equivalence is what makes reuse safe.
+  const lcao::AOBasis ao2 = lcao::make_ao_basis(lcao::gto_rmax(alpha));
+  const Matrix Sx2 = sol.rad.overlap(ao2.rad);
+  const Vector b2 = lcao::project_ao(ao2, Sx2, l, alpha, eval_gto);
+  check((b - b2).cwiseAbs().maxCoeff() == 0.0,
+        "reusing an AO basis reproduces a rebuilt one exactly");
+
+  // The AO is normalized on its own basis by construction.
+  const Vector c = lcao::ao_coefficients(ao, l, alpha, eval_gto);
+  check(std::abs(c.dot(ao.Sao * c) - 1.0) < 1e-12,
+        "AO expansion is normalized on its own basis");
+
+  // A projection onto an orthonormal space cannot exceed the AO's norm.
+  const double Y = lcao::completeness(Sinvh, b);
+  check(Y > 0.0 && Y <= 1.0 + 1e-10, "completeness lies in (0, 1]");
+
+  // This AO is well inside the solution basis's range, so it should be
+  // nearly fully represented.
+  check(Y > 0.99, "a well-resolved GTO is almost completely represented");
+
+  // Importance against a single occupied column is a plain projection,
+  // and cannot exceed the completeness measured over the whole space.
+  const Matrix Cocc = Sinvh.leftCols(3);
+  check(lcao::importance(Cocc, b) <= Y + 1e-10,
+        "importance never exceeds completeness");
+
+  // The box heuristics are the documented ones.
+  check(std::abs(lcao::gto_rmax(50.0) - 1.0) < 1e-15, "gto_rmax(50) == 1");
+  check(std::abs(lcao::sto_rmax(60.0) - 1.0) < 1e-15, "sto_rmax(60) == 1");
+
+  // The LIP restriction is enforced, not assumed: the nodal-coefficient
+  // construction is invalid for a Hermite or Legendre basis.
+  bool threw = false;
+  try {
+    lcao::make_ao_basis(1.0, /*primbas=*/5);
+  } catch (const std::logic_error &) {
+    threw = true;
+  }
+  check(threw, "a non-LIP primitive basis is refused");
+
+  printf("%s\n", failures ? "FAILURES" : "All tests passed.");
+  return failures ? 1 : 0;
+}

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -27,6 +27,7 @@
 #include "../general/scf_helpers.h"
 #include "../general/scf_driver_common.h"
 #include "../general/lcao.h"
+#include "../general/lcao_projection.h"
 #include "../atomic/basis.h"
 #include "scf.h"
 #include "../general/otr_solver.h"
@@ -107,97 +108,6 @@ static helfem::Matrix effective_potential_table(
   return result;
 }
 
-// Function-specific FE expansion of a trial radial AO for the profiles
-// below. The AO is expanded as u(r) = r*R(r) on its own exponent-scaled
-// radial grid: LIP coefficients are nodal values, so the expansion needs
-// no quadrature, and on the AO's own scale the interpolation is
-// spectrally accurate. Every integral against the solution basis then
-// goes through the auto-converging cross-basis overlap, which
-// quadratures each element-pair intersection separately, so neither
-// basis's rule has to resolve the other's scale.
-//
-// The previous implementation instead evaluated the AOs at the SOLUTION
-// basis's quadrature nodes with the fixed SCF rule, which misintegrates
-// both ends of the profile: a tight AO (alpha ~ 1e10, support ~1e-5 au)
-// lives entirely between the first element's quadrature nodes, and a
-// diffuse one extends far beyond the last element boundary, which also
-// breaks its normalization.
-struct AOBasis {
-  /// Exponent-scaled radial basis for the trial AO
-  helfem::atomic::basis::FEMRadialBasis rad;
-  /// Radius of each basis function's interpolation node
-  helfem::Vector rnode;
-};
-
-static AOBasis make_ao_basis(double rmax) {
-  const int nnodes = 15, nelem = 10;
-  static const std::shared_ptr<const polynomial_basis::PolynomialBasis> poly(
-      polynomial_basis::make_basis(/*primbas=*/4, nnodes)); // LIP: nodal dofs
-  const helfem::Vector bval = helfem::Vector::LinSpaced(nelem + 1, 0.0, rmax);
-  // Dirichlet at both ends: u(0) = 0, and rmax is chosen so the AO has
-  // decayed to negligible size there.
-  polynomial_basis::FiniteElementBasis fem(poly, bval, true, false, true, false);
-
-  AOBasis ao;
-  ao.rad = helfem::atomic::basis::FEMRadialBasis(fem, 2 * nnodes);
-  const helfem::Vector x0 = poly->nodes();
-  ao.rnode = helfem::Vector::Zero(ao.rad.Nbf());
-  for (size_t iel = 0; iel < ao.rad.Nel(); iel++) {
-    size_t ifirst, ilast;
-    ao.rad.idx(iel, ifirst, ilast);
-    const helfem::IVec en = ao.rad.fem().basis(iel)->enabled();
-    for (Eigen::Index j = 0; j < en.size(); j++)
-      ao.rnode(ifirst + j) = ao.rad.r(x0(en(j)), iel);
-  }
-  return ao;
-}
-
-// Completeness profile Y(alpha, l): the norm of the projection of the
-// trial AO (STO/GTO) onto the orthonormalized FE space -- how completely
-// the FE basis reproduces that AO (1 = fully represented). Importance
-// profile I(alpha, l): the norm of its projection onto the occupied SCF
-// orbitals -- how important the exponent is for the converged density.
-// Column 0 is alpha; columns 1..lmax+1 are the per-l profiles. Both come
-// from the same cross-basis overlap, which only depends on the grids, so
-// they are computed together: one AO basis and one cross overlap per
-// exponent, shared by every l channel and both profiles.
-static void ao_profiles(
-    const helfem::sadatom::basis::TwoDBasis & basis, const helfem::Matrix & Sinvh,
-    const helfem::Cube & C, const Eigen::VectorXi & occs, int lmax,
-    const helfem::Vector & expn,
-    const std::function<double(double r, int l, double ex)> & eval_ao,
-    const std::function<double(double ex)> & ao_rmax,
-    helfem::Matrix & completeness, helfem::Matrix & importance) {
-  const helfem::atomic::basis::FEMRadialBasis & solrad = basis.radial();
-  completeness = helfem::Matrix::Zero(expn.size(), lmax + 2);
-  importance = helfem::Matrix::Zero(expn.size(), lmax + 2);
-  completeness.col(0) = expn;
-  importance.col(0) = expn;
-  for (Eigen::Index ix = 0; ix < expn.size(); ix++) {
-    const double ex = expn(ix);
-    const AOBasis ao = make_ao_basis(ao_rmax(ex));
-    const helfem::Matrix Sao = ao.rad.overlap();
-    // <u_i | v_j> between the solution basis and the AO basis, via the
-    // auto-converging element-pair-intersection quadrature.
-    const helfem::Matrix Sx = solrad.overlap(ao.rad);
-    for (int l = 0; l <= lmax; l++) {
-      // Nodal expansion coefficients of u_AO = r * R_AO(r), normalized
-      // numerically so the interpolation and box-truncation error can't
-      // push the profile past 1.
-      helfem::Vector c(ao.rnode.size());
-      for (Eigen::Index i = 0; i < c.size(); i++)
-        c(i) = ao.rnode(i) * eval_ao(ao.rnode(i), l, ex);
-      c /= std::sqrt(c.dot(Sao * c));
-      const helfem::Vector b = Sx * c;   // <u_i | u_AO>
-      completeness(ix, l + 1) = (Sinvh.transpose() * b).norm();
-      if (l < occs.size() && occs(l) > 0) {
-        const int nocc = (int) std::ceil(occs(l) / (2.0 * (2.0 * l + 1.0)));
-        importance(ix, l + 1) = (C[l].leftCols(nocc).transpose() * b).norm();
-      }
-    }
-  }
-}
-
 // Write GTO and STO completeness/importance profiles for the converged
 // density to <El>_{gto,sto}_{completeness,importance}.dat, over a
 // log-spaced exponent grid.
@@ -210,24 +120,21 @@ static void write_profiles(
       [](double x) { return std::pow(10.0, x); });
   const helfem::Matrix Sinvh = result.basis.Sinvh();
 
-  // AO box sizes: alpha*rmax^2 = 50 (GTO) and zeta*rmax = 60 (STO) put
-  // the exponential factor below 1e-21; the r^(l+1) prefactor cannot
-  // bring that back to significance for any sane l.
   auto eval_gto = [](double r, int l, double ex) {
     return helfem::lcao::radial_GTO(r, l, ex); };
-  auto rmax_gto = [](double ex) { return std::sqrt(50.0 / ex); };
   auto eval_sto = [](double r, int l, double ex) {
     return helfem::lcao::radial_STO(r, l, ex); };
-  auto rmax_sto = [](double ex) { return 60.0 / ex; };
 
   const std::string el = element_symbols[Z];
   helfem::Matrix comp, imp;
-  ao_profiles(result.basis, Sinvh, result.orbs_a, result.occs_a, lmax, expn,
-              eval_gto, rmax_gto, comp, imp);
+  helfem::lcao::ao_profiles(result.basis.radial(), Sinvh, result.orbs_a,
+                            result.occs_a, lmax, expn, eval_gto,
+                            helfem::lcao::gto_rmax, comp, imp);
   io::write_raw_ascii(el + "_gto_completeness.dat", comp);
   io::write_raw_ascii(el + "_gto_importance.dat", imp);
-  ao_profiles(result.basis, Sinvh, result.orbs_a, result.occs_a, lmax, expn,
-              eval_sto, rmax_sto, comp, imp);
+  helfem::lcao::ao_profiles(result.basis.radial(), Sinvh, result.orbs_a,
+                            result.occs_a, lmax, expn, eval_sto,
+                            helfem::lcao::sto_rmax, comp, imp);
   io::write_raw_ascii(el + "_sto_completeness.dat", comp);
   io::write_raw_ascii(el + "_sto_importance.dat", imp);
   printf("Wrote GTO/STO completeness and importance profiles for %s.\n", el.c_str());


### PR DESCRIPTION
The cross-basis projection of GTO/STO functions onto a converged FEM solution lived as file-static helpers inside the `gensap` driver, so nothing outside that translation unit could reach it — while `lcao.h` exposed the *evaluation* half publicly. That split was backwards: the evaluators are the easy part. `libatomscf` needs the projection to seed analytic exponent optimization from a numerically exact FEM reference.

Moved to `src/general/lcao_projection.{h,cpp}` rather than into `lcao.h` itself, so `lcao.h` keeps its single `Matrix.h` include instead of pulling in the radial-basis headers only the projection needs.

## Three changes, not a straight lift

**The primitive is now the interface.**

```cpp
Vector project_ao(const AOBasis& ao, const Matrix& Sx, int l, double ex, const RadialAO& eval);
double completeness(const Matrix& Sinvh, const Vector& b);
double importance (const Matrix& Cocc,  const Vector& b);
```

`completeness` and `importance` are one-line consumers, and `ao_profiles` becomes a loop over `project_ao`. A caller driving an optimizer wants the single projection inside its own loop, not a sweep.

**The AO basis and its cross-overlap are caller-owned.** Neither depends on the angular momentum or on the evaluator — only on the two grids — so `project_ao` takes them as arguments. Rebuilding them per exponent is negligible amortised over a 501-point profile and exactly the wrong thing in an optimizer's inner loop. `AOBasis` carries its own overlap too, since the normalization needs it.

**The LIP restriction is enforced, not assumed.** `make_ao_basis` takes `primbas`, `nnodes` and `nelem` instead of hardcoding 4, 15, 10 — but throws for any `primbas` other than 4. The coefficient construction reads the AO at the interpolation nodes and uses those values directly as expansion coefficients, which is valid only for a basis cardinal at those nodes: a Hermite basis carries values *and* derivatives as its degrees of freedom, and a Legendre basis is modal. The old code said `// LIP: nodal dofs` and left it at that.

I took the enforce-and-throw branch rather than adding a HIP path, since supporting Hermite needs an evaluator returning `(R, dR/dr)` and that is a behaviour change, not a refactor. The parameter is threaded through, so it is easy to add later.

`ao_profiles` also lost its `sadatom::basis::TwoDBasis` argument — it takes the solution `FEMRadialBasis` directly, which is what made it sadatom-only in the first place.

The box heuristics that were anonymous lambdas are now named: `gto_rmax` (`alpha*rmax^2 = 50`) and `sto_rmax` (`zeta*rmax = 60`).

## Behaviour is unchanged, verified rather than assumed

`gensap --completeness` on **Be and N**: all eight `.dat` files byte-identical to the same run on plain master. (Checked against this branch's actual base — an earlier check on a different branch would not have transferred, since `gensap` links `trustregion_scf` and that differs there.)

## Test

`lcao_projection_test` pins what the sweep does not exercise: **that a reused AO basis reproduces a rebuilt one exactly**, which is the path an optimizer takes and the whole reason for the second change above. Also covers the normalization, the completeness bound, the named heuristics, and that a non-LIP primitive basis is refused. 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
