### PR TITLE
diatomic: parallelize the XC quadrature

### DIFF
--- a/src/diatomic/dftgrid.cpp
+++ b/src/diatomic/dftgrid.cpp
@@ -530,6 +530,34 @@ namespace helfem {
       DFTGrid::~DFTGrid() {
       }
 
+      static inline int helfem_omp_max_threads() {
+#ifdef _OPENMP
+        return omp_get_max_threads();
+#else
+        return 1;
+#endif
+      }
+      static inline int helfem_omp_thread_num() {
+#ifdef _OPENMP
+        return omp_get_thread_num();
+#else
+        return 0;
+#endif
+      }
+
+      /// The (element, radial point) pairs the grid loops over, flattened.
+      /// A molecule has only a handful of radial elements, so parallelising
+      /// the element loop alone would leave most of a machine idle; one task
+      /// per radial point is dozens.
+      static std::vector<std::pair<size_t, size_t>>
+      grid_tasks(const helfem::diatomic::basis::TwoDBasis *basp) {
+        std::vector<std::pair<size_t, size_t>> tasks;
+        for (size_t iel = 0; iel < basp->rad_Nel(); iel++)
+          for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++)
+            tasks.push_back({iel, irad});
+        return tasks;
+      }
+
       void DFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars, const helfem::Matrix & P_e, helfem::Matrix & H_e, double & Exc, double & Nel, double & Ekin, double thr) {
         // Eigen flows straight through the worker and remove_boundaries.
         helfem::Matrix H = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
@@ -538,18 +566,41 @@ namespace helfem {
         double ekin=0.0;
         double nel=0.0;
         {
-          DFTGridWorker grid(basp,lang,mang);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
           // Loop-invariant: expand once, not once per grid point.
           const helfem::Matrix P_exp(basp->expand_boundaries(P_e));
+          const std::vector<std::pair<size_t, size_t>> tasks = grid_tasks(basp);
+          // Each thread accumulates its own Fock matrix and its own energy
+          // sums; the partials are summed afterwards in thread order. The
+          // scatter writes basis
+          // functions that neighbouring radial points share, so no partition
+          // of the tasks makes the writes disjoint -- and summing under a
+          // critical section would make the result depend on which thread
+          // arrived first, since floating-point addition is not associative.
+          // The schedule is left static for the same reason: a dynamic one
+          // hands a different set of points to each thread on every run,
+          // which perturbs the partial sums even at a fixed thread count.
+          const int nthread = helfem_omp_max_threads();
+          std::vector<helfem::Matrix> Hpart(nthread);
+          std::vector<double> excp(nthread, 0.0), ekinp(nthread, 0.0), nelp(nthread, 0.0);
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+          {
+            DFTGridWorker grid(basp,lang,mang);
+            grid.check_grad_tau_lapl(x_func,c_func);
+            const int tid = helfem_omp_thread_num();
+            helfem::Matrix & Hloc = Hpart[tid];
+            Hloc = helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy());
 
-          for(size_t iel=0;iel<basp->rad_Nel();iel++) {
-            for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
+#ifdef _OPENMP
+#pragma omp for
+#endif
+            for (long it = 0; it < (long) tasks.size(); it++) {
+              const size_t iel = tasks[it].first, irad = tasks[it].second;
               grid.compute_bf(iel,irad);
               grid.update_density(P_exp);
-              nel+=grid.compute_Nel();
-              ekin+=grid.compute_Ekin();
+              nelp[tid]+=grid.compute_Nel();
+              ekinp[tid]+=grid.compute_Ekin();
 
               grid.init_xc();
               if(x_func>0)
@@ -560,10 +611,17 @@ namespace helfem {
               // the assembly contracts a general vector field; build it once
               grid.build_vgrad();
 
-              exc+=grid.eval_Exc();
-              grid.eval_Fxc(H);
+              excp[tid]+=grid.eval_Exc();
+              grid.eval_Fxc(Hloc);
             }
           }
+          for (int t = 0; t < nthread; t++) {
+            exc += excp[t]; ekin += ekinp[t]; nel += nelp[t];
+          }
+          for (int t = 0; t < nthread; t++)
+            if (Hpart[t].size()) {
+              H += Hpart[t];
+            }
         }
 
         // Save outputs
@@ -583,19 +641,38 @@ namespace helfem {
         double nel=0.0;
         double ekin=0.0;
         {
-          DFTGridWorker grid(basp,lang,mang);
-          grid.check_grad_tau_lapl(x_func,c_func);
-
           // Loop-invariant: expand once, not once per grid point.
           const helfem::Matrix Pa_exp(basp->expand_boundaries(Pa_e));
           const helfem::Matrix Pb_exp(basp->expand_boundaries(Pb_e));
 
-          for(size_t iel=0;iel<basp->rad_Nel();iel++) {
-            for(size_t irad=0;irad<(size_t) basp->r(iel).size();irad++) {
+          const std::vector<std::pair<size_t, size_t>> tasks = grid_tasks(basp);
+          // See the restricted driver above for why every partial -- Fock
+          // matrices and energy sums alike -- is summed in thread order
+          // rather than folded in under a critical section.
+          const int nthread = helfem_omp_max_threads();
+          std::vector<helfem::Matrix> Hapart(nthread), Hbpart(nthread);
+          std::vector<double> excp(nthread, 0.0), ekinp(nthread, 0.0), nelp(nthread, 0.0);
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+          {
+            DFTGridWorker grid(basp,lang,mang);
+            grid.check_grad_tau_lapl(x_func,c_func);
+            const int tid = helfem_omp_thread_num();
+            helfem::Matrix & Haloc = Hapart[tid];
+            helfem::Matrix & Hbloc = Hbpart[tid];
+            Haloc = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
+            Hbloc = helfem::Matrix::Zero(basp->Ndummy(),basp->Ndummy());
+
+#ifdef _OPENMP
+#pragma omp for
+#endif
+            for (long it = 0; it < (long) tasks.size(); it++) {
+              const size_t iel = tasks[it].first, irad = tasks[it].second;
               grid.compute_bf(iel,irad);
               grid.update_density(Pa_exp,Pb_exp);
-              nel+=grid.compute_Nel();
-              ekin+=grid.compute_Ekin();
+              nelp[tid]+=grid.compute_Nel();
+              ekinp[tid]+=grid.compute_Ekin();
 
               grid.init_xc();
               if(x_func>0)
@@ -606,10 +683,15 @@ namespace helfem {
               // the assembly contracts a general vector field; build it once
               grid.build_vgrad();
 
-              exc+=grid.eval_Exc();
-              grid.eval_Fxc(Ha,Hb,beta);
+              excp[tid]+=grid.eval_Exc();
+              grid.eval_Fxc(Haloc,Hbloc,beta);
             }
           }
+          for (int t = 0; t < nthread; t++) {
+            exc += excp[t]; ekin += ekinp[t]; nel += nelp[t];
+          }
+          for (int t = 0; t < nthread; t++)
+            if (Hapart[t].size()) { Ha += Hapart[t]; Hb += Hbpart[t]; }
         }
 
         // Save outputs

--- a/src/diatomic/dftgrid_purem.cpp
+++ b/src/diatomic/dftgrid_purem.cpp
@@ -19,6 +19,9 @@
 #include "../general/spherical_harmonics.h"
 #include <algorithm>
 #include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 namespace helfem {
   namespace diatomic {
@@ -672,21 +675,79 @@ namespace helfem {
       PureMDFTGrid::~PureMDFTGrid() {
       }
 
+      static inline int helfem_omp_max_threads() {
+#ifdef _OPENMP
+        return omp_get_max_threads();
+#else
+        return 1;
+#endif
+      }
+      static inline int helfem_omp_thread_num() {
+#ifdef _OPENMP
+        return omp_get_thread_num();
+#else
+        return 0;
+#endif
+      }
+
+      /// The (element, radial point) pairs the grid loops over, flattened.
+      ///
+      /// The pure-m grid works one radial point at a time, and a molecule has
+      /// only a handful of radial elements -- five in a typical run -- so
+      /// parallelising the element loop alone would leave most of a machine
+      /// idle. Flattening gives one task per radial point, which is dozens.
+      static std::vector<std::pair<size_t, size_t>>
+      grid_tasks(const helfem::diatomic::basis::TwoDBasis *basp) {
+        std::vector<std::pair<size_t, size_t>> tasks;
+        for (size_t iel = 0; iel < basp->rad_Nel(); iel++)
+          for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++)
+            tasks.push_back({iel, irad});
+        return tasks;
+      }
+
       void PureMDFTGrid::eval_Fxc(int x_func, const helfem::Vector & x_pars, int c_func, const helfem::Vector & c_pars,
                                    const helfem::Matrix & P, helfem::Matrix & H_e,
                                    double & Exc, double & Nel, double & Ekin, double thr) {
         helfem::Matrix H = helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy());
         double exc = 0.0, ekin = 0.0, nel = 0.0;
         {
-          PureMDFTGridWorker grid(basp, lang);
-          grid.check_grad_tau_lapl(x_func, c_func);
+          const std::vector<std::pair<size_t, size_t>> tasks = grid_tasks(basp);
+          // Each thread accumulates into its own Fock matrix and its own
+          // energy sums. The scatter
+          // writes per-m blocks whose index sets two radial points share, so
+          // no partition of the tasks makes the writes disjoint, and an
+          // atomic per matrix element would cost more than the integrand.
+          //
+          // The partials are summed afterwards in thread order rather than
+          // folded in under a critical section: floating-point addition is
+          // not associative, so a critical section would make the Fock matrix
+          // depend on which thread happened to arrive first. The schedule is
+          // left static for the same reason: a dynamic one hands a different
+          // set of points to each thread on every run, which perturbs the
+          // partial sums even at a fixed thread count. Together these make a
+          // given thread count reproduce itself exactly.
+          const int nthread = helfem_omp_max_threads();
+          std::vector<helfem::Matrix> Hpart(nthread);
+          std::vector<double> excp(nthread, 0.0), ekinp(nthread, 0.0), nelp(nthread, 0.0);
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+          {
+            PureMDFTGridWorker grid(basp, lang);
+            grid.check_grad_tau_lapl(x_func, c_func);
+            const int tid = helfem_omp_thread_num();
+            helfem::Matrix & Hloc = Hpart[tid];
+            Hloc = helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy());
 
-          for (size_t iel = 0; iel < basp->rad_Nel(); iel++) {
-            for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++) {
+#ifdef _OPENMP
+#pragma omp for
+#endif
+            for (long it = 0; it < (long) tasks.size(); it++) {
+              const size_t iel = tasks[it].first, irad = tasks[it].second;
               grid.compute_bf(iel, irad);
               grid.update_density(P);
-              nel  += grid.compute_Nel();
-              ekin += grid.compute_Ekin();
+              nelp[tid]  += grid.compute_Nel();
+              ekinp[tid] += grid.compute_Ekin();
 
               grid.init_xc();
               if (x_func > 0) grid.compute_xc(x_func, x_pars, thr);
@@ -694,10 +755,15 @@ namespace helfem {
 
               // the assembly contracts a general vector field; build it once
               grid.build_vgrad();
-              exc += grid.eval_Exc();
-              grid.eval_Fxc(H);
+              excp[tid] += grid.eval_Exc();
+              grid.eval_Fxc(Hloc);
             }
           }
+          for (int t = 0; t < nthread; t++) {
+            exc += excp[t]; ekin += ekinp[t]; nel += nelp[t];
+          }
+          for (int t = 0; t < nthread; t++)
+            if (Hpart[t].size()) H += Hpart[t];
         }
         Exc = exc; Ekin = ekin; Nel = nel;
         H_e = basp->remove_boundaries(H);
@@ -711,15 +777,34 @@ namespace helfem {
         helfem::Matrix Hb = helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy());
         double exc = 0.0, ekin = 0.0, nel = 0.0;
         {
-          PureMDFTGridWorker grid(basp, lang);
-          grid.check_grad_tau_lapl(x_func, c_func);
+          const std::vector<std::pair<size_t, size_t>> tasks = grid_tasks(basp);
+          // See the restricted driver above for why each thread accumulates
+          // its own Fock matrices and energy sums, and why they are summed
+          // in thread order.
+          const int nthread = helfem_omp_max_threads();
+          std::vector<helfem::Matrix> Hapart(nthread), Hbpart(nthread);
+          std::vector<double> excp(nthread, 0.0), ekinp(nthread, 0.0), nelp(nthread, 0.0);
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+          {
+            PureMDFTGridWorker grid(basp, lang);
+            grid.check_grad_tau_lapl(x_func, c_func);
+            const int tid = helfem_omp_thread_num();
+            helfem::Matrix & Haloc = Hapart[tid];
+            helfem::Matrix & Hbloc = Hbpart[tid];
+            Haloc = helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy());
+            Hbloc = helfem::Matrix::Zero(basp->Ndummy(), basp->Ndummy());
 
-          for (size_t iel = 0; iel < basp->rad_Nel(); iel++) {
-            for (size_t irad = 0; irad < (size_t) basp->r(iel).size(); irad++) {
+#ifdef _OPENMP
+#pragma omp for
+#endif
+            for (long it = 0; it < (long) tasks.size(); it++) {
+              const size_t iel = tasks[it].first, irad = tasks[it].second;
               grid.compute_bf(iel, irad);
               grid.update_density(Pa, Pb);
-              nel  += grid.compute_Nel();
-              ekin += grid.compute_Ekin();
+              nelp[tid]  += grid.compute_Nel();
+              ekinp[tid] += grid.compute_Ekin();
 
               grid.init_xc();
               if (x_func > 0) grid.compute_xc(x_func, x_pars, thr);
@@ -727,10 +812,15 @@ namespace helfem {
 
               // the assembly contracts a general vector field; build it once
               grid.build_vgrad();
-              exc += grid.eval_Exc();
-              grid.eval_Fxc(Ha, Hb, beta);
+              excp[tid] += grid.eval_Exc();
+              grid.eval_Fxc(Haloc, Hbloc, beta);
             }
           }
+          for (int t = 0; t < nthread; t++) {
+            exc += excp[t]; ekin += ekinp[t]; nel += nelp[t];
+          }
+          for (int t = 0; t < nthread; t++)
+            if (Hapart[t].size()) { Ha += Hapart[t]; Hb += Hbpart[t]; }
         }
         Exc = exc; Ekin = ekin; Nel = nel;
         Ha_e = basp->remove_boundaries(Ha);


### PR DESCRIPTION
Both diatomic XC grid drivers — `dftgrid_purem.cpp` (the default path for `--symmetry >= 1`) and the general 3D `dftgrid.cpp` — ran serially. On an N₂/LDA run with `--symmetry=3` the XC quadrature is about three quarters of the wall clock, which is why the diatomic program measured **0.93×** on six cores: slightly *worse* than serial, because the only threading it had was inside the BLAS calls between grid evaluations.

## What changed

The grid works one `(element, radial point)` pair at a time, and a molecule has only a handful of radial elements — five in a typical run — so parallelizing the element loop alone would leave most of a machine idle. The pairs are flattened into a task list instead, giving dozens of tasks; each thread builds its own worker and accumulates into its own Fock matrix and energy sums.

## Reproducibility

Two things are load-bearing here, and both were found by measurement rather than reasoning:

- **The partials are summed in thread order, not folded in under a `critical` section.** Floating-point addition is not associative, so a critical section makes the Fock matrix depend on which thread happens to arrive first.
- **The loop schedule is left static.** This one I got wrong first: with `schedule(dynamic)`, two six-thread runs of the same input differed in the last digit of the energy, because a dynamic schedule hands a *different set of points* to each thread on every run, perturbing the partial sums even at a fixed thread count. Indexing the partials by thread fixes the combination order but not the partition. With a static schedule the entire SCF trace is bit-identical between runs.

The result is the property the rest of the codebase already has: reproducible at a fixed thread count, differing in the last digit across thread counts.

## Measurements

N₂, `--nelem=5 --lmax=13,9 --symmetry=3 --method=lda_x-lda_c_vwn`. Best of three paired runs, since run-to-run scatter on this box is large (the 1-thread XC time ranged 77–130 s across repeats):

| | 1 thread | 6 threads | speedup |
|---|---|---|---|
| XC quadrature | 77.4 s | 27.7 s | **2.80×** |
| SCF total | 107.5 s | 49.6 s | 2.17× |

All six timing runs converge to `-108.6999084569`, as do the unrestricted runs at one and six threads.

## Regression gate

The diatomic suite is unchanged: **62 cases at their reference energies, 0 failures.** The two `diatomic-CH-pi±-lda` cases are the pre-existing 900 s timeouts. Four cases timed out in the batch run under `--jobs 3`; two of them are `--method=HF`, which never enters an XC grid at all, and both reproduce their reference energies when re-run alone — the timeouts are contention on a 6-core box, not regressions.

## Note

The inner `omp parallel for` in `update_density` is now nested inside this region. Nesting is off by default, so it collapses to serial — which is what we want, the outer loop being the coarser and better-balanced of the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)