### PR TITLE
tests: drive the gensap cases the way gensap should be driven

### DIFF
--- a/tests/cases.json
+++ b/tests/cases.json
@@ -2092,15 +2092,20 @@
       "tags": [
         "spherical",
         "hf",
-        "ci"
+        "ci",
+        "secondorder"
       ],
       "args": [
         "--Z=H",
         "--M=2",
         "--lmax=0",
         "--nelem=3",
-        "--method=HF"
-      ]
+        "--method=HF",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-He-hf",
@@ -2108,15 +2113,20 @@
       "tags": [
         "spherical",
         "hf",
-        "ci"
+        "ci",
+        "secondorder"
       ],
       "args": [
         "--Z=He",
         "--M=1",
         "--lmax=0",
         "--nelem=4",
-        "--method=HF"
-      ]
+        "--method=HF",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-He-lda",
@@ -2124,90 +2134,120 @@
       "tags": [
         "spherical",
         "lda",
-        "ci"
+        "ci",
+        "secondorder"
       ],
       "args": [
         "--Z=He",
         "--M=1",
         "--lmax=0",
         "--nelem=4",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-Be-lda",
       "code": "gensap",
       "tags": [
         "spherical",
-        "lda"
+        "lda",
+        "secondorder"
       ],
       "args": [
         "--Z=Be",
         "--M=1",
         "--lmax=0",
         "--nelem=4",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-N-hf",
       "code": "gensap",
       "tags": [
         "spherical",
-        "hf"
+        "hf",
+        "secondorder"
       ],
       "args": [
         "--Z=N",
         "--M=4",
         "--lmax=1",
         "--nelem=4",
-        "--method=HF"
-      ]
+        "--method=HF",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-Ne-lda",
       "code": "gensap",
       "tags": [
         "spherical",
-        "lda"
+        "lda",
+        "secondorder"
       ],
       "args": [
         "--Z=Ne",
         "--M=1",
         "--lmax=1",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-P-lda",
       "code": "gensap",
       "tags": [
         "spherical",
-        "lda"
+        "lda",
+        "secondorder"
       ],
       "args": [
         "--Z=P",
         "--M=4",
         "--lmax=1",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-Ar-lda",
       "code": "gensap",
       "tags": [
         "spherical",
-        "lda"
+        "lda",
+        "secondorder"
       ],
       "args": [
         "--Z=Ar",
         "--M=1",
         "--lmax=1",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-Cr-lda",
@@ -2215,15 +2255,20 @@
       "tags": [
         "spherical",
         "lda",
-        "slow"
+        "slow",
+        "secondorder"
       ],
       "args": [
         "--Z=Cr",
         "--M=7",
         "--lmax=2",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "gensap-Zn-lda",
@@ -2231,15 +2276,20 @@
       "tags": [
         "spherical",
         "lda",
-        "slow"
+        "slow",
+        "secondorder"
       ],
       "args": [
         "--Z=Zn",
         "--M=1",
         "--lmax=2",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ],
+      "_why": " Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it."
     },
     {
       "name": "aij-Al-jellium",
@@ -2281,15 +2331,19 @@
       "tags": [
         "spherical",
         "lda",
-        "consistency"
+        "consistency",
+        "secondorder"
       ],
-      "_why": "bare Al, the limit aij must reproduce at njellium=0",
+      "_why": "bare Al, the limit aij must reproduce at njellium=0 Runs 30 first-order iterations and then hands over to the second-order optimizer, which is how gensap should be driven: the spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly. This case converges in 6-8 Fock builds at first order alone -- the switch is here so the suite exercises the recommended workflow across the periodic table, not because this element needs it.",
       "args": [
         "--Z=Al",
         "--M=2",
         "--lmax=2",
         "--nelem=5",
-        "--method=lda_x"
+        "--method=lda_x",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
       ]
     },
     {
@@ -3655,7 +3709,7 @@
         "unrestricted",
         "consistency"
       ],
-      "_why": "spin-polarized Fe at Hartree-Fock, where the Fock matrix carries exact exchange. Paired with the second-order run below: exchange is the one term of the response the DFT cases never exercise.",
+      "_why": "spin-polarized Fe at Hartree-Fock, where the Fock matrix carries exact exchange. Paired with the second-order run below: exchange is the one term of the response the DFT cases never exercise. Deliberately left at first order when the rest of the gensap cases were switched over: it is the reference half of gensap-secondorder-equals-firstorder-Fe-hf, and without it nothing here would compare the two paths directly.",
       "args": [
         "--Z=Fe",
         "--M=5",


### PR DESCRIPTION
The spherically averaged atom optimizes its occupations as well as its orbitals, and first order handles a fractionally occupied degenerate shell badly — that is the whole reason the second-order optimizer exists. The gensap cases nonetheless all ran first order alone, so the suite exercised a workflow nobody should use on a hard atom.

Every gensap case now runs **30 first-order iterations and hands over**.

## Two things from measuring it rather than assuming

**None of the existing cases actually needed this.** First-order Fock builds to convergence:

| | builds | | builds |
|---|---|---|---|
| H/HF | 6 | Ar | 7 |
| He/HF | 6 | Cr | 8 |
| Be | 6 | Zn | 8 |
| N/HF | 8 | Al | 6 |
| Ne | 7 | **Fe/HF** | **51** |
| P | 6 | | |

They are high-spin or closed-shell atoms that never meet the degeneracy problem. So the switch buys coverage of the second-order path across the periodic table, not robustness for these particular elements — and it means the cases keep working if the first-order default changes under them, which is relevant given the pending DIIS question.

**Thirty iterations, not twenty.** At `preiter=20` ten of the eleven converge to energies identical to first order, but **Fe/HF fails outright**: the second-order phase spends 149 macroiterations with the gradient stuck at 5.4e+2 and the trust radius collapsed to 1e-4, then OpenTrustRegion gives up with error 101. At 30 every case converges, all to the energies first order produced. That is the documented handover sensitivity, and it is why the number is measured rather than picked from the middle of the suggested range.

## Verification

19 gensap/aij cases: **0 failed, 0 invariant violations**. The three cases carrying references in `ci.json` (H/HF, He/HF, He/LDA) still match their recorded first-order values, so the reference comparison *is* a first-versus-second check for those.

## One deliberate exception

`gensap-Fe-hf-firstorder` stays at first order. It is the reference half of `gensap-secondorder-equals-firstorder-Fe-hf`, and converting it would leave nothing in the suite comparing the two paths head to head on a system where it matters. Say the word if you would rather it went too — the ci.json references would still provide a weaker version of that check.

Independent of #329: no conflict (verified with `git merge-tree`), despite both touching `tests/cases.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
