### PR TITLE
Test whether quad precision builds instead of assuming it does

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,71 @@ option(HELFEM_PYTHON "Build the HelFEM Python (pybind11) bindings" OFF)
 # compiler floor moves unless they ask for it. Everything still builds and runs
 # at double and long double either way.
 include(CheckCXXCompilerFlag)
+include(CheckCXXSourceCompiles)
+
+# Whether the toolchain can actually build the quad path, tested by
+# compiling what the code uses rather than by asking whether the compiler
+# advertises C++23.
+#
+# Those are not the same question, and the difference is a real bug: GCC 11
+# advertises cxx_std_23 (it has partial C++23 via -std=c++2b) while its
+# libstdc++ provides none of the _Float128 support. Defaulting ON there gave
+# hundreds of errors inside libhelfem -- missing operator""f128, ambiguous
+# std::pow/abs/erfc against the legacy __float128 overloads, no
+# numeric_limits -- with nothing to tell the user that a default had enabled
+# an optional feature they never asked for. The feature test arrives a
+# release or two before the feature.
+#
+# Each line below corresponds to one of those failure modes, so a toolchain
+# that passes this compiles the quad instantiation.
+set(_helfem_f128_probe "
+#include <cmath>
+#include <limits>
+int main() {
+  _Float128 x = 1.0f128;               // operator\"\"f128
+  int n = 2;
+  x = std::pow(x, n);                  // ambiguous against __float128 overloads
+  x = std::abs(x);
+  x = std::erfc(x);
+  x = std::exp(x);
+  return std::numeric_limits<_Float128>::is_specialized ? 0 : 1;
+}
+")
+set(HELFEM_FLOAT128_DEFAULT OFF)
 if(cxx_std_23 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
-  set(HELFEM_FLOAT128_DEFAULT ON)
-else()
-  set(HELFEM_FLOAT128_DEFAULT OFF)
+  # Use whichever flag this CMake would give the helfem targets for
+  # cxx_std_23, so the probe is compiled the way the sources will be.
+  set(_helfem_f128_saved_flags "${CMAKE_REQUIRED_FLAGS}")
+  if(DEFINED CMAKE_CXX23_STANDARD_COMPILE_OPTION)
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CMAKE_CXX23_STANDARD_COMPILE_OPTION}")
+  else()
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++23")
+  endif()
+  check_cxx_source_compiles("${_helfem_f128_probe}" HELFEM_FLOAT128_WORKS)
+  set(CMAKE_REQUIRED_FLAGS "${_helfem_f128_saved_flags}")
+  if(HELFEM_FLOAT128_WORKS)
+    set(HELFEM_FLOAT128_DEFAULT ON)
+  else()
+    message(STATUS
+      "Quad precision default OFF: the compiler advertises C++23 but its "
+      "standard library does not provide the _Float128 support the quad "
+      "path needs (literal suffix, <cmath> overloads, numeric_limits). "
+      "GCC 11 is the common case. Everything builds at double and long "
+      "double; -DHELFEM_FLOAT128=ON to override.")
+  endif()
 endif()
 option(HELFEM_FLOAT128 "Instantiate the templated core at _Float128 (needs C++23)" ${HELFEM_FLOAT128_DEFAULT})
+
+# An explicit request on a toolchain that cannot do it fails here, with a
+# reason, instead of a wall of errors a thousand lines into libhelfem.
+if(HELFEM_FLOAT128 AND DEFINED HELFEM_FLOAT128_WORKS AND NOT HELFEM_FLOAT128_WORKS)
+  message(FATAL_ERROR
+    "HELFEM_FLOAT128=ON was requested, but this toolchain cannot compile the "
+    "quad path: the probe using the f128 literal suffix, std::pow/abs/erfc on "
+    "_Float128 and std::numeric_limits<_Float128> does not build. Advertising "
+    "C++23 is not enough -- GCC 11 does, without providing any of it. "
+    "Configure with -DHELFEM_FLOAT128=OFF for double and long double.")
+endif()
 # Route Eigen's dense products (GEMM/GEMV/SYRK/...) through an external
 # BLAS via EIGEN_USE_BLAS, instead of Eigen's own kernels. Vendor BLAS
 # libraries are typically faster for large dense products, and this makes


### PR DESCRIPTION
`HELFEM_FLOAT128` defaulted ON whenever the compiler advertised `cxx_std_23`. That is a proxy for the real requirement rather than the requirement itself — and the proxy is satisfied a release or two before the feature is.

GCC 11 advertises C++23 through partial support, while its libstdc++ provides none of the `_Float128` machinery the quad path needs. HelFEM therefore failed out of the box there: hundreds of errors at 12% of the build (missing `operator""f128`, `std::pow`/`abs`/`erfc` ambiguous against the legacy `__float128` overloads, no `numeric_limits`), all inside libhelfem, with nothing to tell the user that a default had enabled an optional feature they never asked for.

The comment above the old check already stated the requirement precisely. Since that requirement is exactly *"does this snippet compile"*, it is now compiled.

## What changed

The probe uses the same constructs the sources do — the `f128` literal suffix, `std::pow` with an **integer** exponent (the reported ambiguity), `std::abs`, `std::erfc`, `std::exp`, and `std::numeric_limits<_Float128>`.

Two details beyond the suggested patch:

- It is compiled with whichever flag this CMake would give the helfem targets for `cxx_std_23` (`CMAKE_CXX23_STANDARD_COMPILE_OPTION`), rather than a hardcoded `-std=c++23`. That matters because the probe should be built the way the sources will be, and an older compiler may not accept that spelling at all — in which case the probe would fail for the wrong reason.
- The `cxx_std_23` membership test is kept as a cheap gate in *front* of the probe, so ancient compilers are ruled out without invoking a compiler.

On the ungraceful-failure point: an explicit `-DHELFEM_FLOAT128=ON` on a toolchain that cannot do it now stops at configure time with the reason, instead of a thousand lines into libhelfem.

## Verified three ways

| | result |
|---|---|
| this toolchain (GCC 16) | probe succeeds, quad stays enabled, full build clean |
| probe forced to fail | default goes OFF with an explanatory notice, `-- Quad precision (_Float128) disabled` |
| probe failing **and** explicit `=ON` | configure stops with the reason |

The probe also discriminates rather than merely passing: it compiles at C++23 and is rejected at C++17.

I could not reproduce GCC 11 directly — this machine has GCC 16 — so the broken-toolchain paths are exercised by forcing the probe result rather than by a genuine GCC 11. Worth a confirmation from the reporter on the actual compiler. One incidental finding while checking: on GCC 16 at C++17 only `std::pow` and `std::erfc` are rejected, while the literal, `abs` and `numeric_limits` compile — so which individual construct fails is toolchain-dependent, and the probe's value is that it is a conjunction that fails if any of them is missing.

I also dropped a claim I could not verify: an earlier draft of the error message said libstdc++ provides these "only from GCC 13". I have not checked that boundary, so the message now says only that advertising C++23 is not enough and names GCC 11 as the known case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
