### PR TITLE
Bump OpenOrbitalOptimizer to bef468d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,8 +387,11 @@ if(NOT OpenOrbitalOptimizer_FOUND)
     # dependency. Bump this deliberately, in its own commit, so the bump is
     # bisectable like any other change.
     #
-    # a3abae9 is 83 commits past v0.4.0 and carries the Aufbau/occupation
+    # bef468d is 105 commits past v0.4.0 and carries the Aufbau/occupation
     # fixes; pinning to the v0.4.0 tag instead would silently revert them.
+    # It also fixes the cleanup() segfault on a single-entry orbital
+    # history, which a one-electron ion reaches through the default method
+    # set as soon as the first DIIS error exceeds 1 and DIIS is dropped.
     FetchContent_Declare(OpenOrbitalOptimizer
         GIT_REPOSITORY https://github.com/susilehtola/OpenOrbitalOptimizer.git
         GIT_TAG        bef468dfb24241ea6e44d73e2d749182d45dce16


### PR DESCRIPTION
`atomic` segfaulted on any highly charged one-electron ion:

```
atomic --Z=10 --nela=1 --nelb=0 --lmax=0 --mmax=0 --method=HF
```

died in `OpenOrbitalOptimizer::SCFSolver::cleanup()` right after the first step. `cleanup()` sized its `density_differences` vector as `orbital_history_.size()-1` and then indexed it at 0, so a single-entry history read off the end. Upstream `bef468d` guards it.

## A note on the upstream reachability claim

The upstream commit records the bug as reachable only through method sets *without* DIIS — `ODA + CG` and `ODA + LBFGS` — and therefore not through the defaults. That is incomplete. This case reaches it with the default `DIIS + ODA + CG`, because DIIS is not merely absent but **abandoned at runtime** once its error exceeds 1, which the SAP guess for a one-electron ion does immediately:

```
Switching DIIS -> ODA: DIIS max error 1.001260e+00 exceeds threshold 1.000000e+00
```

Z=1 and Z=2 converge (their guess is good enough that DIIS survives); Z=10 and up did not.

## Result

One-electron ions now give −Z²/2 exactly, `nelem=5 nnodes=15`:

| Z | 1 | 2 | 10 | 30 | 54 | 118 |
|---|---|---|---|---|---|---|
| error | 0 | 0 | 0 | 0 | 0 | 1e-10 |

## Gating

The bump carries 21 further commits, and several change SCF *behaviour* rather than fixing crashes — the occupation cleanup now works on the energy alone, the polytope walk is off by default, and there is a new augmented Roothaan-Hall step. So it is gated on the whole suite rather than on the reproducer: **181 passed, 0 failed**, unchanged from the previous pin.

Two cases are worth naming:

- `aij-Fe-firstorder` still reports no energy, exactly as it did before the bump (verified against a pre-bump run). It is a pure first-order run on Fe, which CLAUDE.md documents as not converging under ODA alone, so it never prints a convergence line.
- `aij-Fe-secondorder` went the other way and now **converges** where the previous pin left it stalled above its threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)