### PR TITLE
sadatom: restore the orbital table, shared between gensap and aij

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ general/atomdb.cpp general/atomdb_data.cpp
 general/checkpoint.cpp general/otr_solver.cpp general/trustregion_scf.cpp atomic/basis.cpp
 atomic/TwoDBasis.cpp
 atomic/dftgrid.cpp sadatom/basis.cpp
-sadatom/dftgrid.cpp sadatom/scf.cpp
+sadatom/dftgrid.cpp sadatom/scf.cpp sadatom/orbital_table.cpp
 diatomic/basis.cpp diatomic/quadrature.cpp
 diatomic/dftgrid.cpp diatomic/dftgrid_purem.cpp diatomic/twodquadrature.cpp
 general/model_potential.cpp

--- a/src/sadatom/aij.cpp
+++ b/src/sadatom/aij.cpp
@@ -24,6 +24,7 @@
 #include "openorbitaloptimizer/scfsolver.hpp"
 
 #include "basis.h"
+#include "orbital_table.h"
 #include "dftgrid.h"
 
 #include <Eigen/Eigenvalues>
@@ -727,63 +728,20 @@ int main(int argc, char **argv) {
     return fockmat;
   };
 
-  // Diagonalize a Fock matrix block to obtain orbital energies and orbital
-  // coefficients in the non-orthonormal basis.
-  auto diagonalize_blocks = [&](const OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock,
+  // Orbital energies and AO-basis coefficients of the converged solution.
+  // The energies are the diagonal eps_i = <i|F|i> rather than a fresh
+  // diagonalization, so that they stay aligned with the occupations even
+  // when the second-order phase hands back stationary but non-canonical
+  // orbitals; see sadatom/orbital_table.h. The coefficients are then the
+  // converged orbitals themselves, which is also what gets saved.
+  auto converged_orbitals = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm,
+                                const OpenOrbitalOptimizer::FockMatrix<OOO_Real> & fock,
                                 std::vector<helfem::Vector> & Eblock,
                                 std::vector<helfem::Matrix> & Cblock) {
-    Eblock.resize(fock.size());
-    Cblock.resize(fock.size());
-    for(size_t b=0; b<fock.size(); b++) {
-      helfem::Matrix fsym = 0.5*(fock[b] + fock[b].transpose());
-      Eigen::SelfAdjointEigenSolver<helfem::Matrix> es(fsym);
-      Eblock[b] = es.eigenvalues();
-      Cblock[b] = Sinvh * es.eigenvectors();
-    }
-  };
-
-  // Print orbital information (occupation, energy, <r>, r(max)) for the
-  // requested range of blocks. The block index modulo lmax+1 gives l.
-  auto print_orbitals = [&](const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real> & dm,
-                            const std::vector<helfem::Vector> & Eblock,
-                            const std::vector<helfem::Matrix> & Cblock,
-                            const std::vector<std::string> & block_descriptions,
-                            size_t bstart, size_t bend) {
-    static const char shtype[] = "spdfgh";
-    const auto & occupations = dm.second;
-
-    std::vector< std::pair<int, helfem::Matrix> > rmat(basis.Rmatrices());
-
-    for(size_t b=bstart; b<bend; b++) {
-      int l = (int)(b % (lmax+1));
-
-      printf("\n%s orbitals\n", block_descriptions[b].c_str());
-      printf("%3s %8s %16s","nl","occ","E");
-      for(size_t ir=0;ir<rmat.size();ir++) {
-        std::ostringstream oss;
-        oss << "<r>(" << rmat[ir].first << ")";
-        printf(" %12s",oss.str().c_str());
-      }
-      printf(" %12s\n","r(max)");
-
-      for(Eigen::Index io=0;io<Eblock[b].size();io++) {
-        double occ = occupations[b](io);
-        if(std::abs(occ) < savethr)
-          continue;
-
-        helfem::Vector orb = Cblock[b].col(io);
-        helfem::Matrix P = orb*orb.transpose();
-
-        int n = (int)io + l + 1;
-        char ltag = (l < 6) ? shtype[l] : '?';
-        printf("%2i%c % 8.4f % 16.9f", n, ltag, occ, Eblock[b](io));
-        for(size_t ir=0;ir<rmat.size();ir++) {
-          double rpos = std::pow((P*rmat[ir].second).trace(), 1.0/rmat[ir].first);
-          printf(" %12e", rpos);
-        }
-        printf(" %12e\n", basis.electron_density_maximum_radius(P));
-      }
-    }
+    Eblock = helfem::sadatom::orbital_energies(dm.first, fock);
+    Cblock.resize(dm.first.size());
+    for(size_t b=0; b<dm.first.size(); b++)
+      Cblock[b] = Sinvh * dm.first[b];
   };
 
   // Save the radial values of all occupied orbitals from the requested block
@@ -961,9 +919,10 @@ int main(int argc, char **argv) {
     {
       std::vector<helfem::Vector> Eblock;
       std::vector<helfem::Matrix> Cblock;
-      diagonalize_blocks(fock, Eblock, Cblock);
+      converged_orbitals(dm, fock, Eblock, Cblock);
       if(verbosity >= 1)
-        print_orbitals(dm, Eblock, Cblock, block_descriptions, 0, fock.size());
+        helfem::sadatom::print_orbital_table(basis, Cblock, dm.second, Eblock,
+                                             0, fock.size(), "Restricted", savethr);
       if(saveorb)
         save_orbitals(dm, Eblock, Cblock, 0, fock.size(), orb_prefix);
     }
@@ -1044,15 +1003,13 @@ int main(int argc, char **argv) {
     {
       std::vector<helfem::Vector> Eblock;
       std::vector<helfem::Matrix> Cblock;
-      diagonalize_blocks(fock, Eblock, Cblock);
-      if(verbosity >= 1)
-        printf("\nAlpha orbitals\n");
-      if(verbosity >= 1)
-        print_orbitals(dm, Eblock, Cblock, block_descriptions, 0, lmax+1);
-      if(verbosity >= 1)
-        printf("\nBeta orbitals\n");
-      if(verbosity >= 1)
-        print_orbitals(dm, Eblock, Cblock, block_descriptions, lmax+1, 2*lmax+2);
+      converged_orbitals(dm, fock, Eblock, Cblock);
+      if(verbosity >= 1) {
+        helfem::sadatom::print_orbital_table(basis, Cblock, dm.second, Eblock,
+                                             0, lmax+1, "Alpha", savethr);
+        helfem::sadatom::print_orbital_table(basis, Cblock, dm.second, Eblock,
+                                             lmax+1, 2*lmax+2, "Beta", savethr);
+      }
       if(saveorb) {
         save_orbitals(dm, Eblock, Cblock, 0,        lmax+1,   orb_prefix + "_alpha");
         save_orbitals(dm, Eblock, Cblock, lmax+1,   2*lmax+2, orb_prefix + "_beta");

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -30,6 +30,7 @@
 #include "../general/lcao_projection.h"
 #include "../atomic/basis.h"
 #include "scf.h"
+#include "orbital_table.h"
 #include "../general/otr_solver.h"
 #include "../general/eigen_io.h"
 // std::abs / std::round / std::lround for the --occs integrality check.
@@ -422,78 +423,18 @@ int main(int argc, char **argv) {
   if (parser.get<bool>("completeness"))
     write_profiles(result, Z, lmax);
 
-  // Orbital table: occupation, orbital energy and the radial extents
-  // <r^n>^(1/n) of every occupied orbital, plus the radius at which its
-  // density peaks. This is the summary the bespoke gensap printed from
-  // OrbitalChannel::Print, and aij still prints the same table.
+  // Per-shell summary: occupation, orbital energy, radial extents and
+  // the per-l gap. Shared with aij; see sadatom/orbital_table.h.
   if (verbosity >= 1) {
-    static const char shtype[] = "spdfgh";
-    // An orbital counts as occupied above this; matches the aij --savethr
-    // default, so the two drivers draw the same line.
-    const double occthr = 1e-6;
-    const std::vector< std::pair<int, helfem::Matrix> > rmat(result.basis.Rmatrices());
-
-    auto print_channel = [&](const helfem::Cube & orbs,
-                             const std::vector<helfem::Vector> & occs,
-                             const std::vector<helfem::Vector> & energies,
-                             const char * label) {
-      printf("\n%s orbitals\n", label);
-      printf("%3s %8s %16s", "nl", "occ", "E");
-      for (size_t ir = 0; ir < rmat.size(); ir++) {
-        std::ostringstream oss;
-        oss << "<r>(" << rmat[ir].first << ")";
-        printf(" %12s", oss.str().c_str());
-      }
-      printf(" %12s\n", "r(max)");
-
-      for (size_t l = 0; l < orbs.size(); l++) {
-        if (l >= occs.size() || l >= energies.size()) continue;
-        for (Eigen::Index io = 0; io < occs[l].size(); io++) {
-          const double occ = occs[l](io);
-          // Skip the virtuals: the table is about the occupied shells.
-          if (std::abs(occ) < occthr) continue;
-          const helfem::Vector orb = orbs[l].col(io);
-          const helfem::Matrix P = orb * orb.transpose();
-          const int n = (int) io + (int) l + 1;
-          const char ltag = (l < 6) ? shtype[l] : '?';
-          printf("%2i%c % 8.4f % 16.9f", n, ltag, occ, energies[l](io));
-          for (size_t ir = 0; ir < rmat.size(); ir++)
-            printf(" %12e", std::pow((P * rmat[ir].second).trace(), 1.0 / rmat[ir].first));
-          printf(" %12e\n", result.basis.electron_density_maximum_radius(P));
-        }
-      }
-
-      // Per-l gap between the lowest unoccupied and the highest occupied
-      // orbital of the channel, as the bespoke gensap printed from
-      // OrbitalChannel::GetGap. With no occupied orbital in the channel
-      // the gap is the orbital energy itself.
-      printf("%s HOMO-LUMO gap (eV) per l:", label);
-      for (size_t l = 0; l < orbs.size(); l++) {
-        if (l >= occs.size() || l >= energies.size() || occs[l].size() == 0) {
-          printf("  %s", "n/a");
-          continue;
-        }
-        double gap = 0.0;
-        bool have = false;
-        for (Eigen::Index io = 0; io < occs[l].size(); io++) {
-          if (std::abs(occs[l](io)) >= occthr) continue;
-          gap = (io == 0) ? energies[l](io) : energies[l](io) - energies[l](io - 1);
-          have = true;
-          break;
-        }
-        if (have)
-          printf("  %.4f", gap * HARTREEINEV);
-        else
-          printf("  %s", "n/a");
-      }
-      printf("\n");
-    };
-
+    const size_t nl = result.orbs_a.size();
     if (restricted) {
-      print_channel(result.orbs_a, result.occs_orb_a, result.orb_E_a, "Restricted");
+      sadatom::print_orbital_table(result.basis, result.orbs_a, result.occs_orb_a,
+                                   result.orb_E_a, 0, nl, "Restricted");
     } else {
-      print_channel(result.orbs_a, result.occs_orb_a, result.orb_E_a, "Alpha");
-      print_channel(result.orbs_b, result.occs_orb_b, result.orb_E_b, "Beta");
+      sadatom::print_orbital_table(result.basis, result.orbs_a, result.occs_orb_a,
+                                   result.orb_E_a, 0, nl, "Alpha");
+      sadatom::print_orbital_table(result.basis, result.orbs_b, result.occs_orb_b,
+                                   result.orb_E_b, 0, result.orbs_b.size(), "Beta");
     }
   }
 

--- a/src/sadatom/main.cpp
+++ b/src/sadatom/main.cpp
@@ -422,6 +422,81 @@ int main(int argc, char **argv) {
   if (parser.get<bool>("completeness"))
     write_profiles(result, Z, lmax);
 
+  // Orbital table: occupation, orbital energy and the radial extents
+  // <r^n>^(1/n) of every occupied orbital, plus the radius at which its
+  // density peaks. This is the summary the bespoke gensap printed from
+  // OrbitalChannel::Print, and aij still prints the same table.
+  if (verbosity >= 1) {
+    static const char shtype[] = "spdfgh";
+    // An orbital counts as occupied above this; matches the aij --savethr
+    // default, so the two drivers draw the same line.
+    const double occthr = 1e-6;
+    const std::vector< std::pair<int, helfem::Matrix> > rmat(result.basis.Rmatrices());
+
+    auto print_channel = [&](const helfem::Cube & orbs,
+                             const std::vector<helfem::Vector> & occs,
+                             const std::vector<helfem::Vector> & energies,
+                             const char * label) {
+      printf("\n%s orbitals\n", label);
+      printf("%3s %8s %16s", "nl", "occ", "E");
+      for (size_t ir = 0; ir < rmat.size(); ir++) {
+        std::ostringstream oss;
+        oss << "<r>(" << rmat[ir].first << ")";
+        printf(" %12s", oss.str().c_str());
+      }
+      printf(" %12s\n", "r(max)");
+
+      for (size_t l = 0; l < orbs.size(); l++) {
+        if (l >= occs.size() || l >= energies.size()) continue;
+        for (Eigen::Index io = 0; io < occs[l].size(); io++) {
+          const double occ = occs[l](io);
+          // Skip the virtuals: the table is about the occupied shells.
+          if (std::abs(occ) < occthr) continue;
+          const helfem::Vector orb = orbs[l].col(io);
+          const helfem::Matrix P = orb * orb.transpose();
+          const int n = (int) io + (int) l + 1;
+          const char ltag = (l < 6) ? shtype[l] : '?';
+          printf("%2i%c % 8.4f % 16.9f", n, ltag, occ, energies[l](io));
+          for (size_t ir = 0; ir < rmat.size(); ir++)
+            printf(" %12e", std::pow((P * rmat[ir].second).trace(), 1.0 / rmat[ir].first));
+          printf(" %12e\n", result.basis.electron_density_maximum_radius(P));
+        }
+      }
+
+      // Per-l gap between the lowest unoccupied and the highest occupied
+      // orbital of the channel, as the bespoke gensap printed from
+      // OrbitalChannel::GetGap. With no occupied orbital in the channel
+      // the gap is the orbital energy itself.
+      printf("%s HOMO-LUMO gap (eV) per l:", label);
+      for (size_t l = 0; l < orbs.size(); l++) {
+        if (l >= occs.size() || l >= energies.size() || occs[l].size() == 0) {
+          printf("  %s", "n/a");
+          continue;
+        }
+        double gap = 0.0;
+        bool have = false;
+        for (Eigen::Index io = 0; io < occs[l].size(); io++) {
+          if (std::abs(occs[l](io)) >= occthr) continue;
+          gap = (io == 0) ? energies[l](io) : energies[l](io) - energies[l](io - 1);
+          have = true;
+          break;
+        }
+        if (have)
+          printf("  %.4f", gap * HARTREEINEV);
+        else
+          printf("  %s", "n/a");
+      }
+      printf("\n");
+    };
+
+    if (restricted) {
+      print_channel(result.orbs_a, result.occs_orb_a, result.orb_E_a, "Restricted");
+    } else {
+      print_channel(result.orbs_a, result.occs_orb_a, result.orb_E_a, "Alpha");
+      print_channel(result.orbs_b, result.occs_orb_b, result.orb_E_b, "Beta");
+    }
+  }
+
   // Density / atomic-size diagnostics (parity with bespoke gensap).
   {
     const helfem::Matrix & Pdiag = result.Prad;

--- a/src/sadatom/orbital_table.cpp
+++ b/src/sadatom/orbital_table.cpp
@@ -1,0 +1,98 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#include "orbital_table.h"
+#include "../general/constants.h"
+
+#include <cmath>
+#include <cstdio>
+#include <sstream>
+
+namespace helfem {
+  namespace sadatom {
+
+    std::vector<helfem::Vector> orbital_energies(const helfem::Cube & orbitals_orth,
+                                                 const helfem::Cube & fock_orth) {
+      std::vector<helfem::Vector> E(orbitals_orth.size());
+      for (size_t b = 0; b < orbitals_orth.size(); b++) {
+        const helfem::Matrix & C = orbitals_orth[b];
+        const helfem::Matrix Fmo = C.transpose() * fock_orth[b] * C;
+        E[b] = Fmo.diagonal();
+      }
+      return E;
+    }
+
+    void print_orbital_table(const basis::TwoDBasis & basis,
+                             const helfem::Cube & orbs_ao,
+                             const std::vector<helfem::Vector> & occs,
+                             const std::vector<helfem::Vector> & energies,
+                             size_t bstart, size_t bend,
+                             const std::string & label,
+                             double occthr) {
+      static const char shtype[] = "spdfgh";
+      const std::vector< std::pair<int, helfem::Matrix> > rmat(basis.Rmatrices());
+
+      printf("\n%s orbitals\n", label.c_str());
+      printf("%3s %8s %16s", "nl", "occ", "E");
+      for (size_t ir = 0; ir < rmat.size(); ir++) {
+        std::ostringstream oss;
+        oss << "<r>(" << rmat[ir].first << ")";
+        printf(" %12s", oss.str().c_str());
+      }
+      printf(" %12s\n", "r(max)");
+
+      for (size_t b = bstart; b < bend; b++) {
+        const int l = (int) (b - bstart);
+        const helfem::Vector & occ_l = occs[b];
+        const helfem::Vector & E_l = energies[b];
+        for (Eigen::Index io = 0; io < occ_l.size(); io++) {
+          // Skip the virtuals: the table is about the occupied shells.
+          if (std::abs(occ_l(io)) < occthr) continue;
+          const helfem::Vector orb = orbs_ao[b].col(io);
+          const helfem::Matrix P = orb * orb.transpose();
+          const int n = (int) io + l + 1;
+          const char ltag = (l < 6) ? shtype[l] : '?';
+          printf("%2i%c % 8.4f % 16.9f", n, ltag, occ_l(io), E_l(io));
+          for (size_t ir = 0; ir < rmat.size(); ir++)
+            printf(" %12e", std::pow((P * rmat[ir].second).trace(), 1.0 / rmat[ir].first));
+          printf(" %12e\n", basis.electron_density_maximum_radius(P));
+        }
+      }
+
+      // Per-l gap between the lowest unoccupied and the highest occupied
+      // orbital of the channel, as the bespoke sadatom solver printed
+      // from OrbitalChannel::GetGap. With no occupied orbital in the
+      // channel the gap is the orbital energy itself.
+      printf("%s HOMO-LUMO gap (eV) per l:", label.c_str());
+      for (size_t b = bstart; b < bend; b++) {
+        const helfem::Vector & occ_l = occs[b];
+        const helfem::Vector & E_l = energies[b];
+        bool have = false;
+        double gap = 0.0;
+        for (Eigen::Index io = 0; io < occ_l.size() && io < E_l.size(); io++) {
+          if (std::abs(occ_l(io)) >= occthr) continue;
+          gap = (io == 0) ? E_l(io) : E_l(io) - E_l(io - 1);
+          have = true;
+          break;
+        }
+        if (have)
+          printf("  %.4f", gap * HARTREEINEV);
+        else
+          printf("  %s", "n/a");
+      }
+      printf("\n");
+    }
+
+  } // namespace sadatom
+} // namespace helfem

--- a/src/sadatom/orbital_table.h
+++ b/src/sadatom/orbital_table.h
@@ -1,0 +1,68 @@
+/*
+ *                This source code is part of
+ *
+ *                          HelFEM
+ *                             -
+ * Finite element methods for electronic structure calculations on small systems
+ *
+ * Written by Susi Lehtola, 2018-
+ * Copyright (c) 2018- Susi Lehtola
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * See the LICENSE file at the root of this source distribution
+ * for the full license text.
+ */
+#ifndef SADATOM_ORBITAL_TABLE_H
+#define SADATOM_ORBITAL_TABLE_H
+
+#include "basis.h"
+#include <string>
+
+namespace helfem {
+  namespace sadatom {
+
+    /// An orbital counts as occupied above this occupation. Matches the
+    /// aij --savethr default, so the two drivers draw the same line.
+    const double default_occupation_threshold = 1e-6;
+
+    /// Orbital energies eps_i = <i|F|i> of a converged solution, one
+    /// vector per block.
+    ///
+    /// Both arguments live in the orthonormal basis: orbitals_orth is
+    /// what OpenOrbitalOptimizer hands back, fock_orth the Fock matrix
+    /// built at the converged density.
+    ///
+    /// The diagonal form is deliberate. A converged first-order solution
+    /// has orbitals that diagonalize the Fock matrix, so this is the
+    /// usual eigenvalue; but the second-order phase returns orbitals
+    /// that are stationary without being canonical, and there a fresh
+    /// diagonalization produces a different set of vectors whose index
+    /// no longer labels the same orbital as the occupation vector's.
+    /// The diagonal stays aligned column-by-column with the occupations,
+    /// and it is the Janak derivative dE/dn_i -- the quantity the
+    /// occupation optimization is about.
+    std::vector<helfem::Vector> orbital_energies(const helfem::Cube & orbitals_orth,
+                                                 const helfem::Cube & fock_orth);
+
+    /// Print the per-shell summary of one spin channel: occupation,
+    /// orbital energy, the radial extents <r^n>^(1/n) for the n the
+    /// basis tabulates, and the radius at which the shell density peaks,
+    /// followed by the per-l gap between the lowest unoccupied and the
+    /// highest occupied orbital of each l.
+    ///
+    /// The block range [bstart, bend) is one channel's worth of l
+    /// blocks, so block b carries angular momentum l = b - bstart.
+    /// orbs_ao holds the orbitals in the non-orthonormal (AO) basis;
+    /// occs and energies are indexed by absolute block, like orbs_ao.
+    void print_orbital_table(const basis::TwoDBasis & basis,
+                             const helfem::Cube & orbs_ao,
+                             const std::vector<helfem::Vector> & occs,
+                             const std::vector<helfem::Vector> & energies,
+                             size_t bstart, size_t bend,
+                             const std::string & label,
+                             double occthr = default_occupation_threshold);
+
+  } // namespace sadatom
+} // namespace helfem
+
+#endif // SADATOM_ORBITAL_TABLE_H

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -760,6 +760,34 @@ namespace helfem {
         AtomicSCFResult result;
         result.basis = basis;
 
+        // Orbital energies of the converged solution. OpenOrbitalOptimizer
+        // hands back orbitals and occupations but no energies, so rebuild
+        // the Fock matrix at the converged density and read off
+        // eps_i = <i|F|i>. One extra build against a whole SCF is
+        // negligible, and the diagonal form -- rather than a fresh
+        // diagonalization -- is what stays aligned with the occupations
+        // when the second-order phase returns stationary but non-canonical
+        // orbitals. It is also the Janak derivative dE/dn_i, which is the
+        // quantity the occupation optimization is about.
+        {
+          std::string discard;
+          const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real>
+            dm_final(orbitals, occupations);
+          const auto ef = build_fock(dm_final, &discard, nullptr);
+          const auto & fock_final = ef.second;
+          auto extract_energies = [&](size_t t, std::vector<helfem::Vector> & E_out) {
+            E_out.assign(nblock, helfem::Vector());
+            for (size_t l = 0; l < nblock; ++l) {
+              const auto & C = orbitals[t * nblock + l];
+              const helfem::Matrix Fmo = C.transpose() * fock_final[t * nblock + l] * C;
+              E_out[l] = Fmo.diagonal();
+            }
+          };
+          extract_energies(0, result.orb_E_a);
+          if (!restricted)
+            extract_energies(1, result.orb_E_b);
+        }
+
         auto extract_channel = [&](size_t t, helfem::Cube & orbs_out, Eigen::VectorXi & occs_out,
                                    std::vector<helfem::Vector> & occs_orb_out) {
           orbs_out.assign(nblock, helfem::Matrix::Zero(Nrad, Nrad));

--- a/src/sadatom/scf.cpp
+++ b/src/sadatom/scf.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "scf.h"
+#include "orbital_table.h"
 #include "dftgrid.h"
 #include "../general/dftfuncs.h"
 #include "../general/scf_helpers.h"
@@ -763,29 +764,20 @@ namespace helfem {
         // Orbital energies of the converged solution. OpenOrbitalOptimizer
         // hands back orbitals and occupations but no energies, so rebuild
         // the Fock matrix at the converged density and read off
-        // eps_i = <i|F|i>. One extra build against a whole SCF is
-        // negligible, and the diagonal form -- rather than a fresh
-        // diagonalization -- is what stays aligned with the occupations
-        // when the second-order phase returns stationary but non-canonical
-        // orbitals. It is also the Janak derivative dE/dn_i, which is the
-        // quantity the occupation optimization is about.
+        // eps_i = <i|F|i>; see orbital_table.h for why the diagonal
+        // rather than a fresh diagonalization. One extra build against a
+        // whole SCF is negligible.
         {
           std::string discard;
           const OpenOrbitalOptimizer::DensityMatrix<OOO_Real, OOO_Real>
             dm_final(orbitals, occupations);
           const auto ef = build_fock(dm_final, &discard, nullptr);
           const auto & fock_final = ef.second;
-          auto extract_energies = [&](size_t t, std::vector<helfem::Vector> & E_out) {
-            E_out.assign(nblock, helfem::Vector());
-            for (size_t l = 0; l < nblock; ++l) {
-              const auto & C = orbitals[t * nblock + l];
-              const helfem::Matrix Fmo = C.transpose() * fock_final[t * nblock + l] * C;
-              E_out[l] = Fmo.diagonal();
-            }
-          };
-          extract_energies(0, result.orb_E_a);
+          const std::vector<helfem::Vector> E_all =
+            sadatom::orbital_energies(orbitals, fock_final);
+          result.orb_E_a.assign(E_all.begin(), E_all.begin() + nblock);
           if (!restricted)
-            extract_energies(1, result.orb_E_b);
+            result.orb_E_b.assign(E_all.begin() + nblock, E_all.begin() + 2 * nblock);
         }
 
         auto extract_channel = [&](size_t t, helfem::Cube & orbs_out, Eigen::VectorXi & occs_out,

--- a/src/sadatom/scf.h
+++ b/src/sadatom/scf.h
@@ -153,6 +153,18 @@ namespace helfem {
         /// SAD databases genuinely need them). occs_a above is their
         /// rounded per-l sum.
         std::vector<helfem::Vector> occs_orb_a, occs_orb_b;
+        /// Per-l, per-orbital orbital energies of the converged
+        /// solution, aligned column-by-column with orbs_a / occs_orb_a
+        /// (and orbs_b / occs_orb_b). Obtained as the diagonal of the
+        /// converged Fock matrix in the converged orbital basis, i.e.
+        /// eps_i = <i|F|i>, which is the Janak derivative dE/dn_i and
+        /// therefore the quantity the occupations are optimized
+        /// against. For a solution converged by the ordinary SCF the
+        /// orbitals diagonalize the Fock matrix and this is the usual
+        /// eigenvalue; the diagonal form is what stays aligned with the
+        /// occupations when the second-order phase hands back orbitals
+        /// that are only stationary, not canonical.
+        std::vector<helfem::Vector> orb_E_a, orb_E_b;
         /// Converged total radial density matrix (alpha+beta),
         /// Nrad x Nrad. Consumed by the gensap effective-potential /
         /// SAP-table output path (basis::coulomb_screening /


### PR DESCRIPTION
The OOO refactor retired the bespoke sadatom solver, and with it `OrbitalChannel::Print` and `OrbitalChannel::GetGap`, which printed the per-shell summary at the end of every `gensap` run. `aij` kept an equivalent table; `gensap` has printed nothing since. This restores it, and puts both drivers on one implementation.

Columns are as before: shell label, occupation, orbital energy, the radial extents `<r^n>^(1/n)` for each `n` the basis tabulates, and the radius at which the shell density peaks — followed by the per-`l` HOMO–LUMO gap in eV.

```
Restricted orbitals
 nl      occ                E      <r>(-2)      <r>(-1)       <r>(1)       <r>(2)       <r>(3)       r(max)
 1s   2.0000   -254.004702504 2.766778e-02 3.925825e-02 5.924521e-02 6.859867e-02 7.772529e-02 3.902500e-02
 4s   1.1885     -0.133795508 9.623418e-01 2.497608e+00 3.261377e+00 3.541567e+00 3.826268e+00 2.552835e+00
 3d   6.8115     -0.133795508 7.273615e-01 8.710009e-01 1.250977e+00 1.495782e+00 1.773659e+00 7.149178e-01
Restricted HOMO-LUMO gap (eV) per l:  3.6919  54.0751  3.9163
```

## Where the energies come from

OpenOrbitalOptimizer hands back orbitals and occupations but no orbital energies, so the Fock matrix is rebuilt once at the converged density and `eps_i = <i|F|i>` read off it.

The diagonal rather than a fresh diagonalization is deliberate, and it is also a fix. The second-order phase returns orbitals that are stationary without being canonical, so re-diagonalizing there produces a different set of vectors — index `io` of the eigenvalue vector then no longer labels the same orbital as index `io` of the occupation vector printed beside it. `aij` had exactly that latent mismatch; it never surfaced because the two coincide at a converged first-order solution. The diagonal stays aligned by construction, and it is the Janak derivative `dE/dn_i`, which is the quantity the occupation optimization is about. The Fe/LDA excerpt above is the check: 4s and 3d, the two fractionally occupied shells, come out at exactly the same energy — the degeneracy that makes that system hard in the first place.

One extra Fock build per SCF is the cost.

## Deduplication

`sadatom/orbital_table.{h,cpp}` is now the only copy: 152 lines out of the two drivers, 166 in shared with the reasoning attached. `gensap` reaches it through new `orb_E_a` / `orb_E_b` fields on `AtomicSCFResult`; `aij` calls it directly.

Three things change for `aij` as a result:

- orbital energies come from the diagonal, as above — and `--saveorb` now writes the converged orbitals rather than re-diagonalized ones, matching what `gensap` saves and what the density was built from;
- it gains the per-`l` HOMO–LUMO gap line, which only `gensap` used to print;
- it prints one table per spin channel with all `l` in it, instead of one table per `l` block, which is the layout the bespoke solver had.

Two smaller differences from the retired version apply to both: occupations print as fractions rather than the old integer `nocc`, since both drivers optimize them; and the occupied/virtual cut is `1e-6`, the `aij --savethr` default, which `aij` still passes through.

## Testing

Cross-check on Al, `--M=2`, LDA exchange: `aij --njellium=0` and `gensap` are the same system through separate energy expressions, Fock builders and SCF drivers. Their tables agree to 5e-6 Eh in the orbital energies and 1e-5 relative in the radial extents — the residual between two runs converged to 1e-7 — at the same total energy `-240.3560519787`.

`gensap`/`aij` regression subset at `OMP_NUM_THREADS=1`: **22 passed, 0 failed, 0 errored, 0 invariant violations**, identical before and after the refactor. `gensap-Fe-secondorder` and `aij-Fe-secondorder` still agree at `-1258.9186876173`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)