### PR TITLE
Set the standard for the _Float128 probe, don't append a flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,16 +106,32 @@ int main() {
 ")
 set(HELFEM_FLOAT128_DEFAULT OFF)
 if(cxx_std_23 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
-  # Use whichever flag this CMake would give the helfem targets for
-  # cxx_std_23, so the probe is compiled the way the sources will be.
-  set(_helfem_f128_saved_flags "${CMAKE_REQUIRED_FLAGS}")
-  if(DEFINED CMAKE_CXX23_STANDARD_COMPILE_OPTION)
-    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CMAKE_CXX23_STANDARD_COMPILE_OPTION}")
+  # Raise the standard for the probe by setting CMAKE_CXX_STANDARD, NOT by
+  # pushing -std=c++23 into CMAKE_REQUIRED_FLAGS. try_compile() appends the
+  # flag for CMAKE_CXX_STANDARD *after* CMAKE_REQUIRED_FLAGS, so the latter
+  # loses to whatever standard the surrounding project has set: embedded in
+  # a project that asks for C++17, the probe compiled as
+  # "-std=c++23 -std=c++17", C++17 won, 1.0f128 did not exist, and quad was
+  # silently disabled on a toolchain that supports it perfectly. With
+  # HELFEM_FLOAT128=ON cached that turned into the FATAL_ERROR below. A
+  # standalone HelFEM build never saw it, because it sets no
+  # CMAKE_CXX_STANDARD of its own and there was nothing to append.
+  if(DEFINED CMAKE_CXX_STANDARD)
+    set(_helfem_f128_had_std TRUE)
+    set(_helfem_f128_saved_std "${CMAKE_CXX_STANDARD}")
   else()
-    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++23")
+    set(_helfem_f128_had_std FALSE)
   endif()
+  set(_helfem_f128_saved_req "${CMAKE_CXX_STANDARD_REQUIRED}")
+  set(CMAKE_CXX_STANDARD 23)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
   check_cxx_source_compiles("${_helfem_f128_probe}" HELFEM_FLOAT128_WORKS)
-  set(CMAKE_REQUIRED_FLAGS "${_helfem_f128_saved_flags}")
+  if(_helfem_f128_had_std)
+    set(CMAKE_CXX_STANDARD "${_helfem_f128_saved_std}")
+  else()
+    unset(CMAKE_CXX_STANDARD)
+  endif()
+  set(CMAKE_CXX_STANDARD_REQUIRED "${_helfem_f128_saved_req}")
   if(HELFEM_FLOAT128_WORKS)
     set(HELFEM_FLOAT128_DEFAULT ON)
   else()


### PR DESCRIPTION
Reported against `76d62fa` by a downstream project embedding HelFEM.

`check_cxx_source_compiles()` goes through `try_compile()`, which appends the flag for `CMAKE_CXX_STANDARD` **after** `CMAKE_REQUIRED_FLAGS`. Putting `-std=c++23` in the latter therefore loses to whatever standard the surrounding project set — the probe compiled as

```
-std=c++23 ... -std=c++17
```

C++17 won, `1.0f128` did not exist, the probe failed, and quad was silently disabled on a toolchain that supports it perfectly. Worse, with `HELFEM_FLOAT128=ON` cached it became the `FATAL_ERROR` intended for GCC 11 — blaming a standard library that was fine.

The fix sets `CMAKE_CXX_STANDARD` around the check instead, saving and restoring it, and *unsetting* it again when the caller had none. That last part is why a standalone HelFEM build never saw this: HelFEM sets no `CMAKE_CXX_STANDARD` of its own, so there was nothing to append and the flag stood.

## Reproduced and fixed

On GCC 16.2.1, which supports the quad path completely:

| CMAKE_CXX_STANDARD | before | after |
|---|---|---|
| 17 (embedded) | **Failed** | Success |
| 20 | Failed | Success |
| 23 | Failed | Success |
| unset (standalone) | Success | Success |

And end-to-end, not just the probe: `libhelfem` builds cleanly with `HELFEM_FLOAT128=ON` while embedded at `-DCMAKE_CXX_STANDARD=17`, so the probe's answer and the build now agree.

## The negative path is unchanged

Checked by breaking the probe body to stand in for a toolchain that advertises C++23 without providing the `_Float128` support (GCC 11, the case the probe exists for). It still reports `Failed`, still defaults quad OFF with the explanatory message, and an explicit `HELFEM_FLOAT128=ON` still stops at the `FATAL_ERROR` rather than a wall of errors a thousand lines into libhelfem.

One thing that looks like a leak but is not: with quad enabled, `libhelfem`'s sources compile as `-std=gnu++23` even in a C++17 embedding. That is the documented design — quad "raises the standard on the helfem targets only" — not the probe's standard escaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)