### PR TITLE
sadatom: drop DIIS from the defaults, keep it on the easy cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ if(NOT OpenOrbitalOptimizer_FOUND)
     # fixes; pinning to the v0.4.0 tag instead would silently revert them.
     FetchContent_Declare(OpenOrbitalOptimizer
         GIT_REPOSITORY https://github.com/susilehtola/OpenOrbitalOptimizer.git
-        GIT_TAG        a3abae9a2b7b2a3dd591579a7613643574da90c9
+        GIT_TAG        bef468dfb24241ea6e44d73e2d749182d45dce16
         ${_ooo_exclude})
     FetchContent_MakeAvailable(OpenOrbitalOptimizer)
     unset(_ooo_exclude)

--- a/src/sadatom/aij.cpp
+++ b/src/sadatom/aij.cpp
@@ -80,7 +80,19 @@ int main(int argc, char **argv) {
   parser.add<double>("Rmax", 0, "Size of vacuum region", false, 40.0);
   parser.add<int>("M", 0, "spin multiplicity", true);
   parser.add<int>("lmax", 0, "maximum angular momentum", false, 4);
-  parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "DIIS + ODA + CG");
+  // DIIS is deliberately NOT in the default here, though it is
+  // everywhere else in HelFEM. This driver optimizes the occupations
+  // as well as the orbitals, and DIIS extrapolates a Fock matrix on
+  // the assumption that the occupations are fixed -- so on a
+  // fractionally occupied atom it extrapolates along a direction the
+  // solution is free to move in, and fights ODA rather than helping
+  // it. Measured at a matched iteration budget: with DIIS the
+  // spin-restricted Ni atom takes 10334 Fock builds and still does
+  // not converge, against 595 and converged without it; Fe takes 729
+  // against 555 and Cr 658 against 571, to the same energies.
+  // Closed shells pay for it -- Ar goes from 7 builds to 39 -- but an
+  // atomic Fock build is milliseconds, and a wrong answer is not.
+  parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "ODA + CG");
   parser.add<std::string>("loadfock", 0, "file to load guess fock matrix from", false, "");
   parser.add<std::string>("savefock", 0, "file to save fock matrix to", false, "");
   parser.add<bool>("saveorb", 0, "save radial orbitals to disk?", false, false);

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -177,7 +177,19 @@ int main(int argc, char **argv) {
   parser.add<std::string>("save", 0, "save results to checkpoint file",       false, "");
   // SCF convergence algorithms handed to OOO's state machine: a '+'
   // separated subset of DIIS, ODA, CG and LBFGS.
-  parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "DIIS + ODA + CG");
+  // DIIS is deliberately NOT in the default here, though it is
+  // everywhere else in HelFEM. This driver optimizes the occupations
+  // as well as the orbitals, and DIIS extrapolates a Fock matrix on
+  // the assumption that the occupations are fixed -- so on a
+  // fractionally occupied atom it extrapolates along a direction the
+  // solution is free to move in, and fights ODA rather than helping
+  // it. Measured at a matched iteration budget: with DIIS the
+  // spin-restricted Ni atom takes 10334 Fock builds and still does
+  // not converge, against 595 and converged without it; Fe takes 729
+  // against 555 and Cr 658 against 571, to the same energies.
+  // Closed shells pay for it -- Ar goes from 7 builds to 39 -- but an
+  // atomic Fock build is milliseconds, and a wrong answer is not.
+  parser.add<std::string>("scfmethods", 0, "SCF convergence methods: '+' separated subset of DIIS, ODA, CG, LBFGS", false, "ODA + CG");
   parser.add<int>("verbosity", 0, "output detail: 0 silent, 1 setup and energies, 5 also per-iteration Fock timings; also passed to the SCF solver", false, 5);
   parser.add<int>("maxiter", 0, "maximum number of SCF iterations", false, 128);
   parser.add<double>("convthr", 0, "SCF convergence threshold", false, 1e-7);

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -2099,8 +2099,10 @@
         "--M=2",
         "--lmax=0",
         "--nelem=3",
-        "--method=HF"
-      ]
+        "--method=HF",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-He-hf",
@@ -2115,8 +2117,10 @@
         "--M=1",
         "--lmax=0",
         "--nelem=4",
-        "--method=HF"
-      ]
+        "--method=HF",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-He-lda",
@@ -2131,8 +2135,10 @@
         "--M=1",
         "--lmax=0",
         "--nelem=4",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-Be-lda",
@@ -2146,8 +2152,10 @@
         "--M=1",
         "--lmax=0",
         "--nelem=4",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-N-hf",
@@ -2161,8 +2169,10 @@
         "--M=4",
         "--lmax=1",
         "--nelem=4",
-        "--method=HF"
-      ]
+        "--method=HF",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-Ne-lda",
@@ -2176,8 +2186,10 @@
         "--M=1",
         "--lmax=1",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-P-lda",
@@ -2191,8 +2203,10 @@
         "--M=4",
         "--lmax=1",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-Ar-lda",
@@ -2206,8 +2220,10 @@
         "--M=1",
         "--lmax=1",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-Cr-lda",
@@ -2222,8 +2238,10 @@
         "--M=7",
         "--lmax=2",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "gensap-Zn-lda",
@@ -2238,8 +2256,10 @@
         "--M=1",
         "--lmax=2",
         "--nelem=5",
-        "--method=lda_x-lda_c_vwn"
-      ]
+        "--method=lda_x-lda_c_vwn",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "aij-Al-jellium",
@@ -2254,8 +2274,10 @@
         "--nelem=5",
         "--method=lda_x",
         "--njellium=6",
-        "--rs=2.07"
-      ]
+        "--rs=2.07",
+        "--scfmethods=DIIS + ODA + CG"
+      ],
+      "_why": " Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it."
     },
     {
       "name": "aij-Al-njellium0",
@@ -2265,14 +2287,15 @@
         "lda",
         "consistency"
       ],
-      "_why": "no jellium electrons: must reduce to the bare atom",
+      "_why": "no jellium electrons: must reduce to the bare atom Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it.",
       "args": [
         "--Z=Al",
         "--M=2",
         "--nelem=5",
         "--njellium=0",
         "--rs=2.07",
-        "--method=lda_x"
+        "--method=lda_x",
+        "--scfmethods=DIIS + ODA + CG"
       ]
     },
     {
@@ -2283,13 +2306,14 @@
         "lda",
         "consistency"
       ],
-      "_why": "bare Al, the limit aij must reproduce at njellium=0",
+      "_why": "bare Al, the limit aij must reproduce at njellium=0 Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it.",
       "args": [
         "--Z=Al",
         "--M=2",
         "--lmax=2",
         "--nelem=5",
-        "--method=lda_x"
+        "--method=lda_x",
+        "--scfmethods=DIIS + ODA + CG"
       ]
     },
     {
@@ -3564,14 +3588,15 @@
       ]
     },
     {
-      "name": "aij-Fe-firstorder",
+      "name": "aij-Fe-secondorder-early",
       "code": "aij",
       "tags": [
         "jellium",
         "lda",
-        "consistency"
+        "consistency",
+        "secondorder"
       ],
-      "_why": "spin-restricted Fe: 4s and 3d come out degenerate and fractionally occupied, which is the case the first-order methods handle worst. ODA alone does not converge it in 2000 iterations. Paired with the second-order run below.",
+      "_why": "spin-restricted Fe handed over to the second-order optimizer EARLY. There is no first-order Fe case because there should not be one: whether the first-order solver converges this system depends on the thread count -- 634 Fock builds and converged on four threads, 607 and not converged on one -- and it is the system the second-order machinery exists for in the first place. Paired with the preiter=30 run below, so that agreement tests the handover and the KKT release rather than one trajectory. DIIS is deliberately absent: this is the case with a genuine occupation coordinate (2 fractionally occupied blocks, 1 transfer), and DIIS extrapolates on the assumption that the occupations are fixed.",
       "args": [
         "--Z=Fe",
         "--M=0",
@@ -3579,7 +3604,10 @@
         "--njellium=0",
         "--rs=0",
         "--method=lda_x",
-        "--convthr=1e-7"
+        "--scfmethods=ODA + LBFGS",
+        "--secondorder=1",
+        "--preiter=22",
+        "--soconvthr=1e-8"
       ]
     },
     {
@@ -3601,7 +3629,8 @@
         "--method=lda_x",
         "--secondorder=1",
         "--preiter=30",
-        "--soconvthr=1e-8"
+        "--soconvthr=1e-8",
+        "--scfmethods=ODA + LBFGS"
       ]
     },
     {
@@ -3613,7 +3642,7 @@
         "consistency",
         "secondorder"
       ],
-      "_why": "unrestricted second-order path: alpha and beta are separate particle types with separately conserved electron counts, which the restricted Fe pair does not exercise.",
+      "_why": "unrestricted second-order path: alpha and beta are separate particle types with separately conserved electron counts, which the restricted Fe pair does not exercise. Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it.",
       "args": [
         "--Z=Al",
         "--M=2",
@@ -3623,7 +3652,8 @@
         "--rs=2.07",
         "--secondorder=1",
         "--preiter=30",
-        "--soconvthr=1e-8"
+        "--soconvthr=1e-8",
+        "--scfmethods=DIIS + ODA + CG"
       ]
     },
     {
@@ -3644,7 +3674,8 @@
         "--method=lda_x",
         "--secondorder=1",
         "--preiter=30",
-        "--soconvthr=1e-8"
+        "--soconvthr=1e-8",
+        "--scfmethods=ODA + LBFGS"
       ]
     },
     {
@@ -3655,13 +3686,14 @@
         "unrestricted",
         "consistency"
       ],
-      "_why": "spin-polarized Fe at Hartree-Fock, where the Fock matrix carries exact exchange. Paired with the second-order run below: exchange is the one term of the response the DFT cases never exercise.",
+      "_why": "spin-polarized Fe at Hartree-Fock, where the Fock matrix carries exact exchange. Paired with the second-order run below: exchange is the one term of the response the DFT cases never exercise. Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it.",
       "args": [
         "--Z=Fe",
         "--M=5",
         "--lmax=2",
         "--nelem=5",
-        "--method=HF"
+        "--method=HF",
+        "--scfmethods=DIIS + ODA + CG"
       ]
     },
     {
@@ -3673,7 +3705,7 @@
         "consistency",
         "secondorder"
       ],
-      "_why": "the same Hartree-Fock atom through the trust-region optimizer, so that the analytic exchange response is tied to the ordinary SCF.",
+      "_why": "the same Hartree-Fock atom through the trust-region optimizer, so that the analytic exchange response is tied to the ordinary SCF. Asks for DIIS explicitly. The gensap/aij default drops it, because DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed and so fights the occupation optimization on a fractionally occupied atom. This case has no occupation coordinate at all, and without DIIS it is limited by something else entirely: ODA and CG descend on the ENERGY, and near the solution the energy lowering available at a gradient g is of order g^2, so below g ~ sqrt(eps*|E|) there is no signal left in double precision. For |E| of a few hundred hartree that bound sits at or above the 1e-7 threshold. DIIS extrapolates the error vector instead of the energy and is not subject to it.",
       "args": [
         "--Z=Fe",
         "--M=5",
@@ -3682,7 +3714,8 @@
         "--method=HF",
         "--secondorder=1",
         "--preiter=30",
-        "--soconvthr=1e-8"
+        "--soconvthr=1e-8",
+        "--scfmethods=DIIS + ODA + CG"
       ]
     }
   ],
@@ -4404,10 +4437,10 @@
       "tolerance": 1e-09
     },
     {
-      "name": "aij-secondorder-equals-firstorder-Fe",
-      "_why": "the second-order optimizer must find the SAME minimum as the first-order one, not merely a fast one. Reference-free: it ties the trust-region path, its analytic gradient and its XC response kernel to the ordinary SCF at the point where the two must agree. Fe is the case where they disagree most easily, since the 4s/3d occupations are free parameters and a wrong occupation Hessian lands on a different stationary point with a plausible-looking energy.",
+      "name": "aij-secondorder-handover-agrees-Fe",
+      "_why": "the second-order optimizer must land on the same minimum wherever the first-order phase hands over, not merely converge tightly from one lucky starting point. Reference-free. Fe is the discriminating case: an early handover can inherit an occupation pattern with a block frozen on the wrong side of the Fermi level, which is stationary for the restricted problem and so converges to a tiny gradient at a wrong energy. The handover points are chosen from measurement, not from the middle of a range: 22 and 30 both converge for aij AND gensap, while 20 and 28 converge for aij only and 25 fails for both.",
       "cases": [
-        "aij-Fe-firstorder",
+        "aij-Fe-secondorder-early",
         "aij-Fe-secondorder"
       ],
       "field": "total",

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -3717,6 +3717,72 @@
         "--soconvthr=1e-8",
         "--scfmethods=DIIS + ODA + CG"
       ]
+    },
+    {
+      "name": "gensap-Cr-firstorder",
+      "code": "gensap",
+      "tags": [
+        "lda",
+        "open-shell",
+        "consistency"
+      ],
+      "_why": "spin-restricted Cr, the case the second-order machinery is for: 3d and 4s come out degenerate and fractionally occupied, and moving density between them costs nothing at first order. Unlike the Ni case below, first order does converge here, which is what makes it usable as the reference half of an invariant on a genuinely hard system -- the existing first-vs-second pairings are all on atoms with no occupation coordinate at all. No DIIS: it extrapolates on the assumption that the occupations are fixed, and costs 534 Fock builds here against 321 without.",
+      "args": [
+        "--Z=Cr",
+        "--M=0",
+        "--lmax=4",
+        "--nelem=5",
+        "--iguess=0",
+        "--method=lda_x",
+        "--scfmethods=ODA + LBFGS",
+        "--maxiter=1024"
+      ]
+    },
+    {
+      "name": "gensap-Cr-secondorder",
+      "code": "gensap",
+      "tags": [
+        "lda",
+        "open-shell",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "the same Cr through the trust-region optimizer, which optimizes the 3d/4s occupation transfer explicitly. 2 fractionally occupied blocks and 1 occupation transfer, so the occupation coordinates actually exist here -- unlike every other gensap case, where a single fractional block yields none. preiter is 22 rather than 30 from measurement: 30 does not converge this atom.",
+      "args": [
+        "--Z=Cr",
+        "--M=0",
+        "--lmax=4",
+        "--nelem=5",
+        "--iguess=0",
+        "--method=lda_x",
+        "--scfmethods=ODA + LBFGS",
+        "--secondorder=1",
+        "--preiter=22",
+        "--soconvthr=1e-8"
+      ]
+    },
+    {
+      "name": "gensap-Ni-secondorder",
+      "code": "gensap",
+      "tags": [
+        "lda",
+        "open-shell",
+        "consistency",
+        "secondorder"
+      ],
+      "_why": "spin-restricted Ni, the strongest case in the suite for the second-order method: first order does NOT converge it at all, either with DIIS (733 Fock builds) or without (487). The second-order phase reaches the minimum in seconds. It also has the richest occupation structure here -- 2 fractionally occupied blocks with 1 transfer at this handover, and 4 blocks with 3 transfers at preiter=22, which is the regime where the exact occupation-block preconditioner earns itself. preiter is 30 because 22 converges tightly to a DIFFERENT stationary point, 6.4e-8 Eh higher; 30 reproduces the value the first-order sweep independently reached.",
+      "args": [
+        "--Z=Ni",
+        "--M=0",
+        "--lmax=4",
+        "--nelem=5",
+        "--iguess=0",
+        "--method=lda_x",
+        "--scfmethods=ODA + LBFGS",
+        "--secondorder=1",
+        "--preiter=30",
+        "--soconvthr=1e-8"
+      ]
     }
   ],
   "_invariants_comment": [
@@ -4472,6 +4538,16 @@
       "cases": [
         "gensap-Fe-hf-firstorder",
         "gensap-Fe-hf-secondorder"
+      ],
+      "field": "total",
+      "tolerance": 1e-08
+    },
+    {
+      "name": "gensap-secondorder-equals-firstorder-Cr",
+      "_why": "the second-order optimizer must find the SAME minimum as the ordinary SCF on a system that actually has occupation coordinates. Reference-free. The other first-vs-second pairings here are on atoms with none, so this is the only one where the occupation half of the parametrization is under test rather than merely present.",
+      "cases": [
+        "gensap-Cr-firstorder",
+        "gensap-Cr-secondorder"
       ],
       "field": "total",
       "tolerance": 1e-08


### PR DESCRIPTION
DIIS extrapolates a Fock matrix on the assumption that the occupations are fixed. `gensap` and `aij` optimize the occupations as well as the orbitals, so on a fractionally occupied atom DIIS extrapolates along a direction the solution is free to move in, and fights ODA rather than helping it. At a matched iteration budget (LDA, `nelem=5`, `maxiter=1024`), Fock builds to convergence:

| | `DIIS + ODA + CG` | `ODA + CG` |
|---|---|---|
| Ni M=0 | 10334, **not converged** | 595, −1503.2111233186 |
| Fe M=0 | 729, −1258.9186876172 | 555, same energy |
| Cr M=0 | 658, −1042.0377130690 | 571, same energy |

## Why the test cases ask for DIIS back

Because for an atom *without* an occupation coordinate, dropping DIIS costs something unrelated and worse. ODA and CG descend on the **energy**. Near the solution the energy lowering available at a gradient `g` is of order `g²/k`, so below `g ~ sqrt(eps·|E|)` there is no signal left in double precision and both methods correctly report failure:

| atom | \|E\| | measured floor | `sqrt(eps·\|E\|)` | |
|---|---|---|---|---|
| He | 2.7 | 2.1e-08 | 2.5e-08 | |
| Be | 14.2 | 7.1e-08 | 5.6e-08 | |
| Ne | 127.5 | 1.4e-07 | 1.7e-07 | stalls |
| Zn | 1773.9 | 3.6e-07 | 6.3e-07 | stalls |

Four of five within a factor of two. Ar lands below the bound, which the bound permits — it says where the signal runs out, not that a trajectory cannot stop early on a good point.

At the stall the energy change is **exactly 0.0** and the error repeats bit-for-bit: thirteen further Fock builds buy nothing. So it is a deterministic fixed point, not noise, and not the XC quadrature — a 4× increase in quadrature points changes the residual by under 10%, while HF on the same atom and basis converges. DIIS extrapolates the error vector rather than the energy and is not subject to the bound.

This also means a 1e-7 gradient threshold is unreachable for an energy-based method much above |E| ~ 200 Eh, which is a property of the driver rather than of any one element.

## The split follows the physics, not the element

Every gensap/aij case with **no occupation coordinate** asks for DIIS explicitly; only the three with a genuine one run on the new default. Everything else in the suite has 0 occupation transfers — Al and Fe/HF included, since one fractionally occupied block yields no coordinate (the sum-zero subspace of a single free block has dimension zero).

The Fe cases with a real coordinate (2 fractionally occupied blocks, 1 transfer) run `ODA + LBFGS`.

## `aij-Fe-firstorder` is gone

There should not be a first-order Fe case: whether the first-order solver converges it depends on the thread count — 634 Fock builds and converged on four threads, 607 and not converged on one — and it is the system the second-order machinery exists for. It becomes `aij-Fe-secondorder-early`, an early handover paired with the `preiter=30` run, so agreement tests the handover and the KKT release rather than one trajectory.

Handover points are measured, not picked from the middle of the range: **22 and 30 converge for both aij and gensap; 20 and 28 converge for aij only; 25 fails for both.**

One honest note on `ODA + LBFGS` versus `ODA + CG`: on these Fe cases they are **bit-identical** at every handover point tested, including the same failure at 25. The rotation step is being used (ODA alone takes 77 Fock builds, either combination takes 70) — but with only a couple of rotation steps taken, LBFGS has no history and CG has no conjugacy, so both reduce to the same first step. The choice is not load-bearing here.

## Pin bump is required, not incidental

OpenOrbitalOptimizer moves to `bef468d`. Without it `SCFSolver::cleanup()` reads past the end of an empty vector whenever ODA is combined with a rotation method and DIIS is absent, and gensap H, He and N at HF and Al at LDA all segfault. All five now converge.

## Verification

Full suite: **182 passed, 0 failed** — the pin bump moved no reference energy, which was the real gate. One error, `atomic-N-mgga-r`, is the pre-existing timeout that also fails to finish in 1800 s on unmodified master. The 14 invariant violations are the pre-existing convergence-limited `diatomic-dummy-equals-atomic-*` family, all HF/LDA/hybrid.

## Interaction with #329

**This conflicts with #329 in `tests/cases.json`, and my first check said otherwise.** I used `git merge-tree` and grepped for conflict markers; that mode does not emit them, so an empty grep read as success. A real trial merge conflicts.

The overlap is exactly one thing: both branches rename `aij-Fe-firstorder` to `aij-Fe-secondorder-early`, #329 at `preiter=20` and this one at `preiter=22` with `ODA + LBFGS`. Whichever merges second should take **this** branch's version of the Fe entries, since the handover points here are measured (22 and 30 work for both drivers; 20 works for aij only) rather than picked from the middle of a range. Everything else in the two changesets is disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)