### PR TITLE
sadatom: restore the CLI options the OOO rewrite dropped

### DIFF
--- a/src/sadatom/1e.cpp
+++ b/src/sadatom/1e.cpp
@@ -22,6 +22,8 @@
 #include "utils.h"
 #include "dftgrid.h"
 #include "../atomic/basis.h"
+#include "../general/model_potential.h"
+#include "../general/radial_block_helper.h"
 #include "Matrix.h"
 #include <Eigen/Eigenvalues>
 #include <cfloat>
@@ -111,11 +113,30 @@ int main(int argc, char **argv) {
   const helfem::Matrix Sinvh = scf::form_Sinvh(S, /*chol=*/false);
   const helfem::Matrix T     = radial.kinetic();
   const helfem::Matrix Tl    = radial.kinetic_l();
-  const helfem::Matrix V     = radial.nuclear();
+
+  // Nuclear attraction. radial.nuclear() is the bare -<1/r>, so the point
+  // nucleus scales it by Z; a model potential's V(r) already carries the
+  // charge, so it REPLACES that product rather than scaling it. The
+  // per-element route is the one that splits the element at the nuclear
+  // radius, which the uniform sphere and hollow shell need -- their kink
+  // otherwise refines only algebraically and grinds to the quadrature
+  // order cap.
+  const modelpotential::nuclear_model_t nucmodel =
+      (modelpotential::nuclear_model_t) finitenuc;
+  helfem::Matrix V;
+  if (nucmodel != modelpotential::POINT_NUCLEUS) {
+    modelpotential::ModelPotential *pot =
+        modelpotential::nuclear_model<double>(nucmodel, Z, Rrms);
+    V = helfem::assemble_radial_diagonal(radial,
+        [&](size_t iel) { return radial.model_potential(pot, iel); });
+    delete pot;
+  } else {
+    V = Z * radial.nuclear();
+  }
 
   for (int l = 0; l <= lmax; ++l) {
     const helfem::Matrix H0 =
-        Sinvh.transpose() * (T + Z * V + l * (l + 1) * Tl) * Sinvh;
+        Sinvh.transpose() * (T + V + l * (l + 1) * Tl) * Sinvh;
     Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(H0);
     const helfem::Vector E = es.eigenvalues();
     helfem::Matrix C = Sinvh * es.eigenvectors();

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -159,6 +159,12 @@ int main(int argc, char **argv) {
   parser.add<std::string>("method", 0, "method to use", false, "lda_x");
   parser.add<double>("dftthr", 0, "density threshold for dft", false, 1e-12);
   parser.add<int>("primbas", 0, "primitive radial basis", false, 5);
+  parser.add<int>("finitenuc", 0, "finite nuclear model", false, 0);
+  parser.add<double>("Rrms", 0, "finite nuclear rms radius", false, 0.0);
+  parser.add<int>("nelem0", 0, "number of elements in the nuclear sub-grid", false, 0);
+  parser.add<int>("grid0", 0, "type of nuclear sub-grid: 1 for linear, 2 for quadratic, 3 for polynomial, 4 for exponential", false, 4);
+  parser.add<double>("zexp0", 0, "parameter in the nuclear sub-grid", false, 2.0);
+  parser.add<bool>("zeroder", 0, "zero derivative at Rmax?", false, false);
   parser.add<std::string>("x_pars", 0, "file for parameters for exchange functional", false, "");
   parser.add<std::string>("c_pars", 0, "file for parameters for correlation functional", false, "");
 
@@ -216,6 +222,13 @@ int main(int argc, char **argv) {
 
   const int igrid   = parser.get<int>("grid");
   const double zexp = parser.get<double>("zexp");
+  const modelpotential::nuclear_model_t finitenuc =
+      (modelpotential::nuclear_model_t) parser.get<int>("finitenuc");
+  const double Rrms = parser.get<double>("Rrms");
+  const int    Nelem0 = parser.get<int>("nelem0");
+  const int    igrid0 = parser.get<int>("grid0");
+  const double zexp0  = parser.get<double>("zexp0");
+  const bool   zeroder = parser.get<bool>("zeroder");
   const int Nelem   = parser.get<int>("nelem");
   const int Z       = element_Z(parser.get<std::string>("Z"));
         int Q       = parser.get<int>("Q");
@@ -282,8 +295,8 @@ int main(int argc, char **argv) {
     throw std::logic_error("The specified correlation functional is not currently supported in HelFEM.\n");
 
   const helfem::Vector bval = atomic::basis::form_grid(
-      modelpotential::POINT_NUCLEUS, 0.0, Nelem, Rmax, igrid, zexp,
-      0, 0, 0.0, Z, 0, 0, 0.0,
+      finitenuc, Rrms, Nelem, Rmax, igrid, zexp,
+      Nelem0, igrid0, zexp0, Z, 0, 0, 0.0,
       iconf ? add_conf : false, shift_conf);
 
   sadatom::scf::AtomicSCFOptions opts;
@@ -291,6 +304,9 @@ int main(int argc, char **argv) {
   opts.lmax         = lmax;
   opts.poly         = poly;
   opts.Nquad        = Nquad;
+  opts.finitenuc    = finitenuc;
+  opts.Rrms         = Rrms;
+  opts.zeroder      = zeroder;
   opts.bval         = bval;
   opts.nela         = nela;
   opts.nelb         = nelb;


### PR DESCRIPTION
`atomic` has had `--finitenuc`/`--Rrms` all along, and so has the sadatom SCF layer: `AtomicSCFOptions` carries `finitenuc`, `Rrms` and `zeroder`, and `scf.cpp` passes all three to `TwoDBasis`, whose `nuclear()` already branches on the model. Only the `gensap` command line was missing, so those fields sat at their defaults and the flags could not be reached.

Comparing gensap's parser against `b6642e4^` — the commit that retired the bespoke drivers — shows what went missing there and never came back:

| restored | |
|---|---|
| `--finitenuc` `--Rrms` | nuclear model and its rms radius |
| `--nelem0` `--grid0` `--zexp0` | the nuclear sub-grid |
| `--zeroder` | zero derivative at Rmax |

Deliberate rather than lost, and left alone: `--maxit` was renamed `--maxiter`, and `--diisthr`/`--diiseps`/`--diisorder` went when OOO took over DIIS (`--scfmethods` selects the methods now). `--shift` was the bespoke solver's level shift and has no OOO equivalent to wire to, so restoring it would mean inventing behaviour.

## 1e.cpp needed more than plumbing

It passed `finitenuc` and `Rrms` to `form_grid` only, so they shaped the grid while the Hamiltonian kept a point nucleus — the flag provably did nothing, giving identical eigenvalues at `Rrms=0` and `Rrms=0.1`. It now assembles the model potential per element, which is the route that splits the element at the nuclear radius; the uniform sphere and hollow shell have a kink there that otherwise refines only algebraically and grinds to the quadrature order cap.

Note the model potential's `V(r)` already carries the charge, so it *replaces* `Z*nuclear()` rather than scaling it.

## Verified live, not merely present

Every one of these defaults to the old behaviour, so a silent no-op would look like a pass. My first check — "does the energy change?" — showed UNCHANGED for all four of the non-nucleus flags, and that was the test being wrong, not the wiring: `--nelem0`/`--grid0`/`--zexp0` are consumed only by `finite_nuclear_grid`, so with a point nucleus they are ignored by design, and `--zeroder` maps to `zero_deriv_right`, which `LIPBasis::drop_last` explicitly discards, so it can only bite on a Hermite basis.

Tested in the right configuration:

| option | evidence it reaches the machinery |
|---|---|
| `--finitenuc` | Og 1s moves +1.58 Eh at the real rms radius; `1e_atom` agrees with `gensap` to 1e-11 across three radii — independent routes, since gensap goes through the pre-existing `TwoDBasis::nuclear()` branch |
| `--nelem0` | grid points 6 → 12 → 18 |
| `--grid0` | sub-grid breakpoints differ, linear against exponential |
| `--zexp0` | energy moves at 1e-9 |
| `--zeroder` | cond(S) 18.15 → 16.92 on a Hermite basis |

Point-nucleus results are byte-identical: `1e_atom` on Z=118 at 20 and 50 nodes, and `gensap` on Og (`-46303.5053560219`). gensap and aij regression cases: **18 passed, 0 failed** (the one error is the pre-existing `aij-Fe-secondorder` `--preiter` knife-edge).

## Left out

`aij` still hardcodes `POINT_NUCLEUS` at its own `TwoDBasis` construction. Same one-line shape, but whether a finite nucleus belongs in the jellium model is a physics call rather than plumbing, so it is left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)