### PR TITLE
Make radial_df_factors terminate when the tolerance is unreachable

### DIFF
--- a/src/atomic/TwoDBasis.cpp
+++ b/src/atomic/TwoDBasis.cpp
@@ -23,6 +23,7 @@
 #include "../general/gaunt.h"
 #include "utils.h"
 #include "../general/scf_helpers.h"
+#include "../general/eigen_io.h"   // fmt_sci, for the residual report
 #include <cassert>
 #include <cfloat>
 #include <algorithm>
@@ -580,6 +581,29 @@ namespace helfem {
         return V;
       }
 
+      namespace {
+        /// Report an incomplete density-fitting factorisation once per
+        /// process. The caller gets the best factorisation achieved
+        /// rather than a hang or a silent claim of success, and is told
+        /// what residual it actually has: no caller can know in advance
+        /// which tolerances a given basis can reach.
+        template <typename T>
+        void warn_df_incomplete(int L, size_t nvec, T achieved, T tol,
+                                const char *why) {
+          static bool warned = false;
+          if (warned)
+            return;
+          warned = true;
+          printf("Warning: TwoDBasis::radial_df_factors stopped at multipole "
+                 "L=%d after %d vectors (%s) with residual %s, above the "
+                 "requested %s; using the factorization obtained.\n",
+                 L, (int) nvec, why,
+                 helfem::io::fmt_sci(achieved).c_str(),
+                 helfem::io::fmt_sci(tol).c_str());
+          fflush(stdout);
+        }
+      }
+
       template <typename T>
       std::vector<std::vector<helfem::Mat<T>>>
       TwoDBasisT<T>::radial_df_factors(T tol) const {
@@ -655,6 +679,32 @@ namespace helfem {
           //    Cholesky vectors, normalises, appends, and updates the
           //    diagonal.
           std::vector<helfem::Mat<T>> B_L_vecs;
+
+          // Two bounds on the loop below. Without them the only exit was
+          // D_pivot < tol, so a tol the metric cannot reach never
+          // terminated -- no error, no output, just spinning. Reported
+          // against a HIP3 basis, where 1000*eps was unattainable.
+          //
+          // The rank bound is the principled one: the residual lives on
+          // the SYMMETRIC pair index, whose dimension is
+          // Nrad(Nrad+1)/2, so the exact factorisation cannot need more
+          // vectors than that and anything beyond it is round-off.
+          //
+          // The stall bound catches the same failure sooner. In exact
+          // arithmetic the pivot diagonal is monotone non-increasing --
+          // each step zeroes the element it consumes -- but in floating
+          // point it settles onto the metric's own round-off floor,
+          // which for an ill-conditioned basis sits well above a tight
+          // tol. Ties are legitimate and systematic here (D is
+          // symmetric, so every off-diagonal pair appears twice), which
+          // is why the window is generous rather than tripping on the
+          // first non-decrease.
+          const size_t maxvec =
+              (size_t) Nrad_e * (size_t) (Nrad_e + 1) / 2;
+          const size_t stall_window = 50;
+          T best_pivot = D.maxCoeff();
+          size_t nstall = 0;
+
           while (true) {
             // Eigen is column-major, so maxCoeff scans in the same order
             // as the old arma index_max column-major flatten -- identical
@@ -662,6 +712,18 @@ namespace helfem {
             Eigen::Index i_star = 0, j_star = 0;
             const T D_pivot = D.maxCoeff(&i_star, &j_star);
             if (D_pivot < tol) break;
+
+            if (B_L_vecs.size() >= maxvec) {
+              warn_df_incomplete(L, B_L_vecs.size(), D_pivot, tol, "rank");
+              break;
+            }
+            if (D_pivot < best_pivot) {
+              best_pivot = D_pivot;
+              nstall = 0;
+            } else if (++nstall >= stall_window) {
+              warn_df_incomplete(L, B_L_vecs.size(), D_pivot, tol, "stalled");
+              break;
+            }
 
             // Build the symmetric pair-density indicator P. For i == j:
             //   P = e_i e_i^T (single 1 on the diagonal).


### PR DESCRIPTION
Fixes the reported non-termination of `TwoDBasis::radial_df_factors` on a HIP3 (primbas 9) basis.

The pivoted Cholesky had **one** exit, `D_pivot < tol`, and no bound on the number of vectors. A tolerance the metric cannot reach therefore never terminated — no error, no output, just spinning.

## Two bounds

**The rank bound is the principled one.** The residual lives on the *symmetric* pair index, so its dimension — and hence the exact rank of R^L — is at most `Nrad(Nrad+1)/2`. Past that there is nothing left to factor and every further vector is round-off. That alone guarantees termination.

**The stall bound catches the same failure sooner.** In exact arithmetic the pivot diagonal is monotone non-increasing, each step zeroing the element it consumes; in floating point it settles onto the metric's own round-off floor, which for an ill-conditioned basis sits well above a tight `tol`. The window is 50 rather than tripping on the first non-decrease because ties here are legitimate and systematic — `D` is symmetric, so every off-diagonal pair appears twice and the maximum genuinely repeats.

Either way the caller gets the best factorization obtained and is **told the residual it actually has**. No caller can know in advance which tolerances a given basis can reach, so an unattainable request has to degrade to "here is what I got", never to non-termination.

## The reproducer

The reported case (`maxl=1 nnodes=5 nelem=3 Rmax=60 primbas=9`, tol `2.22e-13`) previously had to be killed. It now returns in about a second:

```
Warning: TwoDBasis::radial_df_factors stopped at multipole L=0 after 1275 vectors
(rank) with residual 7.2820533128870046e-12, above the requested
2.2204460492503131e-13; using the factorization obtained.
RETURNED: 3 multipoles, sizes: 1275 92 1275
```

1275 is exactly `Nrad(Nrad+1)/2` for this basis, and **7.28e-12 explains the reported threshold boundary**: 1e-11 was reachable, 1e-12 was not.

## Every reported case, before and after

| case | before | after |
|---|---|---|
| primbas 4 (LIP, nnodes=20) | returns | returns, no warning, 111 vectors |
| primbas 5 (HIP, nnodes=10) | returns | returns, no warning |
| primbas 8 (HIP2, nnodes=7) | returns | returns, no warning |
| **primbas 9 (HIP3, nnodes=5)** | **hangs** | returns + warns, 1275 (rank) |
| tol 1e-11 | returns | returns, no warning, 84 vectors |
| **tol 1e-12 / 1e-13 / 2.22e-13** | **hangs** | returns + warns |
| **nelem 4, 6** | **hangs** | returns + warns |
| nelem 5 | returns | returns, no warning |
| Rmax 40 | returns | returns, no warning |
| **Rmax 45, 50** | **hangs** | returns + warns |

Cases that already worked are unchanged, vector counts included.

The erratic `(nelem, Rmax)` pattern in the report is **explained** rather than merely fixed: whether the run terminated depended on whether the requested residual happened to be attainable for that metric, which is a property of the conditioning and not of the dimension — exactly the diagnosis in the report.

## One cost worth naming

When the rank bound is what stops it, the loop still runs to that bound — 56 s for `nelem=6`, where the residual was creeping down without reaching `tol`. Tightening the stall window would cut that, at the risk of stopping a run still making progress. Correctness seemed worth the seconds, and the warning says what happened. Happy to trade differently if you'd rather it bailed earlier.

Regression suite: **191 passed, 0 failed, 0 errored.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)